### PR TITLE
[Style] Convert some OptionSet based properties to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2752,6 +2752,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/align/StyleGapGutter.h
 
     style/values/anchor-position/StyleAnchorName.h
+    style/values/anchor-position/StylePositionVisibility.h
 
     style/values/borders/StyleBorderRadius.h
     style/values/borders/StyleBoxShadow.h
@@ -2759,6 +2760,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/borders/StyleShadow.h
 
     style/values/box/StyleMargin.h
+    style/values/box/StyleMarginTrim.h
     style/values/box/StylePadding.h
 
     style/values/color/StyleColor.h
@@ -2868,6 +2870,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/text/StyleTextIndent.h
 
+    style/values/text-decoration/StyleTextDecorationLine.h
     style/values/text-decoration/StyleTextDecorationThickness.h
     style/values/text-decoration/StyleTextEmphasisStyle.h
     style/values/text-decoration/StyleTextShadow.h

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -4,3 +4,5 @@ platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cv/VideoFrameCV.mm
 platform/mac/WebCoreObjCExtras.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h
+style/values/primitives/StylePrimitiveKeywordSet+Serialization.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3141,6 +3141,7 @@ style/UserAgentStyle.cpp
 style/values/borders/StyleBorderRadius.cpp
 style/values/borders/StyleBoxShadow.cpp
 style/values/borders/StyleCornerShapeValue.cpp
+style/values/box/StyleMarginTrim.cpp
 style/values/color-adjust/StyleColorScheme.cpp
 style/values/color/StyleColor.cpp
 style/values/color/StyleColorLayers.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4844,6 +4844,13 @@
 		BC0929AB2E2AA30A002ACB2C /* StyleScrollBehavior.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0929A82E2AA1D6002ACB2C /* StyleScrollBehavior.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC0929AF2E2AA652002ACB2C /* StyleWebKitTouchCallout.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0929AC2E2AA595002ACB2C /* StyleWebKitTouchCallout.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC0929B22E2AA9BA002ACB2C /* StyleWebKitOverflowScrolling.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0929B12E2AA9BA002ACB2C /* StyleWebKitOverflowScrolling.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A462E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A452E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A4B2E2EF0BC002ACB2C /* StylePositionVisibility.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A4A2E2EF0BC002ACB2C /* StylePositionVisibility.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A4D2E2EF3B4002ACB2C /* StyleTextDecorationLine.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A482E2EEB26002ACB2C /* StyleTextDecorationLine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A502E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A4F2E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A522E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A512E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A542E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A532E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A562E2F0507002ACB2C /* StyleMarginTrim.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A552E2F0507002ACB2C /* StyleMarginTrim.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10137C25C3624B00DC773C /* ColorModels.h in Headers */ = {isa = PBXBuildFile; fileRef = BC10137B25C3624B00DC773C /* ColorModels.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10137F25C3631600DC773C /* ColorTransferFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC10137E25C3631600DC773C /* ColorTransferFunctions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10D76817D8EE71005E2626 /* RenderBlockFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = BCFB45F317D8E39200444446 /* RenderBlockFlow.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -18000,6 +18007,15 @@
 		BC0929B12E2AA9BA002ACB2C /* StyleWebKitOverflowScrolling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleWebKitOverflowScrolling.h; sourceTree = "<group>"; };
 		BC092A0C2E2D75E6002ACB2C /* StyleTextDecorationThickness.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleTextDecorationThickness.cpp; sourceTree = "<group>"; };
 		BC092A1B2E2DBC36002ACB2C /* StyleViewTransitionName.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleViewTransitionName.cpp; sourceTree = "<group>"; };
+		BC092A452E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSPrimitiveKeywordSet.h; sourceTree = "<group>"; };
+		BC092A482E2EEB26002ACB2C /* StyleTextDecorationLine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleTextDecorationLine.h; sourceTree = "<group>"; };
+		BC092A4A2E2EF0BC002ACB2C /* StylePositionVisibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePositionVisibility.h; sourceTree = "<group>"; };
+		BC092A4E2E2EFBC1002ACB2C /* StylePrimitiveKeywordSet+CSSValueConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+CSSValueConversion.h"; sourceTree = "<group>"; };
+		BC092A4F2E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+CSSValueCreation.h"; sourceTree = "<group>"; };
+		BC092A512E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+Serialization.h"; sourceTree = "<group>"; };
+		BC092A532E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+Logging.h"; sourceTree = "<group>"; };
+		BC092A552E2F0507002ACB2C /* StyleMarginTrim.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleMarginTrim.h; sourceTree = "<group>"; };
+		BC092A572E2FEF84002ACB2C /* StyleMarginTrim.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleMarginTrim.cpp; sourceTree = "<group>"; };
 		BC0CA74C264AED0A004FDC62 /* PixelBufferConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PixelBufferConversion.h; sourceTree = "<group>"; };
 		BC0CA74D264AED0A004FDC62 /* PixelBufferConversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PixelBufferConversion.cpp; sourceTree = "<group>"; };
 		BC10137B25C3624B00DC773C /* ColorModels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorModels.h; sourceTree = "<group>"; };
@@ -35020,6 +35036,7 @@
 			isa = PBXGroup;
 			children = (
 				BC2A0EF72E1214CD003CBA0E /* StyleAnchorName.h */,
+				BC092A4A2E2EF0BC002ACB2C /* StylePositionVisibility.h */,
 			);
 			path = "anchor-position";
 			sourceTree = "<group>";
@@ -35130,6 +35147,7 @@
 		BC3078E42D02884200630D75 /* text-decoration */ = {
 			isa = PBXGroup;
 			children = (
+				BC092A482E2EEB26002ACB2C /* StyleTextDecorationLine.h */,
 				BC092A0C2E2D75E6002ACB2C /* StyleTextDecorationThickness.cpp */,
 				1CB6B4F8217B83930093B9CD /* StyleTextDecorationThickness.h */,
 				BCD9EFEE2E19879200D1C3DF /* StyleTextEmphasisStyle.cpp */,
@@ -35534,6 +35552,8 @@
 			isa = PBXGroup;
 			children = (
 				BC9ABA102DECC1CA00F7E52D /* StyleMargin.h */,
+				BC092A572E2FEF84002ACB2C /* StyleMarginTrim.cpp */,
+				BC092A552E2F0507002ACB2C /* StyleMarginTrim.h */,
 				BC9ABA122DECC1CA00F7E52D /* StylePadding.h */,
 			);
 			path = box;
@@ -35889,6 +35909,7 @@
 				BCB271D82CC0142C00265123 /* CSSPosition.h */,
 				BC2C0C8E2D32EBCB00FCFBA0 /* CSSPrimitiveData.h */,
 				BC2C0C8D2D32EBBD00FCFBA0 /* CSSPrimitiveKeywordList.h */,
+				BC092A452E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h */,
 				BC2C0C8F2D32F35000FCFBA0 /* CSSPrimitiveNumeric.h */,
 				BCD67C112D1F10BB0079EB9C /* CSSPrimitiveNumericConcepts.h */,
 				BC2C0C902D32F3F200FCFBA0 /* CSSPrimitiveNumericOrKeyword.h */,
@@ -35946,6 +35967,10 @@
 				BC2A0F232E144E0A003CBA0E /* StylePrimitiveKeyword+CSSValueConversion.h */,
 				BC2A0D332E05D43F003CBA0E /* StylePrimitiveKeyword+CSSValueCreation.h */,
 				BC2A0D312E05D409003CBA0E /* StylePrimitiveKeyword+Serialization.h */,
+				BC092A4E2E2EFBC1002ACB2C /* StylePrimitiveKeywordSet+CSSValueConversion.h */,
+				BC092A4F2E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h */,
+				BC092A532E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h */,
+				BC092A512E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h */,
 				BC2A0E322E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h */,
 				BC2C0C912D32F46F00FCFBA0 /* StylePrimitiveNumeric.h */,
 				BC6AFC732DFE6FA10065FA1D /* StylePrimitiveNumericAdaptors.h */,
@@ -41401,6 +41426,7 @@
 				977B3863122883E900B81FF8 /* CSSPreloadScanner.h in Headers */,
 				BC2C0C972D32FCE600FCFBA0 /* CSSPrimitiveData.h in Headers */,
 				BC2C0C992D32FF3F00FCFBA0 /* CSSPrimitiveKeywordList.h in Headers */,
+				BC092A462E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h in Headers */,
 				BC2C0C982D32FCF500FCFBA0 /* CSSPrimitiveNumeric.h in Headers */,
 				BCD67C122D1F10BB0079EB9C /* CSSPrimitiveNumericConcepts.h in Headers */,
 				BC2C0C9A2D3316C200FCFBA0 /* CSSPrimitiveNumericOrKeyword.h in Headers */,
@@ -45237,6 +45263,7 @@
 				BC2387AC2D8744E100698102 /* StyleLineBoxContain.h in Headers */,
 				4C96385829BF4A51003E5741 /* StyleListStyleType.h in Headers */,
 				BC9ABA1A2DED228100F7E52D /* StyleMargin.h in Headers */,
+				BC092A562E2F0507002ACB2C /* StyleMarginTrim.h in Headers */,
 				BC5EB72A0E81DE8100B25965 /* StyleMarqueeData.h in Headers */,
 				BC675B6C2DEE8BB700AD4D79 /* StyleMaximumSize.h in Headers */,
 				0FF50272102BA96A0066F39A /* StyleMedia.h in Headers */,
@@ -45264,9 +45291,13 @@
 				BCD9F1782E2040DC00D1C3DF /* StylePerspectiveOrigin.h in Headers */,
 				BCB2720E2CC1F1DB00265123 /* StylePolygonFunction.h in Headers */,
 				BCB272212CC20CAC00265123 /* StylePosition.h in Headers */,
+				BC092A4B2E2EF0BC002ACB2C /* StylePositionVisibility.h in Headers */,
 				BC675B6E2DEE8BB700AD4D79 /* StylePreferredSize.h in Headers */,
 				BC2A0D342E05D43F003CBA0E /* StylePrimitiveKeyword+CSSValueCreation.h in Headers */,
 				BC2A0D322E05D409003CBA0E /* StylePrimitiveKeyword+Serialization.h in Headers */,
+				BC092A502E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h in Headers */,
+				BC092A542E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h in Headers */,
+				BC092A522E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h in Headers */,
 				BC2A0E332E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h in Headers */,
 				BCE434662D4320400030D140 /* StylePrimitiveNumeric.h in Headers */,
 				BC6AFC742DFE70590065FA1D /* StylePrimitiveNumericAdaptors.h in Headers */,
@@ -45319,6 +45350,7 @@
 				E46B72512B61141D00A1F9B5 /* StyleSheetContentsCache.h in Headers */,
 				A8EA800A0A19516E00A8EF5F /* StyleSheetList.h in Headers */,
 				BC5EB5E50E81BF6D00B25965 /* StyleSurroundData.h in Headers */,
+				BC092A4D2E2EF3B4002ACB2C /* StyleTextDecorationLine.h in Headers */,
 				1C73A71521857587004CCEA5 /* StyleTextDecorationThickness.h in Headers */,
 				DD1C779029354C77003BD79B /* StyleTextEdge.h in Headers */,
 				BCD9EFED2E18E5A000D1C3DF /* StyleTextEmphasisStyle.h in Headers */,

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1683,14 +1683,14 @@ LineDecorationStyle::LineDecorationStyle(RenderObject& renderer)
 {
     const auto& style = renderer.style();
     auto decor = style.textDecorationLineInEffect();
-    if (decor & TextDecorationLine::Underline || decor & TextDecorationLine::LineThrough) {
+    if (decor & CSS::Keyword::Underline { } || decor & CSS::Keyword::LineThrough { }) {
         auto decorationStyles = TextDecorationPainter::stylesForRenderer(renderer, decor);
-        if (decor & TextDecorationLine::Underline) {
+        if (decor & CSS::Keyword::Underline { }) {
             hasUnderline = true;
             underlineColor = decorationStyles.underline.color;
         }
 
-        if (decor & TextDecorationLine::LineThrough) {
+        if (decor & CSS::Keyword::LineThrough { }) {
             hasLinethrough = true;
             linethroughColor = decorationStyles.linethrough.color;
         }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2217,10 +2217,10 @@ void AXObjectCache::onStyleChange(RenderText& renderText, StyleDifference differ
 
     auto oldDecor = oldStyle->textDecorationLineInEffect();
     auto newDecor = newStyle.textDecorationLineInEffect();
-    if ((oldDecor & TextDecorationLine::Underline) != (newDecor & TextDecorationLine::Underline))
+    if ((oldDecor & CSS::Keyword::Underline { }) != (newDecor & CSS::Keyword::Underline { }))
         tree->queueNodeUpdate(object->objectID(), { AXProperty::HasUnderline });
 
-    if ((oldDecor & TextDecorationLine::LineThrough) != (newDecor & TextDecorationLine::LineThrough))
+    if ((oldDecor & CSS::Keyword::LineThrough { }) != (newDecor & CSS::Keyword::LineThrough { }))
         tree->queueNodeUpdate(object->objectID(), { AXProperty::HasLinethrough });
 
     if (oldStyle->textDecorationColor() != newStyle.textDecorationColor())

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2888,7 +2888,7 @@ bool AccessibilityRenderObject::hasUnderline() const
     if (!m_renderer)
         return false;
     
-    return m_renderer->style().textDecorationLineInEffect().contains(TextDecorationLine::Underline);
+    return m_renderer->style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { });
 }
 
 String AccessibilityRenderObject::secureFieldValue() const

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -788,8 +788,8 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::fontDPI()), "pt"_s));
         addAttributeIfNeeded("weight"_s, makeString(static_cast<float>(style.fontCascade().weight())));
         addAttributeIfNeeded("style"_s, style.fontCascade().italic() ? "italic"_s : "normal"_s);
-        addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine() & TextDecorationLine::LineThrough ? "true"_s : "false"_s);
-        addAttributeIfNeeded("underline"_s, style.textDecorationLine() & TextDecorationLine::Underline ? "single"_s : "none"_s);
+        addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine() & CSS::Keyword::LineThrough { } ? "true"_s : "false"_s);
+        addAttributeIfNeeded("underline"_s, style.textDecorationLine() & CSS::Keyword::Underline { } ? "single"_s : "none"_s);
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);
         addAttributeIfNeeded("editable"_s, m_coreObject->canSetValueAttribute() ? "true"_s : "false"_s);
         addAttributeIfNeeded("direction"_s, style.writingMode().isBidiLTR() ? "ltr"_s : "rtl"_s);

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -270,7 +270,7 @@ static void attributeStringSetStyle(NSMutableAttributedString *attrString, Rende
     attributedStringSetFont(attrString, style.fontCascade().primaryFont()->getCTFont(), range);
 
     auto decor = style.textDecorationLineInEffect();
-    if (decor & TextDecorationLine::Underline)
+    if (decor & CSS::Keyword::Underline { })
         attributedStringSetNumber(attrString, AccessibilityTokenUnderline, @YES, range);
 
     // Add code context if this node is within a <code> block.

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1221,12 +1221,6 @@ template<> constexpr TextJustify fromCSSValueID(CSSValueID valueID)
     return TextJustify::Auto;
 }
 
-#define TYPE TextDecorationLine
-#define FOR_EACH(CASE) CASE(Underline) CASE(Overline) CASE(LineThrough) CASE(Blink)
-DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
-#undef TYPE
-#undef FOR_EACH
-
 #define TYPE TextDecorationStyle
 #define FOR_EACH(CASE) CASE(Solid) CASE(Double) CASE(Dotted) CASE(Dashed) CASE(Wavy)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
@@ -2615,12 +2609,6 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 
 #define TYPE Style::PositionTryOrder
 #define FOR_EACH(CASE) CASE(Normal) CASE(MostWidth) CASE(MostHeight) CASE(MostBlockSize) CASE(MostInlineSize)
-DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
-#undef TYPE
-#undef FOR_EACH
-
-#define TYPE PositionVisibility
-#define FOR_EACH(CASE) CASE(AnchorsValid) CASE(AnchorsVisible) CASE(NoOverflow)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5426,7 +5426,7 @@
                 "inline-end"
             ],
             "codegen-properties": {
-                "style-converter": "MarginTrim",
+                "style-converter": "StyleType<MarginTrim>",
                 "parser-function": "consumeMarginTrim",
                 "parser-grammar-unused": "none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."
@@ -10274,7 +10274,7 @@
                 "initial-letter"
             ],
             "codegen-properties": {
-                "style-converter": "LineBoxContain",
+                "style-converter": "StyleType<LineBoxContain>",
                 "parser-grammar": "none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]"
             },
             "status": {
@@ -10815,10 +10815,10 @@
                 }
             ],
             "codegen-properties": {
-                "style-converter": "TextDecorationLine",
                 "aliases": [
                     "-webkit-text-decoration-line"
                 ],
+                "style-converter": "StyleType<TextDecorationLine>",
                 "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt)",
                 "parser-exported": true
             },
@@ -10960,7 +10960,7 @@
             "inherited": true,
             "codegen-properties": {
                 "skip-style-builder": true,
-                "style-extractor-converter": "TextDecorationLine",
+                "style-extractor-converter": "StyleType<TextDecorationLine>",
                 "render-style-name-for-methods": "TextDecorationLineInEffect",
                 "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt)",
                 "comment": "FIXME: Should this be an alias of text-decoration-line?"
@@ -12296,7 +12296,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningPositionVisibilityEnabled",
-                "style-converter": "PositionVisibility",
+                "style-converter": "StyleType<PositionVisibility>",
                 "parser-grammar": "always | [ anchors-valid || anchors-visible || no-overflow ]@(no-single-item-opt)"
             },
             "specification": {

--- a/Source/WebCore/css/scripts/process-css-values.py
+++ b/Source/WebCore/css/scripts/process-css-values.py
@@ -364,6 +364,7 @@ class GenerationContext:
         to.write(f"template<CSSValueID C> struct Constant {{\n")
         to.write(f"    static constexpr auto value = C;\n")
         to.write(f"    constexpr bool operator==(const Constant<C>&) const = default;\n")
+        to.write(f"    constexpr bool operator==(CSSValueID other) const {{ return value == other; }}\n")
         to.write(f"}};\n\n")
 
         to.write(f"namespace CSS::Keyword {{\n\n")

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordSet.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordSet.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordList.h"
+#include <wtf/MathExtras.h>
+
+namespace WebCore {
+namespace CSS {
+
+// `OptionSet`-like type for sets of CSS keywords.
+template<typename Derived, PrimitiveKeyword EmptyCase, PrimitiveKeyword... Ks> struct PrimitiveKeywordSet {
+    using Base = PrimitiveKeywordSet<Derived, EmptyCase, Ks...>;
+    using Keywords = PrimitiveKeywordList<Ks...>;
+
+    static constexpr auto bits = Keywords::count;
+    static_assert(bits <= 32);
+
+    using Storage = std::conditional_t<bits <= 8, uint8_t, std::conditional_t<bits <= 16, uint16_t, uint32_t>>;
+
+    static constexpr auto emptyCase = EmptyCase { };
+
+    struct Value {
+        constexpr Value(ValidKeywordForList<Keywords> auto keyword)
+            : value(static_cast<uint8_t>(Keywords::offsetForKeyword(keyword)))
+        {
+        }
+
+        PrimitiveKeywordSet toSet() const { return PrimitiveKeywordSet::fromRaw(1 << value); }
+
+        bool operator==(const Value&) const = default;
+
+    private:
+        uint8_t value;
+    };
+
+    static constexpr Derived all() { return fromRaw(-1); }
+
+    static constexpr Derived fromRaw(Storage raw) { return Derived(raw); }
+
+    constexpr PrimitiveKeywordSet() = default;
+
+    constexpr PrimitiveKeywordSet(EmptyCase)
+        : m_storage { 0 }
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(Storage storage)
+        : m_storage { storage }
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(ValidKeywordForList<Keywords> auto keyword)
+        : m_storage(toBit(keyword))
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(Value value)
+        : PrimitiveKeywordSet { value.toSet() }
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(std::initializer_list<PrimitiveKeywordSet> initializerList)
+    {
+        for (auto& keywordSet : initializerList) {
+            ASSERT_UNDER_CONSTEXPR_CONTEXT(hasOneBitSet(keywordSet.m_storage));
+            m_storage |= keywordSet.m_storage;
+        }
+    }
+
+    constexpr Storage toRaw() const { return m_storage; }
+
+    constexpr bool isEmpty() const { return !m_storage; }
+    constexpr explicit operator bool() const { return !isEmpty(); }
+
+    // MARK: - Operators
+
+    constexpr friend Derived operator|(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage | rhs.m_storage);
+    }
+
+    constexpr PrimitiveKeywordSet& operator|=(const PrimitiveKeywordSet& other)
+    {
+        add(other);
+        return *this;
+    }
+
+    constexpr friend Derived operator&(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage & rhs.m_storage);
+    }
+
+    constexpr friend Derived operator-(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage & ~rhs.m_storage);
+    }
+
+    constexpr friend Derived operator^(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage ^ rhs.m_storage);
+    }
+
+    constexpr bool contains(ValidKeywordForList<Keywords> auto keyword) const
+    {
+        return containsAny(keyword);
+    }
+
+    constexpr bool contains(Value keyword) const
+    {
+        return containsAny(keyword.toSet());
+    }
+
+    constexpr bool containsAny(PrimitiveKeywordSet set) const
+    {
+        return !!(*this & set);
+    }
+
+    constexpr bool containsAll(PrimitiveKeywordSet set) const
+    {
+        return (*this & set) == set;
+    }
+
+    constexpr bool containsOnly(PrimitiveKeywordSet set) const
+    {
+        return *this == (*this & set);
+    }
+
+    constexpr void add(PrimitiveKeywordSet set)
+    {
+        m_storage |= set.m_storage;
+    }
+
+    constexpr void remove(PrimitiveKeywordSet set)
+    {
+        m_storage &= ~set.m_storage;
+    }
+
+    constexpr void set(PrimitiveKeywordSet set, bool value)
+    {
+        if (value)
+            add(set);
+        else
+            remove(set);
+    }
+
+    constexpr bool hasExactlyOneBitSet() const
+    {
+        return m_storage && !(m_storage & (m_storage - 1));
+    }
+
+    constexpr bool operator==(const PrimitiveKeywordSet&) const = default;
+
+private:
+    static constexpr Storage toBit(ValidKeywordForList<Keywords> auto keyword)
+    {
+        return static_cast<Storage>(1 << Keywords::offsetForKeyword(keyword));
+    }
+
+    Storage m_storage;
+};
+
+// MARK: - Concepts
+
+template<typename T> concept PrimitiveKeywordSetDerived = WTF::IsBaseOfTemplate<PrimitiveKeywordSet, T>::value  && VariantLike<T>;
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4653,9 +4653,9 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
         }
     } else {
         auto decoration = style->textDecorationLineInEffect();
-        if (decoration & TextDecorationLine::LineThrough)
+        if (decoration & CSS::Keyword::LineThrough { })
             attributes.hasStrikeThrough = true;
-        if (decoration & TextDecorationLine::Underline)
+        if (decoration & CSS::Keyword::Underline { })
             attributes.hasUnderline = true;
     }
 

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -343,12 +343,12 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
     UNUSED_PARAM(elementQualifiesForWritingToolsPreservationCache);
 #endif
 
