### PR TITLE
Import html/semantics/forms/the-input-element WPTs 07/22/2025

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color-attributes.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color-attributes.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ InputTypeColorEnhancementsEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ InputTypeColorEnhancementsEnabled=false ] -->
+<!DOCTYPE html>
 <!-- This test can be removed once all browsers support the alpha and colorspace attributes. -->
 <meta charset=utf-8>
 <title>Form input type=color</title>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.window.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ InputTypeColorEnhancementsEnabled=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror-expected.txt
@@ -1,0 +1,8 @@
+input_valueAsDate_TypeError
+
+
+FAIL valueAsDate setter with non-Date object (input type date) assert_throws_js: function "() => input.valueAsDate = {}" did not throw
+FAIL valueAsDate setter with non-Date object (input type time) assert_throws_js: function "() => input.valueAsDate = {}" did not throw
+FAIL valueAsDate setter with non-Date object (input type week) assert_throws_js: function "() => input.valueAsDate = {}" did not throw
+FAIL valueAsDate setter with non-Date object (input type month) assert_throws_js: function "() => input.valueAsDate = {}" did not throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>Forms</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <h3>input_valueAsDate_TypeError</h3>
+  <hr>
+  <div id="log"></div>
+  <input id="input_date" type="date">
+  <input id="input_time" type="time">
+  <input id="input_week" type="week">
+  <input id="input_month" type="month">
+
+  <script>
+    "use strict";
+
+    function testExpectTypeError(input) {
+      test(
+        () => assert_throws_js(TypeError, () => input.valueAsDate = {}),
+        `valueAsDate setter with non-Date object (input type ${input.type})`,
+        'expected TypeError'
+      );
+    }
+
+    testExpectTypeError(document.getElementById("input_date"));
+    testExpectTypeError(document.getElementById("input_time"));
+    testExpectTypeError(document.getElementById("input_week"));
+    testExpectTypeError(document.getElementById("input_month"));
+  </script>
+
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror-expected.txt
@@ -1,0 +1,16 @@
+input_valueAsNumber_TypeError
+
+
+FAIL valueAsNumber = Infinity (input type does apply) assert_throws_js: function "() => input.valueAsNumber = value" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL valueAsNumber = -Infinity (input type does apply) assert_throws_js: function "() => input.valueAsNumber = value" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL valueAsNumber = Infinity (input type does not apply) assert_throws_js: function "() => input.valueAsNumber = value" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL valueAsNumber = -Infinity (input type does not apply) assert_throws_js: function "() => input.valueAsNumber = value" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>Forms</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <h3>input_valueAsNumber_TypeError</h3>
+  <hr>
+  <div id="log"></div>
+
+  <input id="input_number" type="number" />
+  <input id="input_checkbox" type="checkbox" />
+
+  <script>
+    "use strict";
+
+    function testExpectTypeError(input, input_type_applies, values) {
+      for (const value of values) {
+        test(
+          () => assert_throws_js(TypeError, () => input.valueAsNumber = value),
+          `valueAsNumber = ${value} (input type ${input_type_applies})`,
+          'expected TypeError'
+        );
+      }
+    }
+
+    const input_number = document.getElementById("input_number");
+    testExpectTypeError(input_number, "does apply", [Infinity, -Infinity]);
+
+    const input_checkbox = document.getElementById("input_checkbox");
+    testExpectTypeError(input_checkbox, "does not apply", [Infinity, -Infinity]);
+  </script>
+
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-expected.txt
@@ -32,4 +32,5 @@ PASS value with a leading form feed
 PASS value with a leading carriage return
 PASS value with a leading space
 PASS value = 1trailing junk
+PASS full-width digits
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number.html
@@ -40,7 +40,8 @@
     {value: "\f1", expected: "", testname: "value with a leading form feed"},
     {value: "\r1", expected: "", testname: "value with a leading carriage return"},
     {value: " 1", expected: "", testname: "value with a leading space"},
