### PR TITLE
Fix debug assert in ScrollingEffectsController::processWheelEventForScrollSnap

### DIFF
--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -532,6 +532,7 @@ enum class WheelEventStatus {
     UserScrollBegin,
     UserScrolling,
     UserScrollEnd,
+    MomentumScrollWillBegin,
     MomentumScrollBegin,
     MomentumScrolling,
     MomentumScrollEnd,
@@ -555,11 +556,14 @@ static inline WheelEventStatus toWheelEventStatus(PlatformWheelEventPhase phase,
         case PlatformWheelEventPhase::None:
             return WheelEventStatus::DiscreteScrollEvent;
 
+        case PlatformWheelEventPhase::WillBegin:
+            return WheelEventStatus::MomentumScrollWillBegin;
+
         default:
             return WheelEventStatus::Unknown;
         }
     }
-    if (momentumPhase == PlatformWheelEventPhase::None) {
+    if (momentumPhase == PlatformWheelEventPhase::None || momentumPhase == PlatformWheelEventPhase::WillBegin) {
         switch (phase) {
         case PlatformWheelEventPhase::Began:
         case PlatformWheelEventPhase::MayBegin:
@@ -571,7 +575,8 @@ static inline WheelEventStatus toWheelEventStatus(PlatformWheelEventPhase phase,
         case PlatformWheelEventPhase::Ended:
         case PlatformWheelEventPhase::Cancelled:
             return WheelEventStatus::UserScrollEnd;
-                
+        case PlatformWheelEventPhase::WillBegin:
+            return WheelEventStatus::MomentumScrollWillBegin;
         default:
             return WheelEventStatus::Unknown;
         }
@@ -586,6 +591,7 @@ static TextStream& operator<<(TextStream& ts, WheelEventStatus status)
     case WheelEventStatus::UserScrollBegin: ts << "UserScrollBegin"_s; break;
     case WheelEventStatus::UserScrolling: ts << "UserScrolling"_s; break;
     case WheelEventStatus::UserScrollEnd: ts << "UserScrollEnd"_s; break;
+    case WheelEventStatus::MomentumScrollWillBegin: ts << "MomentumScrollWillBegin"_s; break;
     case WheelEventStatus::MomentumScrollBegin: ts << "MomentumScrollBegin"_s; break;
     case WheelEventStatus::MomentumScrolling: ts << "MomentumScrolling"_s; break;
     case WheelEventStatus::MomentumScrollEnd: ts << "MomentumScrollEnd"_s; break;
@@ -700,6 +706,8 @@ bool ScrollingEffectsController::processWheelEventForScrollSnap(const PlatformWh
     case WheelEventStatus::DiscreteScrollEvent:
         m_scrollSnapState->transitionToUserInteractionState();
         scheduleDiscreteScrollSnap(wheelEvent.delta());
+        break;
+    case WheelEventStatus::MomentumScrollWillBegin:
         break;
     case WheelEventStatus::Unknown:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 7802b9e685f8ab29f91f8602f22ae22d9b2fa429
<pre>
Fix debug assert in ScrollingEffectsController::processWheelEventForScrollSnap
<a href="https://bugs.webkit.org/show_bug.cgi?id=296352">https://bugs.webkit.org/show_bug.cgi?id=296352</a>
<a href="https://rdar.apple.com/156449395">rdar://156449395</a>

Reviewed by Simon Fraser.

Have ScrollingEffectsController::processWheelEventForScrollSnap handle wheel events
that have momentumPhase=WillBegin.

* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::toWheelEventStatus):
(WebCore::operator&lt;&lt;):
(WebCore::ScrollingEffectsController::processWheelEventForScrollSnap):

Canonical link: <a href="https://commits.webkit.org/297840@main">https://commits.webkit.org/297840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cb2973aff475521aac649d491565c9343b894ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85910 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36661 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101550 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66215 "Found 143 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestAuthentication:/webkit/Authentication/authentication-ephemeral, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94775 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94513 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36076 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18186 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45347 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->