### PR TITLE
Alternative bmalloc modulemap arrangement

### DIFF
--- a/Source/bmalloc/Configurations/module.modulemap
+++ b/Source/bmalloc/Configurations/module.modulemap
@@ -1,5 +1,4 @@
 module bmalloc {
-    requires cplusplus11
     // List of "semi-public" bmalloc headers. What does "semi-public" mean? These are
     // the headers which, in practice, are included by WTF headers. WTF headers are
     // exported as part of the WebKit SPI, and therefore these headers need to be
@@ -14,22 +13,25 @@ module bmalloc {
     // Or, bmalloc would need to be tested in two different configurations instead
     // of producing an #error. This complexity is the main reason why bmalloc
     // has a narrower, hand-curated list of headers in its module.
-    header "Algorithm.h"
-    header "BAssert.h"
-    header "BCompiler.h"
-    header "BInline.h"
-    header "BPlatform.h"
-    header "BVMTags.h"
-    header "CompactAllocationMode.h"
-    header "Gigacage.h"
-    header "GigacageConfig.h"
-    header "GigacageKind.h"
-    header "IsoHeap.h"
-    header "IsoHeapInlines.h"
-    header "Logging.h"
-    header "Sizes.h"
-    header "TZoneHeap.h"
-    header "TZoneHeapInlines.h"
+    explicit module bmalloc_cpp {
+        requires cplusplus11
+        header "Algorithm.h"
+        header "BAssert.h"
+        header "BCompiler.h"
+        header "BInline.h"
+        header "BPlatform.h"
+        header "BVMTags.h"
+        header "CompactAllocationMode.h"
+        header "Gigacage.h"
+        header "GigacageConfig.h"
+        header "GigacageKind.h"
+        header "IsoHeap.h"
+        header "IsoHeapInlines.h"
+        header "Logging.h"
+        header "Sizes.h"
+        header "TZoneHeap.h"
+        header "TZoneHeapInlines.h"
+    }
     // The following header contains only plain C definitions so
     // we declare this in a submodule which doesn't require cplusplus11
     explicit module bexport {


### PR DESCRIPTION
#### c57ed16f51ebf8a135e0d8a94b398edfd13606fe
<pre>
Alternative bmalloc modulemap arrangement
<a href="https://bugs.webkit.org/show_bug.cgi?id=296328">https://bugs.webkit.org/show_bug.cgi?id=296328</a>
<a href="https://rdar.apple.com/156408246">rdar://156408246</a>

Reviewed by Daniel Liu.

This rearranges the modulemap so that the &apos;requires cplusplus11&apos; only
applies to a submodule.

* Source/bmalloc/Configurations/module.modulemap:

Canonical link: <a href="https://commits.webkit.org/297775@main">https://commits.webkit.org/297775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1ee04d39166514ed17eac5ded5a51bb1989892d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/22920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/118909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63246 "Built successfully") | [✅ 🛠 ios-apple](https://apple.com) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85779 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36454 "") | [✅ 🛠 mac-apple](https://apple.com) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101395 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66087 "Found 143 new API test failures: /WPE/TestLoaderClient:/webkit/WebKitWebView/loading-status, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebKitFindController:/webkit/WebKitFindController/options, /WPE/TestLoaderClient:/webkit/WebKitWebView/reload, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebKitWebView:/webkit/WebKitWebView/disable-web-security, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-plain-text, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme ... (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19526 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62668 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105224 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122130 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111324 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94646 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94388 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24113 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39503 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35885 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39672 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135556 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39311 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36420 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42644 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->