-    if (style.textDecorationLineInEffect() & TextDecorationLine::Underline)
+    if (style.textDecorationLineInEffect() & CSS::Keyword::Underline { })
         [attributes setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSUnderlineStyleAttributeName];
     else
         [attributes removeObjectForKey:NSUnderlineStyleAttributeName];
 
-    if (style.textDecorationLineInEffect() & TextDecorationLine::LineThrough)
+    if (style.textDecorationLineInEffect() & CSS::Keyword::LineThrough { })
         [attributes setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSStrikethroughStyleAttributeName];
     else
         [attributes removeObjectForKey:NSStrikethroughStyleAttributeName];

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -30,6 +30,7 @@
 #include "LayoutBox.h"
 #include "LayoutUnits.h"
 #include "LengthFunctions.h"
+#include "StyleLineBoxContain.h"
 #include "StyleTextEdge.h"
 #include <wtf/OptionSet.h>
 
@@ -169,7 +170,7 @@ private:
         TextBoxTrim textBoxTrim;
         TextEdge textBoxEdge;
         TextEdge lineFitEdge;
-        OptionSet<WebCore::Style::LineBoxContain> lineBoxContain;
+        WebCore::Style::LineBoxContain lineBoxContain;
         InlineLayoutUnit primaryFontSize { 0 };
         VerticalAlignment verticalAlignment { };
     };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -73,18 +73,18 @@ inline InlineLevelBox InlineLevelBox::createRootInlineBox(const Box& layoutBox, 
 inline bool InlineLevelBox::mayStretchLineBox() const
 {
     if (isRootInlineBox())
-        return m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Block, WebCore::Style::LineBoxContain::Inline }) || (hasContent() && m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::InitialLetter, WebCore::Style::LineBoxContain::Font, WebCore::Style::LineBoxContain::Glyphs }));
+        return m_style.lineBoxContain.containsAny({ CSS::Keyword::Block { }, CSS::Keyword::Inline { } }) || (hasContent() && m_style.lineBoxContain.containsAny({ CSS::Keyword::InitialLetter { }, CSS::Keyword::Font { }, CSS::Keyword::Glyphs { } }));
 
     if (isAtomicInlineBox())
-        return m_style.lineBoxContain.contains(WebCore::Style::LineBoxContain::Replaced);
+        return m_style.lineBoxContain.contains(CSS::Keyword::Replaced { });
 
     if (isInlineBox()) {
         // Either the inline box itself is included or its text content through Glyph and Font.
-        return m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Inline, WebCore::Style::LineBoxContain::InlineBox }) || (hasContent() && m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Font, WebCore::Style::LineBoxContain::Glyphs }));
+        return m_style.lineBoxContain.containsAny({ CSS::Keyword::Inline { }, CSS::Keyword::InlineBox { } }) || (hasContent() && m_style.lineBoxContain.containsAny({ CSS::Keyword::Font { }, CSS::Keyword::Glyphs { } }));
     }
 
     if (isLineBreakBox())
-        return m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Inline, WebCore::Style::LineBoxContain::InlineBox }) || (hasContent() && m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Font, WebCore::Style::LineBoxContain::Glyphs }));
+        return m_style.lineBoxContain.containsAny({ CSS::Keyword::Inline { }, CSS::Keyword::InlineBox { } }) || (hasContent() && m_style.lineBoxContain.containsAny({ CSS::Keyword::Font { }, CSS::Keyword::Glyphs { } }));
 
     return true;
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -510,7 +510,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
     // Collect layout bounds based on the contain property and set them on the inline boxes when they are applicable.
     HashMap<InlineLevelBox*, TextUtil::EnclosingAscentDescent> inlineBoxBoundsMap;
 
-    if (lineBoxContain.contains(Style::LineBoxContain::InlineBox)) {
+    if (lineBoxContain.contains(CSS::Keyword::InlineBox { })) {
         for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
             if (!inlineLevelBox.isInlineBox())
                 continue;
@@ -521,7 +521,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         }
     }
 
-    if (lineBoxContain.contains(Style::LineBoxContain::Font)) {
+    if (lineBoxContain.contains(CSS::Keyword::Font { })) {
         // Assign font based layout bounds to all inline boxes.
         auto ensureFontMetricsBasedHeight = [&] (auto& inlineBox) {
             ASSERT(inlineBox.isInlineBox());
@@ -546,7 +546,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         }
     }
 
-    if (lineBoxContain.contains(Style::LineBoxContain::Glyphs)) {
+    if (lineBoxContain.contains(CSS::Keyword::Glyphs { })) {
         // Compute text content (glyphs) hugging inline box layout bounds.
         for (auto run : lineLayoutResult().inlineContent) {
             if (!run.isText())
@@ -566,7 +566,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         }
     }
 
-    if (lineBoxContain.contains(Style::LineBoxContain::InitialLetter)) {
+    if (lineBoxContain.contains(CSS::Keyword::InitialLetter { })) {
         // Initial letter contain is based on the font metrics cap geometry and we hug descent.
         auto& rootInlineBox = lineBox.rootInlineBox();
         auto& fontMetrics = rootInlineBox.primarymetricsOfPrimaryFont();
@@ -597,7 +597,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         auto inlineBoxLayoutBounds = inlineBox->layoutBounds();
 
         // "line-box-container: block" The extended block progression dimension of the root inline box must fit within the line box.
-        auto mayShrinkLineBox = inlineBox->isRootInlineBox() ? !lineBoxContain.contains(Style::LineBoxContain::Block) : true;
+        auto mayShrinkLineBox = inlineBox->isRootInlineBox() ? !lineBoxContain.contains(CSS::Keyword::Block { }) : true;
         auto ascent = mayShrinkLineBox ? enclosingAscentDescentForInlineBox.ascent : std::max(enclosingAscentDescentForInlineBox.ascent, inlineBoxLayoutBounds.ascent);
         auto descent = mayShrinkLineBox ? enclosingAscentDescentForInlineBox.descent : std::max(enclosingAscentDescentForInlineBox.descent, inlineBoxLayoutBounds.descent);
         inlineBox->setLayoutBounds({ ceilf(ascent), ceilf(descent) });

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -841,7 +841,7 @@ LineBuilder::RectAndFloatConstraints LineBuilder::adjustedLineRectWithCandidateI
         if (inlineItem.isText()) {
             auto& styleToUse = isFirstFormattedLine() ? inlineItem.firstLineStyle() : inlineItem.style();
             candidateContentHeight = std::max<InlineLayoutUnit>(candidateContentHeight, styleToUse.computedLineHeight());
-        } else if (inlineItem.isAtomicInlineBox() && lineBoxContain.contains(Style::LineBoxContain::Replaced))
+        } else if (inlineItem.isAtomicInlineBox() && lineBoxContain.contains(CSS::Keyword::Replaced { }))
             candidateContentHeight = std::max(candidateContentHeight, InlineLayoutUnit { formattingContext().geometryForBox(inlineItem.layoutBox()).marginBoxHeight() });
     }
     if (candidateContentHeight <= m_lineLogicalRect.height())

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -104,7 +104,7 @@ bool InlineQuirks::inlineBoxAffectsLineBox(const InlineLevelBox& inlineLevelBox)
 std::optional<LayoutUnit> InlineQuirks::initialLetterAlignmentOffset(const Box& floatBox, const RenderStyle& lineBoxStyle) const
 {
     ASSERT(floatBox.isFloatingPositioned());
-    if (!floatBox.style().lineBoxContain().contains(Style::LineBoxContain::InitialLetter))
+    if (!floatBox.style().lineBoxContain().contains(CSS::Keyword::InitialLetter { }))
         return { };
     auto& primaryFontMetrics = lineBoxStyle.fontCascade().metricsOfPrimaryFont();
     auto lineHeight = [&]() -> InlineLayoutUnit {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1020,14 +1020,14 @@ static float logicalBottomForTextDecorationContent(const InlineDisplay::Boxes& b
     for (auto& displayBox : boxes) {
         if (displayBox.isRootInlineBox())
             continue;
-        if (!displayBox.style().textDecorationLineInEffect().contains(TextDecorationLine::Underline))
+        if (!displayBox.style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { }))
             continue;
         if (displayBox.isText() || displayBox.style().textDecorationSkipInk() == TextDecorationSkipInk::None) {
             auto contentLogicalBottom = isHorizontalWritingMode ? displayBox.bottom() : displayBox.right();
             logicalBottom = logicalBottom ? std::max(*logicalBottom, contentLogicalBottom) : contentLogicalBottom;
         }
     }
-    // This function is not called unless there's at least one run on the line with TextDecorationLine::Underline.
+    // This function is not called unless there's at least one run on the line with TextDecorationLine CSS::Keyword::Underline.
     ASSERT(logicalBottom);
     return logicalBottom.value_or(0.f);
 }
@@ -1051,7 +1051,7 @@ void InlineDisplayContentBuilder::collectInkOverflowForTextDecorations(InlineDis
             continue;
 
         auto decorationOverflow = [&] {
-            if (!textDecorations.contains(TextDecorationLine::Underline))
+            if (!textDecorations.contains(CSS::Keyword::Underline { }))
                 return inkOverflowForDecorations(parentStyle);
 
             if (!logicalBottomForTextDecoration)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -846,9 +846,9 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
     auto& marginLeft = child.style().marginStart(writingMode());
     auto& marginRight = child.style().marginEnd(writingMode());
     LayoutUnit margin;
-    if (auto fixedMarginLeft = marginLeft.tryFixed(); fixedMarginLeft && !shouldTrimChildMargin(MarginTrimType::InlineStart, child))
+    if (auto fixedMarginLeft = marginLeft.tryFixed(); fixedMarginLeft && !shouldTrimChildMargin(CSS::Keyword::InlineStart { }, child))
         margin += fixedMarginLeft->value;
-    if (auto fixedMarginRight = marginRight.tryFixed(); fixedMarginRight && !shouldTrimChildMargin(MarginTrimType::InlineEnd, child))
+    if (auto fixedMarginRight = marginRight.tryFixed(); fixedMarginRight && !shouldTrimChildMargin(CSS::Keyword::InlineEnd { }, child))
         margin += fixedMarginRight->value;
     return margin;
 }
@@ -2905,28 +2905,28 @@ bool RenderBlock::updateFragmentRangeForBoxChild(const RenderBox& box) const
     return false;
 }
 
-void RenderBlock::setTrimmedMarginForChild(RenderBox &child, MarginTrimType marginTrimType)
+void RenderBlock::setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::BlockStart keyword)
 {
-    switch (marginTrimType) {
-    case MarginTrimType::BlockStart:
-        setMarginBeforeForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::BlockStart);
-        break;
-    case MarginTrimType::BlockEnd:
-        setMarginAfterForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::BlockEnd);
-        break;
-    case MarginTrimType::InlineStart:
-        setMarginStartForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::InlineStart);
-        break;
-    case MarginTrimType::InlineEnd:
-        setMarginEndForChild(child, 0_lu);
-        child.markMarginAsTrimmed(MarginTrimType::InlineEnd);
-        break;
-    default:
-        ASSERT_NOT_IMPLEMENTED_YET();
-    }
+    setMarginBeforeForChild(child, 0_lu);
+    child.markMarginAsTrimmed(keyword);
+}
+
+void RenderBlock::setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::BlockEnd keyword)
+{
+    setMarginAfterForChild(child, 0_lu);
+    child.markMarginAsTrimmed(keyword);
+}
+
+void RenderBlock::setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::InlineStart keyword)
+{
+    setMarginStartForChild(child, 0_lu);
+    child.markMarginAsTrimmed(keyword);
+}
+
+void RenderBlock::setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::InlineEnd keyword)
+{
+    setMarginEndForChild(child, 0_lu);
+    child.markMarginAsTrimmed(keyword);
 }
 
 LayoutUnit RenderBlock::collapsedMarginBeforeForChild(const RenderBox& child) const

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -105,7 +105,7 @@ public:
     bool hasMarginBeforeQuirk(const RenderBox& child) const;
     bool hasMarginAfterQuirk(const RenderBox& child) const;
 
-    virtual bool shouldChildInlineMarginContributeToContainerIntrinsicSize(MarginTrimType /* marginSide */, const RenderElement&) const { return true; }
+    virtual bool shouldChildInlineMarginContributeToContainerIntrinsicSize(Style::MarginTrim::Value /* marginSide */, const RenderElement&) const { return true; }
 
     void markOutOfFlowBoxesForLayout();
     void markForPaginationRelayoutIfNeeded() override;
@@ -198,7 +198,10 @@ public:
     void setMarginEndForChild(RenderBox& child, LayoutUnit value) const { child.setMarginEnd(value, writingMode()); }
     void setMarginBeforeForChild(RenderBox& child, LayoutUnit value) const { child.setMarginBefore(value, writingMode()); }
     void setMarginAfterForChild(RenderBox& child, LayoutUnit value) const { child.setMarginAfter(value, writingMode()); }
-    void setTrimmedMarginForChild(RenderBox& child, MarginTrimType);
+    void setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::BlockStart);
+    void setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::BlockEnd);
+    void setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::InlineStart);
+    void setTrimmedMarginForChild(RenderBox& child, CSS::Keyword::InlineEnd);
     LayoutUnit collapsedMarginBeforeForChild(const RenderBox& child) const;
     LayoutUnit collapsedMarginAfterForChild(const RenderBox& child) const;
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -837,7 +837,7 @@ void RenderBlockFlow::layoutBlockChildren(RelayoutChildren relayoutChildren, Lay
 
     bool marginTrimBlockStartFromContainingBlock = layoutState->marginTrimBlockStart();
     bool newMarginTrimBlockStartForSubtree = [&] {
-        if (style().marginTrim().contains(MarginTrimType::BlockStart))
+        if (style().marginTrim().contains(CSS::Keyword::BlockStart { }))
             return true;
         if (!marginInfo.canCollapseMarginBeforeWithChildren() && marginTrimBlockStartFromContainingBlock)
             return false;
@@ -910,7 +910,7 @@ void RenderBlockFlow::layoutBlockChildren(RelayoutChildren relayoutChildren, Lay
         layoutBlockChild(child, marginInfo, previousFloatLogicalBottom, maxFloatLogicalBottom);
     }
     
-    if (style().marginTrim().contains(MarginTrimType::BlockEnd))
+    if (style().marginTrim().contains(CSS::Keyword::BlockEnd { }))
         trimBlockEndChildrenMargins();
     // Now do the handling of the bottom of the block, adding in our bottom border/padding and
     // determining the correct collapsed bottom margin information.
@@ -923,12 +923,12 @@ void RenderBlockFlow::trimBlockEndChildrenMargins()
     auto trimSelfCollapsingChildDescendantsMargins = [&](RenderBox& child) {
         ASSERT(child.isSelfCollapsingBlock());
         for (auto itr = RenderIterator<RenderBox>(&child, child.firstChildBox()); itr; itr = itr.traverseNext()) {
-            setTrimmedMarginForChild(*itr, MarginTrimType::BlockStart);
-            setTrimmedMarginForChild(*itr, MarginTrimType::BlockEnd);
+            setTrimmedMarginForChild(*itr, CSS::Keyword::BlockStart { });
+            setTrimmedMarginForChild(*itr, CSS::Keyword::BlockEnd { });
         }
     };
 
-    ASSERT(style().marginTrim().contains(MarginTrimType::BlockEnd));
+    ASSERT(style().marginTrim().contains(CSS::Keyword::BlockEnd { }));
     // If we are trimming the block end margin, we need to make sure we trim the margin of the children
     // at the end of the block by walking back up the container. Any self collapsing children will also need to
     // have their position adjusted to below the last non self-collapsing child in its containing block
@@ -940,9 +940,9 @@ void RenderBlockFlow::trimBlockEndChildrenMargins()
         }
 
         auto* childContainingBlock = child->containingBlock();
-        setTrimmedMarginForChild(*child, MarginTrimType::BlockEnd);
+        setTrimmedMarginForChild(*child, CSS::Keyword::BlockEnd { });
         if (child->isSelfCollapsingBlock()) {
-            setTrimmedMarginForChild(*child, MarginTrimType::BlockStart);
+            setTrimmedMarginForChild(*child, CSS::Keyword::BlockStart { });
             childContainingBlock->setLogicalTopForChild(*child, childContainingBlock->logicalHeight());
             
             // If this self-collapsing child has any other children, which must also be
@@ -951,7 +951,7 @@ void RenderBlockFlow::trimBlockEndChildrenMargins()
                 trimSelfCollapsingChildDescendantsMargins(*child);
 
             child = child->previousSiblingBox();
-        }  else if (auto* nestedBlock = dynamicDowncast<RenderBlockFlow>(child); nestedBlock && nestedBlock->isBlockContainer() && !nestedBlock->childrenInline() && !nestedBlock->style().marginTrim().contains(MarginTrimType::BlockEnd)) {
+        }  else if (auto* nestedBlock = dynamicDowncast<RenderBlockFlow>(child); nestedBlock && nestedBlock->isBlockContainer() && !nestedBlock->childrenInline() && !nestedBlock->style().marginTrim().contains(CSS::Keyword::BlockEnd { })) {
             MarginInfo nestedBlockMarginInfo(*nestedBlock, nestedBlock->borderAndPaddingBefore(), nestedBlock->borderAndPaddingAfter());
             // The margins *inside* this nested block are protected so we should not introspect and try to
             // trim any of them.
@@ -1444,14 +1444,14 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Margi
         auto childBlockFlow = dynamicDowncast<RenderBlockFlow>(child);
         if (childBlockFlow)
             childBlockFlow->setMaxMarginBeforeValues(0_lu, 0_lu);
-        setTrimmedMarginForChild(*child, MarginTrimType::BlockStart);
+        setTrimmedMarginForChild(*child, CSS::Keyword::BlockStart { });
 
         // The margin after for a self collapsing child should also be trimmed so it does not 
         // influence the margins of the first non collapsing child
         if (childIsSelfCollapsing) {
             if (childBlockFlow)
                 childBlockFlow->setMaxMarginAfterValues(0_lu, 0_lu);
-            setTrimmedMarginForChild(*child, MarginTrimType::BlockEnd);
+            setTrimmedMarginForChild(*child, CSS::Keyword::BlockEnd { });
         }
     };
     if (frame().view()->layoutContext().layoutState()->marginTrimBlockStart()) {
@@ -1560,29 +1560,27 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Margi
     return logicalTop;
 }
 
-bool RenderBlockFlow::isChildEligibleForMarginTrim(MarginTrimType marginTrimType, const RenderBox& child) const
+bool RenderBlockFlow::isChildEligibleForMarginTrim(Style::MarginTrim::Value marginTrim, const RenderBox& child) const
 {
-    ASSERT(style().marginTrim().contains(marginTrimType));
+    ASSERT(style().marginTrim().contains(marginTrim));
     if (!child.style().isDisplayBlockLevel())
         return false;
+
     // https://drafts.csswg.org/css-box-4/#margin-trim-block
     // 3.3.1. Trimming Block Container Content
     // For block containers specifically, margin-trim discards:
-    switch (marginTrimType) {
-    case MarginTrimType::BlockStart:
+
+    if (marginTrim == CSS::Keyword::BlockStart { })
         // The block-start margin of a block-level first child, when trimming at the block-start edge.
         return firstInFlowChildBox() == &child;
-    case MarginTrimType::BlockEnd:
+
+    if (marginTrim == CSS::Keyword::BlockEnd { })
         // The block-end margin of a block-level last child, when trimming at the block-end edge.
         return lastInFlowChildBox() == &child;
-    case MarginTrimType::InlineStart:
-    case MarginTrimType::InlineEnd:
-        // It has no effect on the inline-axis margins of block-level descendants, nor on any margins of inline-level descendants.
-        return false;
-    default:
-        ASSERT_NOT_REACHED();
-        return false;
-    }
+
+    ASSERT(marginTrim == CSS::Keyword::InlineStart { } || marginTrim == CSS::Keyword::InlineEnd { });
+    // It has no effect on the inline-axis margins of block-level descendants, nor on any margins of inline-level descendants.
+    return false;
 }
 
 LayoutUnit RenderBlockFlow::clearFloatsIfNeeded(RenderBox& child, MarginInfo& marginInfo, LayoutUnit oldTopPosMargin, LayoutUnit oldTopNegMargin, LayoutUnit yPos)
@@ -1741,7 +1739,7 @@ void RenderBlockFlow::setCollapsedBottomMargin(const MarginInfo& marginInfo)
     if (marginInfo.canCollapseWithMarginAfter() && !marginInfo.canCollapseWithMarginBefore()) {
         // Update our max pos/neg bottom margins, since we collapsed our bottom margins
         // with our children.
-        auto shouldTrimBlockEndMargin = style().marginTrim().contains(MarginTrimType::BlockEnd);
+        auto shouldTrimBlockEndMargin = style().marginTrim().contains(CSS::Keyword::BlockEnd { });
         auto propagatedPositiveMargin = shouldTrimBlockEndMargin ? 0_lu : marginInfo.positiveMargin();
         auto propagatedNegativeMargin = shouldTrimBlockEndMargin ? 0_lu : marginInfo.negativeMargin();
         setMaxMarginAfterValues(std::max(maxPositiveMarginAfter(), propagatedPositiveMargin), std::max(maxNegativeMarginAfter(), propagatedNegativeMargin));

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -237,7 +237,6 @@ public:
         LayoutUnit margin() const { return m_positiveMargin - m_negativeMargin; }
     };
 
-    bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const;
     void performBlockStepSizing(RenderBox& child, LayoutUnit blockStepSizeForChild) const;
 
     void layoutBlockChild(RenderBox& child, MarginInfo&, LayoutUnit& previousFloatLogicalBottom, LayoutUnit& maxFloatLogicalBottom);
@@ -411,7 +410,7 @@ public:
     std::optional<LayoutUnit> lowestInitialLetterLogicalBottom() const;
 
 protected:
-    bool isChildEligibleForMarginTrim(MarginTrimType, const RenderBox&) const final;
+    bool isChildEligibleForMarginTrim(Style::MarginTrim::Value, const RenderBox&) const final;
 
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1450,7 +1450,7 @@ void RenderBox::clearOverridingLogicalWidthForFlexBasisComputation()
         gOverridingLogicalWidthMapForFlexBasisComputation->remove(*this);
 }
 
