### PR TITLE
[JSC] Report which tests are killed when interrupting stress tests

### DIFF
--- a/JSTests/wasm/stress/inline-simd-function.js
+++ b/JSTests/wasm/stress/inline-simd-function.js
@@ -1,3 +1,4 @@
+//@ slow!
 //@ skip if !$isWasmPlatform or $buildType == "debug"
 
 function instantiate(moduleBase64, importObject) {

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -165,7 +165,7 @@ $model = nil
 $runJITlessWasm = true
 $filter = nil
 $envVars = []
-$mode = "full"
+$mode = :full
 $buildType = "release"
 $forceCollectContinuously = false
 $reportExecutionTime = false
@@ -271,6 +271,7 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
                ['--release', GetoptLong::NO_ARGUMENT],
                ['--quick', '-q', GetoptLong::NO_ARGUMENT],
                ['--basic', GetoptLong::NO_ARGUMENT],
+               ['--no-slow', GetoptLong::NO_ARGUMENT],
                ['--jitless-wasm', GetoptLong::NO_ARGUMENT],
                ['--no-retry', GetoptLong::NO_ARGUMENT]).each {
     | opt, arg |
@@ -382,9 +383,11 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
     when '--env-vars'
         $envVars = arg.gsub(/\s+/, ' ').split(' ')
     when '--quick'
-        $mode = "quick"
+        $mode = :quick
     when '--basic'
-        $mode = "basic"
+        $mode = :basic
+    when '--no-slow'
+        $mode = :noSlow
     when '--jitless-wasm'
         $runJITlessWasm = true
     when '--debug'
@@ -947,7 +950,7 @@ end
 
 def slow!
     $runCommandOptions[:isSlow] = true
-    skip() if ($mode == "quick")
+    skip() if ($mode == :quick or $mode == :basic or $mode == :noSlow)
 end
 
 def mustCrash!
@@ -1579,7 +1582,7 @@ BASE_MODES.each { |mode|
 # Default set of tests to run; propagates the cfg to every callee.
 def defaultRunCfg(cfg, subsetOptions, *optionalTestSpecificOptions)
     cfg.freeze
-    if not subsetOptions.has_key?(:ignoreQuickMode) and $mode == "quick"
+    if not subsetOptions.has_key?(:ignoreQuickMode) and $mode == :quick
         defaultQuickRunCfg(cfg, *optionalTestSpecificOptions)
     else
         runDefaultCfg(cfg, *optionalTestSpecificOptions)
@@ -1594,7 +1597,7 @@ def defaultRunCfg(cfg, subsetOptions, *optionalTestSpecificOptions)
             runNoCJITCollectContinuouslyCfg(cfg, *optionalTestSpecificOptions) if shouldCollectContinuously?
             if not subsetOptions.has_key?(:skipEager)
                 runDFGEagerCfg(cfg)
-                if $mode != "basic"
+                if $mode != :basic
                     runDFGEagerNoCJITValidateCfg(cfg, *optionalTestSpecificOptions)
                     runEagerJettisonNoCJITCfg(cfg, *optionalTestSpecificOptions)
                 end
@@ -1609,7 +1612,7 @@ def defaultRunCfg(cfg, subsetOptions, *optionalTestSpecificOptions)
             end
             runFTLNoCJITSmallPoolCfg(cfg, *optionalTestSpecificOptions)
 
-            return if $mode == "basic"
+            return if $mode == :basic
 
             runFTLNoCJITValidateCfg(cfg, *optionalTestSpecificOptions)
             runFTLNoCJITB3O0Cfg(cfg, *optionalTestSpecificOptions)
@@ -1832,7 +1835,7 @@ end
 def runWebAssembly
     return unless $isWasmPlatform
     run("default-wasm", "-m", *FTL_OPTIONS)
-    if $mode != "quick"
+    if $mode != :quick
         run("wasm-no-cjit", "-m", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager", "-m", "--useRandomizingExecutableIslandAllocation=true", *(FTL_OPTIONS + EAGER_OPTIONS))
         run("wasm-eager-jettison", "-m", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
@@ -1865,7 +1868,7 @@ def runWebAssemblyJetStream2
 
     run("default-wasm", *FTL_OPTIONS)
 
-    if $mode != "quick"
+    if $mode != :quick
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager", "--useRandomizingExecutableIslandAllocation=true", *(FTL_OPTIONS + EAGER_OPTIONS))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--verifyGC=true", *FTL_OPTIONS)
@@ -1900,7 +1903,7 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
       optionalTestSpecificOptions.unshift "-m"
     end
     runDefaultWasm(*optionalTestSpecificOptions)
-    if $mode != "quick"
+    if $mode != :quick
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
@@ -1934,7 +1937,7 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
       optionalTestSpecificOptions.unshift "-m"
     end
     runDefaultWasm(*optionalTestSpecificOptions)
-    if $mode != "quick"
+    if $mode != :quick
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
@@ -1989,7 +1992,7 @@ def runWebAssemblyWithHarness(*optionalTestSpecificOptions)
     prepareExtraRelativeFiles(wasmFiles.map { |f| f.basename }, $collection)
 
     runWasmHarnessTest("default-wasm", *(FTL_OPTIONS + optionalTestSpecificOptions))
-    if $mode != "quick"
+    if $mode != :quick
         runWasmHarnessTest("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-eager", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
@@ -2017,7 +2020,7 @@ def runWebAssemblyEmscripten(mode)
     wasm = $benchmark.to_s.sub! '.js', '.wasm'
     prepareExtraRelativeFiles([Pathname('..') + wasm], $collection)
     run("default-wasm", *FTL_OPTIONS)
-    if $mode != "quick"
+    if $mode != :quick
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
@@ -2055,7 +2058,7 @@ def runWebAssemblySpecTestBase(mode, specHarnessPath, postfix, *optionalTestSpec
 
     specHarnessJsPath = "../" + specHarnessPath + ".js"
     runWithOutputHandler("default-wasm" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, *(FTL_OPTIONS + optionalTestSpecificOptions))
-    if $mode != "quick"
+    if $mode != :quick
         runWithOutputHandler("wasm-no-cjit" + (postfix || ''), noisyOutputHandler, specHarnessJsPath,  *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         # FIXME: We should probably only run these two for GC spec tests.
         runWithOutputHandler("wasm-eager-jettison" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
@@ -2222,7 +2225,7 @@ def defaultQuickRunLayoutTest
 end
 
 def defaultRunLayoutTest
-    if $mode == "quick"
+    if $mode == :quick
         defaultQuickRunLayoutTest
     else
         runLayoutTestDefault
@@ -2365,7 +2368,7 @@ def defaultQuickRunMozillaTest(mode, *extraFiles)
 end
 
 def defaultRunMozillaTest(mode, *extraFiles)
-    if $mode == "quick"
+    if $mode == :quick
         defaultQuickRunMozillaTest(mode, *extraFiles)
     else
         runMozillaTestNoFTL(mode, *extraFiles)

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -289,6 +289,7 @@ class Plan < BasePlan
                 outp.puts "START_TIME=$(($(date +%s%N)/1000000))"
             end
             outp.puts "echo Running #{Shellwords.shellescape(@name)}"
+            outp.puts "trap 'echo \"Killing #{@name}\" 1>&2' SIGINT"
             #
             # +--------------------------------------------------------------------+
             # | +-----------------------------------------------+                  |


### PR DESCRIPTION
#### e3d3e12bbe8810357c7bcd5f9c72b8ba83cf8dcf
<pre>
[JSC] Report which tests are killed when interrupting stress tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=296307">https://bugs.webkit.org/show_bug.cgi?id=296307</a>
<a href="https://rdar.apple.com/156359784">rdar://156359784</a>

Reviewed by Mark Lam and Yusuke Suzuki.

While trying to figure out which of my tests was taking forever I would try to kill `run-jsc-stress-tests`
but that wouldn&apos;t log the list of tests were currently running. This patch adds a trap hook for the various
runner scripts to log the test if they receive a SIGINT.

Additionally, mark said test as `slow!` and make it easier to skip slow tests.

Lastly, use ruby symbols for the test mode rather than a string.

Canonical link: <a href="https://commits.webkit.org/297732@main">https://commits.webkit.org/297732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d6b9d98b70a96d64ecf632e5bc328dab28e1298

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63129 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85731 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36350 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101339 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66039 "Found 142 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25658 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19475 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62611 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105167 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122073 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111267 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94596 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94338 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35815 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39615 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135499 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39254 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36406 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/40993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->