-    {value: "1trailing junk", expected: "", testname: "value = 1trailing junk"}
+    {value: "1trailing junk", expected: "", testname: "value = 1trailing junk"},
+    {value: "１２３", expected: "", testname: "full-width digits"},
   ];
   for (var i = 0; i < numbers.length; i++) {
     var w = numbers[i];

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
@@ -1,0 +1,10 @@
+
+
+
+
+FAIL Focus the new checked radio in the focused radio group. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="end"></input>
+PASS Focusable radio can be focused even with a checked radio in the group.
+FAIL Focus the checked radio in the group. assert_equals: expected Element node <input type="radio" name="radio"></input> but got Element node <input type="text" id="end"></input>
+FAIL Focus the checked radio in the focused radio group. assert_false: expected false got true
+FAIL When `checked` is false on a radio element, focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="end"></input>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Focus Navigation for the radio group</title>
+<link rel="author" href="mailto:zhoupeng.1996@bytedance.com">
+<link rel="help" href="https://issues.chromium.org/issues/421837104">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/focus-utils.js"></script>
+
+<input type="text" id="start">
+<form>
+  <input type="radio" name="radio" id="a">
+  <input type="radio" name="radio" id="b">
+</form>
+<input type="text" id="end">
+
+<script>
+const c = document.createElement('input');
+c.type = 'radio';
+c.name = 'radio';
+c.checked = true;
+
+promise_test(async () => {
+  start.focus();
+  assert_equals(document.activeElement, start);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, a);
+  // Append checked radio element.
+  document.querySelector('form').appendChild(c);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, c);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, c);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+}, 'Focus the new checked radio in the focused radio group.');
+
+promise_test(async () => {
+  assert_true(c.checked);
+  a.focus();
+  assert_equals(document.activeElement, a);
+}, 'Focusable radio can be focused even with a checked radio in the group.');
+
+promise_test(async () => {
+  start.focus();
+  assert_equals(document.activeElement, start);
+  assert_true(c.checked);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, c);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, c);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+}, 'Focus the checked radio in the group.');
+
+promise_test(async () => {
+  a.focus();
+  assert_equals(document.activeElement, a);
+  // Set as the checked radio.
+  b.checked = true;
+  assert_false(c.checked);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, b);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, b);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+}, 'Focus the checked radio in the focused radio group.');
+
+promise_test(async () => {
+  b.checked = false;
+  start.focus();
+  await navigateFocusForward();
+  assert_equals(document.activeElement, a);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, a);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+}, 'When `checked` is false on a radio element, focus navigation target the radio group first element.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
@@ -1,0 +1,7 @@
+Outside form
+disabled checked  enabled 1  enabled 2
+Outside form
+
+FAIL Should be able to tab focus in radio group even when the checked radio button is disabled. assert_equals: expected Element node <input type="radio" name="radio" id="b"></input> but got Element node <body><form>
+ <label><input type="radio" name="start" id=...
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="author" href="mailto:dizhangg@chromium.org">
+<link rel="help" href="http://crbug.com/427520278">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/focus-utils.js"></script>
+
+<form>
+ <label><input type="radio" name="start" id="start">Outside form</label>
+</form>
+<form>
+ <label><input type="radio" name="radio" id="a" disabled checked>disabled checked</label>
+ <label><input type="radio" name="radio" id="b">enabled 1</label>
+ <label><input type="radio" name="radio" id="c">enabled 2</label>
+</form>
+<form>
+ <label><input type="radio" name="end" id="end">Outside form</label>
+</form>
+
+<script>
+
+promise_test(async () => {
+    start.focus();
+    assert_equals(document.activeElement, start);
+    await navigateFocusForward();
+    assert_equals(document.activeElement, b);
+    await navigateFocusForward();
+    assert_equals(document.activeElement, end);
+    await navigateFocusBackward();
+    assert_equals(document.activeElement, b);
+    await navigateFocusBackward();
+    assert_equals(document.activeElement, start);
+}, 'Should be able to tab focus in radio group even when the checked radio button is disabled.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+
+FAIL Both forward and backward focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="end"></input>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Focus Navigation for the radio group</title>
+<link rel="author" href="mailto:zhoupeng.1996@bytedance.com">
+<link rel="help" href="https://issues.chromium.org/issues/421837104">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/focus-utils.js"></script>
+
+<input type="text" id="start">
+<form>
+  <input type="radio" name="radio" id="a">
+  <input type="radio" name="radio" id="b">
+  <input type="radio" name="radio" id="c">
+</form>
+<input type="text" id="end">
+
+<script>
+promise_test(async () => {
+  start.focus();
+  assert_equals(document.activeElement, start);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, a);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, a);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+}, 'Both forward and backward focus navigation target the radio group first element.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
@@ -1,0 +1,7 @@
+
+enabled 1  Button  enabled 2  enabled 3
+
+
+FAIL Focusable elements between radio elements in a group can be focused. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="end"></input>
+FAIL During arrow key navigation, focus and checked is set on the radio element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="end"></input>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Focus Navigation for the radio group</title>
+<link rel="author" href="mailto:zhoupeng.1996@bytedance.com">
+<link rel="help" href="https://issues.chromium.org/issues/421837104">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="resources/focus-utils.js"></script>
+
+<input type="text" id="start">
+<form>
+  <label><input type="radio" name="radio" id="a">enabled 1</label>
+  <button id="btn">Button</button>
+  <label><input type="radio" name="radio" id="b">enabled 2</label>
+  <label><input type="radio" name="radio" id="c">enabled 3</label>
+</form>
+<input type="text" id="end">
+
+<script>
+promise_test(async () => {
+  start.focus();
+  assert_equals(document.activeElement, start);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, a);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, btn);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, btn);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, a);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+  // Focus on the checked radio element.
+  b.checked = true;
+  start.focus();
+  await navigateFocusForward();
+  assert_equals(document.activeElement, btn);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, b);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, b);
+}, 'Focusable elements between radio elements in a group can be focused.');
+
+promise_test(async () => {
+  b.checked = false;
+  start.focus();
+  assert_equals(document.activeElement, start);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, a);
+  // Arrow key navigation, skip btn.
+  await arrowDown();
+  assert_equals(document.activeElement, b);
+  assert_true(b.checked);
+  await arrowUp();
+  assert_equals(document.activeElement, a);
+  assert_true(a.checked);
+  await arrowDown();
+  assert_equals(document.activeElement, b);
+  assert_true(b.checked);
+  await navigateFocusForward();
+  assert_equals(document.activeElement, end);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, b);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, btn);
+  await navigateFocusBackward();
+  assert_equals(document.activeElement, start);
+}, 'During arrow key navigation, focus and checked is set on the radio element.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
@@ -1,0 +1,6 @@
+Radio buttons should scroll into view when focused (if off-screen)
+
+
+
+PASS Focusing offscreen radio via keyboard should scroll it into view
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Radio buttons should scroll into view when focused (if off-screen)</title>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#keyboard-accessibility-navigation-radios">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <style>
+    input[type="radio"] {
+      display: block;
+    }
+    #offscreen-radio {
+      margin-top: 200vh;
+    }
+  </style>
+</head>
+<body>
+
+<h1>Radio buttons should scroll into view when focused (if off-screen)</h1>
+
+<form>
+  <input type="radio" name="group" id="radio1">
+  <input type="radio" name="group" id="radio2">
+  <input type="radio" name="group" id="offscreen-radio">
+</form>
+
+<script>
+  function simulateArrowDown() {
+    return new test_driver.Actions()
+      .keyDown("\uE015") // "ArrowDown" code point: https://www.w3.org/TR/webdriver2/#keyboard-actions
+      .send();
+  }
+
+  promise_test(async t => {
+    const firstRadio = document.getElementById("radio1");
+    const offscreenRadio = document.getElementById("offscreen-radio");
+    const focusPromise = new Promise(resolve =>
+      offscreenRadio.onfocus = () => t.step_timeout(resolve, 50)
+    );
+
+    firstRadio.focus();
+    await simulateArrowDown();
+    await simulateArrowDown();
+    await focusPromise;
+
+    const scrollTop = document.scrollingElement.scrollTop;
+
+    assert_equals(offscreenRadio, document.activeElement, 'offscreen radio is focused');
+    assert_greater_than(scrollTop, 500, `out-of-viewport radio should trigger scroll — scrollTop=${scrollTop}`);
+  }, 'Focusing offscreen radio via keyboard should scroll it into view');
+
+</script>
+
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/focus-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/focus-utils.js
@@ -1,0 +1,42 @@
+'use strict';
+
+function waitForRender() {
+  return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+async function pressKey(keyCode) {
+  await waitForRender();
+  await new test_driver.Actions()
+    .keyDown(keyCode)
+    .keyUp(keyCode)
+    .send();
+  await waitForRender();
+}
+
+async function arrowUp() {
+  const kArrowUp = '\uE013';
+  await pressKey(kArrowUp);
+}
+
+async function arrowDown() {
+  const kArrowDown = '\uE015';
+  await pressKey(kArrowDown);
+}
+
+async function navigateFocusForward() {
+  const kTab = '\uE004';
+  await pressKey(kTab);
+}
+
+async function navigateFocusBackward() {
+  await waitForRender();
+  const kShift = '\uE008';
+  const kTab = '\uE004';
+  await new test_driver.Actions()
+    .keyDown(kShift)
+    .keyDown(kTab)
+    .keyUp(kTab)
+    .keyUp(kShift)
+    .send();
+  await waitForRender();
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/focus-utils.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/image-submit-click.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/loadresolver.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/range-restore-events.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly.html
@@ -37,10 +37,12 @@ for (const inputType of inputTypes) {
       const input = document.createElement("input");
       input.setAttribute("type", inputType);
       input.setAttribute("readonly", "");
+      document.body.appendChild(input);
 
       await test_driver.bless('show picker');
       input.showPicker();
       input.blur();
+      input.remove();
 
       assert_false(navigator.userActivation.isActive, 'User activation is consumed for non-readonly showPicker() call');
     }, `input[type=${inputType}] showPicker() doesn't throw when readonly`);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/w3c-import.log
@@ -86,9 +86,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-value-invalidstateerr.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-invalidstateerr.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-stepping.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-invalidstateerr.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-stepping.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-whitespace.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-width.html
@@ -118,6 +120,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/placeholder-update.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-disconnected-group-owner.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-double-activate-pseudo.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-groupname-case.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-input-cancel.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-keyboard-navigation-order.html

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt
@@ -17,7 +17,7 @@ FAIL Invalid color: keyword crimson assert_equals: expected "#000000" but got "#
 FAIL Invalid color: keyword bisque assert_equals: expected "#000000" but got "#ffe4c4"
 PASS Invalid color: keyword currentColor
 PASS Invalid color: keyword transparent
-FAIL Invalid color: keyword ActiveBorder assert_equals: expected "#000000" but got "#0067f4"
+FAIL Invalid color: keyword ActiveBorder assert_equals: expected "#000000" but got "#ffffff"
 PASS Invalid color: keyword inherit
 FAIL Invalid color: rgb(1,1,1) assert_equals: expected "#000000" but got "#010101"
 FAIL Invalid color: rgb(1,1,1,1) assert_equals: expected "#000000" but got "#010101"

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
@@ -1,0 +1,10 @@
+
+
+
+
+FAIL Focus the new checked radio in the focused radio group. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+PASS Focusable radio can be focused even with a checked radio in the group.
+FAIL Focus the checked radio in the group. assert_equals: expected Element node <input type="radio" name="radio"></input> but got Element node <input type="text" id="start"></input>
+FAIL Focus the checked radio in the focused radio group. assert_false: expected false got true
+FAIL When `checked` is false on a radio element, focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
@@ -1,0 +1,6 @@
+Outside form
+disabled checked  enabled 1  enabled 2
+Outside form
+
+FAIL Should be able to tab focus in radio group even when the checked radio button is disabled. assert_equals: expected Element node <input type="radio" name="radio" id="b"></input> but got Element node <input type="radio" name="start" id="start"></input>
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+
+FAIL Both forward and backward focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
@@ -1,0 +1,7 @@
+
+enabled 1  Button  enabled 2  enabled 3
+
+
+FAIL Focusable elements between radio elements in a group can be focused. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+FAIL During arrow key navigation, focus and checked is set on the radio element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
@@ -1,0 +1,8 @@
+Radio buttons should scroll into view when focused (if off-screen)
+
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Focusing offscreen radio via keyboard should scroll it into view Test timed out
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt
@@ -17,7 +17,7 @@ FAIL Invalid color: keyword crimson assert_equals: expected "#000000" but got "#
 FAIL Invalid color: keyword bisque assert_equals: expected "#000000" but got "#ffe4c4"
 PASS Invalid color: keyword currentColor
 PASS Invalid color: keyword transparent
-FAIL Invalid color: keyword ActiveBorder assert_equals: expected "#000000" but got "#0067f4"
+FAIL Invalid color: keyword ActiveBorder assert_equals: expected "#000000" but got "#ffffff"
 PASS Invalid color: keyword inherit
 FAIL Invalid color: rgb(1,1,1) assert_equals: expected "#000000" but got "#010101"
 FAIL Invalid color: rgb(1,1,1,1) assert_equals: expected "#000000" but got "#010101"

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
@@ -1,0 +1,10 @@
+
+
+
+
+FAIL Focus the new checked radio in the focused radio group. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+PASS Focusable radio can be focused even with a checked radio in the group.
+FAIL Focus the checked radio in the group. assert_equals: expected Element node <input type="radio" name="radio"></input> but got Element node <input type="text" id="start"></input>
+FAIL Focus the checked radio in the focused radio group. assert_false: expected false got true
+FAIL When `checked` is false on a radio element, focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
@@ -1,0 +1,6 @@
+Outside form
+disabled checked  enabled 1  enabled 2
+Outside form
+
+FAIL Should be able to tab focus in radio group even when the checked radio button is disabled. assert_equals: expected Element node <input type="radio" name="radio" id="b"></input> but got Element node <input type="radio" name="start" id="start"></input>
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+
+FAIL Both forward and backward focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
@@ -1,0 +1,7 @@
+
+enabled 1  Button  enabled 2  enabled 3
+
+
+FAIL Focusable elements between radio elements in a group can be focused. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+FAIL During arrow key navigation, focus and checked is set on the radio element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
@@ -1,0 +1,8 @@
+Radio buttons should scroll into view when focused (if off-screen)
+
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Focusing offscreen radio via keyboard should scroll it into view Test timed out
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror-expected.txt
@@ -1,0 +1,18 @@
+input_valueAsDate_TypeError
+
+
+Harness Error (FAIL), message = 1 duplicate test name: "valueAsDate setter with non-Date object (input type text)"
+
+FAIL valueAsDate setter with non-Date object (input type text) assert_throws_js: function "() => input.valueAsDate = {}" threw object "InvalidStateError: The object is in an invalid state." ("InvalidStateError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL valueAsDate setter with non-Date object (input type text) assert_throws_js: function "() => input.valueAsDate = {}" threw object "InvalidStateError: The object is in an invalid state." ("InvalidStateError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL valueAsDate setter with non-Date object (input type text) assert_throws_js: function "() => input.valueAsDate = {}" threw object "InvalidStateError: The object is in an invalid state." ("InvalidStateError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL valueAsDate setter with non-Date object (input type text) assert_throws_js: function "() => input.valueAsDate = {}" threw object "InvalidStateError: The object is in an invalid state." ("InvalidStateError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt
@@ -1,5 +1,6 @@
 OPEN FILE PANEL
 
+
 PASS input[type=button] showPicker() throws when disabled
 PASS input[type=checkbox] showPicker() throws when disabled
 PASS input[type=color] showPicker() throws when disabled

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt
@@ -17,7 +17,7 @@ FAIL Invalid color: keyword crimson assert_equals: expected "#000000" but got "#
 FAIL Invalid color: keyword bisque assert_equals: expected "#000000" but got "#ffe4c4"
 PASS Invalid color: keyword currentColor
 PASS Invalid color: keyword transparent
-FAIL Invalid color: keyword ActiveBorder assert_equals: expected "#000000" but got "#0067f4"
+FAIL Invalid color: keyword ActiveBorder assert_equals: expected "#000000" but got "#ffffff"
 PASS Invalid color: keyword inherit
 FAIL Invalid color: rgb(1,1,1) assert_equals: expected "#000000" but got "#010101"
 FAIL Invalid color: rgb(1,1,1,1) assert_equals: expected "#000000" but got "#010101"

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt
@@ -1,0 +1,10 @@
+
+
+
+
+FAIL Focus the new checked radio in the focused radio group. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+PASS Focusable radio can be focused even with a checked radio in the group.
+FAIL Focus the checked radio in the group. assert_equals: expected Element node <input type="radio" name="radio"></input> but got Element node <input type="text" id="start"></input>
+FAIL Focus the checked radio in the focused radio group. assert_false: expected false got true
+FAIL When `checked` is false on a radio element, focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt
@@ -1,0 +1,6 @@
+Outside form
+disabled checked  enabled 1  enabled 2
+Outside form
+
+FAIL Should be able to tab focus in radio group even when the checked radio button is disabled. assert_equals: expected Element node <input type="radio" name="radio" id="b"></input> but got Element node <input type="radio" name="start" id="start"></input>
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+
+FAIL Both forward and backward focus navigation target the radio group first element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt
@@ -1,0 +1,7 @@
+
+enabled 1  Button  enabled 2  enabled 3
+
+
+FAIL Focusable elements between radio elements in a group can be focused. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+FAIL During arrow key navigation, focus and checked is set on the radio element. assert_equals: expected Element node <input type="radio" name="radio" id="a"></input> but got Element node <input type="text" id="start"></input>
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt
@@ -1,0 +1,8 @@
+Radio buttons should scroll into view when focused (if off-screen)
+
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Focusing offscreen radio via keyboard should scroll it into view Test timed out
+


### PR DESCRIPTION
#### 428c1c9b2f6d7480b37f48c803b72e6e8e589101
<pre>
Import html/semantics/forms/the-input-element WPTs 07/22/2025
<a href="https://bugs.webkit.org/show_bug.cgi?id=296361">https://bugs.webkit.org/show_bug.cgi?id=296361</a>

Reviewed by Tim Nguyen.

Import html/semantics/forms/the-input-element tests at upstream commit:
<a href="https://github.com/web-platform-tests/wpt/commit/70e23bfdc22a1c1d9bf46edf38c649533946c7b4">https://github.com/web-platform-tests/wpt/commit/70e23bfdc22a1c1d9bf46edf38c649533946c7b4</a>

This PR re-baselines imported WPT tests for platforms: ios, mac, gtk, wpe.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color-attributes.window.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.window.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasnumber-typeerror.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/focus-utils.js: Added.
(waitForRender):
(async pressKey):
(async arrowUp):
(async arrowDown):
(async navigateFocusForward):
(async navigateFocusBackward):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/w3c-import.log:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-valueasdate-typeerror-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-disabled-readonly-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/color.tentative-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-checked-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-disabled-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-first-focus-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focus-navigation-group-focusable-focus-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/radio-focused-and-scrolled-into-view-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/298346@main">https://commits.webkit.org/298346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a876b1a7b5edddbeb3bc014f18adb0d796db70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65834 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87544 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21557 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64978 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97747 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96345 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96132 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24456 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19189 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38134 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->