-void RenderBox::markMarginAsTrimmed(MarginTrimType newTrimmedMargin)
+void RenderBox::markMarginAsTrimmed(Style::MarginTrim newTrimmedMargin)
 {
     auto& rareData = ensureRareData();
     rareData.trimmedMargins = rareData.trimmedMargins | newTrimmedMargin;
@@ -1462,13 +1462,13 @@ void RenderBox::clearTrimmedMarginsMarkings()
     ensureRareData().trimmedMargins = { };
 }
 
-bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) const
+bool RenderBox::hasTrimmedMargin(std::optional<Style::MarginTrim::Value> marginTrim) const
 {
     if (!isInFlow())
         return false;
     if (!hasRareData())
         return false;
-    return marginTrimType ? rareData().trimmedMargins.contains(*marginTrimType) : !rareData().trimmedMargins.isEmpty();
+    return marginTrim ? rareData().trimmedMargins.contains(*marginTrim) : !rareData().trimmedMargins.isEmpty();
 }
 
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Style::Length<CSS::Nonnegative, float>& logicalWidth) const
@@ -2733,10 +2733,10 @@ void RenderBox::computeLogicalWidth(LogicalExtentComputedValues& computedValues)
 
     // Margin calculations.
     if (hasPerpendicularContainingBlock || isFloating() || isInline()) {
-        computedValues.m_margins.m_start = computeOrTrimInlineMargin(containingBlock, MarginTrimType::BlockStart, [&] {
+        computedValues.m_margins.m_start = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::BlockStart { }, [&] {
             return Style::evaluateMinimum(styleToUse.marginStart(), containerLogicalWidth);
         });
-        computedValues.m_margins.m_end = computeOrTrimInlineMargin(containingBlock, MarginTrimType::BlockEnd, [&] {
+        computedValues.m_margins.m_end = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::BlockEnd { }, [&] {
             return Style::evaluateMinimum(styleToUse.marginEnd(), containerLogicalWidth);
         });
     } else {
@@ -2792,10 +2792,10 @@ LayoutUnit RenderBox::fillAvailableMeasure(LayoutUnit availableLogicalWidth, Lay
     auto& marginStartLength = style().marginStart();
     auto& marginEndLength = style().marginEnd();
     LayoutUnit availableSizeForResolvingMargin = isOrthogonalElement ? containingBlockLogicalWidthForContent() : availableLogicalWidth;
-    marginStart = computeOrTrimInlineMargin(*container, MarginTrimType::InlineStart, [&] {
+    marginStart = computeOrTrimInlineMargin(*container, CSS::Keyword::InlineStart { }, [&] {
         return Style::evaluateMinimum(marginStartLength, availableSizeForResolvingMargin);
     });
-    marginEnd = computeOrTrimInlineMargin(*container, MarginTrimType::InlineEnd, [&] {
+    marginEnd = computeOrTrimInlineMargin(*container, CSS::Keyword::InlineEnd { }, [&] {
         return Style::evaluateMinimum(marginEndLength, availableSizeForResolvingMargin);
     });
     return availableLogicalWidth - marginStart - marginEnd;
@@ -3084,7 +3084,7 @@ bool RenderBox::sizesPreferredLogicalWidthToFitContent() const
 }
 
 template<typename Function>
-LayoutUnit RenderBox::computeOrTrimInlineMargin(const RenderBlock& containingBlock, MarginTrimType marginSide, NOESCAPE const Function& computeInlineMargin) const
+LayoutUnit RenderBox::computeOrTrimInlineMargin(const RenderBlock& containingBlock, Style::MarginTrim::Value marginSide, NOESCAPE const Function& computeInlineMargin) const
 {
     if (containingBlock.shouldTrimChildMargin(marginSide, *this)) {
         // FIXME(255434): This should be set when the margin is being trimmed
@@ -3092,7 +3092,7 @@ LayoutUnit RenderBox::computeOrTrimInlineMargin(const RenderBlock& containingBlo
         // be done at this level within RenderBox. We should be able to leave the 
         // trimming responsibility to each of those contexts and not need to
         // do any of it here (trimming the margin and setting the rare data bit)
-        if (isGridItem() && (marginSide == MarginTrimType::InlineStart || marginSide == MarginTrimType::InlineEnd))
+        if (isGridItem() && Style::MarginTrim::inlineTrims().contains(marginSide))
             const_cast<RenderBox&>(*this).markMarginAsTrimmed(marginSide);
         return 0_lu;
     }
@@ -3113,10 +3113,10 @@ void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock
 
     if (isInline()) {
         // Inline blocks/tables don't have their margins increased.
-        marginStart = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineStart, [&] {
+        marginStart = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineStart { }, [&] {
             return Style::evaluateMinimum(marginStartLength, containerWidth);
         });
-        marginEnd = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineStart, [&] {
+        marginEnd = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineStart { }, [&] {
             return Style::evaluateMinimum(marginEndLength, containerWidth);
         });
         return;
@@ -3139,13 +3139,13 @@ void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock
         auto alignModeCenter = containingBlock.style().textAlign() == TextAlignMode::WebKitCenter && !marginStartLength.isAuto() && !marginEndLength.isAuto();
         if (marginAutoCenter || alignModeCenter) {
             // Other browsers center the margin box for align=center elements so we match them here.
-            marginStart = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineStart, [&] {
+            marginStart = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineStart { }, [&] {
                 LayoutUnit marginStartWidth = Style::evaluateMinimum(marginStartLength, containerWidthForMarginAuto);
                 LayoutUnit marginEndWidth = Style::evaluateMinimum(marginEndLength, containerWidthForMarginAuto);
                 LayoutUnit centeredMarginBoxStart = std::max<LayoutUnit>(0, (containerWidthForMarginAuto - childWidth - marginStartWidth - marginEndWidth) / 2);
                 return centeredMarginBoxStart + marginStartWidth;
             });
-            marginEnd = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineEnd, [&] {
+            marginEnd = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineEnd { }, [&] {
                 LayoutUnit marginEndWidth = Style::evaluateMinimum(marginEndLength, containerWidthForMarginAuto);
                 return containerWidthForMarginAuto - childWidth - marginStart + marginEndWidth;
             });
@@ -3163,10 +3163,10 @@ void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock
         auto pushToEndFromTextAlign = !marginEndLength.isAuto() && ((!containingBlockStyle.writingMode().isBidiLTR() && containingBlockStyle.textAlign() == TextAlignMode::WebKitLeft)
             || (containingBlockStyle.writingMode().isBidiLTR() && containingBlockStyle.textAlign() == TextAlignMode::WebKitRight));
         if ((marginStartLength.isAuto() || pushToEndFromTextAlign) && childWidth < containerWidthForMarginAuto) {
-            marginEnd = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineEnd, [&] {
+            marginEnd = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineEnd { }, [&] {
                 return Style::evaluate(marginEndLength, containerWidthForMarginAuto);
             });
-            marginStart = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineStart, [&] {
+            marginStart = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineStart { }, [&] {
                 return containerWidthForMarginAuto - childWidth - marginEnd;
             });
             return true;
@@ -3178,10 +3178,10 @@ void RenderBox::computeInlineDirectionMargins(const RenderBlock& containingBlock
     
     // Case Four: Either no auto margins, or our width is >= the container width (css2.1, 10.3.3). In that case
     // auto margins will just turn into 0.
-    marginStart = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineStart, [&] {
+    marginStart = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineStart { }, [&] {
         return Style::evaluateMinimum(marginStartLength, containerWidth);
     });
-    marginEnd = computeOrTrimInlineMargin(containingBlock, MarginTrimType::InlineEnd, [&] {
+    marginEnd = computeOrTrimInlineMargin(containingBlock, CSS::Keyword::InlineEnd { }, [&] {
         return Style::evaluateMinimum(marginEndLength, containerWidth);
     });
 }
@@ -4184,8 +4184,8 @@ void RenderBox::computeBlockDirectionMargins(const RenderBlock& containingBlock,
     // Margins are calculated with respect to the logical width of
     // the containing block (8.3)
     LayoutUnit cw = containingBlockLogicalWidthForContent();
-    marginBefore = constrainBlockMarginInAvailableSpaceOrTrim(containingBlock, cw, MarginTrimType::BlockStart);
-    marginAfter = constrainBlockMarginInAvailableSpaceOrTrim(containingBlock, cw, MarginTrimType::BlockEnd); 
+    marginBefore = constrainBlockMarginInAvailableSpaceOrTrim(containingBlock, cw, CSS::Keyword::BlockStart { });
+    marginAfter = constrainBlockMarginInAvailableSpaceOrTrim(containingBlock, cw, CSS::Keyword::BlockEnd { });
 }
 
 void RenderBox::computeAndSetBlockDirectionMargins(const RenderBlock& containingBlock)
@@ -4197,10 +4197,10 @@ void RenderBox::computeAndSetBlockDirectionMargins(const RenderBlock& containing
     containingBlock.setMarginAfterForChild(*this, marginAfter);
 }
 
-LayoutUnit RenderBox::constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox& containingBlock, LayoutUnit availableSpace, MarginTrimType marginSide) const
+LayoutUnit RenderBox::constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox& containingBlock, LayoutUnit availableSpace, Style::MarginTrim::Value marginSide) const
 {
     
-    ASSERT(marginSide == MarginTrimType::BlockStart || marginSide == MarginTrimType::BlockEnd);
+    ASSERT(marginSide == CSS::Keyword::BlockStart { } || marginSide == CSS::Keyword::BlockEnd { });
     if (containingBlock.shouldTrimChildMargin(marginSide, *this)) {
         // FIXME(255434): This should be set when the margin is being trimmed
         // within the context of its layout system (block, flex, grid) and should not 
@@ -4212,7 +4212,7 @@ LayoutUnit RenderBox::constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox
         return 0_lu;
     }
     
-    return marginSide == MarginTrimType::BlockStart
+    return marginSide == CSS::Keyword::BlockStart { }
         ? Style::evaluateMinimum(style().marginBefore(containingBlock.writingMode()), availableSpace)
         : Style::evaluateMinimum(style().marginAfter(containingBlock.writingMode()), availableSpace);
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -257,7 +257,7 @@ public:
     virtual LayoutUnit collapsedMarginBefore() const { return marginBefore(); }
     virtual LayoutUnit collapsedMarginAfter() const { return marginAfter(); }
 
-    LayoutUnit constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox& containingBlock, LayoutUnit availableSpace, MarginTrimType marginSide) const;
+    LayoutUnit constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox& containingBlock, LayoutUnit availableSpace, Style::MarginTrim::Value marginSide) const;
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const override;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;
@@ -305,9 +305,9 @@ public:
     void clearOverridingLogicalHeightForFlexBasisComputation();
     void clearOverridingLogicalWidthForFlexBasisComputation();
 
-    void markMarginAsTrimmed(MarginTrimType);
+    void markMarginAsTrimmed(Style::MarginTrim);
     void clearTrimmedMarginsMarkings();
-    bool hasTrimmedMargin(std::optional<MarginTrimType>) const;
+    bool hasTrimmedMargin(std::optional<Style::MarginTrim::Value>) const;
 
     LayoutSize offsetFromContainer(const RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
     
@@ -652,8 +652,8 @@ protected:
 
     void willBeDestroyed() override;
 
-    inline bool shouldTrimChildMargin(MarginTrimType, const RenderBox&) const;
-    virtual bool isChildEligibleForMarginTrim(MarginTrimType, const RenderBox&) const { return false; }
+    inline bool shouldTrimChildMargin(Style::MarginTrim::Value, const RenderBox&) const;
+    virtual bool isChildEligibleForMarginTrim(Style::MarginTrim::Value, const RenderBox&) const { return false; }
 
     virtual bool shouldResetLogicalHeightBeforeLayout() const;
     void resetLogicalHeightBeforeLayoutIfNeeded();
@@ -723,7 +723,7 @@ private:
 
     bool fixedElementLaysOutRelativeToFrame(const LocalFrameView&) const;
 
-    template<typename Function> LayoutUnit computeOrTrimInlineMargin(const RenderBlock& containingBlock, MarginTrimType marginSide, NOESCAPE const Function& computeInlineMargin) const;
+    template<typename Function> LayoutUnit computeOrTrimInlineMargin(const RenderBlock& containingBlock, Style::MarginTrim::Value marginSide, NOESCAPE const Function& computeInlineMargin) const;
 
     bool isScrollableOrRubberbandableBox() const override;
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -67,7 +67,7 @@ inline int RenderBox::scrollbarLogicalHeight() const { return writingMode().isHo
 inline int RenderBox::scrollbarLogicalWidth() const { return writingMode().isHorizontal() ? verticalScrollbarWidth() : horizontalScrollbarHeight(); }
 inline void RenderBox::setLogicalLocation(LayoutPoint location) { setLocation(writingMode().isHorizontal() ? location : location.transposedPoint()); }
 inline void RenderBox::setLogicalSize(LayoutSize size) { setSize(writingMode().isHorizontal() ? size : size.transposedSize()); }
-inline bool RenderBox::shouldTrimChildMargin(MarginTrimType type, const RenderBox& child) const { return style().marginTrim().contains(type) && isChildEligibleForMarginTrim(type, child); }
+inline bool RenderBox::shouldTrimChildMargin(Style::MarginTrim::Value marginTrim, const RenderBox& child) const { return style().marginTrim().contains(marginTrim) && isChildEligibleForMarginTrim(marginTrim, child); }
 inline bool RenderBox::stretchesToViewport() const { return document().inQuirksMode() && style().logicalHeight().isAuto() && !isFloatingOrOutOfFlowPositioned() && (isDocumentElementRenderer() || isBody()) && !shouldComputeLogicalHeightFromAspectRatio() && !isInline(); }
 inline bool RenderBox::isColumnSpanner() const { return style().columnSpan() == ColumnSpan::All; }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -871,16 +871,16 @@ void RenderFlexibleBox::initializeMarginTrimState()
     // these margins do not incorrectly constribute to the box's min/max width
     auto marginTrim = style().marginTrim();
     auto isRowsFlexbox = isHorizontalFlow();
-    if (auto flexItem = firstInFlowChildBox(); flexItem && marginTrim.contains(MarginTrimType::InlineStart))
+    if (auto flexItem = firstInFlowChildBox(); flexItem && marginTrim.contains(CSS::Keyword::InlineStart { }))
         isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineStart.add(*flexItem) : m_marginTrimItems.m_itemsOnFirstFlexLine.add(*flexItem);
-    if (auto flexItem = lastInFlowChildBox(); flexItem && marginTrim.contains(MarginTrimType::InlineEnd))
+    if (auto flexItem = lastInFlowChildBox(); flexItem && marginTrim.contains(CSS::Keyword::InlineEnd { }))
         isRowsFlexbox ? m_marginTrimItems.m_itemsAtFlexLineEnd.add(*flexItem) : m_marginTrimItems.m_itemsOnLastFlexLine.add(*flexItem);
 }
 
 bool RenderFlexibleBox::canFitItemWithTrimmedMarginEnd(const FlexLayoutItem& flexLayoutItem, LayoutUnit sumHypotheticalMainSize, LayoutUnit lineBreakLength) const
 {
     auto marginTrim = style().marginTrim();
-    if ((isHorizontalFlow() && marginTrim.contains(MarginTrimType::InlineEnd)) || (isColumnFlow() && marginTrim.contains(MarginTrimType::BlockEnd)))
+    if ((isHorizontalFlow() && marginTrim.contains(CSS::Keyword::InlineEnd { })) || (isColumnFlow() && marginTrim.contains(CSS::Keyword::BlockEnd { })))
         return sumHypotheticalMainSize + flexLayoutItem.hypotheticalMainAxisMarginBoxSize() - flowAwareMarginEndForFlexItem(flexLayoutItem.renderer) <= lineBreakLength;
     return false;
 }
@@ -924,45 +924,53 @@ LayoutUnit RenderFlexibleBox::crossAxisMarginExtentForFlexItem(const RenderBox& 
     return marginStart + marginEnd;
 }
 
-bool RenderFlexibleBox::isChildEligibleForMarginTrim(MarginTrimType marginTrimType, const RenderBox& flexItem) const
+bool RenderFlexibleBox::isChildEligibleForMarginTrim(Style::MarginTrim::Value marginTrim, const RenderBox& flexItem) const
 {
-    ASSERT(style().marginTrim().contains(marginTrimType));
-    auto isMarginParallelWithMainAxis = [this](MarginTrimType marginTrimType) {
-        if (isHorizontalFlow())
-            return marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::BlockEnd;
-        return marginTrimType == MarginTrimType::InlineStart || marginTrimType == MarginTrimType::InlineEnd;
+    ASSERT(style().marginTrim().contains(marginTrim));
+
+    auto isMarginParallelWithMainAxis = [&] {
+        return isHorizontalFlow()
+            ? Style::MarginTrim::blockTrims().contains(marginTrim)
+            : Style::MarginTrim::inlineTrims().contains(marginTrim);
     };
-    if (isMarginParallelWithMainAxis(marginTrimType))
-        return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsOnFirstFlexLine.contains(flexItem) : m_marginTrimItems.m_itemsOnLastFlexLine.contains(flexItem);
-    return (marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::InlineStart) ? m_marginTrimItems.m_itemsAtFlexLineStart.contains(flexItem) : m_marginTrimItems.m_itemsAtFlexLineEnd.contains(flexItem);
+
+    if (isMarginParallelWithMainAxis()) {
+        return Style::MarginTrim::startTrims().contains(marginTrim)
+            ? m_marginTrimItems.m_itemsOnFirstFlexLine.contains(flexItem)
+            : m_marginTrimItems.m_itemsOnLastFlexLine.contains(flexItem);
+    }
+
+    return Style::MarginTrim::startTrims().contains(marginTrim)
+        ? m_marginTrimItems.m_itemsAtFlexLineStart.contains(flexItem)
+        : m_marginTrimItems.m_itemsAtFlexLineEnd.contains(flexItem);
 }
 
 bool RenderFlexibleBox::shouldTrimMainAxisMarginStart() const
 {
     if (isHorizontalFlow())
-        return style().marginTrim().contains(MarginTrimType::InlineStart);
-    return style().marginTrim().contains(MarginTrimType::BlockStart);
+        return style().marginTrim().contains(CSS::Keyword::InlineStart { });
+    return style().marginTrim().contains(CSS::Keyword::BlockStart { });
 }
 
 bool RenderFlexibleBox::shouldTrimMainAxisMarginEnd() const
 {
     if (isHorizontalFlow())
-        return style().marginTrim().contains(MarginTrimType::InlineEnd);
-    return style().marginTrim().contains(MarginTrimType::BlockEnd);
+        return style().marginTrim().contains(CSS::Keyword::InlineEnd { });
+    return style().marginTrim().contains(CSS::Keyword::BlockEnd { });
 }
 
 bool RenderFlexibleBox::shouldTrimCrossAxisMarginStart() const
 {
     if (isHorizontalFlow())
-        return style().marginTrim().contains(MarginTrimType::BlockStart);
-    return style().marginTrim().contains(MarginTrimType::InlineStart);
+        return style().marginTrim().contains(CSS::Keyword::BlockStart { });
+    return style().marginTrim().contains(CSS::Keyword::InlineStart { });
 }
 
 bool RenderFlexibleBox::shouldTrimCrossAxisMarginEnd() const
 {
     if (isHorizontalFlow())
-        return style().marginTrim().contains(MarginTrimType::BlockEnd);
-    return style().marginTrim().contains(MarginTrimType::InlineEnd);
+        return style().marginTrim().contains(CSS::Keyword::BlockEnd { });
+    return style().marginTrim().contains(CSS::Keyword::InlineEnd { });
 }
 
 void RenderFlexibleBox::trimMainAxisMarginStart(const FlexLayoutItem& flexLayoutItem)
@@ -972,9 +980,9 @@ void RenderFlexibleBox::trimMainAxisMarginStart(const FlexLayoutItem& flexLayout
         ? flexLayoutItem.renderer->marginStart(writingMode())
         : flexLayoutItem.renderer->marginBefore(writingMode());
     if (horizontalFlow)
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::InlineStart);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::InlineStart { });
     else
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::BlockStart);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::BlockStart { });
     m_marginTrimItems.m_itemsAtFlexLineStart.add(flexLayoutItem.renderer);
 }
 
@@ -985,27 +993,27 @@ void RenderFlexibleBox::trimMainAxisMarginEnd(const FlexLayoutItem& flexLayoutIt
         ? flexLayoutItem.renderer->marginEnd(writingMode())
         : flexLayoutItem.renderer->marginAfter(writingMode());
     if (horizontalFlow)
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::InlineEnd);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::InlineEnd { });
     else
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::BlockEnd);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::BlockEnd { });
     m_marginTrimItems.m_itemsAtFlexLineEnd.add(flexLayoutItem.renderer);
 }
 
 void RenderFlexibleBox::trimCrossAxisMarginStart(const FlexLayoutItem& flexLayoutItem)
 {
     if (isHorizontalFlow())
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::BlockStart);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::BlockStart { });
     else
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::InlineStart);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::InlineStart { });
     m_marginTrimItems.m_itemsOnFirstFlexLine.add(flexLayoutItem.renderer);
 }
 
 void RenderFlexibleBox::trimCrossAxisMarginEnd(const FlexLayoutItem& flexLayoutItem)
 {
     if (isHorizontalFlow())
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::BlockEnd);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::BlockEnd { });
     else
-        setTrimmedMarginForChild(flexLayoutItem.renderer, MarginTrimType::InlineEnd);
+        setTrimmedMarginForChild(flexLayoutItem.renderer, CSS::Keyword::InlineEnd { });
     m_marginTrimItems.m_itemsOnLastFlexLine.add(flexLayoutItem.renderer);
 }
 
