### PR TITLE
[Form Control Refresh] Number fields do not have the same width as text fields

### DIFF
--- a/LayoutTests/fast/forms/input-email-logical-widths-expected.txt
+++ b/LayoutTests/fast/forms/input-email-logical-widths-expected.txt
@@ -1,0 +1,126 @@
+Inputs with type 'text' and 'email' should have the same default logical widths, and the same logical widths with equal inline padding applied.
+
+Testing left-to-right. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-email-logical-widths.html
+++ b/LayoutTests/fast/forms/input-email-logical-widths.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description">Inputs with type 'text' and 'email' should have the same default logical widths, and the same logical widths with equal inline padding applied.</p>
+<div id="console"></div>
+
+<div id=parent>
+<input type=text>
+<input type=email>
+</div>
+
+<script src="resources/input-logical-widths-helper.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/input-number-logical-widths-expected.txt
+++ b/LayoutTests/fast/forms/input-number-logical-widths-expected.txt
@@ -1,0 +1,126 @@
+Inputs with type 'text' and 'number' should have the same default logical widths, and the same logical widths with equal inline padding applied.
+
+Testing left-to-right. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-number-logical-widths.html
+++ b/LayoutTests/fast/forms/input-number-logical-widths.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description">Inputs with type 'text' and 'number' should have the same default logical widths, and the same logical widths with equal inline padding applied.</p>
+<div id="console"></div>
+
+<div id=parent>
+<input type=text>
+<input type=number>
+</div>
+
+<script src="resources/input-logical-widths-helper.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/input-password-logical-widths-expected.txt
+++ b/LayoutTests/fast/forms/input-password-logical-widths-expected.txt
@@ -1,0 +1,126 @@
+Inputs with type 'text' and 'password' should have the same default logical widths, and the same logical widths with equal inline padding applied.
+
+Testing left-to-right. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-password-logical-widths.html
+++ b/LayoutTests/fast/forms/input-password-logical-widths.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description">Inputs with type 'text' and 'password' should have the same default logical widths, and the same logical widths with equal inline padding applied.</p>
+<div id="console"></div>
+
+<div id=parent>
+<input type=text>
+<input type=password>
+</div>
+
+<script src="resources/input-logical-widths-helper.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/input-tel-logical-widths-expected.txt
+++ b/LayoutTests/fast/forms/input-tel-logical-widths-expected.txt
@@ -1,0 +1,126 @@
+Inputs with type 'text' and 'tel' should have the same default logical widths, and the same logical widths with equal inline padding applied.
+
+Testing left-to-right. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-tel-logical-widths.html
+++ b/LayoutTests/fast/forms/input-tel-logical-widths.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description">Inputs with type 'text' and 'tel' should have the same default logical widths, and the same logical widths with equal inline padding applied.</p>
+<div id="console"></div>
+
+<div id=parent>
+<input type=text>
+<input type=tel>
+
+<script src="resources/input-logical-widths-helper.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/input-url-logical-widths-expected.txt
+++ b/LayoutTests/fast/forms/input-url-logical-widths-expected.txt
@@ -1,0 +1,126 @@
+Inputs with type 'text' and 'url' should have the same default logical widths, and the same logical widths with equal inline padding applied.
+
+Testing left-to-right. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left. (no author specified padding)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl. (no author specified padding)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-start: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-start: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing left-to-right.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing right-to-left.(padding-inline-end: 10px)
+PASS testInput.offsetWidth is baseWidth
+
+
+Testing vertical-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing vertical-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-lr with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+Testing sideways-rl with dir=rtl.(padding-inline-end: 10px)
+PASS testInput.offsetHeight is baseWidth
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/input-url-logical-widths.html
+++ b/LayoutTests/fast/forms/input-url-logical-widths.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description">Inputs with type 'text' and 'url' should have the same default logical widths, and the same logical widths with equal inline padding applied.</p>
+<div id="console"></div>
+
+<div id=parent>
+<input type=text>
+<input type=url>
+</div>
+
+<script src="resources/input-logical-widths-helper.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/input-widths.html
+++ b/LayoutTests/fast/forms/input-widths.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description">Text field types should have the same default widths.</p>
@@ -30,6 +30,5 @@ shouldBe('document.getElementById("url").offsetWidth', 'baseWidth');
 
 document.getElementById('parent').innerHTML = '';
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/resources/input-logical-widths-helper.js
+++ b/LayoutTests/fast/forms/resources/input-logical-widths-helper.js
@@ -1,0 +1,101 @@
+var paddingMsg = " (no author specified padding)";
+var inputs = document.querySelectorAll("input");
+var textInput = inputs[0];
+var testInput = inputs[1];
+var baseWidth = textInput.offsetWidth;
+
+function assertLogicalWidthsEqual(isVertical) {
+    if (isVertical)
+        shouldBe('testInput.offsetHeight', 'baseWidth');
+    else
+        shouldBe('testInput.offsetWidth', 'baseWidth');
+    debug("\n");
+}
+function setWritingMode(writingMode) {
+    inputs.forEach((input) => {
+        input.style.writingMode = writingMode;
+    });
+}
+
+function testVerticalLR() {
+    setWritingMode("vertical-lr");
+    baseWidth = textInput.offsetHeight;
+    assertLogicalWidthsEqual(true);
+    setWritingMode("");
+}
+
+function testVerticalRL() {
+    setWritingMode("vertical-rl");
+    baseWidth = textInput.offsetHeight;
+    assertLogicalWidthsEqual(true);
+    setWritingMode("");
+}
+
+function testSidewaysLR() {
+    setWritingMode("sideways-lr");
+    baseWidth = textInput.offsetHeight;
+    assertLogicalWidthsEqual(true);
+    setWritingMode("");
+}
+
+function testSidewaysRL() {
+    setWritingMode("sideways-rl");
+    baseWidth = textInput.offsetHeight;
+    assertLogicalWidthsEqual(true);
+    setWritingMode("");
+}
+
+function test() {
+    debug("Testing left-to-right." + paddingMsg);
+    assertLogicalWidthsEqual(false);
+
+    debug("Testing vertical-rl." + paddingMsg);
+    testVerticalRL();
+
+    debug("Testing vertical-lr." + paddingMsg);
+    testVerticalLR();
+
+    debug("Testing sideways-lr." + paddingMsg);
+    testSidewaysLR();
+
+    debug("Testing sideways-rl." + paddingMsg);
+    testSidewaysLR();
+
+    debug("Testing right-to-left." + paddingMsg);
+    inputs.forEach((input) => {
+        input.setAttribute("dir","RTL");
+    });
+    baseWidth = textInput.offsetWidth;
+    assertLogicalWidthsEqual(false);
+
+    debug("Testing vertical-rl with dir=rtl." + paddingMsg);
+    testVerticalRL();
+
+    debug("Testing vertical-lr with dir=rtl." + paddingMsg);
+    testVerticalLR();
+
+    debug("Testing sideways-lr with dir=rtl." + paddingMsg);
+    testSidewaysLR();
+
+    debug("Testing sideways-rl with dir=rtl." + paddingMsg);
+    testSidewaysLR();
+}
+test();
+
+paddingMsg = "(padding-inline-start: 10px)"
+inputs.forEach((input) => {
+    input.style.paddingInlineStart = "10px";
+});
+baseWidth = textInput.offsetWidth;
+test();
+
+paddingMsg = "(padding-inline-end: 10px)"
+inputs.forEach((input) => {
+    input.style.paddingInlineEnd = "10px";
+});
+baseWidth = textInput.offsetWidth;
+test();
+
+// type=search is not tested intentionally.
+
+document.getElementById('parent').innerHTML = '';

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8157,6 +8157,9 @@ fast/forms/ios/form-control-refresh/color/paint-within-box.html [ ImageOnlyFailu
 fast/forms/ios/form-control-refresh/select/decoration-color.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-position.html [ ImageOnlyFailure ]
 
+# <rdar://156470462> RTL inputs with type=password have larger logical width than RTL inputs with type number, url, tel, & text
+fast/forms/input-password-logical-widths.html [ Failure ]
+
 webkit.org/b/296338 http/tests/site-isolation/fullscreen.html [ Pass Failure ]
 
 # webkit.org/b/296017 4x imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-021.html (layout-tests) are flakey image failures

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -178,6 +178,8 @@ void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
     }
     // Use average character width. Matches IE.
     maxLogicalWidth = preferredContentLogicalWidth(const_cast<RenderTextControl*>(this)->getAverageCharWidth());
