### PR TITLE
Add the idl files and stubs for User Agent Client Hints

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1508,6 +1508,9 @@ set(WebCore_NON_SVG_IDL_FILES
     page/NavigatorServiceWorker.idl
     page/NavigatorShare.idl
     page/NavigatorStorage.idl
+    page/NavigatorUA.idl
+    page/NavigatorUABrandVersion.idl
+    page/NavigatorUAData.idl
     page/Performance+EventCounts.idl
     page/Performance+NavigationTiming.idl
     page/Performance+PerformanceTimeline.idl
@@ -1545,6 +1548,8 @@ set(WebCore_NON_SVG_IDL_FILES
     page/ShadowRealmGlobalScope.idl
     page/ShareData.idl
     page/StructuredSerializeOptions.idl
+    page/UADataValues.idl
+    page/UALowEntropyJSON.idl
     page/UndoItem.idl
     page/UndoManager.idl
     page/VisualViewport.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1884,6 +1884,9 @@ $(PROJECT_DIR)/page/NavigatorServiceWorker.idl
 $(PROJECT_DIR)/page/NavigatorShare.idl
 $(PROJECT_DIR)/page/NavigatorStorage.idl
 $(PROJECT_DIR)/page/NavigatorStorageManager.idl
+$(PROJECT_DIR)/page/NavigatorUA.idl
+$(PROJECT_DIR)/page/NavigatorUABrandVersion.idl
+$(PROJECT_DIR)/page/NavigatorUAData.idl
 $(PROJECT_DIR)/page/Performance+EventCounts.idl
 $(PROJECT_DIR)/page/Performance+NavigationTiming.idl
 $(PROJECT_DIR)/page/Performance+PerformanceTimeline.idl
@@ -1924,6 +1927,8 @@ $(PROJECT_DIR)/page/Settings.yaml
 $(PROJECT_DIR)/page/ShadowRealmGlobalScope.idl
 $(PROJECT_DIR)/page/ShareData.idl
 $(PROJECT_DIR)/page/StructuredSerializeOptions.idl
+$(PROJECT_DIR)/page/UADataValues.idl
+$(PROJECT_DIR)/page/UALowEntropyJSON.idl
 $(PROJECT_DIR)/page/UndoItem.idl
 $(PROJECT_DIR)/page/UndoManager.idl
 $(PROJECT_DIR)/page/UserMessageHandler.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2089,6 +2089,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorShare.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorShare.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorStorage.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorStorage.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorUA.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorUA.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorUABrandVersion.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorUABrandVersion.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorUAData.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorUAData.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNodeFilter.cpp
@@ -3086,6 +3092,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTrustedTypePolicyOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTrustedTypePolicyOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTypeConversions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSTypeConversions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUADataValues.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUADataValues.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUALowEntropyJSON.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUALowEntropyJSON.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUIEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUIEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUIEventInit.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1541,6 +1541,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/NavigationNavigationType.idl \
     $(WebCore)/page/NavigationTransition.idl \
     $(WebCore)/page/Navigator.idl \
+    $(WebCore)/page/NavigatorUA.idl \
+    $(WebCore)/page/NavigatorUABrandVersion.idl \
+    $(WebCore)/page/NavigatorUAData.idl \
     $(WebCore)/page/Navigator+LoginStatus.idl \
     $(WebCore)/page/Navigator+UserActivation.idl \
     $(WebCore)/page/NavigatorCookies.idl \
@@ -1588,6 +1591,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/ShadowRealmGlobalScope.idl \
     $(WebCore)/page/ShareData.idl \
     $(WebCore)/page/StructuredSerializeOptions.idl \
+    $(WebCore)/page/UADataValues.idl \
+    $(WebCore)/page/UALowEntropyJSON.idl \
     $(WebCore)/page/UndoItem.idl \
     $(WebCore)/page/UndoManager.idl \
     $(WebCore)/page/UserMessageHandler.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2149,6 +2149,7 @@ page/NavigationTransition.cpp
 page/Navigator.cpp
 page/NavigatorBase.cpp
 page/NavigatorLoginStatus.cpp
+page/NavigatorUAData.cpp
 page/OpportunisticTaskScheduler.cpp
 page/OriginAccessEntry.cpp
 page/OriginAccessPatterns.cpp
@@ -4304,6 +4305,9 @@ JSNavigationTransition.cpp
 JSNavigationNavigationType.cpp
 JSNavigator.cpp
 JSNavigatorGPU.cpp
+JSNavigatorUA.cpp
+JSNavigatorUABrandVersion.cpp
+JSNavigatorUAData.cpp
 JSNode.cpp
 JSNodeFilter.cpp
 JSCustomXPathNSResolver.cpp
@@ -4820,6 +4824,8 @@ JSCSSUnitValue.cpp
 JSCSSUnparsedValue.cpp
 JSFragmentDirective.cpp
 JSFullscreenOptions.cpp
+JSUADataValues.cpp
+JSUALowEntropyJSON.cpp
 JSUIEvent.cpp
 JSUIEventInit.cpp
 JSURLPattern.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -332,6 +332,8 @@ namespace WebCore {
     macro(NavigationPreloadManager) \
     macro(NavigationTransition) \
     macro(NavigatorCredentials) \
+    macro(NavigatorUA) \
+    macro(NavigatorUAData) \
     macro(NavigatorMediaDevices) \
     macro(NavigatorPermissions) \
     macro(NavigatorUserMedia) \

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -40,6 +40,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "LocalizedStrings.h"
+#include "NavigatorUAData.h"
 #include "Page.h"
 #include "PermissionsPolicy.h"
 #include "PlatformStrategies.h"
@@ -446,5 +447,22 @@ int Navigator::maxTouchPoints() const
 
     return 0;
 }
+
+void Navigator::initializeNavigatorUAData() const
+{
+    if (m_navigatorUAData)
+        return;
+
+    // FIXME(296489): populate the data structure
+    return;
+}
+
+NavigatorUAData& Navigator::userAgentData() const
+{
+    if (!m_navigatorUAData)
+        initializeNavigatorUAData();
+
+    return *m_navigatorUAData;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -35,6 +35,7 @@ class DOMMimeTypeArray;
 class DOMPluginArray;
 class Page;
 class ShareDataReader;
+class NavigatorUAData;
 
 class Navigator final
     : public NavigatorBase
@@ -60,6 +61,7 @@ public:
     bool onLine() const final;
     bool canShare(Document&, const ShareData&);
     void share(Document&, const ShareData&, Ref<DeferredPromise>&&);
+    NavigatorUAData& userAgentData() const;
     
 #if ENABLE(NAVIGATOR_STANDALONE)
     bool standalone() const;
@@ -84,6 +86,7 @@ private:
     explicit Navigator(ScriptExecutionContext*, LocalDOMWindow&);
 
     void initializePluginAndMimeTypeArrays();
+    void initializeNavigatorUAData() const;
 
     mutable RefPtr<ShareDataReader> m_loader;
     mutable bool m_hasPendingShare { false };
@@ -92,6 +95,7 @@ private:
     mutable RefPtr<DOMMimeTypeArray> m_mimeTypes;
     mutable String m_userAgent;
     mutable String m_platform;
+    mutable RefPtr<NavigatorUAData> m_navigatorUAData;
     RefPtr<GPU> m_gpuForWebGPU;
 };
 }

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -40,3 +40,4 @@ Navigator includes NavigatorServiceWorker;
 Navigator includes NavigatorShare;
 Navigator includes NavigatorStorage;
 Navigator includes NavigatorGPU;
+Navigator includes NavigatorUA;

--- a/Source/WebCore/page/NavigatorUA.idl
+++ b/Source/WebCore/page/NavigatorUA.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+// https://wicg.github.io/ua-client-hints/#idl-index
+[
+  EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled
+] interface mixin NavigatorUA {
+  [SecureContext] readonly attribute NavigatorUAData userAgentData;
+};

--- a/Source/WebCore/page/NavigatorUABrandVersion.h
+++ b/Source/WebCore/page/NavigatorUABrandVersion.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+struct NavigatorUABrandVersion {
+    String brand;
+    String version;
+};
+}

