### PR TITLE
Enable Math.sumPrecise by default

### DIFF
--- a/JSTests/stress/math-sum-precise.js
+++ b/JSTests/stress/math-sum-precise.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useMathSumPreciseMethod=1")
-
 // Copyright (C) 2024 Kevin Gibbons. All rights reserved.
 // This code is governed by the BSD license found in the https://github.com/tc39/test262/blob/main/LICENSE file.
 
@@ -8,7 +6,7 @@ function shouldBe(actual, expected) {
         throw new Error(`Bad value: ${actual}!`);
 }
 
-for (var i = 0; i < testLoopCount; i++) {
+for (var i = 0; i < 1e4; i++) {
     shouldBe(Math.sumPrecise([1, 2, 3]), 6);
     shouldBe(Math.sumPrecise([1e308]), 1e308);
     shouldBe(Math.sumPrecise([1e308, -1e308]), 0);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -643,7 +643,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useMapGetOrInsert, false, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
-    v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
+    v(Bool, useMathSumPreciseMethod, true, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \


### PR DESCRIPTION
Enable Math.sumPrecise() by default
https://bugs.webkit.org/show_bug.cgi?id=295806
rdar://problem/155642395

Reviewed by NOBODY (OOPS!).

This change enables the Math.sumPrecise() method by default by setting the useMathSumPreciseMethod flag to true in OptionsList.h. The implementation was already complete and robust; this change simply removes the feature gate.

The corresponding stress test has also been updated to remove the @requireOptions directive since the feature is now enabled by default.

Source/JavaScriptCore/runtime/OptionsList.h:
(useMathSumPreciseMethod): Set default to true.
JSTests/stress/math-sum-precise.js:
Removed @requireOptions directive.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4651d4ac68347fd6072aea10a7cf86460e13f34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63183 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/40976 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85758 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36404 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115628 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26382 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25681 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19503 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62639 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105195 "Found 7 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-no-llint (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95770 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19577 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122101 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111295 "Found 7 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-no-ftl, jsc-layout-tests.yaml/js/script-tests/Object-getOwnPropertyNames.js.layout-no-llint (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39755 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29625 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94623 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94365 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39477 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17292 "Found 1 new test failure: js/Object-getOwnPropertyNames.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/35853 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45131 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135527 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39282 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36415 "Found 18 jsc stress test failures: stress/arrowfunction-constructor.js.bytecode-cache, stress/arrowfunction-constructor.js.default, stress/arrowfunction-constructor.js.dfg-eager, stress/arrowfunction-constructor.js.dfg-eager-no-cjit-validate, stress/arrowfunction-constructor.js.eager-jettison-no-cjit ...") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->