+    maxLogicalWidth = RenderTheme::singleton().adjustedMaximumLogicalWidthForControl(style(), textFormControlElement(), maxLogicalWidth);
+
     auto& logicalWidth = style().logicalWidth();
     if (logicalWidth.isCalculated())
         minLogicalWidth = std::max(0_lu, Style::evaluate(logicalWidth, 0_lu));

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -265,6 +265,8 @@ public:
 
     virtual bool mayNeedBleedAvoidance(const RenderStyle&) const { return true; }
 
+    virtual float adjustedMaximumLogicalWidthForControl(const RenderStyle&, const Element&, float maximumLogicalWidth) const { return maximumLogicalWidth; }
+
 protected:
     ControlStyle extractControlStyleForRenderer(const RenderObject&) const;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -264,6 +264,8 @@ protected:
     Color disabledSubmitButtonTextColor() const final;
 
     bool mayNeedBleedAvoidance(const RenderStyle&) const final;
+
+    float adjustedMaximumLogicalWidthForControl(const RenderStyle&, const Element&, float) const final;
 #endif
 
 private:


### PR DESCRIPTION
#### 476f1ef1dbfc800d96c21282b529e095ed49a15e
<pre>
[Form Control Refresh] Number fields do not have the same width as text fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=296340">https://bugs.webkit.org/show_bug.cgi?id=296340</a>
<a href="https://rdar.apple.com/156408135">rdar://156408135</a>