--- a/Source/WebCore/page/NavigatorUABrandVersion.idl
+++ b/Source/WebCore/page/NavigatorUABrandVersion.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://wicg.github.io/ua-client-hints/#idl-index
+[
+    JSGenerateToJSObject,
+    EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled
+] dictionary NavigatorUABrandVersion {
+  DOMString brand;
+  DOMString version;
+};
+

--- a/Source/WebCore/page/NavigatorUAData.cpp
+++ b/Source/WebCore/page/NavigatorUAData.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "NavigatorUAData.h"
+
+#include "NotImplemented.h"
+#include "UADataValues.h"
+#include "UALowEntropyJSON.h"
+
+namespace WebCore {
+NavigatorUAData::NavigatorUAData() = default;
+NavigatorUAData::~NavigatorUAData() = default;
+
+Ref<NavigatorUAData> NavigatorUAData::create()
+{
+    return adoptRef(*new NavigatorUAData());
+}
+
+const Vector<NavigatorUABrandVersion>& NavigatorUAData::brands() const
+{
+    return m_brands;
+}
+
+bool NavigatorUAData::mobile() const
+{
+    return false;
+}
+
+const String& NavigatorUAData::platform() const
+{
+    return m_platform;
+}
+
+UALowEntropyJSON NavigatorUAData::toJSON() const
+{
+    return UALowEntropyJSON {
+        { },
+        false,
+        ""_s
+    };
+}
+
+void NavigatorUAData::getHighEntropyValues(const Vector<String>&, NavigatorUAData::ValuesPromise&&) const
+{
+    notImplemented();
+    return;
+}
+}

