### PR TITLE
Sync `ua-client-hints` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -322,7 +322,7 @@
     "web-platform-tests/touch-events": "import",
     "web-platform-tests/trust-tokens": "skip",
     "web-platform-tests/trusted-types": "import",
-    "web-platform-tests/ua-client-hints": "skip",
+    "web-platform-tests/ua-client-hints": "import",
     "web-platform-tests/uievents": "import",
     "web-platform-tests/upgrade-insecure-requests": "import",
     "web-platform-tests/url": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/META.yml
@@ -1,0 +1,1 @@
+spec: https://wicg.github.io/ua-client-hints/

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: ua-client-hints
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any-expected.txt
@@ -1,0 +1,40 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes NavigatorUA: member names are unique
+PASS WorkerNavigator includes NavigatorUA: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator includes NavigatorID: member names are unique
+PASS WorkerNavigator includes NavigatorLanguage: member names are unique
+PASS WorkerNavigator includes NavigatorOnLine: member names are unique
+PASS WorkerNavigator includes NavigatorConcurrentHardware: member names are unique
+FAIL NavigatorUAData interface: existence and properties of interface object assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface object length assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface object name assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: existence and properties of interface prototype object assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: attribute brands assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: attribute mobile assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: attribute platform assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: operation getHighEntropyValues(sequence<DOMString>) assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: operation toJSON() assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData must be primary interface of navigator.userAgentData assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL Stringification of navigator.userAgentData assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "brands" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "mobile" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "platform" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "getHighEntropyValues(sequence<DOMString>)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: calling getHighEntropyValues(sequence<DOMString>) on navigator.userAgentData with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "toJSON()" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: toJSON operation on navigator.userAgentData undefined is not an object (evaluating 'memberHolderObject.toJSON')
+FAIL Navigator interface: attribute userAgentData assert_true: The prototype object must have a property "userAgentData" expected true got false
+FAIL Navigator interface: navigator must inherit property "userAgentData" with the proper type assert_inherits: property "userAgentData" not found in prototype chain
+

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.js
@@ -1,0 +1,21 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+// https://wicg.github.io/ua-client-hints/
+
+idl_test(
+  ['ua-client-hints'],
+  ['html', 'dom'],
+  idl_array => {
+    if (self.GLOBAL.isWorker()) {
+      idl_array.add_objects({ WorkerNavigator: ['navigator'] });
+    } else {
+      idl_array.add_objects({ Navigator: ['navigator'] });
+    }
+    idl_array.add_objects({
+      NavigatorUAData: ['navigator.userAgentData'],
+    });
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.worker-expected.txt
@@ -1,0 +1,40 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes NavigatorUA: member names are unique
+PASS WorkerNavigator includes NavigatorUA: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator includes NavigatorID: member names are unique
+PASS WorkerNavigator includes NavigatorLanguage: member names are unique
+PASS WorkerNavigator includes NavigatorOnLine: member names are unique
+PASS WorkerNavigator includes NavigatorConcurrentHardware: member names are unique
+FAIL NavigatorUAData interface: existence and properties of interface object assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface object length assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface object name assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: existence and properties of interface prototype object assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: attribute brands assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: attribute mobile assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: attribute platform assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: operation getHighEntropyValues(sequence<DOMString>) assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData interface: operation toJSON() assert_own_property: self does not have own property "NavigatorUAData" expected property "NavigatorUAData" missing
+FAIL NavigatorUAData must be primary interface of navigator.userAgentData assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL Stringification of navigator.userAgentData assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "brands" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "mobile" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "platform" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "getHighEntropyValues(sequence<DOMString>)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: calling getHighEntropyValues(sequence<DOMString>) on navigator.userAgentData with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: navigator.userAgentData must inherit property "toJSON()" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+FAIL NavigatorUAData interface: toJSON operation on navigator.userAgentData undefined is not an object (evaluating 'memberHolderObject.toJSON')
+FAIL WorkerNavigator interface: attribute userAgentData assert_true: The prototype object must have a property "userAgentData" expected true got false
+FAIL WorkerNavigator interface: navigator must inherit property "userAgentData" with the proper type assert_inherits: property "userAgentData" not found in prototype chain
+

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL tests for navigator.userAgentData undefined is not an object (evaluating 'navigator.userAgentData.brands')
+FAIL test NavigatorUAData.toJSON() output undefined is not an object (evaluating 'navigator.userAgentData.toJSON')
+FAIL getHighEntropyValues() should return low-entropy hints by default (1). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL getHighEntropyValues() should return low-entropy hints by default (2). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL getHighEntropyValues() should return low-entropy hints by default (3). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL getHighEntropyValues() should return low-entropy hints by default (4). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL Arch should be one of two permitted values. undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.js
@@ -1,0 +1,60 @@
+// META: title=tests for navigator.userAgentData
+
+test(t => {
+  const brands = navigator.userAgentData.brands;
+  assert_true(brands.every(brand => brand.brand.length < 32),
+    "No brand should be longer than 32 characters.");
+});
+
+test(t => {
+  const uaData = navigator.userAgentData.toJSON();
+  assert_own_property(uaData, "brands", "toJSON() output has brands member");
+  assert_own_property(uaData, "mobile", "toJSON() output has mobile member");
+  assert_own_property(uaData, "platform", "toJSON() output has platform member");
+}, "test NavigatorUAData.toJSON() output");
+
+promise_test(() => {
+  return navigator.userAgentData.getHighEntropyValues([]).then(hints => {
+    assert_own_property(hints, "brands", "brands is returned by default");
+    assert_own_property(hints, "mobile", "mobile is returned by default");
+    assert_own_property(hints, "platform", "platform is returned by default");
+  });
+}, "getHighEntropyValues() should return low-entropy hints by default (1).");
+
+promise_test(() => {
+  return navigator.userAgentData.getHighEntropyValues(["wow64"]).then(hints => {
+    assert_own_property(
+        hints, "wow64", "requested high-entropy hint is returned");
+    assert_own_property(hints, "brands", "brands is returned by default");
+    assert_own_property(hints, "mobile", "mobile is returned by default");
+    assert_own_property(hints, "platform", "platform is returned by default");
+  });
+}, "getHighEntropyValues() should return low-entropy hints by default (2).");
+
+promise_test(() => {
+  return navigator.userAgentData.getHighEntropyValues(["brands", "mobile"])
+      .then(hints => {
+        assert_own_property(hints, "brands", "requested brands is returned");
+        assert_own_property(
+            hints, "mobile", "requested mobile is returned by default");
+        assert_own_property(
+            hints, "platform", "platform is returned by default");
+      });
+}, "getHighEntropyValues() should return low-entropy hints by default (3).");
+
+promise_test(() => {
+  return navigator.userAgentData.getHighEntropyValues(["platform", "wow64"])
+      .then(hints => {
+        assert_own_property(hints, "brands", "brands is returned by default");
+        assert_own_property(hints, "mobile", "mobile is returned by default");
+        assert_own_property(
+            hints, "platform", "requested platform is returned");
+        assert_own_property(hints, "wow64", "requested wow64 is returned");
+      });
+}, "getHighEntropyValues() should return low-entropy hints by default (4).");
+
+promise_test(() => {
+  return navigator.userAgentData.getHighEntropyValues(["architecture"]).then(
+    hints => assert_true(["x86", "arm"].some(item => item == hints.architecture))
+  );
+}, "Arch should be one of two permitted values.");

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.worker-expected.txt
@@ -1,0 +1,9 @@
+
+FAIL tests for navigator.userAgentData undefined is not an object (evaluating 'navigator.userAgentData.brands')
+FAIL test NavigatorUAData.toJSON() output undefined is not an object (evaluating 'navigator.userAgentData.toJSON')
+FAIL getHighEntropyValues() should return low-entropy hints by default (1). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL getHighEntropyValues() should return low-entropy hints by default (2). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL getHighEntropyValues() should return low-entropy hints by default (3). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL getHighEntropyValues() should return low-entropy hints by default (4). undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+FAIL Arch should be one of two permitted values. undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Platform version and wow64-ness on Linux should be fixed values undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.js
@@ -1,0 +1,12 @@
+// META: title=tests for navigator.userAgentData on Linux
+
+promise_test(() => {
+  return navigator.userAgentData.getHighEntropyValues(["platformVersion", "wow64"]).then(
+    hints => {
+      if (navigator.userAgentData.platform === "Linux") {
+        assert_true(hints.platformVersion === "");
+        assert_equals(hints.wow64, false);
+      }
+    }
+  );
+}, "Platform version and wow64-ness on Linux should be fixed values");

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Platform version and wow64-ness on Linux should be fixed values undefined is not an object (evaluating 'navigator.userAgentData.getHighEntropyValues')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.js


### PR DESCRIPTION
#### 9aa1bce768dee8e44756b747a15f12fb751b37b7
<pre>
Sync `ua-client-hints` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=296358">https://bugs.webkit.org/show_bug.cgi?id=296358</a>

Reviewed by NOBODY (OOPS!).

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/70e23bfdc22a1c1d9bf46edf38c649533946c7b4">https://github.com/web-platform-tests/wpt/commit/70e23bfdc22a1c1d9bf46edf38c649533946c7b4</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.html:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/idlharness.https.any.worker.html:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.html:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.any.worker.html:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.html:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.js:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/useragentdata.https.tentative.any.worker.html:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/ua-client-hints/WEB_FEATURES.yml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aa1bce768dee8e44756b747a15f12fb751b37b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85843 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36506 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62760 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94704 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94442 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/35979 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39762 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39401 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->