### PR TITLE
[Navigation API] autofocus test fails because it falsely expects disabling to synchronously unfocus

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt
@@ -3,10 +3,7 @@ PASS An element with autofocus, present before navigation, gets focused
 PASS Two elements with autofocus, present before navigation; the first gets focused
 PASS An element with autofocus, present before navigation but disabled before finished, does not get focused
 PASS An element with autofocus, present before navigation but with its autofocus attribute removed before finished, does not get focused
-FAIL Two elements with autofocus, present before navigation, but the first gets disabled; the second gets focused assert_equals: Disabling the initially-focused button temporarily resets focus to the body expected Element node <body>
-
-<script type="module">
-promise_setup(async () => ... but got Element node <button autofocus="" disabled=""></button>
+PASS Two elements with autofocus, present before navigation, but the first gets disabled; the second gets focused
 PASS An element with autofocus, introduced between committed and finished, gets focused
 PASS An element with autofocus, introduced after finished, does not get focused
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus.html
@@ -120,7 +120,6 @@ promise_test(async t => {
   assert_equals(document.activeElement, decoy, "Focus stays on the initially-focused button during the transition");
 
   decoy.disabled = true;
-  assert_equals(document.activeElement, document.body, "Disabling the initially-focused button temporarily resets focus to the body");
 
   await finished;
   assert_equals(document.activeElement, autofocusTarget, "Focus moves to the second autofocused button after the transition");


### PR DESCRIPTION
#### ccc3d8c64b65ac0a076dd1852736538d3fe75e0e
<pre>
[Navigation API] autofocus test fails because it falsely expects disabling to synchronously unfocus
<a href="https://bugs.webkit.org/show_bug.cgi?id=296357">https://bugs.webkit.org/show_bug.cgi?id=296357</a>
<a href="https://rdar.apple.com/156452137">rdar://156452137</a>

Reviewed by Tim Nguyen.

This test has a check that assumes that if an element becomes disabled, and it
was the active/focused element, that document.activeElement should immediately change.

The HTML spec does not enforce that if an element becomes disabled (and thus,
unfocusable), that the focused element must change immediately. So this check
is faulty. Chrome does appear to do this synchronoulsy, but Safari and Mozilla
do not, and so the test fails for them.

This check isn&apos;t actually checking the behavior of the Navigation API, but rather the
behavior of focus. Since the check is faulty, unrelated to the Navigation API, and is
causing the test to fail on 2/3 browsers, we remove it.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/autofocus.html:

Canonical link: <a href="https://commits.webkit.org/297776@main">https://commits.webkit.org/297776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b95506d0abb47cd0e3a6bf83e4f1c48921cb8b7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85847 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36490 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101477 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66153 "Found 131 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestAuthentication:/webkit/Authentication/authentication-ephemeral, /WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-simple, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19608 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122228 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94447 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17388 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35985 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18165 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->