--- a/Source/WebCore/page/NavigatorUAData.h
+++ b/Source/WebCore/page/NavigatorUAData.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IDLTypes.h"
+#include "JSDOMPromiseDeferred.h"
+#include "NavigatorUABrandVersion.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+struct NavigatorUABrandVersion;
+struct UADataValues;
+struct UALowEntropyJSON;
+
+class NavigatorUAData : public RefCounted<NavigatorUAData> {
+public:
+    static Ref<NavigatorUAData> create();
+    const Vector<NavigatorUABrandVersion>& brands() const;
+    bool mobile() const;
+    const String& platform() const;
+    UALowEntropyJSON toJSON() const;
+
+    using ValuesPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<UADataValues>>>;
+    void getHighEntropyValues(const Vector<String>& hints, ValuesPromise&&) const;
+    ~NavigatorUAData();
+
+private:
+    NavigatorUAData();
+
+    const Vector<NavigatorUABrandVersion> m_brands = { };
+    const String m_platform = ""_s;
+};
+}

--- a/Source/WebCore/page/NavigatorUAData.idl
+++ b/Source/WebCore/page/NavigatorUAData.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+  Exposed=(Window,Worker),
+  EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled
+]
+interface NavigatorUAData {
+  readonly attribute FrozenArray<NavigatorUABrandVersion> brands;
+  readonly attribute boolean mobile;
+  readonly attribute DOMString platform;
+  Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints);
+  UALowEntropyJSON toJSON();
+};

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -42,6 +42,7 @@
 #include "VoidCallback.h"
 #include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <JavaScriptCore/ConsoleTypes.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/UADataValues.h
+++ b/Source/WebCore/page/UADataValues.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NavigatorUABrandVersion.h"
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+struct UADataValues {
+    String architecture;
+    String bitness;
+    Vector<NavigatorUABrandVersion> brands;
+    Vector<String> formFactors;
+    Vector<NavigatorUABrandVersion> fullVersionList;
+    String model;
+    bool mobile;
+    String platform;
+    String platformVersion;
+    String uaFullVersion;
+    bool wow64;
+};
+}

--- a/Source/WebCore/page/UADataValues.idl
+++ b/Source/WebCore/page/UADataValues.idl
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://wicg.github.io/ua-client-hints/#idl-index
+[
+    JSGenerateToJSObject,
+    EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled
+] dictionary UADataValues {
+  DOMString architecture;
+  DOMString bitness;
+  sequence<NavigatorUABrandVersion> brands;
+  sequence<DOMString> formFactors;
+  sequence<NavigatorUABrandVersion> fullVersionList;
+  DOMString model;
+  boolean mobile;
+  DOMString platform;
+  DOMString platformVersion;
+  DOMString uaFullVersion; // deprecated in favor of fullVersionList
+  boolean wow64;
+};

--- a/Source/WebCore/page/UALowEntropyJSON.h
+++ b/Source/WebCore/page/UALowEntropyJSON.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NavigatorUABrandVersion.h"
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+struct UALowEntropyJSON {
+    Vector<NavigatorUABrandVersion> brands;
+    bool mobile;
+    String platform;
+};
+}

--- a/Source/WebCore/page/UALowEntropyJSON.idl
+++ b/Source/WebCore/page/UALowEntropyJSON.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://wicg.github.io/ua-client-hints/#idl-index
+[
+  JSGenerateToJSObject,
+  EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled
+] dictionary UALowEntropyJSON {
+  sequence<NavigatorUABrandVersion> brands;
+  boolean mobile;
+  DOMString platform;
+};

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -37,6 +37,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerThread.h"
 #include <wtf/TZoneMallocInlines.h>
