### PR TITLE
[css-anchor-position-1] Integrate anchor positioning with multicol layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
@@ -1,6 +1,6 @@
 Lorem ipsum dolor sit amet.
 Lorem ipsum dolor sit amet.
 
-FAIL getComputedStyle() with fragmented containing block in multicolumn layout assert_equals: expected "25px" but got "135px"
+FAIL getComputedStyle() with fragmented containing block in multicolumn layout assert_equals: expected "-85px" but got "25px"
 PASS getComputedStyle() with fragmented containing block in inline layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003-expected.txt
@@ -5,10 +5,6 @@ width expected 70 but got 10
 FAIL .target 2 assert_equals:
 <div class="target" data-expected-width="70" data-expected-height="50"></div>
 width expected 70 but got 10
-FAIL .target 3 assert_equals:
-<div class="target" data-expected-width="70" data-expected-height="50"></div>
-width expected 70 but got 10
-FAIL .target 4 assert_equals:
-<div class="target" data-expected-width="70" data-expected-height="50"></div>
-width expected 70 but got 10
+PASS .target 3
+PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004-expected.txt
@@ -2,7 +2,5 @@
 FAIL .target 1 assert_equals:
 <div class="target" data-expected-width="40" data-expected-height="50"></div>
 width expected 40 but got 10
-FAIL .target 2 assert_equals:
-<div class="target" data-expected-width="40" data-expected-height="50"></div>
-width expected 40 but got 10
+PASS .target 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt
@@ -7,7 +7,7 @@ FAIL .target 1 assert_equals:
 offsetLeft expected 100 but got 200
 FAIL .target 2 assert_equals:
 <div class="target target1-r" data-offset-x="404" data-expected-height="100"></div>
-offsetLeft expected 404 but got 504
+offsetLeft expected 404 but got 294
 FAIL .target 3 assert_equals:
 <div class="target target1-t" data-offset-y="0" data-expected-width="310"></div>
 width expected 310 but got 100

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt
@@ -25,7 +25,7 @@ PASS .target 17
 PASS .target 18
 FAIL .target 19 assert_equals:
 <span class="target target1-pos" data-offset-x="30" data-offset-y="-40" data-expected-width="80" data-expected-height="50"></span>
-width expected 80 but got 210
+width expected 80 but got 100
 FAIL .target 20 assert_equals:
 <span class="target target1-size" data-offset-x="30" data-offset-y="-40" data-expected-width="80" data-expected-height="50"></span>
 width expected 80 but got 100
@@ -34,11 +34,11 @@ FAIL .target 21 assert_equals:
 width expected 80 but got 210
 FAIL .target 22 assert_equals:
 <span class="target target1-size" data-offset-x="160" data-offset-y="0" data-expected-width="80" data-expected-height="50"></span>
-width expected 80 but got 100
+width expected 80 but got 210
 FAIL .target 23 assert_equals:
 <span class="target target1-pos" data-offset-x="160" data-offset-y="0" data-expected-width="80" data-expected-height="50"></span>
 width expected 80 but got 210
 FAIL .target 24 assert_equals:
 <span class="target target1-size" data-offset-x="160" data-offset-y="0" data-expected-width="80" data-expected-height="50"></span>
-width expected 80 but got 100
+width expected 80 but got 210
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt
@@ -6,27 +6,19 @@ FAIL .target 1 assert_equals:
 width expected 160 but got 50
 FAIL .target 2 assert_equals:
 <div class="target target1-rb" data-offset-x="168" data-offset-y="155"></div>
-offsetLeft expected 168 but got 278
+offsetLeft expected 168 but got 58
 FAIL .target 3 assert_equals:
 <div class="target fixed target1" data-offset-x="26" data-offset-y="70" data-expected-width="160" data-expected-height="100"></div>
 width expected 160 but got 50
 FAIL .target 4 assert_equals:
 <div class="target fixed target1-rb" data-offset-x="176" data-offset-y="160"></div>
-offsetLeft expected 176 but got 286
-FAIL .target 5 assert_equals:
-<div class="target target1" data-offset-x="144" data-offset-y="5" data-expected-width="160" data-expected-height="100"></div>
-width expected 160 but got 50
+offsetLeft expected 176 but got 66
+PASS .target 5
 PASS .target 6
-FAIL .target 7 assert_equals:
-<div class="target fixed target1" data-offset-x="152" data-offset-y="10" data-expected-width="160" data-expected-height="100"></div>
-width expected 160 but got 50
+PASS .target 7
 PASS .target 8
