### PR TITLE
Unreviewed, REGRESSION (297343@main): [ macOS Sequoia wk2 Release arm64 ] 25x http/tests/webgpu/webgpu (layout-tests) are constant text failures

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/pipeline/pipeline_layout_created_with_null_bind_group_layout-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/pipeline/pipeline_layout_created_with_null_bind_group_layout-expected.txt
@@ -8,7 +8,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=1 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -19,7 +19,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=2 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -30,7 +30,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=3 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -41,7 +41,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=0 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -52,7 +52,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=1 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -63,7 +63,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=2 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -74,7 +74,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=3 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -85,7 +85,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=0 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -96,7 +96,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=1 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -107,7 +107,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=2 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -118,7 +118,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=3 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 3.
@@ -129,7 +129,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,rendering:emptyBindGroupLayout
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=0 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -140,7 +140,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=1 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -151,7 +151,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=2 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -162,7 +162,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Null";emptyBindGroupLayoutIndex=3 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -173,7 +173,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=0 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -184,7 +184,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=1 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -195,7 +195,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=2 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -206,7 +206,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Undefined";emptyBindGroupLayoutIndex=3 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -217,7 +217,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=0 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -228,7 +228,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=1 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -239,7 +239,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=2 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -250,7 +250,7 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutType="Empty";emptyBindGroupLayoutIndex=3 assert_unreached:
   - EXPECTATION FAILED: Array had unexpected contents at indices 0 through 0.
@@ -261,6 +261,6 @@ FAIL :pipeline_layout_with_null_bind_group_layout,compute:emptyBindGroupLayoutTy
       at (elided: below max severity)
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout-expected.txt
@@ -110,54 +110,54 @@ PASS :createPipelineLayout,at_over:limitTest="underDefault";testValueName="overL
 FAIL :createPipelineLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";type="storage" assert_unreached:
   - EXPECTATION FAILED: Bind group layout is invalid:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";type="read-only-storage" assert_unreached:
   - EXPECTATION FAILED: Bind group layout is invalid:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";type="storage" assert_unreached:
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";type="read-only-storage" assert_unreached:
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="atMaximum";testValueName="atLimit";type="storage" assert_unreached:
   - EXPECTATION FAILED: Bind group layout is invalid:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="atMaximum";testValueName="atLimit";type="read-only-storage" assert_unreached:
   - EXPECTATION FAILED: Bind group layout is invalid:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="atMaximum";testValueName="overLimit";type="storage" assert_unreached:
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 FAIL :createPipelineLayout,at_over:limitTest="atMaximum";testValueName="overLimit";type="read-only-storage" assert_unreached:
   - EXPECTATION FAILED: unexpected validation error: Storage buffers count(45) exceeded max count per stage(44)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:590:16
  Reached unreachable code
 PASS :createPipelineLayout,at_over:limitTest="overMaximum";testValueName="atLimit";type="storage"
 PASS :createPipelineLayout,at_over:limitTest="overMaximum";testValueName="atLimit";type="read-only-storage"

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout-expected.txt
@@ -30,37 +30,37 @@ PASS :createBindGroupLayout,at_over:limitTest="underDefault";testValueName="over
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=1 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=2 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=3 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=4 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=5 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=6 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";visibility=7 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 PASS :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";visibility=1
 PASS :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";visibility=2