+#include "NavigatorUAData.h"
 
 namespace WebCore {
 
@@ -108,5 +109,22 @@ void WorkerNavigator::clearAppBadge(Ref<DeferredPromise>&& promise)
 {
     setAppBadge(0, WTFMove(promise));
 }
+
+void WorkerNavigator::initializeNavigatorUAData() const
+{
+    if (m_navigatorUAData)
+        return;
+
+    // FIXME(296489): populate the data structure
+    return;
+}
+
+NavigatorUAData& WorkerNavigator::userAgentData() const
+{
+    if (!m_navigatorUAData)
+        initializeNavigatorUAData();
+
+    return *m_navigatorUAData;
+};
 
 } // namespace WebCore

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 class GPU;
+class NavigatorUAData;
 
 class WorkerNavigator final : public NavigatorBase, public Supplementable<WorkerNavigator> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(WorkerNavigator);
@@ -48,12 +49,16 @@ public:
 
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearAppBadge(Ref<DeferredPromise>&&);
+    NavigatorUAData& userAgentData() const;
 
     GPU* gpu();
 
 private:
     explicit WorkerNavigator(ScriptExecutionContext&, const String&, bool isOnline);
 
+    void initializeNavigatorUAData() const;
+
+    mutable RefPtr<NavigatorUAData> m_navigatorUAData;
     String m_userAgent;
     bool m_isOnline;
 #if HAVE(WEBGPU_IMPLEMENTATION)

--- a/Source/WebCore/page/WorkerNavigator.idl
+++ b/Source/WebCore/page/WorkerNavigator.idl
@@ -42,3 +42,4 @@ WorkerNavigator includes NavigatorOnLine;
 WorkerNavigator includes NavigatorServiceWorker;
 WorkerNavigator includes NavigatorStorage;
 WorkerNavigator includes NavigatorGPU;
+WorkerNavigator includes NavigatorUA;

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -30,6 +30,7 @@
 #include "Animation.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "ContainerNodeInlines.h"
 #include "DOMTimer.h"
 #include "Document.h"
 #include "DocumentFullscreen.h"
@@ -40,10 +41,10 @@
 #include "Logging.h"
 #include "NodeRenderStyle.h"
 #include "Page.h"
+#include "Quirks.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderStyleInlines.h"
-#include "Quirks.h"
 #include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 


### PR DESCRIPTION
#### d521e56de4b718ab0be019f5214abfeb2ee56429
<pre>
Add the idl files and stubs for User Agent Client Hints
<a href="https://bugs.webkit.org/show_bug.cgi?id=296355">https://bugs.webkit.org/show_bug.cgi?id=296355</a>
<a href="https://rdar.apple.com/156450572">rdar://156450572</a>

Reviewed by Brent Fulgham.

This change adds the idl files for the User Agent Client Hints JavaScript API as outlined here:
<a href="https://wicg.github.io/ua-client-hints/#idl-index">https://wicg.github.io/ua-client-hints/#idl-index</a>

It also adds the initial stubs for the UserAgentData data structure.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::initializeNavigatorUAData const):
(WebCore::Navigator::userAgentData const):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/Navigator.idl:
* Source/WebCore/page/NavigatorUA.idl: Added.
* Source/WebCore/page/NavigatorUABrandVersion.h: Added.
* Source/WebCore/page/NavigatorUABrandVersion.idl: Added.
* Source/WebCore/page/NavigatorUAData.cpp: Added.
(WebCore::NavigatorUAData::create):
(WebCore::NavigatorUAData::brands const):
(WebCore::NavigatorUAData::mobile const):
(WebCore::NavigatorUAData::platform const):
(WebCore::NavigatorUAData::toJSON const):
(WebCore::NavigatorUAData::getHighEntropyValues const):
* Source/WebCore/page/NavigatorUAData.h: Added.
* Source/WebCore/page/NavigatorUAData.idl: Added.
* Source/WebCore/page/PointerLockController.cpp:
* Source/WebCore/page/UADataValues.h: Added.
* Source/WebCore/page/UADataValues.idl: Added.
* Source/WebCore/page/UALowEntropyJSON.h: Added.
* Source/WebCore/page/UALowEntropyJSON.idl: Added.
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::initializeNavigatorUAData const):
(WebCore::WorkerNavigator::userAgentData const):
* Source/WebCore/page/WorkerNavigator.h:
* Source/WebCore/page/WorkerNavigator.idl:
* Source/WebCore/page/ios/ContentChangeObserver.cpp:

Canonical link: <a href="https://commits.webkit.org/297899@main">https://commits.webkit.org/297899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bafb48895f267ae2aa96f6a47c6aaad25f193bc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63993 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86183 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122659 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95031 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40697 "Hash bafb4889 for PR 48399 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94773 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17737 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36448 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18207 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45697 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43172 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->