-FAIL .target 9 assert_equals:
-<div class="target target1" data-offset-x="144" data-offset-y="5" data-expected-width="160" data-expected-height="100"></div>
-width expected 160 but got 50
+PASS .target 9
 PASS .target 10
-FAIL .target 11 assert_equals:
-<div class="target fixed target1" data-offset-x="152" data-offset-y="10" data-expected-width="160" data-expected-height="100"></div>
-width expected 160 but got 50
+PASS .target 11
 PASS .target 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003-expected.txt
@@ -2,22 +2,14 @@
 FAIL .target 1 assert_equals:
 <div class="target" data-expected-height="50"></div>
 height expected 50 but got 30
-FAIL .target 2 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
-FAIL .target 3 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
+PASS .target 2
+PASS .target 3
 FAIL .target 4 assert_equals:
 <div class="target" data-expected-height="50"></div>
 height expected 50 but got 30
 FAIL .target 5 assert_equals:
 <div class="target" data-expected-height="50"></div>
 height expected 50 but got 30
-FAIL .target 6 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
-FAIL .target 7 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
+PASS .target 6
+PASS .target 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt
@@ -6,11 +6,11 @@ FAIL .target 1 assert_equals:
 width expected 130 but got 20
 FAIL .target 2 assert_equals:
 <div class="target target1-rb" data-offset-x="138" data-offset-y="155"></div>
-offsetLeft expected 138 but got 468
+offsetLeft expected 138 but got 28
 FAIL .target 3 assert_equals:
 <div class="target target1" data-offset-x="34" data-offset-y="225" data-expected-width="130" data-expected-height="100"></div>
 width expected 130 but got 20
 FAIL .target 4 assert_equals:
 <div class="target target1-rb" data-offset-x="154" data-offset-y="315"></div>
-offsetLeft expected 154 but got 484
+offsetLeft expected 154 but got 44
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-006-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL .target 1 assert_equals:
-<div class="target target1" data-expected-height="50"></div>
-height expected 50 but got 30
+PASS .target 1
 PASS .target 2
-FAIL .target 3 assert_equals:
-<div class="target target1" data-expected-height="50"></div>
-height expected 50 but got 30
+PASS .target 3
 PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-colspan-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-colspan-002-expected.txt
@@ -1,8 +1,4 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" data-offset-x="10" data-offset-y="20" data-expected-width="150" data-expected-height="60"></div>
-width expected 150 but got 40
-FAIL .target 2 assert_equals:
-<div class="target" data-offset-x="10" data-offset-y="30" data-expected-width="150" data-expected-height="60"></div>
-width expected 150 but got 40
+PASS .target 1
+PASS .target 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-nested-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-nested-001-expected.txt
@@ -6,8 +6,8 @@ FAIL .target 1 assert_equals:
 width expected 180 but got 20
 FAIL .target 2 assert_equals:
 <div class="target" data-offset-x="13" data-offset-y="97" data-expected-width="180" data-expected-height="100"></div>
-width expected 180 but got 20
+width expected 180 but got 90
 FAIL .target 3 assert_equals:
 <div class="target" data-offset-x="175" data-offset-y="13" data-expected-width="180" data-expected-height="100"></div>
-width expected 180 but got 20
+width expected 180 but got 90
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Scrolling should work in fragmented containing block assert_equals: expected 30 but got -40
+PASS Scrolling should work in fragmented containing block
 

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -101,7 +101,7 @@ public:
     
     virtual void repaintFragmentedFlowContent(const LayoutRect& repaintRect) const;
 
-    virtual void collectLayerFragments(LayerFragments&, const LayoutRect&, const LayoutRect&) { }
+    virtual void collectLayerFragments(LayerFragments&, const LayoutRect&, const LayoutRect&) const { }
 
     void addLayoutOverflowForBox(const RenderBox&, const LayoutRect&);
     void addVisualOverflowForBox(const RenderBox&, const LayoutRect&);

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -750,7 +750,7 @@ bool RenderFragmentedFlow::addForcedFragmentBreak(const RenderBlock* block, Layo
     return false;
 }
 
