### PR TITLE
[CSS] Ensure gutter area remains when toggling overflow:hidden with s…

### DIFF
--- a/LayoutTests/fast/css/scrollbar-gutter-overflow-change-expected.txt
+++ b/LayoutTests/fast/css/scrollbar-gutter-overflow-change-expected.txt
@@ -1,0 +1,2 @@
+PASS
+When scrollbar-gutter: stable is set, the content width remains the same even when overflow changes from auto to hidden, because the gutter area is preserved and not removed with the scrollbar

--- a/LayoutTests/fast/css/scrollbar-gutter-overflow-change.html
+++ b/LayoutTests/fast/css/scrollbar-gutter-overflow-change.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>scrollbar-gutter: content box width stability test</title>
+  <style>
+    #test {
+      overflow: auto;
+      scrollbar-gutter: stable;
+      width: 200px;
+      height: 100px;
+      border: 2px solid black;
+      background: lightblue;
+    }
+
+    .content {
+      width: 100%;
+      height: 200px;
+      background: orange;
+    }
+
+    #test::-webkit-scrollbar {
+      width: 20px;
+      background-color: #f0f0f0;
+    }
+
+    #test::-webkit-scrollbar-thumb {
+      background-color: #888;
+      border-radius: 4px;
+      border: 3px solid #f0f0f0;
+    }
+
+    #test::-webkit-scrollbar-thumb:hover {
+      background-color: #555;
+    }
+  </style>
+</head>
+<body>
+<pre id="result">FAIL: test did not run</pre>
+
+<div id="test">
+  <div class="content">When scrollbar-gutter: stable is set, the content width remains the same even when overflow changes from auto to hidden, because the gutter area is preserved and not removed with the scrollbar</div>
+</div>
+
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  const content = document.querySelector('.content');
+  const container = document.getElementById('test');
+  const resultEl = document.getElementById('result');
+  let before;
+
+  function measureBefore() {
+    before = content.clientWidth;
+    container.style.overflow = 'hidden';
+    requestAnimationFrame(measureAfter);
+  }
+
+  function measureAfter() {
+    const after = content.clientWidth;
+
+    resultEl.textContent = (before === after) ? 'PASS' : 'FAIL';
+
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }
+
+  window.addEventListener('load', () => {
+    requestAnimationFrame(measureBefore);
+  });
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -350,7 +350,7 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     // If our zoom factor changes and we have a defined scrollLeft/Top, we need to adjust that value into the
     // new zoomed coordinate space.
     if (hasNonVisibleOverflow() && layer() && oldStyle && oldStyle->usedZoom() != newStyle.usedZoom()) {
-        if (auto* scrollableArea = layer()->scrollableArea()) {
+        if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea()) {
             ScrollPosition scrollPosition = scrollableArea->scrollPosition();
             float zoomScaleFactor = newStyle.usedZoom() / oldStyle->usedZoom();
             scrollPosition.scale(zoomScaleFactor);
@@ -359,7 +359,7 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     }
 
     if (layer() && oldStyle && oldStyle->shouldPlaceVerticalScrollbarOnLeft() != newStyle.shouldPlaceVerticalScrollbarOnLeft()) {
-        if (auto* scrollableArea = layer()->scrollableArea())
+        if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea())
             scrollableArea->scrollbarsController().scrollbarLayoutDirectionChanged(shouldPlaceVerticalScrollbarOnLeft() ? UserInterfaceLayoutDirection::RTL : UserInterfaceLayoutDirection::LTR);
     }
 
@@ -368,13 +368,13 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     if (layer() && oldStyle && oldStyle->scrollbarWidth() != newStyle.scrollbarWidth()) {
         if (isDocElementRenderer)
             view().frameView().scrollbarWidthChanged(newStyle.scrollbarWidth());
-        else if (auto* scrollableArea = layer()->scrollableArea())
+        else if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea())
             scrollableArea->scrollbarWidthChanged(newStyle.scrollbarWidth());
     }
 
 #if ENABLE(DARK_MODE_CSS)
     if (layer() && oldStyle && oldStyle->colorScheme() != newStyle.colorScheme()) {
-        if (auto* scrollableArea = layer()->scrollableArea())
+        if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea())
             scrollableArea->invalidateScrollbars();
     }
 #endif