@@ -1796,7 +1804,7 @@ RenderFlexibleBox::FlexLayoutItem RenderFlexibleBox::constructFlexLayoutItem(Ren
     if (CheckedPtr flexibleBox = dynamicDowncast<RenderFlexibleBox>(flexItem))
         flexibleBox->resetHasDefiniteHeight();
 
-    if (everHadLayout && flexItem.hasTrimmedMargin(std::optional<MarginTrimType> { }))
+    if (everHadLayout && flexItem.hasTrimmedMargin({ }))
         flexItem.clearTrimmedMarginsMarkings();
     
     if (flexItem.shouldInvalidatePreferredWidths())

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -290,7 +290,7 @@ private:
     void trimMainAxisMarginEnd(const FlexLayoutItem&);
     void trimCrossAxisMarginStart(const FlexLayoutItem&);
     void trimCrossAxisMarginEnd(const FlexLayoutItem&);
-    bool isChildEligibleForMarginTrim(MarginTrimType, const RenderBox&) const final;
+    bool isChildEligibleForMarginTrim(Style::MarginTrim::Value, const RenderBox&) const final;
     bool canFitItemWithTrimmedMarginEnd(const FlexLayoutItem&, LayoutUnit sumHypotheticalMainSize, LayoutUnit lineBreakLength) const;
     void removeMarginEndFromFlexSizes(FlexLayoutItem&, LayoutUnit& sumFlexBaseSize, LayoutUnit& sumHypotheticalMainSize) const;
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1965,21 +1965,20 @@ void RenderGrid::updateAutoMarginsInColumnAxisIfNeeded(RenderBox& gridItem)
     }
 }
 
-bool RenderGrid::isChildEligibleForMarginTrim(MarginTrimType marginTrimType, const RenderBox& gridItem) const
+bool RenderGrid::isChildEligibleForMarginTrim(Style::MarginTrim::Value marginTrim, const RenderBox& gridItem) const
 {
-    ASSERT(style().marginTrim().contains(marginTrimType));
+    ASSERT(style().marginTrim().contains(marginTrim));
 
-    auto isTrimmingBlockDirection = marginTrimType == MarginTrimType::BlockStart || marginTrimType == MarginTrimType::BlockEnd;
+    auto isTrimmingBlockDirection = marginTrim == CSS::Keyword::BlockStart { } || marginTrim == CSS::Keyword::BlockEnd { };
     auto itemGridSpan = isTrimmingBlockDirection ? currentGrid().gridItemSpanIgnoringCollapsedTracks(gridItem, Style::GridTrackSizingDirection::Rows) : currentGrid().gridItemSpanIgnoringCollapsedTracks(gridItem, Style::GridTrackSizingDirection::Columns);
-    switch (marginTrimType) {
-    case MarginTrimType::BlockStart:
-    case MarginTrimType::InlineStart:
+
+    if (marginTrim == CSS::Keyword::BlockStart { } || marginTrim == CSS::Keyword::InlineStart { })
         return !itemGridSpan.startLine();
-    case MarginTrimType::BlockEnd:
+    if (marginTrim == CSS::Keyword::BlockEnd { })
         return itemGridSpan.endLine() == currentGrid().numTracks(Style::GridTrackSizingDirection::Rows);
-    case MarginTrimType::InlineEnd:
+    if (marginTrim == CSS::Keyword::InlineEnd { })
         return itemGridSpan.endLine() == currentGrid().numTracks(Style::GridTrackSizingDirection::Columns);
-    }
+
     ASSERT_NOT_REACHED();
     return false;
 }

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -266,7 +266,7 @@ private:
     void resetAutoMarginsAndLogicalTopInColumnAxis(RenderBox& child);
     void updateAutoMarginsInColumnAxisIfNeeded(RenderBox&);
     void updateAutoMarginsInRowAxisIfNeeded(RenderBox&);
-    bool isChildEligibleForMarginTrim(MarginTrimType, const RenderBox&) const final;
+    bool isChildEligibleForMarginTrim(Style::MarginTrim::Value, const RenderBox&) const final;
 
     std::optional<LayoutUnit> firstLineBaseline() const final;
     std::optional<LayoutUnit> lastLineBaseline() const final;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -30,6 +30,7 @@
 #include "PlatformLayerIdentifier.h"
 #include "RenderObjectEnums.h"
 #include "RenderStyleConstants.h"
+#include "StyleMarginTrim.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -1286,7 +1287,7 @@ private:
         bool hasOutlineAutoAncestor { false };
         // Dirty bit was set with MarkingBehavior::MarkOnlyThis
         bool preferredLogicalWidthsNeedUpdateIsMarkOnlyThis { false };
-        OptionSet<MarginTrimType> trimmedMargins;
+        Style::MarginTrim trimmedMargins;
 
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -49,15 +49,15 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
     auto decorationStyle = pseudoElementStyle->textDecorationStyle();
     auto decorations = pseudoElementStyle->textDecorationLineInEffect();
 
