### PR TITLE
Web process still crashes under PDFPluginBase::dataSpanForRange() after 295775@main

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -287,7 +287,7 @@ PDFIncrementalLoader::PDFIncrementalLoader(PDFPluginBase& plugin)
     , m_streamLoaderClient(adoptRef(*new PDFPluginStreamLoaderClient(*this)))
     , m_requestData(makeUniqueRef<RequestData>())
 {
-    m_pdfThread = Thread::create("PDF document thread"_s, [protectedThis = Ref { *this }, this] () mutable {
+    m_pdfThread = Thread::create("PDF document thread"_s, [protectedThis = Ref { *this }, this] mutable {
         threadEntry(WTFMove(protectedThis));
     });
 }
@@ -771,7 +771,7 @@ void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& protectedLoad
         dataProviderReleaseInfoCallback,
     };
 
-    auto scopeExit = makeScopeExit([protectedLoader = WTFMove(protectedLoader)] () mutable {
+    auto scopeExit = makeScopeExit([protectedLoader = WTFMove(protectedLoader)] mutable {
         // Keep the PDFPlugin alive until the end of this function and the end
         // of the last main thread task submitted by this function.
         callOnMainRunLoop([protectedLoader = WTFMove(protectedLoader)] { });

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -392,11 +392,13 @@ void PDFPluginBase::dataSpanForRange(uint64_t sourcePosition, size_t count, Chec
         if (!m_data)
             return false;
 
-        if (haveStreamedDataForRange(sourcePosition, count))
-            return true;
-
         uint64_t dataLength = CFDataGetLength(m_data.get());
-        if (!isSumSmallerThanOrEqual(sourcePosition, static_cast<uint64_t>(count), dataLength))
+        bool rangeExtentIsSmallerThanBufferSize = isSumSmallerThanOrEqual(sourcePosition, static_cast<uint64_t>(count), dataLength);
+
+        if (haveStreamedDataForRange(sourcePosition, count))
+            return rangeExtentIsSmallerThanBufferSize;
+
+        if (!rangeExtentIsSmallerThanBufferSize)
             return false;
 
         if (checkValidRanges == CheckValidRanges::No)


### PR DESCRIPTION
#### 8653dfc68de69af36ba39186e20402fe98cbdf36
<pre>
Web process still crashes under PDFPluginBase::dataSpanForRange() after 295775@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=296318">https://bugs.webkit.org/show_bug.cgi?id=296318</a>
<a href="https://rdar.apple.com/155917281">rdar://155917281</a>

Reviewed by Wenson Hsieh.

The web content process is still occasionally crashing under
PDFPluginBase::dataSpanForRange(). While the root cause is yet to be
determined, code inspection suggests there is possibility for the
m_streamedBytes count and the m_data buffer length to be out of sync, in
which case comparisons against (source + offset) for range validity
could be different when referencing either.

This patch makes dataSpanForRange() more robust against crashes by
addressing this specific scenario. Instead of blindly returning true if
source + offset &lt; m_streamedBytes, we instead return the source + offset
comparison against the data buffer size. This way, the latter is treated
as the source of ground truth.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::PDFIncrementalLoader):
(WebKit::PDFIncrementalLoader::threadEntry):
    Some drive-by code hygiene fixes.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::dataSpanForRange const):

Canonical link: <a href="https://commits.webkit.org/297764@main">https://commits.webkit.org/297764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283fc63f76325cb07ab5cd938379bc26a6d28fb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63173 "Built successfully") | [⏳ 🛠 ios-apple ](url) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85751 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36394 "An unexpected error occured. Recent messages:Printed configuration") | [⏳ 🛠 mac-apple ](url) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66059 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25672 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62632 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122094 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94616 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94358 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35843 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18161 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45124 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39275 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42608 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->