@@ -599,19 +599,19 @@ int RenderBox::scrollHeight() const
 
 int RenderBox::scrollLeft() const
 {
-    auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     return (hasNonVisibleOverflow() && scrollableArea) ? scrollableArea->scrollPosition().x() : 0;
 }
 
 int RenderBox::scrollTop() const
 {
-    auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     return (hasNonVisibleOverflow() && scrollableArea) ? scrollableArea->scrollPosition().y() : 0;
 }
 
 bool RenderBox::shouldResetLogicalHeightBeforeLayout() const
 {
-    auto* flexBoxParent = dynamicDowncast<RenderFlexibleBox>(parent());
+    CheckedPtr<RenderFlexibleBox> flexBoxParent = dynamicDowncast<RenderFlexibleBox>(parent());
     return flexBoxParent && flexBoxParent->shouldResetFlexItemLogicalHeightBeforeLayout();
 }
 
@@ -633,8 +633,7 @@ void RenderBox::setScrollLeft(int newLeft, const ScrollPositionChangeOptions& op
 {
     if (!hasPotentiallyScrollableOverflow() || !layer())
         return;
-    auto* scrollableArea = layer()->scrollableArea();
-    ASSERT(scrollableArea);
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea();
     setupWheelEventMonitor(*scrollableArea);
     scrollableArea->scrollToXPosition(newLeft, options);
 }
@@ -643,8 +642,7 @@ void RenderBox::setScrollTop(int newTop, const ScrollPositionChangeOptions& opti
 {
     if (!hasPotentiallyScrollableOverflow() || !layer())
         return;
-    auto* scrollableArea = layer()->scrollableArea();
-    ASSERT(scrollableArea);
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea();
     setupWheelEventMonitor(*scrollableArea);
     scrollableArea->scrollToYPosition(newTop, options);
 }
@@ -653,8 +651,7 @@ void RenderBox::setScrollPosition(const ScrollPosition& position, const ScrollPo
 {
     if (!hasPotentiallyScrollableOverflow() || !layer())
         return;
-    auto* scrollableArea = layer()->scrollableArea();
-    ASSERT(scrollableArea);
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea();
     setupWheelEventMonitor(*scrollableArea);
     scrollableArea->setScrollPosition(position, options);
 }
@@ -962,9 +959,20 @@ bool RenderBox::includeHorizontalScrollbarSize() const
             || (style().overflowX() == Overflow::Hidden && !style().scrollbarGutter().isAuto()));
 }
 
+bool RenderBox::shouldReserveVerticalScrollbarGutterSpace() const
+{
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    if (style().scrollbarWidth() != ScrollbarWidth::None
+        && style().scrollbarGutter().isStable()
+        && (scrollableArea && scrollableArea->verticalScrollbar() == nullptr && !verticalScrollbarWidth())
+        && hasNonVisibleOverflow() && layer() && !layer()->hasOverlayScrollbars())
+        return true;
+    return false;
+}
+
 int RenderBox::verticalScrollbarWidth() const
 {
-    auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     if (!scrollableArea)
         return 0;
     return includeVerticalScrollbarSize() ? scrollableArea->verticalScrollbarWidth(OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, isHorizontalWritingMode()) : 0;
@@ -972,7 +980,7 @@ int RenderBox::verticalScrollbarWidth() const
 
 int RenderBox::horizontalScrollbarHeight() const
 {
-    auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     if (!scrollableArea)
         return 0;
     return includeHorizontalScrollbarSize() ? scrollableArea->horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, isHorizontalWritingMode()) : 0;
@@ -996,9 +1004,18 @@ int RenderBox::intrinsicScrollbarLogicalWidthIncludingGutter() const
     return 0;
 }
 
+int RenderBox::effectiveScrollbarGutterWidth() const
+{
+    if (shouldReserveVerticalScrollbarGutterSpace()) {
+        CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+        return scrollableArea ? scrollableArea->computeScrollbarGutterWidth() : 0;
+    }
+    return 0;
+}
+
 bool RenderBox::scrollLayer(ScrollDirection direction, ScrollGranularity granularity, unsigned stepCount, Element** stopElement)
 {
-    auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     if (scrollableArea && scrollableArea->scroll(direction, granularity, stepCount)) {
         if (stopElement)
             *stopElement = element();
@@ -1029,7 +1046,7 @@ bool RenderBox::logicalScroll(ScrollLogicalDirection direction, ScrollGranularit
 {
     bool scrolled = false;
     
-    if (auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
+    if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
 #if PLATFORM(COCOA)
         // On Mac only we reset the inline direction position when doing a document scroll (e.g., hitting Home/End).
         if (granularity == ScrollGranularity::Document)
@@ -1160,7 +1177,7 @@ RenderBox* RenderBox::findAutoscrollable(RenderObject* renderer)
 
 void RenderBox::panScroll(const IntPoint& source)
 {
-    if (auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr)
+    if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr)
         scrollableArea->panScrollFromPoint(source);
 }
 
@@ -1216,7 +1233,7 @@ ScrollPosition RenderBox::scrollPosition() const
         return { 0, 0 };
 
     ASSERT(hasLayer());
-    auto* scrollableArea = layer()->scrollableArea();
+    CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer()->scrollableArea();
     if (!scrollableArea)
         return { 0, 0 };
 
@@ -1904,7 +1921,7 @@ bool RenderBox::computeBackgroundIsKnownToBeObscured(const LayoutPoint& paintOff
     if (!getBackgroundPaintedExtent(paintOffset, backgroundRect))
         return false;
 
-    if (auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
+    if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
         if (scrollableArea->scrollingMayRevealBackground())
             return false;
     }
@@ -2217,7 +2234,7 @@ LayoutRect RenderBox::overflowClipRect(const LayoutPoint& location, OverlayScrol
         clipRect.expandToInfiniteX();
 
     // Subtract out scrollbars if we have them.
-    if (auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
+    if (CheckedPtr<RenderLayerScrollableArea> scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
         if (shouldPlaceVerticalScrollbarOnLeft())
             clipRect.move(scrollableArea->verticalScrollbarWidth(relevancy, isHorizontalWritingMode()), 0);
         clipRect.contract(scrollableArea->verticalScrollbarWidth(relevancy, isHorizontalWritingMode()), scrollableArea->horizontalScrollbarHeight(relevancy, isHorizontalWritingMode()));

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -440,6 +440,7 @@ public:
     WEBCORE_EXPORT virtual int verticalScrollbarWidth() const;
     WEBCORE_EXPORT virtual int horizontalScrollbarHeight() const;
     int intrinsicScrollbarLogicalWidthIncludingGutter() const;
+    int effectiveScrollbarGutterWidth() const;
     inline int scrollbarLogicalWidth() const;
     inline int scrollbarLogicalHeight() const;
     virtual bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint());
@@ -636,6 +637,7 @@ public:
 
     bool includeVerticalScrollbarSize() const;
     bool includeHorizontalScrollbarSize() const;
+    bool shouldReserveVerticalScrollbarGutterSpace() const;
 
     void invalidateAncestorBackgroundObscurationStatus();
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -42,7 +42,7 @@ inline LayoutSize RenderBox::contentBoxLogicalSize() const { return writingMode(
 inline LayoutUnit RenderBox::contentBoxLogicalWidth() const { return writingMode().isHorizontal() ? contentBoxWidth() : contentBoxHeight(); }
 inline LayoutUnit RenderBox::contentBoxLogicalWidth(LayoutUnit overridingBorderBoxWidth) const { return std::max(LayoutUnit(), overridingBorderBoxWidth - borderAndPaddingLogicalWidth() - scrollbarLogicalWidth() - (style().scrollbarGutter().isStableBothEdges() ? scrollbarLogicalWidth() : 0)); }
 inline LayoutSize RenderBox::contentBoxSize() const { return { contentBoxWidth(), contentBoxHeight() }; }
-inline LayoutUnit RenderBox::contentBoxWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0)); }
+inline LayoutUnit RenderBox::contentBoxWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0) - effectiveScrollbarGutterWidth()); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalHeight() const { return writingMode().isHorizontal() ? explicitIntrinsicInnerHeight() : explicitIntrinsicInnerWidth(); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalWidth() const { return writingMode().isHorizontal() ? explicitIntrinsicInnerWidth() : explicitIntrinsicInnerHeight(); }
 inline bool RenderBox::hasHorizontalOverflow() const { return scrollWidth() != roundToInt(paddingBoxWidth()); }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1007,6 +1007,20 @@ int RenderLayerScrollableArea::verticalScrollbarWidth(OverlayScrollbarSizeReleva
     return vBar->width();
 }
 
+int RenderLayerScrollableArea::computeScrollbarGutterWidth()
+{
+    if (!m_gutterWidth) {
+        if (RefPtr<Scrollbar> tempVBar = createScrollbar(ScrollbarOrientation::Vertical)) {
+            m_gutterWidth = tempVBar->width();
+            if (!tempVBar->isCustomScrollbar())
+                willRemoveScrollbar(*tempVBar, ScrollbarOrientation::Vertical);
+            tempVBar->removeFromParent();
+            tempVBar = nullptr;
+        }
+    }
+    return (m_gutterWidth ? m_gutterWidth : ScrollbarTheme::theme().scrollbarThickness(scrollbarWidthStyle()));
+}
+
 int RenderLayerScrollableArea::horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy relevancy, bool isHorizontalWritingMode) const
 {
     RefPtr hBar = m_hBar;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -133,6 +133,7 @@ public:
 
     int verticalScrollbarWidth(OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
     int horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
+    int computeScrollbarGutterWidth();
 
     bool hasOverflowControls() const;
     bool hitTestOverflowControls(HitTestResult&, const IntPoint& localPoint);
@@ -327,6 +328,10 @@ private:
     // The width/height of our scrolled area.
     int m_scrollWidth { 0 };
     int m_scrollHeight { 0 };
+
+    // Reserve gutter space to prevent layout shift with 'scrollbar-gutter: stable'.
+    // Space must be preserved regardless of scrollbar visibility or overflow state.
+    int m_gutterWidth { 0 };
 
     RenderLayer& m_layer;
     ScrollPosition m_scrollPosition;


### PR DESCRIPTION
…crollbar-gutter: stable

https://bugs.webkit.org/show_bug.cgi?id=295113

Reviewed by NOBODY (OOPS!).

When using scrollbar-gutter: stable, the gutter space should remain even when toggling to overflow: hidden, to prevent layout shifts. This patch fixes the behavior so that the gutter area is preserved according to the CSS spec.

The bug was caused by a failure to maintain the correct gutter width when switching from `overflow: auto` to `overflow: hidden` with `scrollbar-gutter: stable`. In this situation, the vertical scrollbar is removed from the layout, and as a result, the scrollbar width becomes zero. This causes the layout to shift unexpectedly, since the gutter space also disappears.

To resolve this, the patch introduces logic to create a temporary vertical scrollbar (only when `scrollbar-gutter` is `stable` and the scrollbar is hidden) to accurately measure the width of a real, rendered scrollbar. The measured width is then cached and used in layout calculations—specifically subtracted from the content box size—to preserve the gutter space.

This approach avoids relying on platform scrollbar thickness APIs, which may return incorrect values that don't match the actual layout. Creating a real scrollbar ensures precise measurement and visual consistency across platforms.

A layout test has also been added to verify the correct behavior when toggling overflow with scrollbar-gutter: stable.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa0df5bc9734685ad47308a9b14c163426be3232

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114016 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33768 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115905 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34396 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86657 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116964 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/34396 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67040 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/34396 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20532 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63891 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/34396 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123409 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41049 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95490 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41427 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95271 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18211 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37166 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40924 "Hash aa0df5bc for PR 48362 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46426 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40552 "Hash aa0df5bc for PR 48362 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43851 "Hash aa0df5bc for PR 48362 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42306 "Hash aa0df5bc for PR 48362 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->