-    if (decorations.contains(TextDecorationLine::Underline)) {
+    if (decorations.contains(CSS::Keyword::Underline { })) {
         style.textDecorationStyles.underline.color = color;
         style.textDecorationStyles.underline.decorationStyle = decorationStyle;
     }
-    if (decorations.contains(TextDecorationLine::Overline)) {
+    if (decorations.contains(CSS::Keyword::Overline { })) {
         style.textDecorationStyles.overline.color = color;
         style.textDecorationStyles.overline.decorationStyle = decorationStyle;
     }
-    if (decorations.contains(TextDecorationLine::LineThrough)) {
+    if (decorations.contains(CSS::Keyword::LineThrough { })) {
         style.textDecorationStyles.linethrough.color = color;
         style.textDecorationStyles.linethrough.decorationStyle = decorationStyle;
     }
@@ -158,15 +158,15 @@ static TextDecorationPainter::Styles computeStylesForTextDecorations(const TextD
 
     auto textDecorationStyles = previousTextDecorationStyles;
 
-    if (textDecorations.contains(TextDecorationLine::Underline)) {
+    if (textDecorations.contains(CSS::Keyword::Underline { })) {
         textDecorationStyles.underline.color = currentTextDecorationStyles.underline.color;
         textDecorationStyles.underline.decorationStyle = currentTextDecorationStyles.underline.decorationStyle;
     }
-    if (textDecorations.contains(TextDecorationLine::Overline)) {
+    if (textDecorations.contains(CSS::Keyword::Overline { })) {
         textDecorationStyles.overline.color = currentTextDecorationStyles.overline.color;
         textDecorationStyles.overline.decorationStyle = currentTextDecorationStyles.overline.decorationStyle;
     }
-    if (textDecorations.contains(TextDecorationLine::LineThrough)) {
+    if (textDecorations.contains(CSS::Keyword::LineThrough { })) {
         textDecorationStyles.linethrough.color = currentTextDecorationStyles.linethrough.color;
         textDecorationStyles.linethrough.decorationStyle = currentTextDecorationStyles.linethrough.decorationStyle;
     }

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -577,7 +577,7 @@ static inline float computedLinethroughCenter(const RenderStyle& styleToUse, flo
     return center - textDecorationThickness / 2;
 }
 
-static inline OptionSet<TextDecorationLine> computedTextDecorationType(const RenderStyle& style, const TextDecorationPainter::Styles& textDecorationStyles)
+static inline Style::TextDecorationLine computedTextDecorationType(const RenderStyle& style, const TextDecorationPainter::Styles& textDecorationStyles)
 {
     auto textDecorations = style.textDecorationLineInEffect();
     textDecorations.add(TextDecorationPainter::textDecorationsInEffectForStyle(textDecorationStyles));
@@ -606,8 +606,8 @@ static inline bool isDecoratingBoxForBackground(const InlineIterator::InlineBox&
         // <font> and <a> are always considered decorating boxes.
         return true;
     }
-    return styleToUse.textDecorationLine().containsAny({ TextDecorationLine::Underline, TextDecorationLine::Overline })
-        || (inlineBox.isRootInlineBox() && styleToUse.textDecorationLineInEffect().containsAny({ TextDecorationLine::Underline, TextDecorationLine::Overline }));
+    return styleToUse.textDecorationLine().containsAny({ CSS::Keyword::Underline { }, CSS::Keyword::Overline { } })
+        || (inlineBox.isRootInlineBox() && styleToUse.textDecorationLineInEffect().containsAny({ CSS::Keyword::Underline { }, CSS::Keyword::Overline { } }));
 }
 
 void TextBoxPainter::collectDecoratingBoxesForBackgroundPainting(DecoratingBoxList& decoratingBoxList, const InlineIterator::TextBoxIterator& textBox, FloatPoint textBoxLocation, const TextDecorationPainter::Styles& overrideDecorationStyle)
@@ -679,7 +679,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
         auto computedBackgroundDecorationGeometry = [&] {
             auto textDecorationThickness = computedTextDecorationThickness(decoratingBox.style, m_document.deviceScaleFactor());
             auto underlineOffset = [&] {
-                if (!computedTextDecorationType.contains(TextDecorationLine::Underline))
+                if (!computedTextDecorationType.contains(CSS::Keyword::Underline { }))
                     return 0.f;
                 auto baseOffset = underlineOffsetForTextBoxPainting(*decoratingBox.inlineBox, decoratingBox.style);
                 auto wavyOffset = decoratingBox.textDecorationStyles.underline.decorationStyle == TextDecorationStyle::Wavy ? wavyOffsetFromDecoration() : 0.f;
@@ -687,7 +687,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
             };
             auto autoTextDecorationThickness = computedAutoTextDecorationThickness(decoratingBox.style, m_document.deviceScaleFactor());
             auto overlineOffset = [&] {
-                if (!computedTextDecorationType.contains(TextDecorationLine::Overline))
+                if (!computedTextDecorationType.contains(CSS::Keyword::Overline { }))
                     return 0.f;
                 auto baseOffset = overlineOffsetForTextBoxPainting(*decoratingBox.inlineBox, decoratingBox.style);
                 baseOffset += (autoTextDecorationThickness - textDecorationThickness);
@@ -733,7 +733,7 @@ void TextBoxPainter::paintForegroundDecorations(TextDecorationPainter& decoratio
         return textDecorations;
     }();
 
-    if (!computedTextDecorationType.contains(TextDecorationLine::LineThrough))
+    if (!computedTextDecorationType.contains(CSS::Keyword::LineThrough { }))
         return;
 
     if (m_isCombinedText)

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -152,16 +152,16 @@ TextDecorationPainter::TextDecorationPainter(GraphicsContext& context, const Fon
 }
 
 // Paint text-shadow, underline, overline
-void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style, const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, OptionSet<TextDecorationLine> decorationType, const Styles& decorationStyle)
+void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style, const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, Style::TextDecorationLine decorationType, const Styles& decorationStyle)
 {
-    auto paintDecoration = [&] (auto decoration, auto underlineStyle, auto& color, auto& rect) {
+    auto paintDecoration = [&](Style::TextDecorationLine decoration, auto underlineStyle, auto& color, auto& rect) {
         m_context.setStrokeColor(color);
 
         auto strokeStyle = textDecorationStyleToStrokeStyle(underlineStyle);
 
         if (underlineStyle == TextDecorationStyle::Wavy)
             strokeWavyTextDecoration(m_context, rect, decorationGeometry.wavyStrokeParameters);
-        else if (decoration == TextDecorationLine::Underline || decoration == TextDecorationLine::Overline) {
+        else if (decoration == CSS::Keyword::Underline { } || decoration == CSS::Keyword::Overline { }) {
             if ((style.textDecorationSkipInk() == TextDecorationSkipInk::Auto
                 || style.textDecorationSkipInk() == TextDecorationSkipInk::All)
                 && !m_writingMode.isVerticalTypographic()) {
@@ -184,9 +184,9 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
             ASSERT_NOT_REACHED();
     };
 
-    auto areLinesOpaque = !m_isPrinting && (!decorationType.contains(TextDecorationLine::Underline) || decorationStyle.underline.color.isOpaque())
-        && (!decorationType.contains(TextDecorationLine::Overline) || decorationStyle.overline.color.isOpaque())
-        && (!decorationType.contains(TextDecorationLine::LineThrough) || decorationStyle.linethrough.color.isOpaque());
+    auto areLinesOpaque = !m_isPrinting && (!decorationType.contains(CSS::Keyword::Underline { }) || decorationStyle.underline.color.isOpaque())
+        && (!decorationType.contains(CSS::Keyword::Overline { }) || decorationStyle.overline.color.isOpaque())
+        && (!decorationType.contains(CSS::Keyword::LineThrough { }) || decorationStyle.linethrough.color.isOpaque());
 
     float extraOffset = 0.f;
     auto boxOrigin = decorationGeometry.boxOrigin;
@@ -211,19 +211,19 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
     // These decorations should match the visual overflows computed in visualOverflowForDecorations().
     auto underlineRect = FloatRect { boxOrigin, FloatSize { decorationGeometry.textBoxWidth, decorationGeometry.textDecorationThickness } };
     auto overlineRect = underlineRect;
-    if (decorationType.contains(TextDecorationLine::Underline))
+    if (decorationType.contains(CSS::Keyword::Underline { }))
         underlineRect.move(0.f, decorationGeometry.underlineOffset);
-    if (decorationType.contains(TextDecorationLine::Overline))
+    if (decorationType.contains(CSS::Keyword::Overline { }))
         overlineRect.move(0.f, decorationGeometry.overlineOffset);
 
     auto draw = [&](const Style::TextShadow* shadow) {
-        if (decorationType.contains(TextDecorationLine::Underline) && !underlineRect.isEmpty())
-            paintDecoration(TextDecorationLine::Underline, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
-        if (decorationType.contains(TextDecorationLine::Overline) && !overlineRect.isEmpty())
-            paintDecoration(TextDecorationLine::Overline, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
+        if (decorationType.contains(CSS::Keyword::Underline { }) && !underlineRect.isEmpty())
+            paintDecoration(CSS::Keyword::Underline { }, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
+        if (decorationType.contains(CSS::Keyword::Overline { }) && !overlineRect.isEmpty())
+            paintDecoration(CSS::Keyword::Overline { }, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
         // We only want to paint the shadow, hence the transparent color, not the actual line-through,
         // which will be painted in paintForegroundDecorations().
-        if (shadow && decorationType.contains(TextDecorationLine::LineThrough))
+        if (shadow && decorationType.contains(CSS::Keyword::LineThrough { }))
             paintLineThrough({ boxOrigin, decorationGeometry.textBoxWidth, decorationGeometry.textDecorationThickness, decorationGeometry.linethroughCenter, decorationGeometry.wavyStrokeParameters }, Color::transparentBlack, decorationStyle);
     };
 
@@ -275,27 +275,27 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, OptionSet<TextDecorationLine> remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
 {
-    auto extractDecorations = [&] (const RenderStyle& style, OptionSet<TextDecorationLine> decorations) {
+    auto extractDecorations = [&] (const RenderStyle& style, Style::TextDecorationLine decorations) {
         if (decorations.isEmpty())
             return;
 
         auto color = TextDecorationPainter::decorationColor(style, paintBehavior);
         auto decorationStyle = style.textDecorationStyle();
 
-        if (decorations.contains(TextDecorationLine::Underline)) {
-            remainingDecorations.remove(TextDecorationLine::Underline);
+        if (decorations.contains(CSS::Keyword::Underline { })) {
+            remainingDecorations.remove(CSS::Keyword::Underline { });
             result.underline.color = color;
             result.underline.decorationStyle = decorationStyle;
         }
-        if (decorations.contains(TextDecorationLine::Overline)) {
-            remainingDecorations.remove(TextDecorationLine::Overline);
+        if (decorations.contains(CSS::Keyword::Overline { })) {
+            remainingDecorations.remove(CSS::Keyword::Overline { });
             result.overline.color = color;
             result.overline.decorationStyle = decorationStyle;
         }
-        if (decorations.contains(TextDecorationLine::LineThrough)) {
-            remainingDecorations.remove(TextDecorationLine::LineThrough);
+        if (decorations.contains(CSS::Keyword::LineThrough { })) {
+            remainingDecorations.remove(CSS::Keyword::LineThrough { });
             result.linethrough.color = color;
             result.linethrough.decorationStyle = decorationStyle;
         }
@@ -345,7 +345,7 @@ Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet
     return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
 {
     if (requestedDecorations.isEmpty())
         return { };
@@ -357,15 +357,15 @@ auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Opti
     return result;
 }
 
-OptionSet<TextDecorationLine> TextDecorationPainter::textDecorationsInEffectForStyle(const TextDecorationPainter::Styles& style)
+Style::TextDecorationLine TextDecorationPainter::textDecorationsInEffectForStyle(const TextDecorationPainter::Styles& style)
 {
-    OptionSet<TextDecorationLine> decorations;
+    Style::TextDecorationLine decorations;
     if (style.underline.color.isValid())
-        decorations.add(TextDecorationLine::Underline);
+        decorations.add(CSS::Keyword::Underline { });
     if (style.overline.color.isValid())
-        decorations.add(TextDecorationLine::Overline);
+        decorations.add(CSS::Keyword::Overline { });
     if (style.linethrough.color.isValid())
-        decorations.add(TextDecorationLine::LineThrough);
+        decorations.add(CSS::Keyword::LineThrough { });
     return decorations;
 }
 

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -36,7 +36,11 @@ class FontCascade;
 class RenderObject;
 class RenderStyle;
 class TextRun;
-    
+
+namespace Style {
+struct TextDecorationLine;
+}
+
 class TextDecorationPainter {
 public:
     TextDecorationPainter(GraphicsContext&, const FontCascade&, const Style::TextShadows&, const FilterOperations*, bool isPrinting, WritingMode);
@@ -63,7 +67,7 @@ public:
         float clippingOffset { 0.f };
         WavyStrokeParameters wavyStrokeParameters;
     };
-    void paintBackgroundDecorations(const RenderStyle&, const TextRun&, const BackgroundDecorationGeometry&, OptionSet<TextDecorationLine>, const Styles&);
+    void paintBackgroundDecorations(const RenderStyle&, const TextRun&, const BackgroundDecorationGeometry&, Style::TextDecorationLine, const Styles&);
 
     struct ForegroundDecorationGeometry {
         FloatPoint boxOrigin;
@@ -75,8 +79,8 @@ public:
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
     static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
-    static Styles stylesForRenderer(const RenderObject&, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
-    static OptionSet<TextDecorationLine> textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
+    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
+    static Style::TextDecorationLine textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:
     void paintLineThrough(const ForegroundDecorationGeometry&, const Color&, const Styles&);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -52,9 +52,11 @@
 #include "StyleExtractor.h"
 #include "StyleImage.h"
 #include "StyleInheritedData.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StyleResolver.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleSelfAlignmentData.h"
+#include "StyleTextDecorationLine.h"
 #include "StyleTextEdge.h"
 #include "StyleTreeResolver.h"
 #include "TransformOperationData.h"
@@ -109,7 +111,7 @@ static_assert(sizeof(RenderStyle) == sizeof(SameSizeAsRenderStyle), "RenderStyle
 
 static_assert(PublicPseudoIDBits == enumToUnderlyingType(PseudoId::FirstInternalPseudoId) - enumToUnderlyingType(PseudoId::FirstPublicPseudoId));
 
-static_assert(!(static_cast<unsigned>(maxTextDecorationLineValue) >> TextDecorationLineBits));
+static_assert(static_cast<unsigned>(Style::TextDecorationLine::bits) == TextDecorationLineBits);
 
 static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
 
@@ -3816,7 +3818,7 @@ void RenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonIn
     LOG_IF_DIFFERENT(usesContainerUnits);
     LOG_IF_DIFFERENT(useTreeCountingFunctions);
 
-    LOG_IF_DIFFERENT_WITH_CAST(TextDecorationLine, textDecorationLine);
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::TextDecorationLine, textDecorationLine);
 
     LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
     LOG_IF_DIFFERENT(disallowsFastPathInheritance);
@@ -3843,7 +3845,7 @@ void RenderStyle::InheritedFlags::dumpDifferences(TextStream& ts, const Inherite
     LOG_IF_DIFFERENT_WITH_CAST(TextWrapStyle, textWrapStyle);
 
     LOG_RAW_OPTIONSET_IF_DIFFERENT(TextTransform, textTransform);
-    LOG_RAW_OPTIONSET_IF_DIFFERENT(TextDecorationLine, textDecorationLineInEffect);
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::TextDecorationLine, textDecorationLineInEffect);
 
     LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
     LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -163,7 +163,6 @@ enum class LineCap : uint8_t;
 enum class LineJoin : uint8_t;
 enum class LineSnap : uint8_t;
 enum class ListStylePosition : bool;
-enum class MarginTrimType : uint8_t;
 enum class MarqueeBehavior : uint8_t;
 enum class MarqueeDirection : uint8_t;
 enum class MathStyle : bool;
@@ -183,7 +182,6 @@ enum class PaintOrder : uint8_t;
 enum class PaintType : uint8_t;
 enum class PointerEvents : uint8_t;
 enum class PositionType : uint8_t;
-enum class PositionVisibility : uint8_t;
 enum class PrintColorAdjust : bool;
 enum class PseudoId : uint32_t;
 enum class Resize : uint8_t;
@@ -203,7 +201,6 @@ enum class TextAlignLast : uint8_t;
 enum class TextAlignMode : uint8_t;
 enum class TextBoxTrim : uint8_t;
 enum class TextCombine : bool;
-enum class TextDecorationLine : uint8_t;
 enum class TextDecorationSkipInk : uint8_t;
 enum class TextDecorationStyle : uint8_t;
 enum class TextEmphasisPosition : uint8_t;
@@ -286,8 +283,10 @@ struct GridTemplateAreas;
 struct GridTemplateList;
 struct GridTrackSizes;
 struct InsetEdge;
+struct LineBoxContain;
 struct ListStyleType;
 struct MarginEdge;
+struct MarginTrim;
 struct MaximumSize;
 struct MinimumSize;
 struct OffsetAnchor;
@@ -298,6 +297,7 @@ struct OffsetRotate;
 struct PaddingEdge;
 struct Perspective;
 struct Position;
+struct PositionVisibility;
 struct PositionX;
 struct PositionY;
 struct PositionTryFallback;
@@ -314,6 +314,7 @@ struct ScrollPaddingEdge;
 struct ScrollTimelines;
 struct ScrollbarColor;
 struct ScrollbarGutter;
+struct TextDecorationLine;
 struct TextDecorationThickness;
 struct TextEmphasisStyle;
 struct TextIndent;
@@ -329,7 +330,6 @@ struct ViewTransitionName;
 
 enum class Change : uint8_t;
 enum class GridTrackSizingDirection : bool;
-enum class LineBoxContain : uint8_t;
 enum class PositionTryOrder : uint8_t;
 enum class ScrollBehavior : bool;
 enum class WebkitOverflowScrolling : bool;
@@ -681,8 +681,8 @@ public:
     inline TextAlignLast textAlignLast() const;
     inline TextGroupAlign textGroupAlign() const;
     inline OptionSet<TextTransform> textTransform() const;
-    inline OptionSet<TextDecorationLine> textDecorationLineInEffect() const;
-    inline OptionSet<TextDecorationLine> textDecorationLine() const;
+    inline Style::TextDecorationLine textDecorationLineInEffect() const;
+    inline Style::TextDecorationLine textDecorationLine() const;
     inline TextDecorationStyle textDecorationStyle() const;
     inline TextDecorationSkipInk textDecorationSkipInk() const;
     inline OptionSet<TextUnderlinePosition> textUnderlinePosition() const;
@@ -695,7 +695,7 @@ public:
     TextEdge textBoxEdge() const;
     TextEdge lineFitEdge() const;
 
-    inline OptionSet<MarginTrimType> marginTrim() const;
+    inline Style::MarginTrim marginTrim() const;
 
     const Length& computedLetterSpacing() const;
     const Length& computedWordSpacing() const;
@@ -1100,7 +1100,7 @@ public:
     inline const LengthSize& pageSize() const;
     inline PageSizeType pageSizeType() const;
 
-    inline OptionSet<Style::LineBoxContain> lineBoxContain() const;
+    inline Style::LineBoxContain lineBoxContain() const;
     inline const LineClampValue& lineClamp() const;
     inline const Style::BlockEllipsis& blockEllipsis() const;
     inline size_t maxLines() const;
@@ -1344,9 +1344,9 @@ public:
     void setTextAlign(TextAlignMode v) { m_inheritedFlags.textAlign = static_cast<unsigned>(v); }
     inline void setTextAlignLast(TextAlignLast);
     inline void setTextGroupAlign(TextGroupAlign);
-    inline void addToTextDecorationLineInEffect(OptionSet<TextDecorationLine>);
-    inline void setTextDecorationLineInEffect(OptionSet<TextDecorationLine>);
-    inline void setTextDecorationLine(OptionSet<TextDecorationLine>);
+    inline void addToTextDecorationLineInEffect(Style::TextDecorationLine);
+    inline void setTextDecorationLineInEffect(Style::TextDecorationLine);
+    inline void setTextDecorationLine(Style::TextDecorationLine);
     inline void setTextDecorationStyle(TextDecorationStyle);
     inline void setTextDecorationSkipInk(TextDecorationSkipInk);
     inline void setTextDecorationThickness(Style::TextDecorationThickness&&);
@@ -1365,7 +1365,7 @@ public:
     void setTextBoxEdge(TextEdge);
     void setLineFitEdge(TextEdge);
 
-    inline void setMarginTrim(OptionSet<MarginTrimType>);
+    inline void setMarginTrim(Style::MarginTrim);
 
 #if ENABLE(TEXT_AUTOSIZING)
     void setSpecifiedLineHeight(Length&&);
@@ -1650,7 +1650,7 @@ public:
     inline void setPageSizeType(PageSizeType);
     inline void resetPageSizeType();
 
-    inline void setLineBoxContain(OptionSet<Style::LineBoxContain>);
+    inline void setLineBoxContain(Style::LineBoxContain);
     inline void setLineClamp(LineClampValue);
     
     inline void setMaxLines(size_t);
@@ -1981,7 +1981,7 @@ public:
     static inline Style::InsetEdge initialInset();
     static inline Length initialRadius();
     static inline Style::MarginEdge initialMargin();
-    static constexpr OptionSet<MarginTrimType> initialMarginTrim();
+    static constexpr Style::MarginTrim initialMarginTrim();
     static inline Style::PaddingEdge initialPadding();
     static inline Style::TextIndent initialTextIndent();
     static constexpr TextBoxTrim initialTextBoxTrim();
@@ -1996,7 +1996,7 @@ public:
     static constexpr TextAlignMode initialTextAlign();
     static constexpr TextAlignLast initialTextAlignLast();
     static constexpr TextGroupAlign initialTextGroupAlign();
-    static constexpr OptionSet<TextDecorationLine> initialTextDecorationLine();
+    static constexpr Style::TextDecorationLine initialTextDecorationLine();
     static constexpr TextDecorationStyle initialTextDecorationStyle();
     static constexpr TextDecorationSkipInk initialTextDecorationSkipInk();
     static constexpr OptionSet<TextUnderlinePosition> initialTextUnderlinePosition();
@@ -2095,7 +2095,7 @@ public:
     static constexpr RubyPosition initialRubyPosition();
     static constexpr RubyAlign initialRubyAlign();
     static constexpr RubyOverhang initialRubyOverhang();
-    static constexpr OptionSet<Style::LineBoxContain> initialLineBoxContain();
+    static constexpr Style::LineBoxContain initialLineBoxContain();
     static constexpr ImageOrientation initialImageOrientation();
     static constexpr ImageRendering initialImageRendering();
     static StyleImage* initialBorderImageSource() { return nullptr; }
@@ -2328,9 +2328,9 @@ public:
     const FixedVector<Style::PositionTryFallback>& positionTryFallbacks() const;
     void setPositionTryFallbacks(FixedVector<Style::PositionTryFallback>&&);
 
-    static constexpr OptionSet<PositionVisibility> initialPositionVisibility();
-    inline OptionSet<PositionVisibility> positionVisibility() const;
-    inline void setPositionVisibility(OptionSet<PositionVisibility>);
+    static constexpr Style::PositionVisibility initialPositionVisibility();
+    inline Style::PositionVisibility positionVisibility() const;
+    inline void setPositionVisibility(Style::PositionVisibility);
 
     inline bool insideDefaultButton() const;
     inline void setInsideDefaultButton(bool);

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -776,17 +776,6 @@ TextStream& operator<<(TextStream& ts, ListStylePosition position)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, MarginTrimType marginTrimType)
-{
-    switch (marginTrimType) {
-    case MarginTrimType::BlockStart: ts << "block-start"_s; break;
-    case MarginTrimType::BlockEnd: ts << "block-end"_s; break;
-    case MarginTrimType::InlineStart: ts << "inline-start"_s; break;
-    case MarginTrimType::InlineEnd: ts << "inline-end"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, MarqueeBehavior marqueeBehavior)
 {
     switch (marqueeBehavior) {
@@ -1176,17 +1165,6 @@ TextStream& operator<<(TextStream& ts, TextCombine textCombine)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextDecorationLine line)
-{
-    switch (line) {
-    case TextDecorationLine::Underline: ts << "underline"_s; break;
-    case TextDecorationLine::Overline: ts << "overline"_s; break;
-    case TextDecorationLine::LineThrough: ts << "line-through"_s; break;
-    case TextDecorationLine::Blink: ts << "blink"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, TextDecorationSkipInk skip)
 {
     switch (skip) {
@@ -1512,16 +1490,6 @@ TextStream& operator<<(TextStream& ts, OverflowContinue overflowContinue)
     case OverflowContinue::Discard:
         ts << "discard"_s;
         break;
-    }
-    return ts;
-}
-
-TextStream& operator<<(TextStream& ts, PositionVisibility positionVisibility)
-{
-    switch (positionVisibility) {
-    case PositionVisibility::AnchorsValid: ts << "anchors-valid"; break;
-    case PositionVisibility::AnchorsVisible: ts << "anchors-visible"; break;
-    case PositionVisibility::NoOverflow: ts << "no-overflow"; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -666,14 +666,6 @@ enum class TextTransform : uint8_t {
 };
 constexpr auto maxTextTransformValue = TextTransform::FullWidth;
 
-enum class TextDecorationLine : uint8_t {
-    Underline     = 1 << 0,
-    Overline      = 1 << 1,
-    LineThrough   = 1 << 2,
-    Blink         = 1 << 3,
-};
-constexpr auto maxTextDecorationLineValue = TextDecorationLine::Blink;
-
 enum class TextDecorationStyle : uint8_t {
     Solid,
     Double,
@@ -719,13 +711,6 @@ enum class TextBoxTrim : uint8_t {
     TrimStart,
     TrimEnd,
     TrimBoth
-};
-
-enum class MarginTrimType : uint8_t {
-    BlockStart = 1 << 0,
-    BlockEnd = 1 << 1,
-    InlineStart = 1 << 2,
-    InlineEnd = 1 << 3
 };
 
 enum class TextEdgeType : uint8_t {
@@ -1233,12 +1218,6 @@ enum class FieldSizing : bool {
     Content
 };
 
-enum class PositionVisibility : uint8_t {
-    AnchorsValid   = 1 << 0,
-    AnchorsVisible = 1 << 1,
-    NoOverflow     = 1 << 2
-};
-
 CSSBoxType transformBoxToCSSBoxType(TransformBox);
 
 constexpr float defaultMiterLimit = 4;
@@ -1304,7 +1283,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, LineAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, LineBreak);
 WTF::TextStream& operator<<(WTF::TextStream&, LineSnap);
 WTF::TextStream& operator<<(WTF::TextStream&, ListStylePosition);
-WTF::TextStream& operator<<(WTF::TextStream&, MarginTrimType);
 WTF::TextStream& operator<<(WTF::TextStream&, MarqueeBehavior);
 WTF::TextStream& operator<<(WTF::TextStream&, MarqueeDirection);
 WTF::TextStream& operator<<(WTF::TextStream&, MaskMode);
@@ -1318,7 +1296,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, OverflowWrap);
 WTF::TextStream& operator<<(WTF::TextStream&, PaintOrder);
 WTF::TextStream& operator<<(WTF::TextStream&, PointerEvents);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionType);
-WTF::TextStream& operator<<(WTF::TextStream&, PositionVisibility);
 WTF::TextStream& operator<<(WTF::TextStream&, PrintColorAdjust);
 WTF::TextStream& operator<<(WTF::TextStream&, PseudoId);
 WTF::TextStream& operator<<(WTF::TextStream&, QuoteType);
@@ -1338,7 +1315,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignLast);
 WTF::TextStream& operator<<(WTF::TextStream&, TextCombine);
-WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationLine);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationSkipInk);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisFill);

--- a/Source/WebCore/rendering/style/RenderStyleDifference.h
+++ b/Source/WebCore/rendering/style/RenderStyleDifference.h
@@ -42,6 +42,9 @@ namespace WebCore {
 #define LOG_IF_DIFFERENT_WITH_CAST(type, name) \
     do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), static_cast<type>(name), static_cast<type>(other.name)); } while (0)
 
+#define LOG_IF_DIFFERENT_WITH_CONSTRUCTION(type, name) \
+    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), type(name), type(other.name)); } while (0)
+
 #define LOG_RAW_OPTIONSET_IF_DIFFERENT(type, name) \
     do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), OptionSet<type>::fromRaw(name), OptionSet<type>::fromRaw(other.name)); } while (0)
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -47,7 +47,6 @@
 #include "StyleGridItemData.h"
 #include "StyleGridTrackSizingDirection.h"
 #include "StyleInheritedData.h"
-#include "StyleLineBoxContain.h"
 #include "StyleMarqueeData.h"
 #include "StyleMiscNonInheritedData.h"
 #include "StyleMultiColData.h"
@@ -55,6 +54,7 @@
 #include "StyleRareInheritedData.h"
 #include "StyleRareNonInheritedData.h"
 #include "StyleSurroundData.h"
+#include "StyleTextDecorationLine.h"
 #include "StyleTransformData.h"
 #include "StyleVisitedLinkColorData.h"
 #include "UnicodeBidi.h"
@@ -413,7 +413,7 @@ inline const IntSize& RenderStyle::initialLetter() const { return m_nonInherited
 inline int RenderStyle::initialLetterDrop() const { return initialLetter().width(); }
 inline int RenderStyle::initialLetterHeight() const { return initialLetter().height(); }
 constexpr LineAlign RenderStyle::initialLineAlign() { return LineAlign::None; }
-constexpr OptionSet<Style::LineBoxContain> RenderStyle::initialLineBoxContain() { return { Style::LineBoxContain::Block, Style::LineBoxContain::Inline, Style::LineBoxContain::Replaced }; }
+constexpr Style::LineBoxContain RenderStyle::initialLineBoxContain() { return { CSS::Keyword::Block { }, CSS::Keyword::Inline { }, CSS::Keyword::Replaced { } }; }
 constexpr LineBreak RenderStyle::initialLineBreak() { return LineBreak::Auto; }
 constexpr LineClampValue RenderStyle::initialLineClamp() { return { }; }
 inline const AtomString& RenderStyle::initialLineGrid() { return nullAtom(); }
@@ -421,7 +421,7 @@ constexpr LineSnap RenderStyle::initialLineSnap() { return LineSnap::None; }
 constexpr ListStylePosition RenderStyle::initialListStylePosition() { return ListStylePosition::Outside; }
 inline Style::ListStyleType RenderStyle::initialListStyleType() { return CSS::Keyword::Disc { }; }
 inline Style::MarginEdge RenderStyle::initialMargin() { return 0_css_px; }
-constexpr OptionSet<MarginTrimType> RenderStyle::initialMarginTrim() { return { }; }
+constexpr Style::MarginTrim RenderStyle::initialMarginTrim() { return CSS::Keyword::None { }; }
 constexpr MarqueeBehavior RenderStyle::initialMarqueeBehavior() { return MarqueeBehavior::Scroll; }
 constexpr MarqueeDirection RenderStyle::initialMarqueeDirection() { return MarqueeDirection::Auto; }
 inline Length RenderStyle::initialMarqueeIncrement() { return { 6, LengthType::Fixed }; }
@@ -456,7 +456,7 @@ inline std::optional<Style::ScopedName> RenderStyle::initialPositionAnchor() { r
 inline std::optional<PositionArea> RenderStyle::initialPositionArea() { return { }; }
 inline FixedVector<Style::PositionTryFallback> RenderStyle::initialPositionTryFallbacks() { return { }; }
 constexpr Style::PositionTryOrder RenderStyle::initialPositionTryOrder() { return Style::PositionTryOrder::Normal; }
-constexpr OptionSet<PositionVisibility> RenderStyle::initialPositionVisibility() { return PositionVisibility::AnchorsVisible; }
+constexpr Style::PositionVisibility RenderStyle::initialPositionVisibility() { return CSS::Keyword::AnchorsVisible { }; }
 constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
 inline Style::Quotes RenderStyle::initialQuotes() { return CSS::Keyword::Auto { }; }
 constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
@@ -488,7 +488,7 @@ constexpr TextAlignLast RenderStyle::initialTextAlignLast() { return TextAlignLa
 constexpr TextBoxTrim RenderStyle::initialTextBoxTrim() { return TextBoxTrim::None; }
 constexpr TextCombine RenderStyle::initialTextCombine() { return TextCombine::None; }
 inline Style::Color RenderStyle::initialTextDecorationColor() { return Style::Color::currentColor(); }
-constexpr OptionSet<TextDecorationLine> RenderStyle::initialTextDecorationLine() { return { }; }
+constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
 constexpr TextDecorationSkipInk RenderStyle::initialTextDecorationSkipInk() { return TextDecorationSkipInk::Auto; }
 constexpr TextDecorationStyle RenderStyle::initialTextDecorationStyle() { return TextDecorationStyle::Solid; }
 inline Style::TextDecorationThickness RenderStyle::initialTextDecorationThickness() { return CSS::Keyword::Auto { }; }
@@ -574,7 +574,7 @@ inline const Style::InsetEdge& RenderStyle::left() const { return m_nonInherited
 inline float RenderStyle::letterSpacing() const { return m_inheritedData->fontData->fontCascade.letterSpacing(); }
 inline const FontCascade& RenderStyle::fontCascade() const { return m_inheritedData->fontData->fontCascade; }
 inline LineAlign RenderStyle::lineAlign() const { return static_cast<LineAlign>(m_rareInheritedData->lineAlign); }
-inline OptionSet<Style::LineBoxContain> RenderStyle::lineBoxContain() const { return OptionSet<Style::LineBoxContain>::fromRaw(m_rareInheritedData->lineBoxContain); }
+inline Style::LineBoxContain RenderStyle::lineBoxContain() const { return Style::LineBoxContain::fromRaw( m_rareInheritedData->lineBoxContain); }
 inline LineBreak RenderStyle::lineBreak() const { return static_cast<LineBreak>(m_rareInheritedData->lineBreak); }
 inline const LineClampValue& RenderStyle::lineClamp() const { return m_nonInheritedData->rareData->lineClamp; }
 inline const AtomString& RenderStyle::lineGrid() const { return m_rareInheritedData->lineGrid; }
@@ -609,7 +609,7 @@ inline const Style::MarginEdge& RenderStyle::marginRight() const { return m_nonI
 inline const Style::MarginEdge& RenderStyle::marginStart() const { return marginStart(writingMode()); }
 inline const Style::MarginEdge& RenderStyle::marginStart(const WritingMode writingMode) const { return m_nonInheritedData->surroundData->margin.start(writingMode); }
 inline const Style::MarginEdge& RenderStyle::marginTop() const { return m_nonInheritedData->surroundData->margin.top(); }
-inline OptionSet<MarginTrimType> RenderStyle::marginTrim() const { return m_nonInheritedData->rareData->marginTrim; }
+inline Style::MarginTrim RenderStyle::marginTrim() const { return Style::MarginTrim(m_nonInheritedData->rareData->marginTrim); }
 inline MarqueeBehavior RenderStyle::marqueeBehavior() const { return static_cast<MarqueeBehavior>(m_nonInheritedData->rareData->marquee->behavior); }
 inline MarqueeDirection RenderStyle::marqueeDirection() const { return static_cast<MarqueeDirection>(m_nonInheritedData->rareData->marquee->direction); }
 inline const Length& RenderStyle::marqueeIncrement() const { return m_nonInheritedData->rareData->marquee->increment; }
@@ -682,7 +682,7 @@ inline const Style::PerspectiveOriginY& RenderStyle::perspectiveOriginY() const 
 inline const std::optional<Style::ScopedName>& RenderStyle::positionAnchor() const { return m_nonInheritedData->rareData->positionAnchor; }
 inline std::optional<PositionArea> RenderStyle::positionArea() const { return m_nonInheritedData->rareData->positionArea; }
 inline Style::PositionTryOrder RenderStyle::positionTryOrder() const { return static_cast<Style::PositionTryOrder>(m_nonInheritedData->rareData->positionTryOrder); }
-inline OptionSet<PositionVisibility> RenderStyle::positionVisibility() const { return OptionSet<PositionVisibility>::fromRaw(m_nonInheritedData->rareData->positionVisibility); }
+inline Style::PositionVisibility RenderStyle::positionVisibility() const { return Style::PositionVisibility(m_nonInheritedData->rareData->positionVisibility); }
 inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpaceCollapse()); }
 inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
 inline const Style::Quotes& RenderStyle::quotes() const { return m_rareInheritedData->quotes; }
@@ -727,11 +727,11 @@ inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<Tex
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }
 inline TextCombine RenderStyle::textCombine() const { return static_cast<TextCombine>(m_rareInheritedData->textCombine); }
 inline const Style::Color& RenderStyle::textDecorationColor() const { return m_nonInheritedData->rareData->textDecorationColor; }
-inline OptionSet<TextDecorationLine> RenderStyle::textDecorationLine() const { return OptionSet<TextDecorationLine>::fromRaw(m_nonInheritedFlags.textDecorationLine); }
+inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return Style::TextDecorationLine(m_nonInheritedFlags.textDecorationLine); }
+inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return Style::TextDecorationLine(m_inheritedFlags.textDecorationLineInEffect); }
 inline TextDecorationSkipInk RenderStyle::textDecorationSkipInk() const { return static_cast<TextDecorationSkipInk>(m_rareInheritedData->textDecorationSkipInk); }
 inline TextDecorationStyle RenderStyle::textDecorationStyle() const { return static_cast<TextDecorationStyle>(m_nonInheritedData->rareData->textDecorationStyle); }
 inline const Style::TextDecorationThickness& RenderStyle::textDecorationThickness() const { return m_nonInheritedData->rareData->textDecorationThickness; }
-inline OptionSet<TextDecorationLine> RenderStyle::textDecorationLineInEffect() const { return OptionSet<TextDecorationLine>::fromRaw(m_inheritedFlags.textDecorationLineInEffect); }
 inline const Style::Color& RenderStyle::textEmphasisColor() const { return m_rareInheritedData->textEmphasisColor; }
 inline const Style::TextEmphasisStyle& RenderStyle::textEmphasisStyle() const { return m_rareInheritedData->textEmphasisStyle; }
 inline OptionSet<TextEmphasisPosition> RenderStyle::textEmphasisPosition() const { return OptionSet<TextEmphasisPosition>::fromRaw(m_rareInheritedData->textEmphasisPosition); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -46,7 +46,7 @@ namespace WebCore {
 
 template<typename T, typename U> inline bool compareEqual(const T& a, const U& b) { return a == b; }
 
-inline void RenderStyle::addToTextDecorationLineInEffect(OptionSet<TextDecorationLine> value) { m_inheritedFlags.textDecorationLineInEffect |= static_cast<unsigned>(value.toRaw()); }
+inline void RenderStyle::addToTextDecorationLineInEffect(Style::TextDecorationLine value) { m_inheritedFlags.textDecorationLineInEffect |= static_cast<unsigned>(value.toRaw()); }
 inline void RenderStyle::clearAnimations() { m_nonInheritedData.access().miscData.access().animations = nullptr; }
 inline void RenderStyle::clearBackgroundLayers() { m_nonInheritedData.access().backgroundData.access().background = FillLayer::create(FillLayerType::Background); }
 inline void RenderStyle::clearMaskLayers() { m_nonInheritedData.access().miscData.access().mask = FillLayer::create(FillLayerType::Mask); }
@@ -205,7 +205,7 @@ inline void RenderStyle::setJustifySelf(const StyleSelfAlignmentData& data) { SE
 inline void RenderStyle::setJustifySelfPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().justifySelf.setPosition(position); }
 inline void RenderStyle::setLeft(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.left(), WTFMove(edge)); }
 inline void RenderStyle::setLineAlign(LineAlign alignment) { SET(m_rareInheritedData, lineAlign, static_cast<unsigned>(alignment)); }
-inline void RenderStyle::setLineBoxContain(OptionSet<Style::LineBoxContain> c) { SET(m_rareInheritedData, lineBoxContain, c.toRaw()); }
+inline void RenderStyle::setLineBoxContain(Style::LineBoxContain c) { SET(m_rareInheritedData, lineBoxContain, c.toRaw()); }
 inline void RenderStyle::setLineBreak(LineBreak rule) { SET(m_rareInheritedData, lineBreak, static_cast<unsigned>(rule)); }
 inline void RenderStyle::setLineClamp(LineClampValue value) { SET_NESTED(m_nonInheritedData, rareData, lineClamp, value); }
 inline void RenderStyle::setLineGrid(const AtomString& name) { SET(m_rareInheritedData, lineGrid, name); }
@@ -216,7 +216,7 @@ inline void RenderStyle::setMarginBox(Style::MarginBox&& box) { SET_NESTED(m_non
 inline void RenderStyle::setMarginLeft(Style::MarginEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, margin.left(), WTFMove(edge)); }
 inline void RenderStyle::setMarginRight(Style::MarginEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, margin.right(), WTFMove(edge)); }
 inline void RenderStyle::setMarginTop(Style::MarginEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, margin.top(), WTFMove(edge)); }
-inline void RenderStyle::setMarginTrim(OptionSet<MarginTrimType> value) { SET_NESTED(m_nonInheritedData, rareData, marginTrim, value); }
+inline void RenderStyle::setMarginTrim(Style::MarginTrim value) { SET_NESTED(m_nonInheritedData, rareData, marginTrim, value.toRaw()); }
 inline void RenderStyle::setMarqueeBehavior(MarqueeBehavior b) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, behavior, static_cast<unsigned>(b)); }
 inline void RenderStyle::setMarqueeDirection(MarqueeDirection d) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, direction, static_cast<unsigned>(d)); }
 inline void RenderStyle::setMarqueeIncrement(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, marquee, increment, WTFMove(length)); }
@@ -264,7 +264,7 @@ inline void RenderStyle::setPerspectiveOriginY(Style::PerspectiveOriginY&& origi
 inline void RenderStyle::setPositionAnchor(const std::optional<Style::ScopedName>& anchor) { SET_NESTED(m_nonInheritedData, rareData, positionAnchor, anchor); }
 inline void RenderStyle::setPositionArea(std::optional<PositionArea> value) { SET_NESTED(m_nonInheritedData, rareData, positionArea, value); }
 inline void RenderStyle::setPositionTryOrder(Style::PositionTryOrder order) { SET_NESTED(m_nonInheritedData, rareData, positionTryOrder, static_cast<unsigned>(order)); }
-inline void RenderStyle::setPositionVisibility(OptionSet<PositionVisibility> value) { SET_NESTED(m_nonInheritedData, rareData, positionVisibility, value.toRaw()); }
+inline void RenderStyle::setPositionVisibility(Style::PositionVisibility value) { SET_NESTED(m_nonInheritedData, rareData, positionVisibility, value.toRaw()); }
 inline void RenderStyle::setResize(Resize r) { SET_NESTED(m_nonInheritedData, miscData, resize, static_cast<unsigned>(r)); }
 inline void RenderStyle::setRight(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.right(), WTFMove(edge)); }
 inline void RenderStyle::setRotate(Style::Rotate&& rotate) { SET_NESTED(m_nonInheritedData, rareData, rotate, WTFMove(rotate)); }
@@ -295,11 +295,11 @@ inline void RenderStyle::setTextAlignLast(TextAlignLast value) { SET(m_rareInher
 inline void RenderStyle::setTextBoxTrim(TextBoxTrim value) { SET_NESTED(m_nonInheritedData, rareData, textBoxTrim, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextCombine(TextCombine value) { SET(m_rareInheritedData, textCombine, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, rareData, textDecorationColor, WTFMove(color)); }
-inline void RenderStyle::setTextDecorationLine(OptionSet<TextDecorationLine> value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }
+inline void RenderStyle::setTextDecorationLine(Style::TextDecorationLine value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }
+inline void RenderStyle::setTextDecorationLineInEffect(Style::TextDecorationLine value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
 inline void RenderStyle::setTextDecorationSkipInk(TextDecorationSkipInk skipInk) { SET(m_rareInheritedData, textDecorationSkipInk, static_cast<unsigned>(skipInk)); }
 inline void RenderStyle::setTextDecorationStyle(TextDecorationStyle value) { SET_NESTED(m_nonInheritedData, rareData, textDecorationStyle, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationThickness(Style::TextDecorationThickness&& textDecorationThickness) { SET_NESTED(m_nonInheritedData, rareData, textDecorationThickness, WTFMove(textDecorationThickness)); }
-inline void RenderStyle::setTextDecorationLineInEffect(OptionSet<TextDecorationLine> value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
 inline void RenderStyle::setTextEmphasisColor(Style::Color&& c) { SET(m_rareInheritedData, textEmphasisColor, WTFMove(c)); }
 inline void RenderStyle::setTextEmphasisStyle(Style::TextEmphasisStyle&& style) { SET(m_rareInheritedData, textEmphasisStyle, style); }
 inline void RenderStyle::setTextEmphasisPosition(OptionSet<TextEmphasisPosition> position) { SET(m_rareInheritedData, textEmphasisPosition, static_cast<unsigned>(position.toRaw())); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -29,6 +29,7 @@
 #include "RenderStyleDifference.h"
 #include "StyleFilterData.h"
 #include "StyleImage.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/PointerComparison.h>
 
@@ -460,7 +461,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(TextEmphasisPosition, textEmphasisPosition);
     LOG_IF_DIFFERENT_WITH_CAST(TextUnderlinePosition, textUnderlinePosition);
 
-    LOG_RAW_OPTIONSET_IF_DIFFERENT(Style::LineBoxContain, lineBoxContain);
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::LineBoxContain, lineBoxContain);
 
     LOG_IF_DIFFERENT_WITH_CAST(ImageOrientation, imageOrientation);
     LOG_IF_DIFFERENT_WITH_CAST(ImageRendering, imageRendering);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -30,8 +30,8 @@
 #include "StyleBlockEllipsis.h"
 #include "StyleColor.h"
 #include "StyleCustomPropertyData.h"
-#include "StyleLineBoxContain.h"
 #include "StyleDynamicRangeLimit.h"
+#include "StyleLineBoxContain.h"
 #include "StyleListStyleType.h"
 #include "StyleQuotes.h"
 #include "StyleScrollbarColor.h"
@@ -147,7 +147,7 @@ public:
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
     PREFERRED_TYPE(TextEmphasisPosition) unsigned textEmphasisPosition : 4;
     PREFERRED_TYPE(TextUnderlinePosition) unsigned textUnderlinePosition : 4;
-    PREFERRED_TYPE(OptionSet<Style::LineBoxContain>) unsigned lineBoxContain: 7;
+    PREFERRED_TYPE(Style::LineBoxContain) unsigned lineBoxContain: Style::LineBoxContain::bits;
     PREFERRED_TYPE(ImageOrientation) unsigned imageOrientation : 1;
     PREFERRED_TYPE(ImageRendering) unsigned imageRendering : 3;
     PREFERRED_TYPE(LineSnap) unsigned lineSnap : 2;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -29,6 +29,7 @@
 #include "RotateTransformOperation.h"
 #include "ScaleTransformOperation.h"
 #include "StyleImage.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include "StyleReflection.h"
 #include "StyleResolver.h"
@@ -49,7 +50,6 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , maxLines(RenderStyle::initialMaxLines())
     , overflowContinue(RenderStyle::initialOverflowContinue())
     , touchActions(RenderStyle::initialTouchActions())
-    , marginTrim(RenderStyle::initialMarginTrim())
     , contain(RenderStyle::initialContainment())
     , initialLetter(RenderStyle::initialInitialLetter())
     , marquee(StyleMarqueeData::create())
@@ -143,6 +143,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , usesAnchorFunctions(false)
     , anchorFunctionScrollCompensatedAxes(0)
     , isPopoverInvoker(false)
+    , marginTrim(RenderStyle::initialMarginTrim().toRaw())
 {
 }
 
@@ -155,7 +156,6 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , maxLines(o.maxLines)
     , overflowContinue(o.overflowContinue)
     , touchActions(o.touchActions)
-    , marginTrim(o.marginTrim)
     , contain(o.contain)
     , initialLetter(o.initialLetter)
     , marquee(o.marquee)
@@ -249,6 +249,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , usesAnchorFunctions(o.usesAnchorFunctions)
     , anchorFunctionScrollCompensatedAxes(o.anchorFunctionScrollCompensatedAxes)
     , isPopoverInvoker(o.isPopoverInvoker)
+    , marginTrim(o.marginTrim)
 {
 }
 
@@ -268,7 +269,6 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && maxLines == o.maxLines
         && overflowContinue == o.overflowContinue
         && touchActions == o.touchActions
-        && marginTrim == o.marginTrim
         && contain == o.contain
         && initialLetter == o.initialLetter
         && marquee == o.marquee
@@ -361,7 +361,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollbarWidth == o.scrollbarWidth
         && usesAnchorFunctions == o.usesAnchorFunctions
         && anchorFunctionScrollCompensatedAxes == o.anchorFunctionScrollCompensatedAxes
-        && isPopoverInvoker == o.isPopoverInvoker;
+        && isPopoverInvoker == o.isPopoverInvoker
+        && marginTrim == o.marginTrim;
 }
 
 OptionSet<Containment> StyleRareNonInheritedData::usedContain() const
@@ -406,7 +407,6 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT(overflowContinue);
 
     LOG_IF_DIFFERENT(touchActions);
-    LOG_IF_DIFFERENT(marginTrim);
     LOG_IF_DIFFERENT(contain);
 
     LOG_IF_DIFFERENT(initialLetter);
@@ -536,6 +536,8 @@ void StyleRareNonInheritedData::dumpDifferences(TextStream& ts, const StyleRareN
     LOG_IF_DIFFERENT_WITH_CAST(bool, usesAnchorFunctions);
     LOG_IF_DIFFERENT_WITH_CAST(bool, anchorFunctionScrollCompensatedAxes);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isPopoverInvoker);
+
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::MarginTrim, marginTrim);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -44,6 +44,7 @@
 #include "StyleContainerName.h"
 #include "StyleContentAlignmentData.h"
 #include "StyleGapGutter.h"
+#include "StyleMarginTrim.h"
 #include "StyleOffsetAnchor.h"
 #include "StyleOffsetDistance.h"
 #include "StyleOffsetPath.h"
@@ -51,6 +52,7 @@
 #include "StyleOffsetRotate.h"
 #include "StylePerspective.h"
 #include "StylePerspectiveOrigin.h"
+#include "StylePositionVisibility.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StyleProgressTimelineAxes.h"
 #include "StyleProgressTimelineName.h"
@@ -150,7 +152,6 @@ public:
     OverflowContinue overflowContinue { OverflowContinue::Auto };
 
     OptionSet<TouchAction> touchActions;
-    OptionSet<MarginTrimType> marginTrim;
     OptionSet<Containment> contain;
 
     IntSize initialLetter;
@@ -267,7 +268,7 @@ public:
     PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
     PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
     PREFERRED_TYPE(Style::PositionTryOrder) unsigned positionTryOrder : 3;
-    PREFERRED_TYPE(OptionSet<PositionVisibility>) unsigned positionVisibility : 3;
+    PREFERRED_TYPE(Style::PositionVisibility) unsigned positionVisibility : Style::PositionVisibility::bits;
     PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
     PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
 #if HAVE(CORE_MATERIAL)
@@ -278,6 +279,7 @@ public:
     PREFERRED_TYPE(OptionSet<BoxAxisFlag>) unsigned anchorFunctionScrollCompensatedAxes : 2;
     PREFERRED_TYPE(bool) unsigned usesTreeCountingFunctions : 1;
     PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
+    PREFERRED_TYPE(Style::MarginTrim) unsigned marginTrim : Style::MarginTrim::bits;
 
 private:
     StyleRareNonInheritedData();

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -220,10 +220,10 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
 
         // Spec: All text decorations except line-through should be drawn before the text is filled and stroked; thus, the text is rendered on top of these decorations.
         auto decorations = style.textDecorationLineInEffect();
-        if (decorations & TextDecorationLine::Underline)
-            paintDecoration(TextDecorationLine::Underline, fragment);
-        if (decorations & TextDecorationLine::Overline)
-            paintDecoration(TextDecorationLine::Overline, fragment);
+        if (decorations & CSS::Keyword::Underline { })
+            paintDecoration(CSS::Keyword::Underline { }, fragment);
+        if (decorations & CSS::Keyword::Overline { })
+            paintDecoration(CSS::Keyword::Overline { }, fragment);
 
         for (auto type : RenderStyle::paintTypesForPaintOrder(style.paintOrder())) {
             switch (type) {
@@ -247,8 +247,8 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
         }
 
         // Spec: Line-through should be drawn after the text is filled and stroked; thus, the line-through is rendered on top of the text.
-        if (decorations & TextDecorationLine::LineThrough)
-            paintDecoration(TextDecorationLine::LineThrough, fragment);
+        if (decorations & CSS::Keyword::LineThrough { })
+            paintDecoration(CSS::Keyword::LineThrough { }, fragment);
 
         m_paintingResourceMode = { };
     }
@@ -396,23 +396,23 @@ bool mapStartEndPositionsIntoFragmentCoordinates(unsigned textBoxStart, const SV
     return true;
 }
 
-static inline float positionOffsetForDecoration(OptionSet<TextDecorationLine> decoration, const FontMetrics& fontMetrics, float thickness)
+static inline float positionOffsetForDecoration(Style::TextDecorationLine decoration, const FontMetrics& fontMetrics, float thickness)
 {
     // FIXME: For SVG Fonts we need to use the attributes defined in the <font-face> if specified.
     // Compatible with Batik/Opera.
     const float ascent = fontMetrics.ascent();
-    if (decoration == TextDecorationLine::Underline)
+    if (decoration == CSS::Keyword::Underline { })
         return ascent + thickness * 1.5f;
-    if (decoration == TextDecorationLine::Overline)
+    if (decoration == CSS::Keyword::Overline { })
         return thickness;
-    if (decoration == TextDecorationLine::LineThrough)
+    if (decoration == CSS::Keyword::LineThrough { })
         return ascent * 5 / 8.0f;
 
     ASSERT_NOT_REACHED();
     return 0.0f;
 }
 
-static inline float thicknessForDecoration(OptionSet<TextDecorationLine>, const FontCascade& font)
+static inline float thicknessForDecoration(Style::TextDecorationLine, const FontCascade& font)
 {
     // FIXME: For SVG Fonts we need to use the attributes defined in the <font-face> if specified.
     // Compatible with Batik/Opera
@@ -420,7 +420,7 @@ static inline float thicknessForDecoration(OptionSet<TextDecorationLine>, const 
 }
 
 template<typename TextBoxPath>
-void SVGTextBoxPainter<TextBoxPath>::paintDecoration(OptionSet<TextDecorationLine> decoration, const SVGTextFragment& fragment)
+void SVGTextBoxPainter<TextBoxPath>::paintDecoration(Style::TextDecorationLine decoration, const SVGTextFragment& fragment)
 {
     if (renderer().style().textDecorationLineInEffect().isEmpty())
         return;
@@ -476,7 +476,7 @@ void SVGTextBoxPainter<TextBoxPath>::paintDecoration(OptionSet<TextDecorationLin
 }
 
 template<typename TextBoxPath>
-void SVGTextBoxPainter<TextBoxPath>::paintDecorationWithStyle(OptionSet<TextDecorationLine> decoration, const SVGTextFragment& fragment, const RenderBoxModelObject& decorationRenderer)
+void SVGTextBoxPainter<TextBoxPath>::paintDecorationWithStyle(Style::TextDecorationLine decoration, const SVGTextFragment& fragment, const RenderBoxModelObject& decorationRenderer)
 {
     ASSERT(!m_legacyPaintingResource);
     ASSERT(!paintingResourceMode().isEmpty());

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
@@ -37,6 +37,10 @@ class RenderStyle;
 class SVGPaintServerHandling;
 struct SVGTextFragment;
 
+namespace Style {
+struct TextDecorationLine;
+}
+
 template<typename TextBoxPath>
 class SVGTextBoxPainter {
 public:
@@ -53,8 +57,8 @@ private:
     const RenderBoxModelObject& parentRenderer() const;
     OptionSet<RenderSVGResourceMode> paintingResourceMode() const { return m_paintingResourceMode; }
 
-    void paintDecoration(OptionSet<TextDecorationLine>, const SVGTextFragment&);
-    void paintDecorationWithStyle(OptionSet<TextDecorationLine>, const SVGTextFragment&, const RenderBoxModelObject&);
+    void paintDecoration(Style::TextDecorationLine, const SVGTextFragment&);
+    void paintDecorationWithStyle(Style::TextDecorationLine, const SVGTextFragment&, const RenderBoxModelObject&);
     void paintTextWithShadows(const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
     void paintText(const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -63,7 +63,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         // For an N-line first-letter and for alphabetic baselines, the cap-height of the first letter needs to equal (N-1)*line-height of paragraph lines + cap-height of the paragraph
         // Mathematically we can't rely on font-size, since font().height() doesn't necessarily match. For reliability, the best approach is simply to
         // compare the final measured cap-heights of the two fonts in order to get to the closest possible value.
-        firstLetterStyle.setLineBoxContain({ Style::LineBoxContain::InitialLetter });
+        firstLetterStyle.setLineBoxContain({ CSS::Keyword::InitialLetter { } });
         int lineHeight = paragraph->style().computedLineHeight();
 
         // Set the font to be one line too big and then ratchet back to get to a precise fit. We can't just set the desired font size based off font height metrics

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -61,7 +61,7 @@ static float minLogicalTopForTextDecorationLineUnder(const InlineIterator::LineB
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
-        if (!run->style().textDecorationLineInEffect().contains(TextDecorationLine::Underline))
+        if (!run->style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { }))
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
         if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
@@ -80,7 +80,7 @@ static float maxLogicalBottomForTextDecorationLineUnder(const InlineIterator::Li
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
-        if (!run->style().textDecorationLineInEffect().contains(TextDecorationLine::Underline))
+        if (!run->style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { }))
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
         if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
@@ -108,7 +108,7 @@ static const RenderElement* enclosingRendererWithTextDecoration(const RenderText
                 // <font> and <a> are always considered decorating boxes.
                 return true;
             }
-            return ancestor->style().textDecorationLine().contains(TextDecorationLine::Underline);
+            return ancestor->style().textDecorationLine().contains(CSS::Keyword::Underline { });
         };
         if (isDecoratingInlineBox())
             return ancestor;
@@ -212,7 +212,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
 
     // These metrics must match where underlines get drawn.
     // FIXME: Share the code in TextDecorationPainter::paintBackgroundDecorations() so we can just query it for the painted geometry.
-    if (decoration & TextDecorationLine::Underline) {
+    if (decoration & CSS::Keyword::Underline { }) {
         ASSERT(underlineOffset);
         if (decorationStyle == TextDecorationStyle::Wavy) {
             overflowResult.extendBottom(*underlineOffset + wavyOffset + wavyStrokeParameters.controlPointDistance + strokeThickness - height);
@@ -222,7 +222,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
             overflowResult.extendTop(-*underlineOffset);
         }
     }
-    if (decoration & TextDecorationLine::Overline) {
+    if (decoration & CSS::Keyword::Overline { }) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
         float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
         rect.move(0, autoTextDecorationThickness - strokeThickness - wavyOffset);
@@ -235,7 +235,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
         overflowResult.extendTop(-rect.y());
         overflowResult.extendBottom(rect.maxY() - height);
     }
-    if (decoration & TextDecorationLine::LineThrough) {
+    if (decoration & CSS::Keyword::LineThrough { }) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
         float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
         auto center = 2 * lineStyle.metricsOfPrimaryFont().ascent() / 3 + autoTextDecorationThickness / 2;
@@ -279,7 +279,7 @@ GlyphOverflow inkOverflowForDecorations(const InlineIterator::LineBoxIterator& l
         textUnderlinePositionUnder = TextUnderlinePositionUnder { textBoxLogicalBottom - textBoxLogicalTop, textRunOffset };
     }
 
-    auto underlineOffset = style.textDecorationLineInEffect().contains(TextDecorationLine::Underline)
+    auto underlineOffset = style.textDecorationLineInEffect().contains(CSS::Keyword::Underline { })
         ? std::make_optional(computedUnderlineOffset({ style, textUnderlinePositionUnder }))
         : std::nullopt;
     return computedInkOverflowForDecorations(style, underlineOffset);
@@ -287,7 +287,7 @@ GlyphOverflow inkOverflowForDecorations(const InlineIterator::LineBoxIterator& l
 
 GlyphOverflow inkOverflowForDecorations(const RenderStyle& style, TextUnderlinePositionUnder textUnderlinePositionUnder)
 {
-    auto underlineOffset = style.textDecorationLineInEffect().contains(TextDecorationLine::Underline)
+    auto underlineOffset = style.textDecorationLineInEffect().contains(CSS::Keyword::Underline { })
         ? std::make_optional(computedUnderlineOffset({ style, textUnderlinePositionUnder }))
         : std::nullopt;
     return computedInkOverflowForDecorations(style, underlineOffset);
@@ -295,7 +295,7 @@ GlyphOverflow inkOverflowForDecorations(const RenderStyle& style, TextUnderlineP
 
 GlyphOverflow inkOverflowForDecorations(const RenderStyle& style)
 {
-    auto underlineOffset = style.textDecorationLineInEffect().contains(TextDecorationLine::Underline)
+    auto underlineOffset = style.textDecorationLineInEffect().contains(CSS::Keyword::Underline { })
         ? std::make_optional(computedUnderlineOffset({ style, { } }))
         : std::nullopt;
     return computedInkOverflowForDecorations(style, underlineOffset);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -78,7 +78,6 @@
 #include "StyleFlexBasis.h"
 #include "StyleInset.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
-#include "StyleLineBoxContain.h"
 #include "StyleMargin.h"
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
@@ -92,6 +91,7 @@
 #include "StylePerspective.h"
 #include "StylePreferredSize.h"
 #include "StylePrimitiveKeyword+CSSValueConversion.h"
+#include "StylePrimitiveKeywordSet+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleRayFunction.h"
@@ -134,7 +134,6 @@ public:
     static TabSize convertTabSize(BuilderState&, const CSSValue&);
     template<typename T> static T convertComputedLength(BuilderState&, const CSSValue&);
     template<typename T> static T convertLineWidth(BuilderState&, const CSSValue&);
-    static OptionSet<TextDecorationLine> convertTextDecorationLine(BuilderState&, const CSSValue&);
     static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
     template<typename T> static T convertNumber(BuilderState&, const CSSValue&);
     template<typename T, CSSValueID> static T convertNumberOrKeyword(BuilderState&, const CSSValue&);
@@ -159,7 +158,6 @@ public:
     static TextEdge convertTextEdge(BuilderState&, const CSSValue&);
     static IntSize convertInitialLetter(BuilderState&, const CSSValue&);
     static float convertTextStrokeWidth(BuilderState&, const CSSValue&);
-    static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
     static RefPtr<ShapeValue> convertShapeValue(BuilderState&, const CSSValue&);
     static ScrollSnapType convertScrollSnapType(BuilderState&, const CSSValue&);
     static ScrollSnapAlign convertScrollSnapAlign(BuilderState&, const CSSValue&);
@@ -208,8 +206,6 @@ public:
 
     static OptionSet<Containment> convertContain(BuilderState&, const CSSValue&);
 
-    static OptionSet<MarginTrimType> convertMarginTrim(BuilderState&, const CSSValue&);
-
     static TextSpacingTrim convertTextSpacingTrim(BuilderState&, const CSSValue&);
     static TextAutospace convertTextAutospace(BuilderState&, const CSSValue&);
 
@@ -219,7 +215,6 @@ public:
 
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
-    static OptionSet<PositionVisibility> convertPositionVisibility(BuilderState&, const CSSValue&);
 
     static size_t convertMaxLines(BuilderState&, const CSSValue&);
 
@@ -345,16 +340,6 @@ inline T BuilderConverter::convertLineWidth(BuilderState& builderState, const CS
         ASSERT_NOT_REACHED();
         return 0;
     }
-}
-
-inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine(BuilderState&, const CSSValue& value)
-{
-    auto result = RenderStyle::initialTextDecorationLine();
-    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
-        for (auto& currentValue : *list)
-            result.add(fromCSSValue<TextDecorationLine>(currentValue));
-    }
-    return result;
 }
 
 inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderState&, const CSSValue& value)
@@ -755,68 +740,6 @@ inline float BuilderConverter::convertTextStrokeWidth(BuilderState& builderState
     }
 
     return width;
-}
-
-inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(BuilderState& builderState, const CSSValue& value)
-{
-    if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        switch (primitive->valueID()) {
-        case CSSValueNone:
-            return { };
-        case CSSValueBlock:
-            return LineBoxContain::Block;
-        case CSSValueInline:
-            return LineBoxContain::Inline;
-        case CSSValueFont:
-            return LineBoxContain::Font;
-        case CSSValueGlyphs:
-            return LineBoxContain::Glyphs;
-        case CSSValueReplaced:
-            return LineBoxContain::Replaced;
-        case CSSValueInlineBox:
-            return LineBoxContain::InlineBox;
-        case CSSValueInitialLetter:
-            return LineBoxContain::InitialLetter;
-        default:
-            builderState.setCurrentPropertyInvalidAtComputedValueTime();
-            return { };
-        }
-    }
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    OptionSet<LineBoxContain> result;
-    for (Ref primitive : *list) {
-        switch (primitive->valueID()) {
-        case CSSValueBlock:
-            result.add(LineBoxContain::Block);
-            break;
-        case CSSValueInline:
-            result.add(LineBoxContain::Inline);
-            break;
-        case CSSValueFont:
-            result.add(LineBoxContain::Font);
-            break;
-        case CSSValueGlyphs:
-            result.add(LineBoxContain::Glyphs);
-            break;
-        case CSSValueReplaced:
-            result.add(LineBoxContain::Replaced);
-            break;
-        case CSSValueInlineBox:
-            result.add(LineBoxContain::InlineBox);
-            break;
-        case CSSValueInitialLetter:
-            result.add(LineBoxContain::InitialLetter);
-            break;
-        default:
-            builderState.setCurrentPropertyInvalidAtComputedValueTime();
-            return { };
-        }
-    }
-    return result;
 }
 
 inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& builderState, const CSSValue& value)
@@ -1354,41 +1277,6 @@ inline OptionSet<HangingPunctuation> BuilderConverter::convertHangingPunctuation
     return result;
 }
 
-inline OptionSet<MarginTrimType> BuilderConverter::convertMarginTrim(BuilderState&, const CSSValue& value)
-{
-    // See if value is "block" or "inline" before trying to parse a list
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->valueID() == CSSValueBlock)
-            return { MarginTrimType::BlockStart, MarginTrimType::BlockEnd };
-        if (primitiveValue->valueID() == CSSValueInline)
-            return { MarginTrimType::InlineStart, MarginTrimType::InlineEnd };
-    }
-    auto list = dynamicDowncast<CSSValueList>(value);
-    if (!list || !list->size())
-        return RenderStyle::initialMarginTrim();
-    OptionSet<MarginTrimType> marginTrim;
-    for (auto& item : *list) {
-        if (item.valueID() == CSSValueBlock)
-            marginTrim.add({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd });
-        if (item.valueID() == CSSValueInline)
-            marginTrim.add({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd });
-    }
-    if (!marginTrim.isEmpty())
-        return marginTrim;
-    for (auto& item : *list) {
-        if (item.valueID() == CSSValueBlockStart)
-            marginTrim.add(MarginTrimType::BlockStart);
-        if (item.valueID() == CSSValueBlockEnd)
-            marginTrim.add(MarginTrimType::BlockEnd);
-        if (item.valueID() == CSSValueInlineStart)
-            marginTrim.add(MarginTrimType::InlineStart);
-        if (item.valueID() == CSSValueInlineEnd)
-            marginTrim.add(MarginTrimType::InlineEnd);
-    }
-    ASSERT(list->size() <= 4);
-    return marginTrim;
-}
-
 inline TextSpacingTrim BuilderConverter::convertTextSpacingTrim(BuilderState&, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
@@ -1857,23 +1745,6 @@ inline std::optional<PositionArea> BuilderConverter::convertPositionArea(Builder
     }
 
     return area;
-}
-
-inline OptionSet<PositionVisibility> BuilderConverter::convertPositionVisibility(BuilderState& builderState, const CSSValue& value)
-{
-    if (value.valueID() == CSSValueAlways)
-        return { };
-
-    auto maybeList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!maybeList)
-        return { };
-    auto list = *maybeList;
-
-    OptionSet<PositionVisibility> result;
-    for (const auto& value : list)
-        result.add(fromCSSValue<PositionVisibility>(value));
-
-    return result;
 }
 
 inline size_t BuilderConverter::convertMaxLines(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -92,7 +92,6 @@
 #include "StyleFilterProperty.h"
 #include "StyleFlexBasis.h"
 #include "StyleInset.h"
-#include "StyleLineBoxContain.h"
 #include "StyleMargin.h"
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
@@ -102,6 +101,7 @@
 #include "StylePerspective.h"
 #include "StylePreferredSize.h"
 #include "StylePrimitiveKeyword+CSSValueCreation.h"
+#include "StylePrimitiveKeywordSet+CSSValueCreation.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleReflection.h"
@@ -170,7 +170,6 @@ public:
     static Ref<CSSValue> convertImageOrNone(ExtractorState&, const StyleImage*);
     static Ref<CSSValue> convertGlyphOrientation(ExtractorState&, GlyphOrientation);
     static Ref<CSSValue> convertGlyphOrientationOrAuto(ExtractorState&, GlyphOrientation);
-    static Ref<CSSValue> convertMarginTrim(ExtractorState&, OptionSet<MarginTrimType>);
     static Ref<CSSValue> convertShapeValue(ExtractorState&, const ShapeValue*);
     static Ref<CSSValue> convertDPath(ExtractorState&, const StylePathData*);
     static Ref<CSSValue> convertStrokeDashArray(ExtractorState&, const FixedVector<WebCore::Length>&);
@@ -194,12 +193,10 @@ public:
     static Ref<CSSValue> convertTabSize(ExtractorState&, const TabSize&);
     static Ref<CSSValue> convertScrollSnapType(ExtractorState&, const ScrollSnapType&);
     static Ref<CSSValue> convertScrollSnapAlign(ExtractorState&, const ScrollSnapAlign&);
-    static Ref<CSSValue> convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain>);
     static Ref<CSSValue> convertWebkitRubyPosition(ExtractorState&, RubyPosition);
     static Ref<CSSValue> convertPosition(ExtractorState&, const LengthPoint&);
     static Ref<CSSValue> convertTouchAction(ExtractorState&, OptionSet<TouchAction>);
     static Ref<CSSValue> convertTextTransform(ExtractorState&, OptionSet<TextTransform>);
-    static Ref<CSSValue> convertTextDecorationLine(ExtractorState&, OptionSet<TextDecorationLine>);
     static Ref<CSSValue> convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition>);
     static Ref<CSSValue> convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition>);
     static Ref<CSSValue> convertSpeakAs(ExtractorState&, OptionSet<SpeakAs>);
@@ -215,7 +212,6 @@ public:
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
     static Ref<CSSValue> convertNameScope(ExtractorState&, const NameScope&);
-    static Ref<CSSValue> convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility>);
 
     // MARK: FillLayer conversions
 
@@ -597,31 +593,6 @@ inline Ref<CSSValue> ExtractorConverter::convertGlyphOrientationOrAuto(Extractor
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertMarginTrim(ExtractorState&, OptionSet<MarginTrimType> marginTrim)
-{
-    if (marginTrim.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
-
-    // Try to serialize into one of the "block" or "inline" shorthands
-    if (marginTrim.containsAll({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd }) && !marginTrim.containsAny({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd }))
-        return CSSPrimitiveValue::create(CSSValueBlock);
-    if (marginTrim.containsAll({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd }) && !marginTrim.containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd }))
-        return CSSPrimitiveValue::create(CSSValueInline);
-    if (marginTrim.containsAll({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd, MarginTrimType::InlineStart, MarginTrimType::InlineEnd }))
-        return CSSValueList::createSpaceSeparated(CSSPrimitiveValue::create(CSSValueBlock), CSSPrimitiveValue::create(CSSValueInline));
-
-    CSSValueListBuilder list;
-    if (marginTrim.contains(MarginTrimType::BlockStart))
-        list.append(CSSPrimitiveValue::create(CSSValueBlockStart));
-    if (marginTrim.contains(MarginTrimType::InlineStart))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineStart));
-    if (marginTrim.contains(MarginTrimType::BlockEnd))
-        list.append(CSSPrimitiveValue::create(CSSValueBlockEnd));
-    if (marginTrim.contains(MarginTrimType::InlineEnd))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineEnd));
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
 inline Ref<CSSValue> ExtractorConverter::convertShapeValue(ExtractorState& state, const ShapeValue* shapeValue)
 {
     if (!shapeValue)
@@ -914,29 +885,6 @@ inline Ref<CSSValue> ExtractorConverter::convertScrollSnapAlign(ExtractorState& 
     );
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain> lineBoxContain)
-{
-    if (!lineBoxContain)
-        return CSSPrimitiveValue::create(CSSValueNone);
-
-    CSSValueListBuilder list;
-    if (lineBoxContain.contains(LineBoxContain::Block))
-        list.append(CSSPrimitiveValue::create(CSSValueBlock));
-    if (lineBoxContain.contains(LineBoxContain::Inline))
-        list.append(CSSPrimitiveValue::create(CSSValueInline));
-    if (lineBoxContain.contains(LineBoxContain::Font))
-        list.append(CSSPrimitiveValue::create(CSSValueFont));
-    if (lineBoxContain.contains(LineBoxContain::Glyphs))
-        list.append(CSSPrimitiveValue::create(CSSValueGlyphs));
-    if (lineBoxContain.contains(LineBoxContain::Replaced))
-        list.append(CSSPrimitiveValue::create(CSSValueReplaced));
-    if (lineBoxContain.contains(LineBoxContain::InlineBox))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineBox));
-    if (lineBoxContain.contains(LineBoxContain::InitialLetter))
-        list.append(CSSPrimitiveValue::create(CSSValueInitialLetter));
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
 inline Ref<CSSValue> ExtractorConverter::convertWebkitRubyPosition(ExtractorState&, RubyPosition position)
 {
     return CSSPrimitiveValue::create([&] {
@@ -998,21 +946,6 @@ inline Ref<CSSValue> ExtractorConverter::convertTextTransform(ExtractorState&, O
     if (textTransform.contains(TextTransform::FullSizeKana))
         list.append(CSSPrimitiveValue::create(CSSValueFullSizeKana));
 
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTextDecorationLine(ExtractorState&, OptionSet<TextDecorationLine> textDecorationLine)
-{
-    // Blink value is ignored.
-    CSSValueListBuilder list;
-    if (textDecorationLine & TextDecorationLine::Underline)
-        list.append(CSSPrimitiveValue::create(CSSValueUnderline));
-    if (textDecorationLine & TextDecorationLine::Overline)
-        list.append(CSSPrimitiveValue::create(CSSValueOverline));
-    if (textDecorationLine & TextDecorationLine::LineThrough)
-        list.append(CSSPrimitiveValue::create(CSSValueLineThrough));
     if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
     return CSSValueList::createSpaceSeparated(WTFMove(list));
@@ -1380,22 +1313,6 @@ inline Ref<CSSValue> ExtractorConverter::convertNameScope(ExtractorState&, const
 
     ASSERT_NOT_REACHED();
     return CSSPrimitiveValue::create(CSSValueNone);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility> positionVisibility)
-{
-    CSSValueListBuilder list;
-    if (positionVisibility & PositionVisibility::AnchorsValid)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsValid));
-    if (positionVisibility & PositionVisibility::AnchorsVisible)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsVisible));
-    if (positionVisibility & PositionVisibility::NoOverflow)
-        list.append(CSSPrimitiveValue::create(CSSValueNoOverflow));
-
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAlways);
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 // MARK: - FillLayer conversions

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -483,7 +483,7 @@ template<CSSPropertyID propertyID> void extractZoomAdjustedInsetSerialization(Ex
 using PhysicalDirection = BoxSide;
 using FlowRelativeDirection = LogicalBoxSide;
 
-inline MarginTrimType toMarginTrimType(const RenderBox& renderer, PhysicalDirection direction)
+inline Style::MarginTrim::Value toMarginTrim(const RenderBox& renderer, PhysicalDirection direction)
 {
     auto formattingContextRootStyle = [](const RenderBox& renderer) -> const RenderStyle& {
         if (auto* ancestorToUse = (renderer.isFlexItem() || renderer.isGridItem()) ? renderer.parent() : renderer.containingBlock())
@@ -494,28 +494,28 @@ inline MarginTrimType toMarginTrimType(const RenderBox& renderer, PhysicalDirect
 
     switch (mapSidePhysicalToLogical(formattingContextRootStyle(renderer).writingMode(), direction)) {
     case FlowRelativeDirection::BlockStart:
-        return MarginTrimType::BlockStart;
+        return CSS::Keyword::BlockStart { };
     case FlowRelativeDirection::BlockEnd:
-        return MarginTrimType::BlockEnd;
+        return CSS::Keyword::BlockEnd { };
     case FlowRelativeDirection::InlineStart:
-        return MarginTrimType::InlineStart;
+        return CSS::Keyword::InlineStart { };
     case FlowRelativeDirection::InlineEnd:
-        return MarginTrimType::InlineEnd;
+        return CSS::Keyword::InlineEnd { };
     default:
         ASSERT_NOT_REACHED();
-        return MarginTrimType::BlockStart;
+        return CSS::Keyword::BlockStart { };
     }
 }
 
-inline bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, MarginTrimType marginTrimType)
+inline bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, Style::MarginTrim::Value marginTrim)
 {
     // A renderer will have a specific margin marked as trimmed by setting its rare data bit if:
     // 1.) The layout system the box is in has this logic (setting the rare data bit for this
     // specific margin) implemented
     // 2.) The block container/flexbox/grid has this margin specified in its margin-trim style
-    // If marginTrimType is empty we will check if any of the supported margins are in the style
+    // If marginTrim is empty we will check if any of the supported margins are in the style
     if (renderer.isFlexItem() || renderer.isGridItem())
-        return renderer.parent()->style().marginTrim().contains(marginTrimType);
+        return renderer.parent()->style().marginTrim().contains(marginTrim);
 
     // Even though margin-trim is not inherited, it is possible for nested block level boxes
     // to get placed at the block-start of an containing block ancestor which does have margin-trim.
@@ -1763,7 +1763,7 @@ inline void ExtractorCustom::extractLeftSerialization(ExtractorState& state, Str
 inline Ref<CSSValue> ExtractorCustom::extractMarginTop(ExtractorState& state)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::BlockStart) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Top)))
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::BlockStart { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Top)))
         return ExtractorConverter::convertNumberAsPixels(state, box->marginTop());
     return extractZoomAdjustedMarginValue<&RenderStyle::marginTop, &RenderBoxModelObject::marginTop>(state);
 }
@@ -1771,7 +1771,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginTop(ExtractorState& state)
 inline void ExtractorCustom::extractMarginTopSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::BlockStart) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Top))) {
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::BlockStart { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Top))) {
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, box->marginTop());
         return;
     }
@@ -1782,7 +1782,7 @@ inline void ExtractorCustom::extractMarginTopSerialization(ExtractorState& state
 inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineEnd) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Right)))
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::InlineEnd { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Right)))
         return ExtractorConverter::convertNumberAsPixels(state, box->marginRight());
 
     auto& marginRight = state.style.marginRight();
