### PR TITLE
[BBQ] Extract Register Allocator for Shared Use

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -876,6 +876,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     jit/RegisterSet.h
     jit/SIMDInfo.h
     jit/SIMDShuffle.h
+    jit/SimpleRegisterAllocator.h
     jit/ScratchRegisterAllocator.h
     jit/Snippet.h
     jit/SnippetParams.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1212,6 +1212,7 @@
 		539BFBB022AD3CDC0023F4C0 /* JSWeakObjectRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 539BFBAF22AD3CDC0023F4C0 /* JSWeakObjectRef.h */; };
 		539DD7F523C1BBB500905F13 /* JSArrayIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 539DD7F423C1BBA900905F13 /* JSArrayIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		539FB8BA1C99DA7C00940FA1 /* JSArrayInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 539FB8B91C99DA7C00940FA1 /* JSArrayInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		53B0D0C42E2E834300FC209B /* SimpleRegisterAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B0D0C32E2E834300FC209B /* SimpleRegisterAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B4BD121F68B32500D2BEA3 /* WasmOps.h in Headers */ = {isa = PBXBuildFile; fileRef = 533B15DE1DC7F463004D500A /* WasmOps.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53B601EC2034B8C5006BE667 /* JSCast.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B601EB2034B8C5006BE667 /* JSCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53C2CE9C22FCC3D6008B2853 /* AirHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C2CE9B22FCC3D6008B2853 /* AirHelpers.h */; };
@@ -4410,6 +4411,7 @@
 		53B0BE331E561AC900A8FC29 /* GetterSetterAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GetterSetterAccessCase.cpp; sourceTree = "<group>"; };
 		53B0BE351E561B0900A8FC29 /* ProxyableAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyableAccessCase.cpp; sourceTree = "<group>"; };
 		53B0BE371E561B2400A8FC29 /* IntrinsicGetterAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntrinsicGetterAccessCase.cpp; sourceTree = "<group>"; };
+		53B0D0C32E2E834300FC209B /* SimpleRegisterAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimpleRegisterAllocator.h; sourceTree = "<group>"; };
 		53B601EB2034B8C5006BE667 /* JSCast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCast.h; sourceTree = "<group>"; };
 		53C2CE9B22FCC3D6008B2853 /* AirHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirHelpers.h; path = b3/air/AirHelpers.h; sourceTree = "<group>"; };
 		53C3D5E421ECE6CE0087FDFC /* basic.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = basic.js; sourceTree = "<group>"; };
@@ -7094,6 +7096,7 @@
 				4B8F57F32953B29600090D27 /* SIMDInfo.cpp */,
 				4BC18E5428FDE6C800ECD68D /* SIMDInfo.h */,
 				E379B58F29834EC5007C4C0E /* SIMDShuffle.h */,
+				53B0D0C32E2E834300FC209B /* SimpleRegisterAllocator.h */,
 				6B731CC02647A8370014646F /* SlowPathCall.cpp */,
 				A709F2EF17A0AC0400512E98 /* SlowPathCall.h */,
 				E3F23A7B1ECF13E500978D99 /* Snippet.h */,
@@ -11854,6 +11857,7 @@
 				4BC18E5628FDE6C800ECD68D /* SIMDInfo.h in Headers */,
 				E379B59029834EC5007C4C0E /* SIMDShuffle.h in Headers */,
 				0F4D8C781FCA3CFA001D32AC /* SimpleMarkingConstraint.h in Headers */,
+				53B0D0C42E2E834300FC209B /* SimpleRegisterAllocator.h in Headers */,
 				0F2B670517B6B5AB00A7AE3F /* SimpleTypedArrayController.h in Headers */,
 				14BA78F113AAB88F005B7C2C /* SlotVisitor.h in Headers */,
 				C2160FE715F7E95E00942DFC /* SlotVisitorInlines.h in Headers */,