@@ -72,37 +72,37 @@ PASS :createBindGroupLayout,at_over:limitTest="betweenDefaultAndMaximum";testVal
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=1 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=2 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=3 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=4 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=5 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=6 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="atLimit";visibility=7 assert_unreached:
   - EXPECTATION FAILED: Uniform buffers count(45) exceeded max count per stage(44):
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 PASS :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="overLimit";visibility=1
 PASS :createBindGroupLayout,at_over:limitTest="atMaximum";testValueName="overLimit";visibility=2

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt
@@ -68,72 +68,72 @@ PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -157,9 +157,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -168,9 +168,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -179,9 +179,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -190,9 +190,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -201,9 +201,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -212,9 +212,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -223,9 +223,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -234,9 +234,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -245,9 +245,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -256,9 +256,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -267,9 +267,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -278,9 +278,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -289,9 +289,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -300,9 +300,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -392,72 +392,72 @@ PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: no error when one was expected:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -481,9 +481,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -492,9 +492,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -503,9 +503,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -514,9 +514,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -525,9 +525,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -536,9 +536,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -547,9 +547,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -558,9 +558,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -569,9 +569,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -580,9 +580,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -591,9 +591,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -602,9 +602,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -613,9 +613,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -624,9 +624,9 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
   - EXPECTATION FAILED: DID NOT REJECT
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldReject@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:297:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:701:24
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -650,171 +650,171 @@ PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -824,9 +824,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -836,9 +836,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -848,9 +848,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -860,9 +860,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -872,9 +872,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -884,9 +884,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -896,9 +896,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -908,9 +908,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -920,9 +920,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -932,9 +932,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -944,9 +944,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -956,9 +956,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -968,9 +968,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -980,9 +980,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -992,9 +992,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1004,9 +1004,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1016,9 +1016,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1028,9 +1028,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1040,9 +1040,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1052,9 +1052,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1064,9 +1064,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1076,9 +1076,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1088,9 +1088,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1100,9 +1100,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1112,9 +1112,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1124,9 +1124,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1136,9 +1136,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1148,9 +1148,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1160,9 +1160,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1172,9 +1172,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1184,9 +1184,9 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1258,171 +1258,171 @@ PASS :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=false;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: vertexScalarComponents > maxVertexShaderOutputComponents:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
+    expectGPUErrorAsync@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:685:16
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1432,9 +1432,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1444,9 +1444,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1456,9 +1456,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1468,9 +1468,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1480,9 +1480,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1492,9 +1492,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1504,9 +1504,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1516,9 +1516,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1528,9 +1528,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1540,9 +1540,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1552,9 +1552,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1564,9 +1564,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1576,9 +1576,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1588,9 +1588,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1600,9 +1600,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1612,9 +1612,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1624,9 +1624,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1636,9 +1636,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1648,9 +1648,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1660,9 +1660,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1672,9 +1672,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1684,9 +1684,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1696,9 +1696,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1708,9 +1708,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1720,9 +1720,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1732,9 +1732,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1744,9 +1744,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1756,9 +1756,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1768,9 +1768,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1780,9 +1780,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16
@@ -1792,9 +1792,9 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     vertexScalarComponents > maxVertexShaderOutputComponents
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:254:33
     shouldResolve@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:276:34
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
+    shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:703:25
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:694:40
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
+    testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:942:43
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:934:36
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:123:16

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInFragmentStage-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInFragmentStage-expected.txt
@@ -264,7 +264,7 @@ FAIL :auto_upgrades_per_stage,maxStorageBuffersPerShaderStage: assert_unreached:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1296:15
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1291:15
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
   - EXPECTATION FAILED: device.limits.maxStorageBuffersPerShaderStage(8) is >= adapter.limits.maxStorageBuffersInFragmentStage(4294967295)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1314:15

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInVertexStage-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInVertexStage-expected.txt
@@ -144,7 +144,7 @@ FAIL :auto_upgrades_per_stage,maxStorageBuffersPerShaderStage: assert_unreached:
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1296:15
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1291:15
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
   - EXPECTATION FAILED: device.limits.maxStorageBuffersPerShaderStage(8) is >= adapter.limits.maxStorageBuffersInVertexStage(4294967295)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1314:15

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInFragmentStage-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInFragmentStage-expected.txt
@@ -384,7 +384,7 @@ FAIL :auto_upgrades_per_stage,maxStorageTexturesPerShaderStage: assert_unreached
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1296:15
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1291:15
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
   - EXPECTATION FAILED: device.limits.maxStorageTexturesPerShaderStage(4) is >= adapter.limits.maxStorageTexturesInFragmentStage(4294967295)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1314:15

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInVertexStage-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInVertexStage-expected.txt
@@ -144,7 +144,7 @@ FAIL :auto_upgrades_per_stage,maxStorageTexturesPerShaderStage: assert_unreached
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1296:15
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1291:15
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
   - EXPECTATION FAILED: device.limits.maxStorageTexturesPerShaderStage(4) is >= adapter.limits.maxStorageTexturesInVertexStage(4294967295)
     expect@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:355:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:1314:15

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/createPipelineLayout-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/createPipelineLayout-expected.txt
@@ -35,7 +35,7 @@ FAIL :number_of_dynamic_buffers_exceeds_the_maximum_value: assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Storage buffers count(45) exceeded max count per stage(44)
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :number_of_bind_group_layouts_exceeds_the_maximum_value: assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
@@ -113,6 +113,6 @@ FAIL :bind_group_layouts,set_pipeline_with_null_bind_group_layouts: assert_unrea
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Validation failure.
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass-expected.txt
@@ -4,7 +4,7 @@ PASS :timestampWrites,query_set_type:queryType="timestamp"
 FAIL :timestampWrites,invalid_query_set:querySetState="valid" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(1) || endOfPassWriteIndex(1) >= querySetCount(1) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(1)
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :timestampWrites,invalid_query_set:querySetState="invalid"
 FAIL :timestampWrites,query_index: assert_unreached:
@@ -63,7 +63,7 @@ FAIL :timestampWrites,query_index: assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(2) || endOfPassWriteIndex(0) >= querySetCount(2) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(0)
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :timestamp_query_set,device_mismatch: assert_unreached:
   - INFO: subcase: mismatched=false
@@ -72,6 +72,6 @@ FAIL :timestamp_query_set,device_mismatch: assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(1) || endOfPassWriteIndex(1) >= querySetCount(1) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(1)
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass-expected.txt
@@ -9,6 +9,6 @@ FAIL :timestamp_query_set,device_mismatch: assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: writeIndices mismatch: beginningOfPassWriteIndex(0) >= querySetCount(1) || endOfPassWriteIndex(1) >= querySetCount(1) || timestampWrite.beginningOfPassWriteIndex(0) == timestampWrite.endOfPassWriteIndex(1)
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/index_access-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/index_access-expected.txt
@@ -24,28 +24,28 @@ FAIL :out_of_bounds:indexCount=4294967295;firstIndex=4294967295;instanceCount=1 
       at (elided: below max severity)
   - EXCEPTION: Error: Device was unexpectedly lost. Reason: unknown, Message:
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
+    release@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
  Reached unreachable code
 FAIL :out_of_bounds:indexCount=4294967295;firstIndex=4294967295;instanceCount=10000 assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
       at (elided: below max severity)
   - EXCEPTION: Error: Device was unexpectedly lost. Reason: unknown, Message:
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
+    release@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
  Reached unreachable code
 FAIL :out_of_bounds:indexCount=4294967295;firstIndex=2;instanceCount=1 assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
       at (elided: below max severity)
   - EXCEPTION: Error: Device was unexpectedly lost. Reason: unknown, Message:
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
+    release@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
  Reached unreachable code
 FAIL :out_of_bounds:indexCount=4294967295;firstIndex=2;instanceCount=10000 assert_unreached:
   - VALIDATION FAILED: Validation succeeded unexpectedly.
       at (elided: below max severity)
   - EXCEPTION: Error: Device was unexpectedly lost. Reason: unknown, Message:
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
+    release@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:106:13
  Reached unreachable code
 PASS :out_of_bounds:indexCount=2;firstIndex=4294967295;instanceCount=1
 PASS :out_of_bounds:indexCount=2;firstIndex=4294967295;instanceCount=10000

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt
@@ -7,7 +7,7 @@ FAIL :setViewport,exceeds_attachment_size: assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.finish: encoder state is 'Locked', expected 'Open'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :setViewport,xy_rect_contained_in_bounds: assert_unreached:
   - INFO: subcase: dimension=0;om=0;od=0;sd=0
@@ -64,7 +64,7 @@ FAIL :setViewport,xy_rect_contained_in_bounds: assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: GPUCommandEncoder.finish: encoder state is 'Locked', expected 'Open'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :setViewport,depth_rangeAndOrder:
 PASS :setScissorRect,x_y_width_height_nonnegative:

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt
@@ -5,7 +5,7 @@ FAIL :shift_left_abstract:inputSource="const";vectorize="_undef_" assert_unreach
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:49: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=2 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
@@ -13,7 +13,7 @@ FAIL :shift_left_abstract:inputSource="const";vectorize=2 assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:61: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=3 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
@@ -21,7 +21,7 @@ FAIL :shift_left_abstract:inputSource="const";vectorize=3 assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:64: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_left_abstract:inputSource="const";vectorize=4 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
@@ -29,7 +29,7 @@ FAIL :shift_left_abstract:inputSource="const";vectorize=4 assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     38:67: shift left value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :shift_left_concrete:type="i32";inputSource="const";vectorize="_undef_"
 PASS :shift_left_concrete:type="i32";inputSource="const";vectorize=2