@@ -1803,7 +1803,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginRight(ExtractorState& state)
 inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineEnd) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Right))) {
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::InlineEnd { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Right))) {
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, box->marginRight());
         return;
     }
@@ -1829,7 +1829,7 @@ inline void ExtractorCustom::extractMarginRightSerialization(ExtractorState& sta
 inline Ref<CSSValue> ExtractorCustom::extractMarginBottom(ExtractorState& state)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::BlockEnd) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Bottom)))
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::BlockEnd { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Bottom)))
         return ExtractorConverter::convertNumberAsPixels(state, box->marginBottom());
     return extractZoomAdjustedMarginValue<&RenderStyle::marginBottom, &RenderBoxModelObject::marginBottom>(state);
 }
@@ -1837,7 +1837,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginBottom(ExtractorState& state)
 inline void ExtractorCustom::extractMarginBottomSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::BlockEnd) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Bottom))) {
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::BlockEnd { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Bottom))) {
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, box->marginBottom());
         return;
     }
@@ -1848,7 +1848,7 @@ inline void ExtractorCustom::extractMarginBottomSerialization(ExtractorState& st
 inline Ref<CSSValue> ExtractorCustom::extractMarginLeft(ExtractorState& state)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineStart) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Left)))
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::InlineStart { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Left)))
         return ExtractorConverter::convertNumberAsPixels(state, box->marginLeft());
     return extractZoomAdjustedMarginValue<&RenderStyle::marginLeft, &RenderBoxModelObject::marginLeft>(state);
 }
