### PR TITLE
Handle semicolons at end of keySplines value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-keySplines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-keySplines-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing correct parsing of keySplines. assert_approx_equals: expected 167 +/- 1 but got 100
+PASS Testing correct parsing of keySplines.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-x-limits-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-x-limits-expected.txt
@@ -1,3 +1,11 @@
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="-1 0 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="2 0 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 0 -1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 0 2 1"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="-10 0 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="10 0 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0 0 -10 1"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0 0 10 1"
 
 PASS 'keySplines' with x-values outside of the 0 to 1 range
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-y-limits-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-y-limits-expected.txt
@@ -1,3 +1,11 @@
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 -1 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 2 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 0 1 -1"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 0 1 2"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0 -10 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0 10 1 1"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0 0 1 -10"
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0 0 1 10"
 
 PASS 'keySplines' with y-values outside of the 0 to 1 range
 

--- a/LayoutTests/svg/animations/keySplines-parsing-error-expected.txt
+++ b/LayoutTests/svg/animations/keySplines-parsing-error-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines=";;"
+CONSOLE MESSAGE: Error: Invalid value for <animate> attribute keySplines="0 ,0  1 , 1  ;;"
+Tests parsing of keySplines attribute.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/animations/keySplines-parsing-error.html
+++ b/LayoutTests/svg/animations/keySplines-parsing-error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests parsing of keySplines attribute.");
+
+var animate = document.createElementNS("http://www.w3.org/2000/svg", "animate");
+animate.setAttribute("keySplines", ";;");
+animate.setAttribute("keySplines", "0 ,0  1 , 1  ;;");
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/animations/keypoints-mismatch-expected.txt
+++ b/LayoutTests/svg/animations/keypoints-mismatch-expected.txt
@@ -1,1 +1,2 @@
+CONSOLE MESSAGE: Error: Invalid value for <animateMotion> attribute keySplines="0"
 Excellent - did not crash. See bug https://bugs.webkit.org/show_bug.cgi?id=35606


### PR DESCRIPTION
#### 5aa55b2b321b3393830bec1d72965cd8fca80575
<pre>
Handle semicolons at end of keySplines value
<a href="https://bugs.webkit.org/show_bug.cgi?id=296363">https://bugs.webkit.org/show_bug.cgi?id=296363</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/182475457181aef90b9f705a5d1557576bde8c50">https://source.chromium.org/chromium/chromium/src/+/182475457181aef90b9f705a5d1557576bde8c50</a>

As discussed in W3C list [1], we want more lenient behavior to allow trailing
semicolon.

[1] <a href="https://lists.w3.org/Archives/Public/www-svg/2014Sep/0016.html">https://lists.w3.org/Archives/Public/www-svg/2014Sep/0016.html</a>

By relaxing `semicolon` handling of a single trailing semicolon, we progress
WPT testcase and make the parsing code a bit simpler.

When using more than one semicolon at the end of keySplines ignore parsing
of the value and report an error on the console - look at rebaselines and
dedicated test.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::parseKeySplines):
(WebCore::SVGAnimationElement::attributeChanged):

&gt; Rebaselines:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-x-limits-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/keysplines-y-limits-expected.txt:
* LayoutTests/svg/animations/keypoints-mismatch-expected.txt:

&gt; Progression:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-keySplines-expected.txt:

&gt; Parser Failure Test:
* LayoutTests/svg/animations/keySplines-parsing-error-expected.txt:
* LayoutTests/svg/animations/keySplines-parsing-error.html:

Canonical link: <a href="https://commits.webkit.org/297793@main">https://commits.webkit.org/297793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/696c06e95042fbc5ba35d812226b8fea531556e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85878 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/36536 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19645 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122266 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94480 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17422 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36027 "Hash 696c06e9 for PR 48410 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45303 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39445 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->