### PR TITLE
[css-anchor-position-1] Handle inline containing blocks

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7702,7 +7702,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-fa
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/position-area-inline-container.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-try-switch-to-fixed-anchor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-add-no-overflow.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
@@ -2,5 +2,5 @@ Lorem ipsum dolor sit amet.
 Lorem ipsum dolor sit amet.
 
 FAIL getComputedStyle() with fragmented containing block in multicolumn layout assert_equals: expected "25px" but got "135px"
-FAIL getComputedStyle() with fragmented containing block in inline layout assert_equals: expected "-120px" but got "0px"
+PASS getComputedStyle() with fragmented containing block in inline layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
@@ -5,32 +5,20 @@ spacer
 a1 345
 0 12 a1 a1 a1 345
 
-FAIL .target 1 assert_equals:
-<span class="target target1-pos" data-offset-x="30" data-offset-y="0" data-expected-width="20" data-expected-height="10"></span>
-offsetLeft expected 30 but got 50
-FAIL .target 2 assert_equals:
-<span class="target target1-size" data-offset-x="30" data-offset-y="0" data-expected-width="20" data-expected-height="10"></span>
-offsetLeft expected 30 but got 50
+PASS .target 1
+PASS .target 2
 PASS .target 3
 PASS .target 4
 PASS .target 5
 PASS .target 6
-FAIL .target 7 assert_equals:
-<span class="target target1-pos" data-offset-x="-20" data-offset-y="0" data-expected-width="100" data-expected-height="20"></span>
-offsetLeft expected -20 but got 0
-FAIL .target 8 assert_equals:
-<span class="target target1-size" data-offset-x="-20" data-offset-y="0" data-expected-width="100" data-expected-height="20"></span>
-offsetLeft expected -20 but got 0
+PASS .target 7
+PASS .target 8
 PASS .target 9
 PASS .target 10
 PASS .target 11
 PASS .target 12
-FAIL .target 13 assert_equals:
-<span class="target target1-pos" data-offset-x="-20" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
-offsetLeft expected -20 but got 0
-FAIL .target 14 assert_equals:
-<span class="target target1-size" data-offset-x="-20" data-offset-y="0" data-expected-width="70" data-expected-height="20"></span>
-offsetLeft expected -20 but got 0
+PASS .target 13
+PASS .target 14
 PASS .target 15
 PASS .target 16
 PASS .target 17

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -215,7 +215,7 @@ void PositionedLayoutConstraints::captureAnchorGeometry()
         return;
 
     // Store the anchor geometry.
-    LayoutRect anchorRect = Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(*m_defaultAnchorBox, *m_renderer->containingBlock());
+    LayoutRect anchorRect = Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock(*m_defaultAnchorBox, *m_container);
     m_anchorArea = extractRange(anchorRect);
 
     // Adjust containing block for position-area.

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -858,10 +858,12 @@ LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child)
     // Per http://www.w3.org/TR/CSS2/visudet.html#abs-non-replaced-width an absolute positioned box with a static position
     // should locate itself as though it is a normal flow box in relation to its containing block.
     LayoutSize logicalOffset;
-    if (!child->style().hasStaticInlinePosition(writingMode().isHorizontal()))
+    if (!child->style().hasStaticInlinePosition(writingMode().isHorizontal())
+        || child->style().positionArea() || child->style().justifySelf().position() == ItemPosition::AnchorCenter)
         logicalOffset.setWidth(inlinePosition);
 
-    if (!child->style().hasStaticBlockPosition(writingMode().isHorizontal()))
+    if (!child->style().hasStaticBlockPosition(writingMode().isHorizontal())
+        || child->style().positionArea() || child->style().alignSelf().position() == ItemPosition::AnchorCenter)
         logicalOffset.setHeight(blockPosition);
 
     return writingMode().isHorizontal() ? logicalOffset : logicalOffset.transposedSize();

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -47,6 +47,7 @@ class LayoutSize;
 class RenderBlock;
 class RenderBox;
 class RenderBoxModelObject;
+class RenderElement;
 class RenderStyle;
 
 enum CSSPropertyID : uint16_t;
@@ -120,7 +121,7 @@ public:
     static void updatePositionsAfterScroll(Document&);
     static void updateAnchorPositionedStateForDefaultAnchor(Element&, const RenderStyle&, AnchorPositionedStates&);
 
-    static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
+    static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderElement& containingBlock);
 
     static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(AnchorPositionedToAnchorMap&);
 


### PR DESCRIPTION
#### c4a1b010711c78e87481893d09ebb06a323d1ab2
<pre>
[css-anchor-position-1] Handle inline containing blocks
<a href="https://bugs.webkit.org/show_bug.cgi?id=296309">https://bugs.webkit.org/show_bug.cgi?id=296309</a>
<a href="https://rdar.apple.com/156362355">rdar://156362355</a>

Reviewed by Alan Baradlay.

computeAnchorRectRelativeToContainingBlock() was only able to operate on
RenderBlock containing blocks, but positioned inlines can also form a
containing block, so this patch updates us to handle those.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt:

Pass more tests. (The still-failing parts are all multicol.)

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureAnchorGeometry):

Pass in the inline containing block.

* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::offsetForInFlowPositionedInline const):

position-area and anchor-center are no longer using static positioning,
so we need to apply the same shift we do to explicit insets.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::offsetFromAncestorContainer):
(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):

Shift inline offset handling into offsetFromAncestorContainer
and add handling of positioned inline containing blocks.

(WebCore::Style::computeInsetValue):
* Source/WebCore/style/AnchorPositionEvaluator.h:

Update API to allow RenderElement not just RenderBlock.

Canonical link: <a href="https://commits.webkit.org/297802@main">https://commits.webkit.org/297802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3680bd640a8a43e1e27c8a88a304bcc971b71482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119114 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41208 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/85926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/63444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115857 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/26576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19701 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/62872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19774 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/122335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39988 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/29817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/122335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97788 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/122335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24132 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39657 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/17475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39874 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/45372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/39514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/42847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->