@@ -1856,7 +1856,7 @@ inline Ref<CSSValue> ExtractorCustom::extractMarginLeft(ExtractorState& state)
 inline void ExtractorCustom::extractMarginLeftSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(state.renderer);
-    if (box && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineStart) && box->hasTrimmedMargin(toMarginTrimType(*box, PhysicalDirection::Left))) {
+    if (box && rendererCanHaveTrimmedMargin(*box, CSS::Keyword::InlineStart { }) && box->hasTrimmedMargin(toMarginTrim(*box, PhysicalDirection::Left))) {
         ExtractorSerializer::serializeNumberAsPixels(state, builder, context, box->marginLeft());
         return;
     }

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -32,6 +32,7 @@
 #include "ColorSerialization.h"
 #include "StyleExtractorConverter.h"
 #include "StylePrimitiveKeyword+Serialization.h"
+#include "StylePrimitiveKeywordSet+Serialization.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 
@@ -89,7 +90,6 @@ public:
     static void serializeImageOrNone(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StyleImage*);
     static void serializeGlyphOrientation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GlyphOrientation);
     static void serializeGlyphOrientationOrAuto(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GlyphOrientation);
-    static void serializeMarginTrim(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<MarginTrimType>);
     static void serializeShapeValue(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ShapeValue*);
     static void serializeDPath(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StylePathData*);
     static void serializeStrokeDashArray(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const FixedVector<WebCore::Length>&);
@@ -114,12 +114,10 @@ public:
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
     static void serializeScrollSnapType(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollSnapType&);
     static void serializeScrollSnapAlign(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollSnapAlign&);
-    static void serializeLineBoxContain(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<Style::LineBoxContain>);
     static void serializeWebkitRubyPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, RubyPosition);
     static void serializePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const LengthPoint&);
     static void serializeTouchAction(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TouchAction>);
     static void serializeTextTransform(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextTransform>);
-    static void serializeTextDecorationLine(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextDecorationLine>);
     static void serializeTextUnderlinePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextUnderlinePosition>);
     static void serializeTextEmphasisPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextEmphasisPosition>);
     static void serializeSpeakAs(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<SpeakAs>);
@@ -134,7 +132,6 @@ public:
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
-    static void serializePositionVisibility(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<PositionVisibility>);
 
     // MARK: FillLayer serializations
 
