### PR TITLE
[Navigation API] Fix beforeunload event timing and info parameter for cross-document traversals.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigate event for navigation.back() - cross-document assert_true: expected true got false
+PASS navigate event for navigation.back() - cross-document
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -548,6 +548,8 @@ private:
 
     bool m_errorOccurredInLoading { false };
     bool m_doNotAbortNavigationAPI { false };
+    bool m_navigationAPITraversalInProgress { false };
+    RefPtr<HistoryItem> m_pendingNavigationAPIItem;
     uint64_t m_requiredCookiesVersion { 0 };
 };
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -736,11 +736,19 @@ void Navigation::promoteUpcomingAPIMethodTracker(const String& destinationKey)
 {
     // FIXME: We should be able to assert m_ongoingAPIMethodTracker is unset.
 
-    if (!destinationKey.isNull())
+    if (!destinationKey.isEmpty())
         m_ongoingAPIMethodTracker = m_upcomingTraverseMethodTrackers.take(destinationKey);
-    else {
+    else if (destinationKey.isNull()) {
         m_ongoingAPIMethodTracker = WTFMove(m_upcomingNonTraverseMethodTracker);
         m_upcomingNonTraverseMethodTracker = nullptr;
+    } else if (destinationKey.isEmpty() && !m_upcomingTraverseMethodTrackers.isEmpty()) {
+        // For traverse navigation where destination key is empty, try to use any available traverse method tracker.
+        // (e.g., cross-document navigation where NavigationHistoryEntry is not found).
+        auto firstTracker = m_upcomingTraverseMethodTrackers.begin();
+        if (firstTracker != m_upcomingTraverseMethodTrackers.end()) {
+            String trackerKey = firstTracker->key;
+            m_ongoingAPIMethodTracker = m_upcomingTraverseMethodTrackers.take(trackerKey);
+        }
     }
 }
 


### PR DESCRIPTION
#### 8c2414bf6f23eb558767447d83e80e81855bfbb5
<pre>
[Navigation API] Fix beforeunload event timing and info parameter for cross-document traversals.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296349">https://bugs.webkit.org/show_bug.cgi?id=296349</a>
<a href="https://rdar.apple.com/156446875">rdar://156446875</a>

Reviewed by Chris Dumez.

This commit resolves two critical issues with the Navigation API&apos;s navigate event handling
for cross-document traversals:
- Navigate events were firing before beforeunload events that is violating the HTML spec.
- `navigation.back({ info: &quot;hi&quot; })` info parameter wasn&apos;t reaching navigate events.

The first issue was in `loadItem()`, navigate events were dispatched immediately for all
navigation types, occurring before `shouldClose()` executed beforeunload handlers.

- For same-document navigation: Dispatch navigate events immediately (no beforeunload)
- For cross-document navigation: Store HistoryItem in `m_pendingNavigationAPIItem` and
  defer dispatch until after `shouldClose()` in `continueLoadAfterNavigationPolicy()`

The second issue was due to `promoteUpcomingAPIMethodTracker()` failed to handle cases where
`destinationKey` was an empty string, preventing API method tracker promotion.

To solve this, enhanced the promotion logic to use any available traverse method tracker
when the destination key is empty, ensuring info parameters are properly propagated.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-navigation-back-cross-document-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::dispatchNavigateEvent):
(WebCore::FrameLoader::loadItem):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::promoteUpcomingAPIMethodTracker):

Canonical link: <a href="https://commits.webkit.org/297824@main">https://commits.webkit.org/297824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca4bb1997c4d5854a34d4a6c2245f77c319255ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66263 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62908 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122371 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94820 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24147 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36137 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->