### PR TITLE
Parallel calls to [WKContentRuleListStore compileContentRuleListForIdentifier:] for the same identifier can fail

### DIFF
--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -78,17 +78,10 @@ public:
     void invalidateContentRuleListHeader(const WTF::String& identifier);
     void getContentRuleListSource(WTF::String&& identifier, CompletionHandler<void(WTF::String)>);
 
-    Ref<ConcurrentWorkQueue> protectedCompileQueue();
-    Ref<WorkQueue> protectedReadQueue();
-    Ref<WorkQueue> protectedRemoveQueue();
-
 private:
     WTF::String defaultStorePath();
 
     const WTF::String m_storePath;
-    const Ref<ConcurrentWorkQueue> m_compileQueue;
-    const Ref<WorkQueue> m_readQueue;
-    const Ref<WorkQueue> m_removeQueue;
 #endif // ENABLE(CONTENT_EXTENSIONS)
 };
 


### PR DESCRIPTION
#### af7d511da998e59d45f98ffd2575db47e4a0b4e6
<pre>
Parallel calls to [WKContentRuleListStore compileContentRuleListForIdentifier:] for the same identifier can fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=296313">https://bugs.webkit.org/show_bug.cgi?id=296313</a>

Reviewed by Alex Christensen.

Parallel calls to [WKContentRuleListStore compileContentRuleListForIdentifier:] for
the same identifier can fail. This is because we process the requests on a concurrent
work queue and different threads may thus end up interacting with the same file.

Address the issue by using a static serial work queue for filesystem operations.

This might fix &lt;<a href="https://rdar.apple.com/156150166">rdar://156150166</a>&gt; though it is hard to confirm this is the root cause.

* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::ContentRuleListStore::compileContentRuleListFile):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(createMixedContentAutoUpgradeJsonRuleList):
(TEST_F(WKContentRuleListStoreTest, ConcurrentCompilations)):

Canonical link: <a href="https://commits.webkit.org/297757@main">https://commits.webkit.org/297757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61066568e39c8a84957e43c2675736515cd1c7d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118912 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85783 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36425 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101400 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66107 "Found 138 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestAuthentication:/webkit/Authentication/authentication-ephemeral, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19530 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62671 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122133 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94648 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94390 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24106 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17317 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35889 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45179 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->