-void RenderFragmentedFlow::collectLayerFragments(LayerFragments& layerFragments, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect)
+void RenderFragmentedFlow::collectLayerFragments(LayerFragments& layerFragments, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) const
 {
     ASSERT(!m_fragmentsInvalidated || isSkippedContent());
 
@@ -758,7 +758,7 @@ void RenderFragmentedFlow::collectLayerFragments(LayerFragments& layerFragments,
         fragment.collectLayerFragments(layerFragments, layerBoundingBox, dirtyRect);
 }
 
-LayoutRect RenderFragmentedFlow::fragmentsBoundingBox(const LayoutRect& layerBoundingBox)
+LayoutRect RenderFragmentedFlow::fragmentsBoundingBox(const LayoutRect& layerBoundingBox) const
 {
     ASSERT(!m_fragmentsInvalidated);
     

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -133,8 +133,8 @@ public:
     virtual bool isPageLogicalHeightKnown() const { return true; }
     bool pageLogicalSizeChanged() const { return m_pageLogicalSizeChanged; }
 
-    void collectLayerFragments(LayerFragments&, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect);
-    LayoutRect fragmentsBoundingBox(const LayoutRect& layerBoundingBox);
+    void collectLayerFragments(LayerFragments&, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) const;
+    LayoutRect fragmentsBoundingBox(const LayoutRect& layerBoundingBox) const;
 
     LayoutUnit offsetFromLogicalTopOfFirstFragment(const RenderBlock*) const;
     void clearRenderBoxFragmentInfoAndCustomStyle(const RenderBox&, const RenderFragmentContainer*, const RenderFragmentContainer*, const RenderFragmentContainer*, const RenderFragmentContainer*);

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -801,7 +801,7 @@ LayoutUnit RenderMultiColumnSet::initialBlockOffsetForPainting() const
     return result;
 }
 
-void RenderMultiColumnSet::collectLayerFragments(LayerFragments& fragments, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect)
+void RenderMultiColumnSet::collectLayerFragments(LayerFragments& fragments, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) const
 {
     static constexpr size_t maximumNumberOfFragments = 2500000;
     // Let's start by introducing the different coordinate systems involved here. They are different

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -162,7 +162,7 @@ private:
 
     void repaintFragmentedFlowContent(const LayoutRect& repaintRect) const override;
 
-    void collectLayerFragments(LayerFragments&, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) override;
+    void collectLayerFragments(LayerFragments&, const LayoutRect& layerBoundingBox, const LayoutRect& dirtyRect) const override;
 
     Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) const final;
     bool contentRectSpansFragments(const LayoutRect&) const final;


### PR DESCRIPTION
#### 90aaff9c95eb97972eee2e25ecc64dc855d313a0
<pre>
[css-anchor-position-1] Integrate anchor positioning with multicol layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=296314">https://bugs.webkit.org/show_bug.cgi?id=296314</a>
<a href="https://rdar.apple.com/156366253">rdar://156366253</a>

Reviewed by Alan Baradlay.

Fixes two problems with anchor positioning integration with multicol layout
(fragmented flows):
1. We shouldn&apos;t do fragmented flow special handling when the containing
   block is inside the fragmented flow along with the anchor.
2. The anchor-size() function wasn&apos;t handling fragmented flows at all.

The patch extracts the multicol bounding box logic into a helper function,
gates it on whether or not the containing block is inside the fragmented flow,
and applies this logic also to anchor-size().

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-inline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-colspan-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-nested-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-003-expected.txt:

Update test expectations.

* Source/WebCore/rendering/RenderFragmentContainer.h:
(WebCore::RenderFragmentContainer::collectLayerFragments const):
(WebCore::RenderFragmentContainer::collectLayerFragments): Deleted.
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::collectLayerFragments const):
(WebCore::RenderFragmentedFlow::fragmentsBoundingBox const):
(WebCore::RenderFragmentedFlow::collectLayerFragments): Deleted.
(WebCore::RenderFragmentedFlow::fragmentsBoundingBox): Deleted.
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::collectLayerFragments const):
(WebCore::RenderMultiColumnSet::collectLayerFragments): Deleted.
* Source/WebCore/rendering/RenderMultiColumnSet.h:

Fix const-ness so we can call fragmentsBoundingBox() on a const object.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::boundingRectForFragmentedAnchor):

Extract bounding box logic into a helper method.

(WebCore::Style::AnchorPositionEvaluator::computeAnchorRectRelativeToContainingBlock):

Call the helper method, gated on whether the containing block is inside the
fragmented flow together with the anchor or not.

(WebCore::Style::AnchorPositionEvaluator::evaluateSize):

Apply the same logic to anchor-size().

Canonical link: <a href="https://commits.webkit.org/297815@main">https://commits.webkit.org/297815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/124f47937593fe3d1e720882e2c232a5a1cf964f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112943 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85951 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66258 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62905 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122368 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94806 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94545 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39682 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39548 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->