Reviewed by Aditya Keerthi.

With form control refresh enabled, number fields previously did not have the
same width as text fields due a difference in inline-end padding. These changes
resolve this issue by adding the difference to the maximum logical width of
numberfields during layout.

Added layout tests for inputs of type `email`, `number`, `password`, `tel`,
and `url` to make sure each input type has the same logical width as text
inputs for all writing-modes and directions. These additional tests also
ensure that the listed input types have the same logical width as text inputs
when both have equal inline-padding.

fast/forms/input-password-logical-widths.html does not pass on iOS due to
an issue where password inputs have a larger logical width than other
text-related inputs for the RTL state.

* LayoutTests/fast/forms/input-email-logical-widths-expected.txt: Added.
* LayoutTests/fast/forms/input-email-logical-widths.html: Added.
* LayoutTests/fast/forms/input-number-logical-widths-expected.txt: Added.
* LayoutTests/fast/forms/input-number-logical-widths.html: Added.
* LayoutTests/fast/forms/input-password-logical-widths-expected.txt: Added.
* LayoutTests/fast/forms/input-password-logical-widths.html: Added.
* LayoutTests/fast/forms/input-tel-logical-widths-expected.txt: Added.
* LayoutTests/fast/forms/input-tel-logical-widths.html: Added.
* LayoutTests/fast/forms/input-url-logical-widths-expected.txt: Added.
* LayoutTests/fast/forms/input-url-logical-widths.html: Added.
* LayoutTests/fast/forms/input-widths.html:
* LayoutTests/fast/forms/resources/input-logical-widths-helper.js: Added.
(assertLogicalWidthsEqual):
(setWritingMode):
(testVerticalRL):
(testSidewaysLR):
(testSidewaysRL):
(test):
(paddingMsg.string_appeared_here.inputs.forEach):
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::adjustedMaximumLogicalWidthForControl const):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::paddingBoxForNumberField):
(WebCore::applyEmPaddingForNumberField):
(WebCore::RenderThemeCocoa::adjustTextFieldStyleForVectorBasedControls const):
(WebCore::RenderThemeCocoa::adjustedMaximumLogicalWidthForControl const):

Canonical link: <a href="https://commits.webkit.org/297890@main">https://commits.webkit.org/297890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcb106250f06f60782c8e6bb60060c048540ae55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119491 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63967 "Built successfully") | ✅ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86217 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66544 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63245 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122708 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95065 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45746 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43221 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->