### PR TITLE
[Absolute Positioning] Add simple end self alignment support for abspos child of a grid.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-end-large-border-padding-ref.html"
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-end-ref.html"
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -97,7 +97,7 @@ private:
     LayoutRange adjustForPositionArea(const LayoutRange rangeToAdjust, const LayoutRange anchorArea, const BoxAxis containerAxis);
 
     bool needsGridAreaAdjustmentBeforeStaticPositioning() const;
-    bool isEligibleForStaticRangeAlignment() const;
+    bool isEligibleForStaticRangeAlignment(LayoutUnit spaceInStaticRange, LayoutUnit itemSize) const;
     void computeStaticPosition();
     void computeInlineStaticDistance();
     void computeBlockStaticDistance();


### PR DESCRIPTION
#### 6a70a59db4a41a280826a4fa5b51e36536c7232e
<pre>
[Absolute Positioning] Add simple end self alignment support for abspos child of a grid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296345">https://bugs.webkit.org/show_bug.cgi?id=296345</a>
<a href="https://rdar.apple.com/156438264">rdar://156438264</a>

Reviewed by Alan Baradlay.

In 297724@main we added some skeleton code for a new codepath which is
supposed to perform alignment of an absolutely positioned box within its
static position rectangle/range. This patch serves as a first step to
build up this path by adding some support when an abspos box is a child
of a grid. Although we relax the eligibility to allow grid content to
potentially run through this new path, we still maintain some strictness
by only allowing content in fairly simple and straightforward contexts.
These restrictions include:

1.) Making sure that the containing block is not the same as the parent.
This is because the definition of the static position rectangle is
different in this context for grids.

2.) Forcing the alignment subject, containing block, and parent to all
be horizontal-tb and LTR. Purely just to keep things simple.

3.) Only allowing end self alignment with default position type and
default overflow behavior which will get expanded on over time.

4.) Making sure that the alignment subject is smaller than the available
space since there is special logic for safety which will need to be
addressed in the future.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html: Added.
Fairly straightforward tests to make sure this new functionality is
correct. Both contain grids with abspos children that are simply aligned
towards the end with lots of available space. One test has variable
border and padding to make sure everything is okay in that context.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::isEligibleForStaticRangeAlignment const):
Modified to take in the remaining space in the static range along with
the size of the box. This is used to make a decision based on the
alignment safety and for now we only support content in which the box
fits within the available space.

(WebCore::PositionedLayoutConstraints::resolvePosition const):
We call into resolveAlignmentShift since it can compute the amount the
box needs to move to satisfy the alignment. Also, add a new lambda which
computes the size of the static range. Since this is a dependency on
eligibility, I opted to create it as a lambda here and not a static
function so that it cannot get called in contexts we do not support yet.
* Source/WebCore/rendering/PositionedLayoutConstraints.h:

Canonical link: <a href="https://commits.webkit.org/297803@main">https://commits.webkit.org/297803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a748996f406ec54b0315203e4c4ed4566f98be4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66206 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62834 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122297 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94501 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36063 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45334 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->