@@ -678,44 +675,6 @@ inline void ExtractorSerializer::serializeGlyphOrientationOrAuto(ExtractorState&
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline void ExtractorSerializer::serializeMarginTrim(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<MarginTrimType> marginTrim)
-{
-    if (marginTrim.isEmpty()) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    // Try to serialize into one of the "block" or "inline" shorthands
-    if (marginTrim.containsAll({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd }) && !marginTrim.containsAny({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd })) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Block { });
-        return;
-    }
-    if (marginTrim.containsAll({ MarginTrimType::InlineStart, MarginTrimType::InlineEnd }) && !marginTrim.containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd })) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Inline { });
-        return;
-    }
-    if (marginTrim.containsAll({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd, MarginTrimType::InlineStart, MarginTrimType::InlineEnd })) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Block { });
-        builder.append(' ');
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Inline { });
-        return;
-    }
-
-    bool listEmpty = true;
-    auto appendOption = [&](MarginTrimType test, CSSValueID value) {
-        if (marginTrim.contains(test)) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(MarginTrimType::BlockStart, CSSValueBlockStart);
-    appendOption(MarginTrimType::InlineStart, CSSValueInlineStart);
-    appendOption(MarginTrimType::BlockEnd, CSSValueBlockEnd);
-    appendOption(MarginTrimType::InlineEnd, CSSValueInlineEnd);
-}
-
 inline void ExtractorSerializer::serializeShapeValue(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const ShapeValue* shapeValue)
 {
     if (!shapeValue) {
@@ -1106,31 +1065,6 @@ inline void ExtractorSerializer::serializeScrollSnapAlign(ExtractorState& state,
     serialize(state, builder, context, alignment.inlineAlign);
 }
 
-inline void ExtractorSerializer::serializeLineBoxContain(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<Style::LineBoxContain> lineBoxContain)
-{
-    if (!lineBoxContain) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    bool listEmpty = true;
-    auto appendOption = [&](LineBoxContain test, CSSValueID value) {
-        if (lineBoxContain.contains(test)) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(LineBoxContain::Block, CSSValueBlock);
-    appendOption(LineBoxContain::Inline, CSSValueInline);
-    appendOption(LineBoxContain::Font, CSSValueFont);
-    appendOption(LineBoxContain::Glyphs, CSSValueGlyphs);
-    appendOption(LineBoxContain::Replaced, CSSValueReplaced);
-    appendOption(LineBoxContain::InlineBox, CSSValueInlineBox);
-    appendOption(LineBoxContain::InitialLetter, CSSValueInitialLetter);
-}
-
 inline void ExtractorSerializer::serializeWebkitRubyPosition(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, RubyPosition position)
 {
     switch (position) {
@@ -1213,26 +1147,6 @@ inline void ExtractorSerializer::serializeTextTransform(ExtractorState& state, S
     };
     appendOption(TextTransform::FullWidth, CSSValueFullWidth);
     appendOption(TextTransform::FullSizeKana, CSSValueFullSizeKana);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-}
-
-inline void ExtractorSerializer::serializeTextDecorationLine(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextDecorationLine> textDecorationLine)
-{
-    // Blink value is ignored.
-    bool listEmpty = true;
-    auto appendOption = [&](TextDecorationLine test, CSSValueID value) {
-        if (textDecorationLine & test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(TextDecorationLine::Underline, CSSValueUnderline);
-    appendOption(TextDecorationLine::Overline, CSSValueOverline);
-    appendOption(TextDecorationLine::LineThrough, CSSValueLineThrough);
 
     if (listEmpty)
         serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
@@ -1509,25 +1423,6 @@ inline void ExtractorSerializer::serializeNameScope(ExtractorState& state, Strin
     }
 
     RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline void ExtractorSerializer::serializePositionVisibility(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<PositionVisibility> positionVisibility)
-{
-    bool listEmpty = true;
-    auto appendOption = [&](PositionVisibility test, CSSValueID value) {
-        if (positionVisibility & test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(PositionVisibility::AnchorsValid, CSSValueAnchorsValid);
-    appendOption(PositionVisibility::AnchorsVisible, CSSValueAnchorsVisible);
-    appendOption(PositionVisibility::NoOverflow, CSSValueNoOverflow);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Always { });
 }
 
 // MARK: - FillLayer serializations

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -37,6 +37,7 @@
 #include "AnimationMalloc.h"
 #include "StyleInterpolationFunctions.h"
 #include "StyleInterpolationWrapperBase.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1590,7 +1590,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
         if (!anchored)
             return false;
 
-        if (style.positionVisibility().contains(PositionVisibility::AnchorsVisible)) {
+        if (style.positionVisibility().contains(CSS::Keyword::AnchorsVisible { })) {
             // "If the box has a default anchor box but that anchor box is invisible or clipped by intervening boxes, the box’s visibility property computes to force-hidden."
             if (AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(*anchored))
                 return true;

--- a/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
+++ b/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,14 +32,14 @@
 namespace WebCore {
 namespace Style {
 
-// <'-webkit-line-box-contain'> = none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]
-// Non-standard
-struct LineBoxContain : CSS::PrimitiveKeywordSet<LineBoxContain, CSS::Keyword::None, CSS::Keyword::Block, CSS::Keyword::Inline, CSS::Keyword::Font, CSS::Keyword::Glyphs, CSS::Keyword::Replaced, CSS::Keyword::InlineBox, CSS::Keyword::InitialLetter> {
+// <'position-visibility'> = always | [ anchors-valid || anchors-visible || no-overflow ]
+// https://www.w3.org/TR/css-anchor-position-1/#propdef-position-visibility
+struct PositionVisibility : CSS::PrimitiveKeywordSet<PositionVisibility, CSS::Keyword::Always, CSS::Keyword::AnchorsValid, CSS::Keyword::AnchorsVisible, CSS::Keyword::NoOverflow> {
     using Base::Base;
 };
-static_assert(sizeof(LineBoxContain) == 1);
+static_assert(sizeof(PositionVisibility) == 1);
 
 } // namespace Style
 } // namespace WebCore
 
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::LineBoxContain)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PositionVisibility)

--- a/Source/WebCore/style/values/box/StyleMarginTrim.cpp
+++ b/Source/WebCore/style/values/box/StyleMarginTrim.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleMarginTrim.h"
+
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<MarginTrim>::operator()(BuilderState& state, const CSSValue& value) -> MarginTrim
+{
+    if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueNone:
+            return CSS::Keyword::None { };
+        case CSSValueBlock:
+            return MarginTrim::blockTrims();
+        case CSSValueInline:
+            return MarginTrim::inlineTrims();
+        case CSSValueBlockStart:
+            return CSS::Keyword::BlockStart { };
+        case CSSValueBlockEnd:
+            return CSS::Keyword::BlockEnd { };
+        case CSSValueInlineStart:
+            return CSS::Keyword::InlineStart { };
+        case CSSValueInlineEnd:
+            return CSS::Keyword::InlineEnd { };
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+
+    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+    if (!list)
+        return CSS::Keyword::None { };
+
+    MarginTrim result;
+
+    for (Ref item : *list) {
+        switch (item->valueID()) {
+        case CSSValueBlock:
+            result.add(MarginTrim::blockTrims());
+            break;
+        case CSSValueInline:
+            result.add(MarginTrim::inlineTrims());
+            break;
+        case CSSValueBlockStart:
+            result.add(CSS::Keyword::BlockStart { });
+            break;
+        case CSSValueBlockEnd:
+            result.add(CSS::Keyword::BlockEnd { });
+            break;
+        case CSSValueInlineStart:
+            result.add(CSS::Keyword::InlineStart { });
+            break;
+        case CSSValueInlineEnd:
+            result.add(CSS::Keyword::InlineEnd { });
+            break;
+        default:
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return CSS::Keyword::None { };
+        }
+    }
+
+    return result;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/box/StyleMarginTrim.h
+++ b/Source/WebCore/style/values/box/StyleMarginTrim.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordSet.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'margin-trim'> = none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]
+//  - `block` is an alias for `block-start block-end`.
+//  - `inline` is an alias for `inline-start inline-end`.
+// https://drafts.csswg.org/css-box-4/#propdef-margin-trim
+
+// A two level structure (`MarginTrim` and `MarginTrimBase`) is used to allow `MarginTrim` to provide customization
+// of the representation while still utilizing the default `CSSValueCreation` and `Serialization` for `MarginTrimBase`
+// by explicit cast to `MarginTrimBase` in `MarginTrim::switchOn`.
+
+struct MarginTrimBase : CSS::PrimitiveKeywordSet<MarginTrimBase, CSS::Keyword::None, CSS::Keyword::BlockStart, CSS::Keyword::InlineStart, CSS::Keyword::BlockEnd, CSS::Keyword::InlineEnd> {
+    using Base::Base;
+};
+
+struct MarginTrim : MarginTrimBase {
+    using MarginTrimBase::MarginTrimBase;
+    MarginTrim(MarginTrimBase base) : MarginTrimBase { base } { }
+
+    static constexpr MarginTrim blockTrims() { return { CSS::Keyword::BlockStart { }, CSS::Keyword::BlockEnd { } }; }
+    static constexpr MarginTrim inlineTrims() { return { CSS::Keyword::InlineStart { }, CSS::Keyword::InlineEnd { } }; }
+    static constexpr MarginTrim startTrims() { return { CSS::Keyword::BlockStart { }, CSS::Keyword::InlineStart { } }; }
+    static constexpr MarginTrim endTrims() { return { CSS::Keyword::BlockEnd { }, CSS::Keyword::InlineEnd { } }; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+
+        if (containsAll(blockTrims()) && !containsAny(inlineTrims()))
+            return visitor(CSS::Keyword::Block { });
+
+        if (containsAll(inlineTrims()) && !containsAny(blockTrims()))
+            return visitor(CSS::Keyword::Inline { });
+
+        if (containsAll(all()))
+            return visitor(SpaceSeparatedTuple { CSS::Keyword::Block { }, CSS::Keyword::Inline { } });
+
+        return visitor(static_cast<const MarginTrimBase&>(*this));
+    }
+};
+static_assert(sizeof(MarginTrim) == 1);
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<MarginTrim> { auto operator()(BuilderState&, const CSSValue&) -> MarginTrim; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::MarginTrimBase)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::MarginTrim)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueConversion.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordSet.h"
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveKeyword+CSSValueConversion.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+template<CSS::PrimitiveKeywordSetDerived T> struct CSSValueConversion<T> {
+    auto operator()(BuilderState& state, const CSSValue& value) -> T
+    {
+        if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(value)) {
+            auto valueID = primitive->valueID();
+
+            if (primitive->valueID() == T::emptyCase)
+                return T::emptyCase;
+
+            std::optional<T> result;
+            auto processKeyword = [&](const auto keyword, CSSValueID valueID) -> bool {
+                if (keyword.value == valueID) {
+                    result = T { keyword };
+                    return true;
+                }
+                return false;
+            };
+            WTF::apply([&](const auto& ...keyword) { (processKeyword(keyword, valueID) || ...); }, T::Keywords::tuple);
+            if (result)
+                return *result;
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return { };
+        }
+
+        auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+        if (!list)
+            return { };
+
+        T result;
+        auto addKeyword = [&](const auto keyword, CSSValueID valueID) -> bool {
+            if (keyword.value == valueID) {
+                result.add(keyword);
+                return true;
+            }
+            return false;
+        };
+
+        for (Ref primitive : *list) {
+            auto valueID = primitive->valueID();
+
+            bool success = WTF::apply([&](const auto& ...keyword) { return (addKeyword(keyword, valueID) || ...); }, T::Keywords::tuple);
+            if (success)
+                continue;
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return { };
+        }
+
+        return result;
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h
@@ -24,16 +24,29 @@
 
 #pragma once
 
-#include "CSSPrimitiveValueMappings.h"
+#include "CSSPrimitiveKeywordSet.h"
+#include "CSSValueList.h"
+#include "StylePrimitiveKeyword+CSSValueCreation.h"
 #include "StyleValueTypes.h"
 
 namespace WebCore {
 namespace Style {
 
-template<typename T> requires std::is_enum_v<T> struct CSSValueConversion<T> {
-    T operator()(BuilderState&, const CSSValue& value)
+template<CSS::PrimitiveKeywordSetDerived T> struct CSSValueCreation<T> {
+    auto operator()(CSSValuePool& pool, const RenderStyle& style, const T& value) -> Ref<CSSValue>
     {
-        return fromCSSValueID<T>(value.valueID());
+        if (!value)
+            return createCSSValue(pool, style, T::emptyCase);
+
+        CSSValueListBuilder list;
+
+        auto appendKeyword = [&](auto keyword) {
+            if (value.contains(keyword))
+                list.append(createCSSValue(pool, style, keyword));
+        };
+        WTF::apply([&](const auto& ...x) { (appendKeyword(x), ...); }, T::Keywords::tuple);
+
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Logging.h
@@ -24,18 +24,33 @@
 
 #pragma once
 
-#include "CSSPrimitiveValueMappings.h"
+#include "CSSPrimitiveKeywordSet.h"
 #include "StyleValueTypes.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
-template<typename T> requires std::is_enum_v<T> struct CSSValueConversion<T> {
-    T operator()(BuilderState&, const CSSValue& value)
-    {
-        return fromCSSValueID<T>(value.valueID());
-    }
-};
+template<CSS::PrimitiveKeywordSetDerived T> TextStream& operator<<(TextStream& ts, const T& value)
+{
+    if (!value)
+        return ts << '[' << T::emptyCase << ']';
+
+    ts << '[';
+
+    bool listEmpty = true;
+    auto appendKeyword = [&](auto keyword) {
+        if (value.contains(keyword)) {
+            if (!listEmpty)
+                ts << ' ';
+            ts << keyword;
+            listEmpty = false;
+        }
+    };
+    WTF::apply([&](const auto& ...x) { (appendKeyword(x), ...); }, T::Keywords::tuple);
+
+    return ts << ']';
+}
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Serialization.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Serialization.h
@@ -24,16 +24,32 @@
 
 #pragma once
 
-#include "CSSPrimitiveValueMappings.h"
+#include "CSSPrimitiveKeywordSet.h"
+#include "CSSSerializationContext.h"
+#include "StylePrimitiveKeyword+Serialization.h"
 #include "StyleValueTypes.h"
 
 namespace WebCore {
 namespace Style {
 
-template<typename T> requires std::is_enum_v<T> struct CSSValueConversion<T> {
-    T operator()(BuilderState&, const CSSValue& value)
+template<CSS::PrimitiveKeywordSetDerived T> struct Serialize<T> {
+    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const T& value)
     {
-        return fromCSSValueID<T>(value.valueID());
+        if (!value) {
+            serializationForCSS(builder, context, style, T::emptyCase);
+            return;
+        }
+
+        bool listEmpty = true;
+        auto appendKeyword = [&](auto keyword) {
+            if (value.contains(keyword)) {
+                if (!listEmpty)
+                    builder.append(' ');
+                serializationForCSS(builder, context, style, keyword);
+                listEmpty = false;
+            }
+        };
+        WTF::apply([&](const auto& ...x) { (appendKeyword(x), ...); }, T::Keywords::tuple);
     }
 };
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,14 +32,14 @@
 namespace WebCore {
 namespace Style {
 
-// <'-webkit-line-box-contain'> = none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]
-// Non-standard
-struct LineBoxContain : CSS::PrimitiveKeywordSet<LineBoxContain, CSS::Keyword::None, CSS::Keyword::Block, CSS::Keyword::Inline, CSS::Keyword::Font, CSS::Keyword::Glyphs, CSS::Keyword::Replaced, CSS::Keyword::InlineBox, CSS::Keyword::InitialLetter> {
+// <'text-decoration-line'> = none | [ underline || overline || line-through || blink ]
+// https://www.w3.org/TR/css-text-decor-3/#propdef-text-decoration-line
+struct TextDecorationLine : CSS::PrimitiveKeywordSet<TextDecorationLine, CSS::Keyword::None, CSS::Keyword::Underline, CSS::Keyword::Overline, CSS::Keyword::LineThrough, CSS::Keyword::Blink> {
     using Base::Base;
 };
-static_assert(sizeof(LineBoxContain) == 1);
+static_assert(sizeof(TextDecorationLine) == 1);
 
 } // namespace Style
 } // namespace WebCore
 
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::LineBoxContain)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextDecorationLine)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9444,7 +9444,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
                     String value = typingStyle->style()->getPropertyValue(CSSPropertyWebkitTextDecorationsInEffect);
                     [_private->_textTouchBarItemController setTextIsUnderlined:value.contains("underline"_s)];
                 } else
-                    [_private->_textTouchBarItemController setTextIsUnderlined:style->textDecorationLineInEffect().contains(TextDecorationLine::Underline)];
+                    [_private->_textTouchBarItemController setTextIsUnderlined:style->textDecorationLineInEffect().contains(CSS::Keyword::Underline { })];
 
                 Color textColor = style->visitedDependentColor(CSSPropertyColor);
                 if (textColor.isValid())


### PR DESCRIPTION
#### 56d8edca88cb6166aac1459c1e1d01a0a51a32d5
<pre>
[Style] Convert some OptionSet based properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296333">https://bugs.webkit.org/show_bug.cgi?id=296333</a>

Reviewed by NOBODY (OOPS!).

Adds a new aggregate, `CSS::PrimitiveKeywordSet`, that acts just like
an OptionSet, but instead of using an `enum`, it uses a set of CSS::Keyword
constants. This allows for completely generating the conversion and
serialization in the general case.

Adopts new type for `text-decoration-line`, `position-visibility`,
`margin-trim`, and `-webkit-line-box-contain`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXCoreObject.cpp:
* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-values.py:
* Source/WebCore/css/values/primitives/CSSPrimitiveKeywordSet.h: Added.
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxInlines.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
* Source/WebCore/rendering/TextDecorationPainter.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleDifference.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/InlineTextBoxStyle.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/values/anchor-position/StylePositionVisibility.h: Added.
* Source/WebCore/style/values/box/StyleMarginTrim.cpp: Added.
* Source/WebCore/style/values/box/StyleMarginTrim.h: Added.
* Source/WebCore/style/values/inline/StyleLineBoxContain.h:
* Source/WebCore/style/values/primitives/StylePrimitiveKeyword+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueConversion.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Logging.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Serialization.h: Added.
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h: Added.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d8edca88cb6166aac1459c1e1d01a0a51a32d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112862 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23075 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119066 "Hash 56d8edca for PR 48378 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63389 "Hash 56d8edca for PR 48378 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41160 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/119066 "Hash 56d8edca for PR 48378 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/63389 "Hash 56d8edca for PR 48378 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115809 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26542 "Found 60 new test failures: accessibility/checkbox-radio-element-rect.html accessibility/visible-character-range-vertical-rl.html compositing/backing/whitespace-nodes-no-backing.html compositing/direct-image-compositing.html compositing/generated-content.html compositing/geometry/root-layer-update.html compositing/geometry/transfrom-origin-on-zero-size-layer.html compositing/sibling-positioning.html css1/basic/containment.html css1/basic/contextual_selectors.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101531 "Found 1 new API test failure: TestWebKitAPI.WKWebView.RequestAllTextRunsWithSubframes (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/119066 "Hash 56d8edca for PR 48378 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25830 "Found 60 new test failures: imported/w3c/web-platform-tests/compat/webkit-text-fill-color-property-001c.html imported/w3c/web-platform-tests/css/CSS2/floats/floats-placement-vertical-001b.xht imported/w3c/web-platform-tests/css/CSS2/floats/floats-placement-vertical-001c.xht imported/w3c/web-platform-tests/css/CSS2/tables/caption-side-applies-to-001.xht imported/w3c/web-platform-tests/css/CSS2/tables/caption-side-applies-to-005.xht imported/w3c/web-platform-tests/css/CSS2/tables/collapsing-border-model-010a.xht imported/w3c/web-platform-tests/css/CSS2/tables/collapsing-border-model-010b.xht imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-vlr.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-vrl.html imported/w3c/web-platform-tests/css/css-anchor-position/parsing/position-visibility-computed.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19663 "Found 60 new test failures: css1/conformance/forward_compatible_parsing.html css1/font_properties/font.html css1/formatting_model/inline_elements.html css1/text_properties/line_height.html css2.1/20110323/absolute-non-replaced-height-002.htm css2.1/20110323/absolute-non-replaced-height-007.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-width-001.htm css2.1/20110323/absolute-non-replaced-width-002.htm css2.1/20110323/absolute-non-replaced-width-003.htm ... (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62824 "Hash 56d8edca for PR 48378 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95936 "Found 11 new API test failures: TestWebKitAPI.EditorStateTests.MarkedTextRange_VerticalRangeSelection, TestWebKitAPI.AccessibilityTests.RectsForSpeakingSelectionBasic, TestWebKitAPI.EditorStateTests.MarkedTextRange_VerticalCaretSelection, TestWebKitAPI.AccessibilityTests.StoreSelection, TestWebKitAPI.RequestTextInputContext.FocusedEditableLineWithOnlyLineBreak, TestWebKitAPI.AccessibilityTests.RectsForSpeakingSelectionWithLineWrapping, TestWebKitAPI.DragAndDropTests.LinkToInput, TestWebKitAPI.FontAttributes.FontAttributesAfterChangingSelection, TestWebKitAPI.WKWebViewEditActions.ToggleStrikeThrough, TestWebKitAPI.EditorStateTests.TypingAttributesUnderline ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19737 "Found 60 new test failures: css1/conformance/forward_compatible_parsing.html css1/font_properties/font.html css1/formatting_model/inline_elements.html css1/text_properties/line_height.html css2.1/20110323/absolute-non-replaced-height-002.htm css2.1/20110323/absolute-non-replaced-height-007.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-width-001.htm css2.1/20110323/absolute-non-replaced-width-002.htm css2.1/20110323/absolute-non-replaced-width-003.htm ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122287 "Hash 56d8edca for PR 48378 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39940 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29784 "Found 11 new test failures: editing/execCommand/toggle-mixed-text-decorations.html fast/block/lineboxcontain/font-replaced.html fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line.html fast/css3-text/css3-text-decoration/text-decoration-line.html imported/w3c/web-platform-tests/css/css-anchor-position/parsing/position-visibility-computed.html imported/w3c/web-platform-tests/css/css-box/inheritance.html imported/w3c/web-platform-tests/css/css-box/parsing/margin-trim-computed.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed.html imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-line.html imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-horizontal.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/122287 "Hash 56d8edca for PR 48378 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97751 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/122287 "Hash 56d8edca for PR 48378 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39627 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17439 "Found 60 new test failures: compositing/scrolling/async-overflow-scrolling/negative-z-in-scroller.html css1/conformance/forward_compatible_parsing.html css1/font_properties/font.html css1/formatting_model/inline_elements.html css1/text_properties/line_height.html css2.1/20110323/absolute-non-replaced-height-002.htm css2.1/20110323/absolute-non-replaced-height-007.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-width-001.htm css2.1/20110323/absolute-non-replaced-width-002.htm ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36051 "Hash 56d8edca for PR 48378 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39826 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45324 "Found 2 new failures in style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h, style/values/primitives/StylePrimitiveKeywordSet+Serialization.h and found 2 fixed files: style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h, style/values/primitives/StylePrimitiveKeywordSet+Serialization.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->