--- a/Source/JavaScriptCore/jit/SimpleRegisterAllocator.h
+++ b/Source/JavaScriptCore/jit/SimpleRegisterAllocator.h
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RegisterSet.h"
+#include <array>
+
+namespace JSC {
+
+// Designed as a flexible register allocator for our non-Air backends. Since those backends emit one bytecode or IR node at a time in isolation this API is designed around that. The expected usage of this API will look something like:
+//
+// 1) Start a new bytecode or IR node
+// 2) Lock some number of operands so they don't get evicted.
+// 3) Allocate any scratches and result registers (possibly locking them).
+// 4) Emit assembly.
+// 5) Unlock anything that was locked.
+//
+// Since a bytecode/IR node could have the same operand more than once it's expected that the number of locks on a register matches the number of unlocks before the then next bytecode/IR node begins (thus any subsequent locks). Between the the first unlock and the remaining unlocks it's invalid to allocate a new register.
+template<typename RegisterBank>
+class SimpleRegisterAllocator {
+    WTF_MAKE_NONCOPYABLE(SimpleRegisterAllocator);
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    using Register = RegisterBank::Register;
+    static_assert(std::is_same_v<Register, GPRReg> || std::is_same_v<Register, FPRReg>);
+    using JITBackend = RegisterBank::JITBackend;
+    static constexpr Register invalidRegister = RegisterBank::invalidRegister;
+    // Usually used by JITBackends to track where:
+    //    1) The type of binding it is (e.g. scratch vs value)
+    //    2) Where this value should be flushed to when spilled.
+    using RegisterBinding = JITBackend::RegisterBinding;
+    using RegisterBindings = std::array<RegisterBinding, RegisterBank::numberOfRegisters>;
+    using SpillHint = JITBackend::SpillHint;
+    // We use the high to signify registers that cannot be used or are locked.
+    static_assert(std::unsigned_integral<SpillHint>);
+    static constexpr SpillHint lockBit = SpillHint(1) << (std::numeric_limits<SpillHint>::digits - 1);
+
+    static constexpr Width registerWidth = RegisterBank::defaultWidth;
+
+    SimpleRegisterAllocator() = default;
+
+    Register allocate(JITBackend& backend, RegisterBinding&& binding, std::optional<SpillHint> hint, Register hintReg = invalidRegister)
+    {
+        Register result;
+        if (hintReg != invalidRegister && m_freeRegisters.contains(hintReg, registerWidth))
+            result = hintReg;
+        else
+            result = m_freeRegisters.isEmpty() ? evictRegister(backend) : nextFreeRegister();
+        bind(result, WTFMove(binding), hint);
+        return result;
+    }
+
+    // Pass nullopt as the hint if you don't want to touch the spill order.
+    void bind(Register reg, RegisterBinding&& binding, std::optional<SpillHint> hint)
+    {
+        ASSERT(m_validRegisters.contains(reg, registerWidth));
+        ASSERT(m_freeRegisters.contains(reg, registerWidth));
+        ASSERT(m_bindings[reg] == RegisterBinding());
+        dataLogLnIf(!m_logPrefix.isNull(), m_logPrefix, "\tBinding ", reg, " to ", binding);
+        m_freeRegisters.remove(reg);
+        m_bindings[reg] = WTFMove(binding);
+        if (hint)
+            m_spiller.setHint(reg, hint.value());
+    }
+
+    void unbind(Register reg, ASCIILiteral reason = "Unbinding"_s)
+    {
+        ASSERT(m_validRegisters.contains(reg, registerWidth));
+        ASSERT(!m_spiller.isLocked(reg));
+        dataLogLnIf(!m_logPrefix.isNull(), m_logPrefix, "\t", reason, " ", reg, " currently bound to ", m_bindings[reg]);
+        m_freeRegisters.add(reg, registerWidth);
+        m_bindings[reg] = RegisterBinding();
+    }
+
+    void flushIf(JITBackend& backend, const Invocable<bool(const RegisterBinding&)> auto& functor)
+    {
+        for (Reg r : m_validRegisters) {
+            Register reg = fromJSCReg(r);
+            if (m_freeRegisters.contains(reg, registerWidth)) {
+                ASSERT(m_bindings[reg] == RegisterBinding());
+                continue;
+            }
+
+            if (!functor(m_bindings[reg]))
+                continue;
+
+            backend.flush(reg, m_bindings[reg]);
+            unbind(reg, "Flushing"_s);
+        }
+    }
+
+    void flushAllRegisters(JITBackend& backend)
+    {
+        flushIf(backend, [&](const RegisterBinding&) ALWAYS_INLINE_LAMBDA { return true; });
+    }
+
+    void clobber(JITBackend& backend, Register reg)
+    {
+        if (m_validRegisters.contains(reg, registerWidth) && !m_freeRegisters.contains(reg, registerWidth)) {
+            backend.flush(reg, m_bindings[reg]);
+            unbind(reg, "Clobbering"_s);
+        }
+    }
+
+    RegisterSet validRegisters() const { return m_validRegisters; }
+    RegisterSet freeRegisters() const { return m_freeRegisters; }
+    const RegisterBinding& bindingFor(Register reg) { return m_bindings[reg]; }
+    // FIXME: We should really compress this since it's copied by slow paths to know how to restore the correct state.
+    RegisterBindings copyBindings() const { return m_bindings; }
+    void assertAllValidRegistersAreUnlocked() const
+    {
+#if ASSERT_ENABLED
+        for (Reg reg : m_validRegisters)
+            ASSERT(!m_spiller.isLocked(fromJSCReg(reg)));
+        for (auto lockCount : m_spiller.m_lockCounts)
+            ASSERT(!lockCount);
+#endif
+    }
+
+    void setSpillHint(Register reg, SpillHint hint)
+    {
+        ASSERT(m_bindings[reg] != RegisterBinding());
+        ASSERT(m_validRegisters.contains(reg, registerWidth));
+        m_spiller.setHint(reg, hint);
+    }
+
+    // Note: It's valid to nest calls to lock on the same register more than once. However it is invalid to
+    // call unlock on that register and allocate before all other matching unlocks have run.
+    void lock(Register reg) { m_spiller.lock(reg); }
+    void unlock(Register reg) { m_spiller.unlock(reg); }
+    bool isLocked(Register reg) const { return m_spiller.isLocked(reg); }
+
+    void initialize(RegisterSet registers, ASCIILiteral logPrefix = ASCIILiteral())
+    {
+        ASSERT(m_validRegisters.isEmpty());
+        m_validRegisters = registers;
+        m_freeRegisters = registers;
+        m_spiller.initialize(registers);
+        m_logPrefix = logPrefix;
+        dataLogLnIf(!m_logPrefix.isNull(), m_logPrefix, "\tUsing ", enumTypeName<Register>(), "s ", m_validRegisters);
+    }
+
+private:
+    Register nextFreeRegister()
+    {
+        auto next = m_freeRegisters.begin();
+        ASSERT(next != m_freeRegisters.end());
+        Register reg = fromJSCReg(*next);
+        ASSERT(m_bindings[reg] == RegisterBinding());
+        return reg;
+    }
+
+    Register evictRegister(JITBackend& backend)
+    {
+        Register result = m_spiller.findMin();
+        ASSERT(m_bindings[result] != RegisterBinding());
+        dataLogLnIf(!m_logPrefix.isNull(), m_logPrefix, "\tEvicting ", result, " currently bound to ", m_bindings[result]);
+        backend.flush(result, m_bindings[result]);
+        m_bindings[result] = RegisterBinding();
+        m_freeRegisters.add(result, registerWidth);
+        return result;
+    }
+
+    static constexpr Register fromJSCReg(Reg reg)
+    {
+        // This pattern avoids an explicit template specialization in class scope, which GCC does not support.
+        if constexpr (std::is_same_v<Register, GPRReg>) {
+            ASSERT(reg.isGPR());
+            return reg.gpr();
+        } else if constexpr (std::is_same_v<Register, FPRReg>) {
+            ASSERT(reg.isFPR());
+            return reg.fpr();
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    class Spiller {
+    public:
+        Spiller()
+        {
+            m_hints.fill(lockBit);
+#if ASSERT_ENABLED
+            m_lockCounts.fill(0);
+#endif
+        }
+
+        void initialize(RegisterSet registers)
+        {
+            registers.forEach([&] (JSC::Reg r) {
+                m_hints[fromJSCReg(r)] = 0;
+            });
+        }
+
+        Register findMin()
+        {
+            int32_t minIndex = -1;
+            SpillHint minHint = lockBit;
+            for (unsigned i = 0; i < m_hints.size(); ++i) {
+                ASSERT_IMPLIES(!isLockedOrInvalid(m_hints[i]), !m_lockCounts[i]);
+                if (m_hints[i] < minHint) {
+                    minHint = m_hints[i];
+                    minIndex = i;
+                }
+            }
+
+            RELEASE_ASSERT_WITH_MESSAGE(!isLockedOrInvalid(minHint), "No remaining allocatable registers in Spiller");
+            ASSERT(minIndex >= 0);
+            return static_cast<Register>(minIndex);
+        }
+
+        void setHint(Register reg, SpillHint newHint)
+        {
+            ASSERT(!isLockedOrInvalid(newHint));
+            ASSERT_IMPLIES(isLockedOrInvalid(m_hints[reg]), m_lockCounts[reg]); // Leave untracked registers alone.
+            m_hints[reg] = (m_hints[reg] & lockBit) + newHint;
+        }
+
+        static bool isLockedOrInvalid(SpillHint hint) { return hint & lockBit; }
+        bool isLocked(Register reg) const
+        {
+            ASSERT(!!m_lockCounts[reg] == isLockedOrInvalid(m_hints[reg]));
+            return isLockedOrInvalid(m_hints[reg]);
+        }
+
+        void lock(Register reg)
+        {
+#if ASSERT_ENABLED
+            ASSERT(!!m_lockCounts[reg] == isLockedOrInvalid(m_hints[reg]));
+            m_lockCounts[reg]++;
+#endif
+            m_hints[reg] |= lockBit;
+        }
+
+        void unlock(Register reg)
+        {
+            m_hints[reg] &= ~lockBit;
+#if ASSERT_ENABLED
+            ASSERT(m_lockCounts[reg]);
+            m_lockCounts[reg]--;
+#endif
+        }
+
+        std::array<SpillHint, RegisterBank::numberOfRegisters> m_hints;
+#if ASSERT_ENABLED
+        std::array<unsigned, RegisterBank::numberOfRegisters> m_lockCounts;
+#endif
+    };
+
+    ASCIILiteral m_logPrefix; // non-empty means log.
+    RegisterSet m_validRegisters;
+    RegisterSet m_freeRegisters;
+    Spiller m_spiller;
+    RegisterBindings m_bindings;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -3712,35 +3712,6 @@ void BBQJIT::emitLoad(TypeKind type, Location src, Location dst)
     }
 }
 
-Location BBQJIT::allocateRegisterPair()
-{
-    GPRReg hi, lo;
-
-    do {
-        // we loop here until we can get _two_ register from m_gprSet
-        // this wouldn't be necessary except that evictGPR modifies m_gprSet and nextGPR _doesn't_
-
-        if (m_gprSet.isEmpty()) {
-            evictGPR();
-            continue;
-        }
-
-        auto iter = m_gprSet.begin();
-        ASSERT(iter != m_gprSet.end());
-        hi = (*iter).gpr();
-        ++iter;
-        if (iter == m_gprSet.end()) {
-            m_gprLRU.lock(hi);
-            evictGPR();
-            m_gprLRU.unlock(hi);
-            continue;
-        }
-        lo = (*iter).gpr();
-
-        return Location::fromGPR2(hi, lo);
-    } while (1);
-}
-
 PartialResult WARN_UNUSED_RETURN BBQJIT::addCallRef(const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
 {
     Value callee = args.takeLast();

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.h
@@ -389,11 +389,11 @@ void BBQJIT::emitCCall(Func function, const Vector<Value, N>& arguments, Value& 
 
     RegisterBinding currentBinding;
     if (resultLocation.isGPR())
-        currentBinding = gprBindings()[resultLocation.asGPR()];
+        currentBinding = bindingFor(resultLocation.asGPR());
     else if (resultLocation.isFPR())
-        currentBinding = fprBindings()[resultLocation.asFPR()];
+        currentBinding = bindingFor(resultLocation.asFPR());
     else if (resultLocation.isGPR2())
-        currentBinding = gprBindings()[resultLocation.asGPRhi()];
+        currentBinding = bindingFor(resultLocation.asGPRhi());
     RELEASE_ASSERT(!currentBinding.isScratch());
 
     bind(result, resultLocation);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -36,6 +36,11 @@
 
 namespace JSC { namespace Wasm { namespace BBQJITImpl {
 
+ALWAYS_INLINE bool BBQJIT::typeNeedsGPR2(TypeKind)
+{
+    return false;
+}
+
 template<typename Functor>
 auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32_t uoffset, uint32_t sizeOfOperation, Functor&& functor) -> decltype(auto)
 {
@@ -556,18 +561,18 @@ void BBQJIT::emitCCall(Func function, const Vector<Value, N>& arguments, Value& 
     case TypeKind::Struct:
     case TypeKind::Func: {
         resultLocation = Location::fromGPR(GPRInfo::returnValueGPR);
-        ASSERT(m_validGPRs.contains(GPRInfo::returnValueGPR, IgnoreVectors));
+        ASSERT(validGPRs().contains(GPRInfo::returnValueGPR, IgnoreVectors));
         break;
     }
     case TypeKind::F32:
     case TypeKind::F64: {
         resultLocation = Location::fromFPR(FPRInfo::returnValueFPR);
-        ASSERT(m_validFPRs.contains(FPRInfo::returnValueFPR, Width::Width128));
+        ASSERT(validFPRs().contains(FPRInfo::returnValueFPR, Width::Width128));
         break;
     }
     case TypeKind::V128: {
         resultLocation = Location::fromFPR(FPRInfo::returnValueFPR);
-        ASSERT(m_validFPRs.contains(FPRInfo::returnValueFPR, Width::Width128));
+        ASSERT(validFPRs().contains(FPRInfo::returnValueFPR, Width::Width128));
         break;
     }
     case TypeKind::Void:
@@ -577,9 +582,9 @@ void BBQJIT::emitCCall(Func function, const Vector<Value, N>& arguments, Value& 
 
     RegisterBinding currentBinding;
     if (resultLocation.isGPR())
-        currentBinding = gprBindings()[resultLocation.asGPR()];
+        currentBinding = bindingFor(resultLocation.asGPR());
     else if (resultLocation.isFPR())
-        currentBinding = fprBindings()[resultLocation.asFPR()];
+        currentBinding = bindingFor(resultLocation.asFPR());
     RELEASE_ASSERT(!currentBinding.isScratch());
 
     bind(result, resultLocation);

--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -170,11 +170,11 @@ constexpr std::span<const char> enumTypeNameImpl()
 #if COMPILER(CLANG)
     const size_t prefix = sizeof("std::span<const char> WTF::enumTypeNameImpl() [E = ") - 1;
     const size_t suffix = sizeof("]") - 1;
-    std::span<const char> name { __PRETTY_FUNCTION__ + prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1 };
+    std::span<const char> name = std::span { __PRETTY_FUNCTION__ }.subspan(prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1);
 #elif COMPILER(GCC)
     const size_t prefix = sizeof("constexpr std::span<const char> WTF::enumTypeNameImpl() [with auto V = ") - 1;
     const size_t suffix = sizeof("]") - 1;
-    std::span<const char> name { __PRETTY_FUNCTION__ + prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1 };
+    std::span<const char> name = std::span { __PRETTY_FUNCTION__ }.subspan(prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1);
 #else
 #error "Unsupported compiler"
 #endif


### PR DESCRIPTION
#### a0315f345b4e886dbfe4ebe74290ba315f3e1a1c
<pre>
[BBQ] Extract Register Allocator for Shared Use
<a href="https://bugs.webkit.org/show_bug.cgi?id=296341">https://bugs.webkit.org/show_bug.cgi?id=296341</a>
<a href="https://rdar.apple.com/156433214">rdar://156433214</a>

Reviewed by Dan Hecht.

This patch extracts BBQ&apos;s register allocator in to a shared header. There shouldn&apos;t be a significant
behavior change between the shared one and the new one. The new allocator takes a RegisterBank template
argument that defines the different details for both the JIT backend and register file in question.

The new class mostly follows the same terminology as BBQ did. The biggest change is that what was
called the LRU is now the Spiller, which operates on a spill hint. When we need to find a register
to evict we search for the value with the smallest hint. The highest bit is reserved for locking
a register or indicating that a register is ineligible. Additionally, the allocator has a abstract
RegisterBinding that it tracks and provides to the backend when requested or flushing. This binding
is intended to track any details the backend needs about the status of the register.

Lastly fix EnumTraits to work with Clang&apos;s safe buffer access for the enum&apos;s type name.

Canonical link: <a href="https://commits.webkit.org/297809@main">https://commits.webkit.org/297809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a01db469299139c6f70566cd5f5fee3064e1bcb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85943 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19712 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62885 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105440 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122348 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111539 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/29827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94801 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94539 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36114 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45386 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135769 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39528 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/36467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->