### PR TITLE
Resync `svg` from WPT upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7912,6 +7912,9 @@ imported/w3c/web-platform-tests/svg/struct/reftests/inner-svg-transform-and-view
 imported/w3c/web-platform-tests/svg/struct/reftests/inner-svg-rotate-transform.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/inner-svg-css-transform.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/struct/reftests/use-event-handler-no-loss-of-events.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css.svg [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001.svg [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002.svg [ ImageOnlyFailure ]
 
 # crashes with `ASSERTION FAILED: !url.protocolIsData()`
 webkit.org/b/290285 imported/w3c/web-platform-tests/svg/struct/reftests/use-data-url-set-attributeName.tentative.svg [ Skip ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -12336,6 +12336,7 @@
         "web-platform-tests/svg/styling/support/circle-padding-right.svg",
         "web-platform-tests/svg/styling/support/circle.svg",
         "web-platform-tests/svg/styling/use-element-transitions-ref.html",
+        "web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-ref.svg",
         "web-platform-tests/svg/text/reftests/first-letter-ref.svg",
         "web-platform-tests/svg/text/reftests/font-size-scaling-ref.html",
         "web-platform-tests/svg/text/reftests/gradient-after-reposition-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting keyPoints invalid and then valid should result in the animation running
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<title>Setting keyPoints invalid and then valid should result in the animation running</title>
+<link rel="help" href="https://svgwg.org/specs/animations/#AnimateMotionElement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/SVGAnimationTestCase-testharness.js"></script>
+<svg>
+  <rect width="100" height="100" fill="red"/>
+  <rect id="target" transform="translate(100, -50)" width="100" height="100" fill="green">
+    <animateMotion dur="5s" keyPoints="X" keyTimes="0;1" path="M-200,50h250"/>
+  </rect>
+</svg>
+<script>
+const rootSVGElement = document.querySelector('svg');
+const animateMotionElement = document.getElementsByTagName("animateMotion")[0];
+
+function sample(expectedX) {
+  const target = document.getElementById('target');
+  const targetCTM = target.getCTM();
+  assert_approx_equals(targetCTM.e, expectedX, 1e-3, 'x position');
+  assert_equals(targetCTM.f, 0, 'y position');
+  const restOfCTM = ['a', 'b', 'c', 'd'].map(p => targetCTM[p]);
+  assert_array_equals(restOfCTM, [1, 0, 0, 1], 'rest of CTM');
+}
+
+smil_async_test(t => {
+  t.step_timeout(() => {
+    animateMotionElement.setAttribute("keyPoints", "1;0");
+    rootSVGElement.setCurrentTime(0);
+    t.step_timeout(() => {
+      runAnimationTest(t, [
+        // [animationId, time, sampleCallback]
+        ['anim', 1, sample.bind(this, 100)],
+        ['anim', 2, sample.bind(this, 50)],
+        ['anim', 3, sample.bind(this, 0)],
+      ]);
+  }, 50);
+}, 50);
+window.animationStartsImmediately = true;
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1974334.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1974334.html
@@ -1,0 +1,73 @@
+<script>
+addEventListener("DOMContentLoaded", () => {
+  document.getElementById('a').appendChild(
+    document.getElementById('b').cloneNode()
+  )
+})
+</script>
+<svg>
+<path id='a'/>
+<polygon/>
+<rect/>
+<ellipse/>
+<line/>
+<circle/>
+<rect/>
+<polyline/>
+<polyline id='c'/>
+<path/>
+<animate/>
+<animateMotion/>
+<animate/>
+<animateTransform/>
+<animateMotion id='b' xlink:href='#c'/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animateMotion/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animateMotion/>
+<animateMotion/>
+<animateTransform/>
+<animate/>
+<animateTransform/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animate/>
+<animateMotion xlink:href='#c'/>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/w3c-import.log
@@ -18,3 +18,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1930221.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1949899.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1957178.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1974334.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/end-of-time-001-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/end-of-time-001-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <title>Seeking the time container to a large value does not cause a crash (or hang)</title>
 <svg>
   <rect height="100" width="100" fill="blue">
@@ -11,5 +11,5 @@
   let svg = document.querySelector("svg");
   svg.setCurrentTime(18446744073709551557);
   let html = document.documentElement;
-  html.addEventListener("TestRendered", () => html.classList.remove("reftest-wait"));
+  html.addEventListener("TestRendered", () => html.classList.remove("test-wait"));
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/end-of-time-002-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/end-of-time-002-crash.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html class="test-wait">
 <title>Seeking the time container to a large value does not cause a crash (or hang)</title>
 <svg>
   <rect height="100" width="100" fill="blue">
@@ -11,5 +11,5 @@
   let svg = document.querySelector("svg");
   svg.setCurrentTime(9000000000000000);
   let html = document.documentElement;
-  html.addEventListener("TestRendered", () => html.classList.remove("reftest-wait"));
+  html.addEventListener("TestRendered", () => html.classList.remove("test-wait"));
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A trailing semicolon is allowed in the 'keyPoints' attribute assert_equals: expected -100 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>A trailing semicolon is allowed in the 'keyPoints' attribute</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<svg>
+  <rect width="100" height="100" x="100" fill="blue">
+    <animateMotion dur="10ms" fill="freeze"
+                   values="0,0; -100,0" keyTimes="0; 1" keyPoints="0; 1;"/>
+  </rect>
+</svg>
+<script>
+  promise_test(async t => {
+    const animation = document.querySelector('rect > animateMotion');
+    const watcher = new EventWatcher(t, animation, 'endEvent');
+    await watcher.wait_for('endEvent');
+    await waitForAtLeastOneFrame();
+    assert_equals(animation.targetElement.getCTM().e, -100);
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A trailing semicolon is allowed in the 'keyTimes' attribute
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>A trailing semicolon is allowed in the 'keyTimes' attribute</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<svg>
+  <rect width="100" height="100" fill="blue" opacity="0">
+    <animate attributeName="opacity" dur="10ms" fill="freeze"
+             values="0; 1" keyTimes="0; 1;"/>
+  </rect>
+</svg>
+<script>
+  promise_test(async t => {
+    const animation = document.querySelector('rect > animate');
+    const watcher = new EventWatcher(t, animation, 'endEvent');
+    await watcher.wait_for('endEvent');
+    await waitForAtLeastOneFrame();
+    assert_equals(getComputedStyle(animation.targetElement).opacity, "1");
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/w3c-import.log
@@ -22,5 +22,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/clear-mapped-animation-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/clear-mapped-animation.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/end-element-on-inactive-element.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/onhover-syncbases.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/paced-value-animation-overwrites-keyTimes.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/w3c-import.log
@@ -73,6 +73,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-fill-remove.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-from-to-rotate-auto.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-001.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-line.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-mpath.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-multiple.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/w3c-import.log
@@ -25,6 +25,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-005-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-005.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/svgtransformlist-replaceitem.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/transform-translate-single-parameter.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/view-invalid-viewBox-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/view-invalid-viewBox.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/view-transform-viewBox-expected.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1966754.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1966754.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<body>
+  <svg>
+    <filter id="crash" x="0" y="0" width="400px" height="400px">
+      <feColorMatrix in="SourceGraphic" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 1 0 0 0"></fecolormatrix>
+      <feGaussianBlur stdDeviation="4"></fegaussianblur>
+    </filter>
+    <rect width="100" height="100" filter="url(#crash)"/>
+  </svg>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/w3c-import.log
@@ -29,3 +29,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1724237.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1753105.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1883804.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1966754.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005-expected.svg
@@ -1,0 +1,4 @@
+<svg width="340" height="140"
+  xmlns="http://www.w3.org/2000/svg">
+  <circle cx="204" cy="56" r="65" fill="blue" />
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>A negative value for rx is invalid and must be ignored</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX"/>
+  <html:link rel="match"  href="circle-ref.svg" />
+  <ellipse cx="204" cy="56" rx="-65" ry="65" fill="blue"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006-expected.svg
@@ -1,0 +1,4 @@
+<svg width="340" height="140"
+  xmlns="http://www.w3.org/2000/svg">
+  <circle cx="204" cy="56" r="65" fill="blue" />
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>A negative value for ry is invalid and must be ignored</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY"/>
+  <html:link rel="match"  href="circle-ref.svg" />
+  <ellipse cx="204" cy="56" rx="65" ry="-65" fill="blue"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/w3c-import.log
@@ -36,6 +36,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-003.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-004-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-004.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-calc-dynamic-viewport-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-calc-dynamic-viewport-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-calc-dynamic-viewport.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-get-bounding-client-rect-in-non-rendered-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-get-bounding-client-rect-in-non-rendered-elements.html
@@ -22,6 +22,13 @@
   <g>
     <rect id="rect6" width="10" height="10" />
   </g>
+  <g id="g1">
+    <rect x="5" y="5" width="10" height="10"/>
+    <g>
+      <!-- This rect has neither fill, nor stroke so has no bounds. -->
+      <rect x="20" y="20" width="30" height="30" fill="none"/>
+    </g>
+  </g>
 </svg>
 <script>
   let rect1 = document.getElementById("rect1"),
@@ -30,7 +37,8 @@
     rect4 = document.getElementById("rect4");
     rect5 = document.getElementById("rect5"),
     rect6 = document.getElementById("rect6"),
-    symbol = document.getElementById("symbol");
+    symbol = document.getElementById("symbol"),
+    g1 = document.getElementById("g1");
 
   test(function () {
     assert_equals(rect1.getBoundingClientRect().width, 0, "rect1");
@@ -40,6 +48,7 @@
     assert_equals(rect5.getBoundingClientRect().width, 0, "rect5");
     assert_equals(rect6.getBoundingClientRect().width, 10, "rect6");
     assert_equals(symbol.getBoundingClientRect().width, 0, "symbol");
+    assert_equals(g1.getBoundingClientRect().width, 10, "g1");
 
     assert_equals(rect1.getBoundingClientRect().height, 0, "rect1");
     assert_equals(rect2.getBoundingClientRect().height, 0, "rect2");
@@ -48,5 +57,6 @@
     assert_equals(rect5.getBoundingClientRect().height, 0, "rect5");
     assert_equals(rect6.getBoundingClientRect().height, 10, "rect6");
     assert_equals(symbol.getBoundingClientRect().height, 0, "symbol");
+    assert_equals(g1.getBoundingClientRect().height, 10, "g1");
   }, "Get Bounding Client Rect");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL async script state assert_true: script is async expected true got undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Check async script state matches attribute</title>
+    <link rel="help" href="https://svgwg.org/svg2-draft/interact.html#ScriptElement"/>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <svg>
+      <script id="script" async href="data:text/javascript, // Do nothing."></script>
+      <script>
+        test(function() {
+          let script = document.getElementById("script");
+          script.remove();
+          assert_true(script.async, "script is async");
+          script.removeAttribute("async");
+          assert_false(script.async, "script is no longer async");
+        }, "async script state");
+      </script>
+    </svg>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/w3c-import.log
@@ -17,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-01.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-02.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-03.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/composed.window.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/defer-01.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/defer-02.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/w3c-import.log
@@ -136,3 +136,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/small-nested-viewbox.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/symbol-in-mask-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/symbol-in-mask.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag.html

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html class="reftest-wait"></html>
+<title>SVG elements inside `&lt;g&gt;` tag with intial scale '0' should be mutable via JS</title>
+<link rel="help" href="https://crbug.com/332328859">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-1/#funcdef-transform-scale">
+<link rel="author" title="Vinay Singh" href="mailto:vinaysingh@microsoft.com">
+<link rel="match" href="../../struct/reftests/reference/green-100x100.html">
+<script src="/common/rendering-utils.js"></script>
+
+<svg width="300" height="300">
+  <g>
+    <g>
+      <rect id="rect" width="125" height="125" fill="green" style="transform: scale(0);" />
+    </g>
+  </g>
+</svg>
+
+<script>
+  waitForAtLeastOneFrame().then(() => {
+    const rect = document.getElementById('rect');
+    rect.style.transform = 'scale(0.8)';
+
+    // Ensure DOM updates are flushed before removing the class
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove('reftest-wait');
+    });
+  });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css.svg
@@ -1,0 +1,14 @@
+<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Width and Height as inline CSS properties on use and referencing svg element</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="match" href="reference/green-100x100.svg"/>
+  </metadata>
+  <defs>
+    <svg id="svg" width="200" height="200">
+      <rect width="400" height="400" fill="green"/>
+    </svg>
+  </defs>
+  <use href="#svg" style="width:100px; height:100px"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001.svg
@@ -1,0 +1,15 @@
+<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Width and Height as inline CSS properties on use and referencing symbol element</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#SymbolElement"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="match" href="reference/green-100x100.svg"/>
+  </metadata>
+  <defs>
+    <symbol id="sym" width="200" height="200">
+      <rect width="400" height="400" fill="green"/>
+    </symbol>
+  </defs>
+  <use href="#sym" style="width:100px; height:100px"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002.svg
@@ -1,0 +1,15 @@
+<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Width and Height as inline CSS properties on use and referencing symbol element doesn't have its width and height</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#SymbolElement"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="match" href="reference/green-100x100.svg"/>
+  </metadata>
+  <defs>
+    <symbol id="sym">
+      <rect width="400" height="400" fill="green"/>
+    </symbol>
+  </defs>
+  <use href="#sym" style="width:100px; height:100px"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003-expected.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003.svg
@@ -1,0 +1,15 @@
+<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>No Width and Height defined on use and referencing symbol element has its width and height</title>
+  <metadata>
+    <html:link rel="author" title="Virali Purbey" href="mailto:viralipurbey@microsoft.com"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#SymbolElement"/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement"/>
+    <html:link rel="match" href="reference/green-100x100.svg"/>
+  </metadata>
+  <defs>
+    <symbol id="sym" width="100" height="100">
+      <rect width="400" height="400" fill="green"/>
+    </symbol>
+  </defs>
+  <use href="#sym"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/w3c-import.log
@@ -92,6 +92,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-dimensions-override-001.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-dimensions-override-002-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-dimensions-override-002.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-switch-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-switch.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.svg
@@ -100,3 +102,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-002.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-display-none-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-display-none.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003.svg

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>'dominant-baseline: central' on &#x3c;text&#x3e; with large font-size (and scaling) (reference)</title>
+  <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <text dominant-baseline="central" fill="green" y="40"
+        font-size="100" font-family="Ahem" text-decoration="underline">X</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-ref.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>'dominant-baseline: central' on &#x3c;text&#x3e; with large font-size (and scaling) (reference)</title>
+  <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <text dominant-baseline="central" fill="green" y="40"
+        font-size="100" font-family="Ahem" text-decoration="underline">X</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>'dominant-baseline: central' on &#x3c;text&#x3e; with large font-size (and scaling)</title>
+  <h:link rel="help" href="https://drafts.csswg.org/css-inline-3/#dominant-baseline-property"/>
+  <h:link rel="help" href="https://crbug.com/389845192"/>
+  <h:link rel="match" href="dominant-baseline-central-large-font-size-ref.svg"/>
+  <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  <svg viewBox="0 0 1000 2000" width="100" height="200">
+    <text dominant-baseline="central" fill="green" y="400"
+          font-size="1000" font-family="Ahem" text-decoration="underline">X</text>
+  </svg>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/w3c-import.log
@@ -14,6 +14,9 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-expected.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-ref.svg
+/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-small-font-size-expected.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-small-font-size.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/first-letter-expected.svg

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getcharnumatposition-slr.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getcharnumatposition-slr.tentative.html
@@ -25,14 +25,16 @@ function newPoint(x, y) {
   return p;
 }
 
-test(() => {
-  const element = document.querySelector('#slr');
-  assert_equals(element.getNumberOfChars(), 3);
-  const start = 200;
-  assert_equals(element.getCharNumAtPosition(newPoint(40, start + 10)), -1);
-  assert_equals(element.getCharNumAtPosition(newPoint(40, start - 10)), 0);
-  assert_equals(element.getCharNumAtPosition(newPoint(40, start - 30)), 1);
-  assert_equals(element.getCharNumAtPosition(newPoint(40, start - 50)), 2);
-  assert_equals(element.getCharNumAtPosition(newPoint(40, start - 70)), -1);
-}, 'sideways-lr');
+document.fonts.ready.then(() => {
+  test(() => {
+    const element = document.querySelector('#slr');
+    assert_equals(element.getNumberOfChars(), 3);
+    const start = 200;
+    assert_equals(element.getCharNumAtPosition(newPoint(40, start + 10)), -1);
+    assert_equals(element.getCharNumAtPosition(newPoint(40, start - 10)), 0);
+    assert_equals(element.getCharNumAtPosition(newPoint(40, start - 30)), 1);
+    assert_equals(element.getCharNumAtPosition(newPoint(40, start - 50)), 2);
+    assert_equals(element.getCharNumAtPosition(newPoint(40, start - 70)), -1);
+  }, 'sideways-lr');
+});
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar.html
@@ -33,43 +33,49 @@ text {
 const FONT_SIZE = 10;
 function $(sel) { return document.querySelector(sel); }
 
-test(() => {
-  const target = $('#vrl');
-  const base = target.getStartPositionOfChar(0).y;
-  assert_equals(base + FONT_SIZE, target.getEndPositionOfChar(0).y);
-  assert_equals(base + FONT_SIZE, target.getStartPositionOfChar(1).y);
-  assert_equals(base + FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
-  assert_equals(base + FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
-  assert_equals(base + FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
-}, 'vertical-rl');
+setup({ explicit_done: true });
 
-test(() => {
-  const target = $('#vlr');
-  const base = target.getStartPositionOfChar(0).y;
-  assert_equals(base + FONT_SIZE, target.getEndPositionOfChar(0).y);
-  assert_equals(base + FONT_SIZE, target.getStartPositionOfChar(1).y);
-  assert_equals(base + FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
-  assert_equals(base + FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
-  assert_equals(base + FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
-}, 'vertical-lr');
+document.fonts.ready.then(() => {
+  test(() => {
+    const target = $('#vrl');
+    const base = target.getStartPositionOfChar(0).y;
+    assert_equals(base + FONT_SIZE, target.getEndPositionOfChar(0).y);
+    assert_equals(base + FONT_SIZE, target.getStartPositionOfChar(1).y);
+    assert_equals(base + FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
+    assert_equals(base + FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
+    assert_equals(base + FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
+  }, 'vertical-rl');
 
-test(() => {
-  const target = $('#srl');
-  const base = target.getStartPositionOfChar(0).y;
-  assert_equals(base + FONT_SIZE, target.getEndPositionOfChar(0).y);
-  assert_equals(base + FONT_SIZE, target.getStartPositionOfChar(1).y);
-  assert_equals(base + FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
-  assert_equals(base + FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
-  assert_equals(base + FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
-}, 'sideways-rl');
+  test(() => {
+    const target = $('#vlr');
+    const base = target.getStartPositionOfChar(0).y;
+    assert_equals(base + FONT_SIZE, target.getEndPositionOfChar(0).y);
+    assert_equals(base + FONT_SIZE, target.getStartPositionOfChar(1).y);
+    assert_equals(base + FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
+    assert_equals(base + FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
+    assert_equals(base + FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
+  }, 'vertical-lr');
 
-test(() => {
-  const target = $('#slr');
-  const base = target.getStartPositionOfChar(0).y;
-  assert_equals(base - FONT_SIZE, target.getEndPositionOfChar(0).y);
-  assert_equals(base - FONT_SIZE, target.getStartPositionOfChar(1).y);
-  assert_equals(base - FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
-  assert_equals(base - FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
-  assert_equals(base - FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
-}, 'sideways-lr');
+  test(() => {
+    const target = $('#srl');
+    const base = target.getStartPositionOfChar(0).y;
+    assert_equals(base + FONT_SIZE, target.getEndPositionOfChar(0).y);
+    assert_equals(base + FONT_SIZE, target.getStartPositionOfChar(1).y);
+    assert_equals(base + FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
+    assert_equals(base + FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
+    assert_equals(base + FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
+  }, 'sideways-rl');
+
+  test(() => {
+    const target = $('#slr');
+    const base = target.getStartPositionOfChar(0).y;
+    assert_equals(base - FONT_SIZE, target.getEndPositionOfChar(0).y);
+    assert_equals(base - FONT_SIZE, target.getStartPositionOfChar(1).y);
+    assert_equals(base - FONT_SIZE * 2, target.getEndPositionOfChar(1).y);
+    assert_equals(base - FONT_SIZE * 2, target.getStartPositionOfChar(2).y);
+    assert_equals(base - FONT_SIZE * 3, target.getEndPositionOfChar(2).y);
+  }, 'sideways-lr');
+
+  done();
+});
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt
@@ -11,8 +11,8 @@ CONSOLE MESSAGE: Error: Invalid negative value for <image> attribute height="-20
 FAIL rect1 assert_equals: rect1: x expected 1 but got 0
 FAIL rect2 assert_equals: rect2: x expected 1 but got 0
 FAIL circle assert_equals: circle: x expected 1 but got 0
-FAIL ellipse1 assert_equals: ellipse1: x expected 1 but got -9
-FAIL ellipse2 assert_equals: ellipse2: y expected 2 but got -3
+PASS ellipse1
+PASS ellipse2
 PASS image3
 PASS image4
 FAIL foreign1 assert_equals: foreign1: x expected 1 but got 0

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
@@ -34,8 +34,8 @@ function testBBox(id, x, y, width, height) {
 testBBox('rect1', 1, 2, 0, 20);
 testBBox('rect2', 1, 2, 10, 0);
 testBBox('circle', 1, 2, 0, 0);
-testBBox('ellipse1', 1, 2, 0, 20);
-testBBox('ellipse2', 1, 2, 10, 0);
+testBBox('ellipse1', -9, 2, 20, 20);
+testBBox('ellipse2', 1, -3, 10, 10);
 testBBox('image3', 1, 2, 0, 20);
 testBBox('image4', 1, 2, 10, 0);
 testBBox('foreign1', 1, 2, 0, 20);

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/w3c-import.log
@@ -18,3 +18,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/svg/README.md
 /LayoutTests/imported/w3c/web-platform-tests/svg/historical.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window.js
+/LayoutTests/imported/w3c/web-platform-tests/svg/sniffing-content-type.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2499,3 +2499,5 @@ imported/w3c/web-platform-tests/css/css-tables/paint/table-border-paint-caption-
 webkit.org/b/296334 media/media-source/media-source-rvfc-paused-offscreen.html [ Pass Failure ]
 
 webkit.org/b/296017 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-022.html [ Pass ImageOnlyFailure ]
+
+[ x86_64 ] imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size.svg [ Skip ]


### PR DESCRIPTION
#### b738e4236868cc1f1696689818399011c288b334
<pre>
Resync `svg` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=296359">https://bugs.webkit.org/show_bug.cgi?id=296359</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/26b155ed94e1687af94e010c71ca0febe4c5346e">https://github.com/web-platform-tests/wpt/commit/26b155ed94e1687af94e010c71ca0febe4c5346e</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-002.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/firefox-bug-1974334.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/end-of-time-001-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/end-of-time-002-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keypoints-attribute-trailing-semi.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/keytimes-attribute-trailing-semi.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/firefox-bug-1966754.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/crashtests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-005.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/ellipse-006.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/reftests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/async-04.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/painting/reftests/zero-scale-svg-transform-inside-g-tag.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-svg-inline-css.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-001.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-002.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-inline-css-003.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/reftests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-expected.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size-ref.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getcharnumatposition-slr.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/scripted/getstartpositionofchar.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/svg-get-bounding-client-rect-in-non-rendered-elements.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/w3c-import.log:
* LayoutTests/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/297792@main">https://commits.webkit.org/297792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44d8e07d72d0776e5c9558cf227a3ab92b7b54cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119060 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85891 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36543 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66195 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122281 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94755 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36044 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39820 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->