@@ -119,7 +119,7 @@ FAIL :shift_right_abstract:inputSource="const";vectorize="_undef_" assert_unreac
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:49: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_right_abstract:inputSource="const";vectorize=2 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
@@ -143,7 +143,7 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=2 assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     48:61: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_right_abstract:inputSource="const";vectorize=3 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
@@ -163,7 +163,7 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=3 assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     363:65: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :shift_right_abstract:inputSource="const";vectorize=4 assert_unreached:
   - EXPECTATION FAILED: Pipeline Creation Error, validation:
@@ -179,7 +179,7 @@ FAIL :shift_right_abstract:inputSource="const";vectorize=4 assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     358:68: shift right value must be less than the bit width of the shifted value, which is 64
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :shift_right_concrete:type="i32";inputSource="const";vectorize="_undef_"
 PASS :shift_right_concrete:type="i32";inputSource="const";vectorize=2

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order-expected.txt
@@ -16,7 +16,7 @@ FAIL :array_index_lhs_assignment: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:265:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:244:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -72,7 +72,7 @@ FAIL :array_index_lhs_member_assignment: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:300:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:276:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -131,7 +131,7 @@ FAIL :array_index_via_ptrs: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:316:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:309:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -192,7 +192,7 @@ FAIL :matrix_index_via_ptr: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:406:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:399:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -258,7 +258,7 @@ FAIL :1d_array_assignment: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:875:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:862:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -307,7 +307,7 @@ FAIL :2d_array_assignment: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:902:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:885:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -364,7 +364,7 @@ FAIL :1d_array_compound_assignment: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:925:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:916:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {
@@ -413,7 +413,7 @@ FAIL :2d_array_compound_assignment: assert_unreached:
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:948:19
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:939:21
-    @http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
     WGSL:
 
     struct Outputs {

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
@@ -707,7 +707,7 @@ FAIL :address_space_access_mode:address_space="private";access_mode="";trailing_
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:3: only variables in the <storage> address space may specify an access mode
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="private";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="private";access_mode="read";trailing_comma=true
@@ -729,7 +729,7 @@ FAIL :address_space_access_mode:address_space="storage";access_mode="";trailing_
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:34: Expected a Identifier, but got a >
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="storage";access_mode="";trailing_comma=false
 FAIL :address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=true assert_unreached:
@@ -745,7 +745,7 @@ FAIL :address_space_access_mode:address_space="storage";access_mode="read";trail
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:25: Expected a >, but got a ,
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=false
 PASS :address_space_access_mode:address_space="storage";access_mode="write";trailing_comma=true
@@ -763,7 +763,7 @@ FAIL :address_space_access_mode:address_space="storage";access_mode="read_write"
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:25: Expected a >, but got a ,
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="storage";access_mode="read_write";trailing_comma=false
 FAIL :address_space_access_mode:address_space="uniform";access_mode="";trailing_comma=true assert_unreached:
@@ -779,7 +779,7 @@ FAIL :address_space_access_mode:address_space="uniform";access_mode="";trailing_
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:25: only variables in the <storage> address space may specify an access mode
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="uniform";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="uniform";access_mode="read";trailing_comma=true
@@ -801,7 +801,7 @@ FAIL :address_space_access_mode:address_space="function";access_mode="";trailing
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     3:9: only variables in the <storage> address space may specify an access mode
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="function";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="function";access_mode="read";trailing_comma=true
@@ -823,7 +823,7 @@ FAIL :address_space_access_mode:address_space="workgroup";access_mode="";trailin
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:3: only variables in the <storage> address space may specify an access mode
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :address_space_access_mode:address_space="workgroup";access_mode="";trailing_comma=false
 PASS :address_space_access_mode:address_space="workgroup";access_mode="read";trailing_comma=true
@@ -896,7 +896,7 @@ FAIL :var_access_mode_bad_other_template_contents:accessMode="read";prefix="stor
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:21: Expected a >, but got a ,
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="storage,";suffix=""
 PASS :var_access_mode_bad_other_template_contents:accessMode="read";prefix="";suffix=",storage"
@@ -920,7 +920,7 @@ FAIL :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:21: Expected a >, but got a ,
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="storage,";suffix=""
 PASS :var_access_mode_bad_other_template_contents:accessMode="read_write";prefix="";suffix=",storage"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
@@ -833,7 +833,7 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=true assert_unr
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:21: value 2147483648 cannot be represented as 'i32'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=false
 FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
@@ -858,7 +858,7 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=true assert
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:24: invalid division by zero
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=false
 FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
@@ -883,7 +883,7 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=true assert
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:30: value Infinity cannot be represented as 'f32'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=false
 FAIL :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
@@ -908,7 +908,7 @@ FAIL :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=true assert_unre
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:21: value NaN cannot be represented as 'f32'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=false
 FAIL :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
@@ -933,7 +933,7 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=true assert_unr
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:20: value 2147483648 cannot be represented as 'i32'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=false
 FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
@@ -958,7 +958,7 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:23: invalid division by zero
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
 FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
@@ -983,7 +983,7 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:29: value Infinity cannot be represented as 'f32'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
 FAIL :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
@@ -1008,7 +1008,7 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=true assert_unre
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:20: value NaN cannot be represented as 'f32'
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=false
 PASS :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=true
@@ -1104,7 +1104,7 @@ FAIL :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=true assert_
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
@@ -1112,7 +1112,7 @@ FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=true ass
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
@@ -1120,7 +1120,7 @@ FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=true ass
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
@@ -1128,7 +1128,7 @@ FAIL :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=true assert_u
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
@@ -1136,7 +1136,7 @@ FAIL :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=true assert_
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
@@ -1144,7 +1144,7 @@ FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true ass
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
@@ -1152,7 +1152,7 @@ FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true ass
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
 FAIL :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
@@ -1160,7 +1160,7 @@ FAIL :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_u
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=false
 PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=false
@@ -1271,7 +1271,7 @@ FAIL :array_override:op="%26%26";a_val=1;b_val=1 assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :array_override:op="%7C%7C";a_val=0;b_val=0
 FAIL :array_override:op="%7C%7C";a_val=0;b_val=1 assert_unreached:
@@ -1279,20 +1279,20 @@ FAIL :array_override:op="%7C%7C";a_val=0;b_val=1 assert_unreached:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :array_override:op="%7C%7C";a_val=1;b_val=0 assert_unreached:
   - INFO: subcase:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :array_override:op="%7C%7C";a_val=1;b_val=1 assert_unreached:
   - INFO: subcase:
     OK
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt
@@ -370,7 +370,7 @@ FAIL :array_zero_value:case="valid_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:57: cannot use override value in constant expression
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :array_zero_value:case="invalid_rta"
 PASS :array_zero_value:case="invalid_override_array"
@@ -397,7 +397,7 @@ FAIL :array_value:case="valid_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     8:57: cannot use override value in constant expression
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :array_value:case="invalid_rta"
 PASS :array_value:case="invalid_override_array"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt
@@ -389,7 +389,7 @@ FAIL :function_attributes:case="diagnostic";placement="func" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:0: invalid attribute for function declaration
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :function_attributes:case="diagnostic";placement="param"
 PASS :function_attributes:case="diagnostic";placement="ret"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt
@@ -52,7 +52,7 @@ FAIL :blankspace:blankspace=["%C2%85","next_line"] assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%8E","left_to_right_mark"] assert_unreached:
   - VALIDATION FAILED: subcase:
@@ -67,7 +67,7 @@ FAIL :blankspace:blankspace=["%E2%80%8E","left_to_right_mark"] assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%8F","right_to_left_mark"] assert_unreached:
   - VALIDATION FAILED: subcase:
@@ -82,7 +82,7 @@ FAIL :blankspace:blankspace=["%E2%80%8F","right_to_left_mark"] assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
   - VALIDATION FAILED: subcase:
@@ -97,7 +97,7 @@ FAIL :blankspace:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :blankspace:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached:
   - VALIDATION FAILED: subcase:
@@ -112,7 +112,7 @@ FAIL :blankspace:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a Invalid
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :bom:include_bom=true
 PASS :bom:include_bom=false

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt
@@ -32,7 +32,7 @@ FAIL :module_var_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:13: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :module_var_name:ident="bf16"
 PASS :module_var_name:ident="bitcast"
@@ -328,7 +328,7 @@ FAIL :module_const_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:6: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :module_const_name:ident="bf16"
 PASS :module_const_name:ident="bitcast"
@@ -624,7 +624,7 @@ FAIL :override_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:9: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :override_name:ident="bf16"
 PASS :override_name:ident="bitcast"
@@ -920,7 +920,7 @@ FAIL :function_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:3: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :function_name:ident="bf16"
 PASS :function_name:ident="bitcast"
@@ -1216,7 +1216,7 @@ FAIL :struct_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:7: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :struct_name:ident="bf16"
 PASS :struct_name:ident="bitcast"
@@ -1512,7 +1512,7 @@ FAIL :alias_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:6: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :alias_name:ident="bf16"
 PASS :alias_name:ident="bitcast"
@@ -1808,7 +1808,7 @@ FAIL :function_param_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     1:5: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :function_param_name:ident="bf16"
 PASS :function_param_name:ident="bitcast"
@@ -2106,7 +2106,7 @@ FAIL :function_const_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:8: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :function_const_name:ident="bf16"
 PASS :function_const_name:ident="bitcast"
@@ -2408,7 +2408,7 @@ FAIL :function_let_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:6: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :function_let_name:ident="bf16"
 PASS :function_let_name:ident="bitcast"
@@ -2710,7 +2710,7 @@ FAIL :function_var_name:ident="binding_array" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:6: Expected a Identifier, but got a ReservedWord
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :function_var_name:ident="bf16"
 PASS :function_var_name:ident="bitcast"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
@@ -3846,7 +3846,7 @@ FAIL :interpolation_validation:attr="trailing_comma_one_arg" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     2:34: Expected a Identifier, but got a )
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :interpolation_validation:attr="trailing_comma_two_arg"
 PASS :interpolation_validation:attr="newline"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continuing-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continuing-expected.txt
@@ -31,7 +31,7 @@ FAIL :placement:stmt="continuing_semicolon" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     9:43: Not a valid statement
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :placement:stmt="continuing_functionn_call"
 PASS :placement:stmt="continuing_let"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/for-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/for-expected.txt
@@ -49,7 +49,7 @@ FAIL :parse:test="init_call" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:8: Expected one of `=`, `++`, or `--`
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :parse:test="init_phony" assert_unreached:
   - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
@@ -68,7 +68,7 @@ FAIL :parse:test="init_phony" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop initialization clause
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :parse:test="init_increment"
 PASS :parse:test="init_compound_assign"
@@ -90,7 +90,7 @@ FAIL :parse:test="cont_call" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:10: Expected one of `=`, `++`, or `--`
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 FAIL :parse:test="cont_phony" assert_unreached:
   - VALIDATION FAILED: Unexpected compilationInfo 'error' message.
@@ -109,7 +109,7 @@ FAIL :parse:test="cont_phony" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop update clause
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :parse:test="cont_increment"
 PASS :parse:test="cont_compound_assign"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt
@@ -134,7 +134,7 @@ FAIL :parse:test="in_for_init" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop initialization clause
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :parse:test="in_for_init_semi"
 FAIL :parse:test="in_for_update" assert_unreached:
@@ -151,7 +151,7 @@ FAIL :parse:test="in_for_update" assert_unreached:
   - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
     4:2: Invalid for-loop update clause
     TestFailedButDeviceReusable@
-    @http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
  Reached unreachable code
 PASS :parse:test="in_for_update_semi"
 PASS :parse:test="in_block"


### PR DESCRIPTION
#### 08dd191658364701daaeb7214bd508787a4967fa
<pre>
Unreviewed, REGRESSION (297343@main): [ macOS Sequoia wk2 Release arm64 ] 25x http/tests/webgpu/webgpu (layout-tests) are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=296282">https://bugs.webkit.org/show_bug.cgi?id=296282</a>
<a href="https://rdar.apple.com/156331513">rdar://156331513</a>

Those tests are not run on EWS. So we cannot detect these failures
before committing. This patch is just rebaselining test expectations.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/pipeline/pipeline_layout_created_with_null_bind_group_layout-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInFragmentStage-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInVertexStage-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInFragmentStage-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInVertexStage-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/createPipelineLayout-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginComputePass-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/beginRenderPass-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/index_access-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/execution/expression/binary/bitwise_shift-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/value_constructor-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continuing-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/for-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt:

Canonical link: <a href="https://commits.webkit.org/297718@main">https://commits.webkit.org/297718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0db6bfcfe9d447ab675682870eafd372669a0e64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118843 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40939 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/63117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101331 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66029 "Found 134 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WPE/TestSSL:/webkit/WebKitWebView/tls-subresource ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19467 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29589 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94331 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39452 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17258 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18138 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39606 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39245 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->