### PR TITLE
Make more Ref member variables const in WebCore and WebGPU

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -68,7 +68,7 @@ public:
         std::optional<KeyValuePair<String, String>> next();
 
     private:
-        Ref<FetchHeaders> m_headers;
+        const Ref<FetchHeaders> m_headers;
         size_t m_currentIndex { 0 };
         size_t m_setCookieIndex { 0 };
         Vector<String> m_keys;

--- a/Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h
+++ b/Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h
@@ -86,7 +86,7 @@ protected:
     }
 
 private:
-    Ref<Thread> m_originThread { Thread::currentSingleton() };
+    const Ref<Thread> m_originThread { Thread::currentSingleton() };
     Lock m_scriptExecutionContextLock;
 };
 

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
@@ -46,7 +46,7 @@ public:
 private:
     static ASCIILiteral supplementName();
 
-    mutable Ref<MediaCapabilities> m_mediaCapabilities;
+    const Ref<MediaCapabilities> m_mediaCapabilities;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
@@ -46,7 +46,7 @@ public:
 private:
     static ASCIILiteral supplementName();
 
-    mutable Ref<MediaCapabilities> m_mediaCapabilities;
+    const Ref<MediaCapabilities> m_mediaCapabilities;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -17,7 +17,6 @@ Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/filesystem/FileSystemFileHandle.cpp
 Modules/filesystem/WorkerFileSystemStorageConnection.cpp
 Modules/identity/CredentialRequestCoordinator.cpp
-Modules/indexeddb/IDBActiveDOMObject.h
 Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBDatabase.cpp
 Modules/indexeddb/IDBIndex.cpp
@@ -759,7 +758,6 @@ platform/graphics/SourceBufferPrivate.cpp
 platform/graphics/TransparencyLayerContextSwitcher.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
-platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -249,7 +249,7 @@ private:
     DatabaseLoader(ScriptExecutionContext* context, Ref<IndexedDBBackendDispatcherHandler::RequestDatabaseCallback>&& requestCallback)
         : ExecutableWithDatabase(context)
         , m_requestCallback(WTFMove(requestCallback)) { }
-    Ref<IndexedDBBackendDispatcherHandler::RequestDatabaseCallback> m_requestCallback;
+    const Ref<IndexedDBBackendDispatcherHandler::RequestDatabaseCallback> m_requestCallback;
 };
 
 static RefPtr<IDBKey> idbKeyFromInspectorObject(Ref<JSON::Object>&& key)
@@ -421,7 +421,7 @@ private:
     {
     }
     InjectedScript m_injectedScript;
-    Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback> m_requestCallback;
+    const Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback> m_requestCallback;
     Ref<JSON::ArrayOf<Inspector::Protocol::IndexedDB::DataEntry>> m_result;
     int m_skipCount;
     unsigned m_pageSize;
@@ -490,11 +490,11 @@ public:
         , m_idbKeyRange(WTFMove(idbKeyRange))
         , m_skipCount(skipCount)
         , m_pageSize(pageSize) { }
-    Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback> m_requestCallback;
+    const Ref<IndexedDBBackendDispatcherHandler::RequestDataCallback> m_requestCallback;
     InjectedScript m_injectedScript;
     String m_objectStoreName;
     String m_indexName;
-    RefPtr<IDBKeyRange> m_idbKeyRange;
+    const RefPtr<IDBKeyRange> m_idbKeyRange;
     int m_skipCount;
     unsigned m_pageSize;
 };
@@ -655,7 +655,7 @@ private:
     {
     }
 
-    Ref<IndexedDBBackendDispatcherHandler::ClearObjectStoreCallback> m_requestCallback;
+    const Ref<IndexedDBBackendDispatcherHandler::ClearObjectStoreCallback> m_requestCallback;
 };
 
 class ClearObjectStore final : public ExecutableWithDatabase {
@@ -703,7 +703,7 @@ public:
     BackendDispatcher::CallbackBase& requestCallback() override { return m_requestCallback.get(); }
 private:
     const String m_objectStoreName;
-    Ref<IndexedDBBackendDispatcherHandler::ClearObjectStoreCallback> m_requestCallback;
+    const Ref<IndexedDBBackendDispatcherHandler::ClearObjectStoreCallback> m_requestCallback;
 };
 
 } // anonymous namespace

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -270,11 +270,11 @@ private:
     WTFLogChannel& contentKeyGroupDataSourceLogChannel() const final;
 #endif // !RELEASE_LOG_DISABLED
 
-    Ref<CDMInstanceFairPlayStreamingAVFObjC> m_instance;
-    RetainPtr<WebAVContentKeyGrouping> m_group;
+    const Ref<CDMInstanceFairPlayStreamingAVFObjC> m_instance;
+    const RetainPtr<WebAVContentKeyGrouping> m_group;
     RetainPtr<AVContentKeySession> m_session;
     std::optional<Request> m_currentRequest;
-    RetainPtr<WebCoreFPSContentKeySessionDelegate> m_delegate;
+    const RetainPtr<WebCoreFPSContentKeySessionDelegate> m_delegate;
     Vector<RetainPtr<NSData>> m_expiredSessions;
     WeakPtr<CDMInstanceSessionClient> m_client;
     String m_sessionId;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -282,7 +282,7 @@ AVContentKeySession* CDMInstanceFairPlayStreamingAVFObjC::contentKeySession()
         return nullptr;
 
     if (!m_delegate)
-        m_delegate = adoptNS([[WebCoreFPSContentKeySessionDelegate alloc] initWithParent:*this]);
+        lazyInitialize(m_delegate, adoptNS([[WebCoreFPSContentKeySessionDelegate alloc] initWithParent:*this]));
 
     [m_session setDelegate:m_delegate.get() queue:dispatch_get_main_queue()];
     return m_session.get();
@@ -1748,7 +1748,7 @@ bool CDMInstanceSessionFairPlayStreamingAVFObjC::ensureSessionOrGroup(KeyGroupin
         return true;
 
     if (auto* session = m_instance->contentKeySession()) {
-        m_group = ContentKeyGroupFactoryAVFObjC::createContentKeyGroup(keyGroupingStrategy, session, *this);
+        lazyInitialize(m_group, ContentKeyGroupFactoryAVFObjC::createContentKeyGroup(keyGroupingStrategy, session, *this));
         return true;
     }
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -46,7 +46,7 @@
 
 static bool setCommandEncoder(auto& buffer, auto& renderPassEncoder)
 {
-    buffer.setCommandEncoder(renderPassEncoder->protectedParentEncoder().get());
+    buffer.setCommandEncoder(renderPassEncoder->parentEncoder());
     return !!renderPassEncoder->renderCommandEncoder();
 }
 
@@ -374,7 +374,7 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
             m_makeSubmitInvalid = true;
     }
 
-    if (NSString* error = pipeline->protectedPipelineLayout()->errorValidatingBindGroupCompatibility(m_bindGroups)) {
+    if (NSString* error = pipeline->pipelineLayout().errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);
         return false;
     }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -99,7 +99,6 @@ public:
     id<MTLRenderCommandEncoder> renderCommandEncoder() const;
     void makeInvalid(NSString* = nil);
     CommandEncoder& parentEncoder() const { return m_parentEncoder; }
-    Ref<CommandEncoder> protectedParentEncoder() const { return m_parentEncoder; }
 
     bool setCommandEncoder(const BindGroupEntryUsageData::Resource&);
     void addResourceToActiveResources(const BindGroupEntryUsageData::Resource&, OptionSet<BindGroupEntryUsage>);
@@ -166,7 +165,7 @@ private:
     Vector<uint32_t> m_priorVertexDynamicOffsets;
     Vector<uint32_t> m_fragmentDynamicOffsets;
     Vector<uint32_t> m_priorFragmentDynamicOffsets;
-    Ref<CommandEncoder> m_parentEncoder;
+    const Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     using EntryUsage = OptionSet<BindGroupEntryUsage>;
     using EntryMap = HashMap<uint64_t, EntryUsage, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -89,7 +89,6 @@ public:
 
     Device& device() const { return m_device; }
     PipelineLayout& pipelineLayout() const { return m_pipelineLayout; }
-    Ref<PipelineLayout> protectedPipelineLayout() const { return m_pipelineLayout; }
     bool colorDepthStencilTargetsMatch(const WGPURenderPassDescriptor&, const Vector<RefPtr<TextureView>>&, const RefPtr<TextureView>&) const;
     bool validateRenderBundle(const WGPURenderBundleEncoderDescriptor&) const;
     bool writesDepth() const;
@@ -129,7 +128,7 @@ private:
     MTLDepthStencilDescriptor *m_depthStencilDescriptor { nil };
     id<MTLDepthStencilState> m_depthStencilState;
     RequiredBufferIndicesContainer m_requiredBufferIndices;
-    Ref<PipelineLayout> m_pipelineLayout;
+    const Ref<PipelineLayout> m_pipelineLayout;
     mutable RefPtr<RenderPipeline> m_lastStrideAsStridePipeline;
     WGPURenderPipelineDescriptor m_descriptor;
     WGPUDepthStencilState m_descriptorDepthStencil;

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -101,7 +101,7 @@ private:
     const std::optional<WGPUExtent3D> m_renderExtent;
 
     const Ref<Device> m_device;
-    Ref<Texture> m_parentTexture;
+    const Ref<Texture> m_parentTexture;
     mutable Vector<uint64_t> m_commandEncoders;
 // FIXME: remove @safe once rdar://151039766 lands
 } __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refTextureView, derefTextureView);

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -64,12 +64,12 @@ id<MTLTexture> TextureView::parentTexture() const
 
 bool TextureView::previouslyCleared() const
 {
-    return Ref { m_parentTexture }->previouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
+    return m_parentTexture->previouslyCleared(m_texture.parentRelativeLevel, m_texture.parentRelativeSlice);
 }
 
 void TextureView::setPreviouslyCleared(uint32_t mipLevel, uint32_t slice)
 {
-    Ref { m_parentTexture }->setPreviouslyCleared(m_texture.parentRelativeLevel + mipLevel, m_texture.parentRelativeSlice + slice);
+    m_parentTexture->setPreviouslyCleared(m_texture.parentRelativeLevel + mipLevel, m_texture.parentRelativeSlice + slice);
 }
 
 uint32_t TextureView::parentRelativeMipLevel() const
@@ -85,17 +85,17 @@ uint32_t TextureView::parentRelativeSlice() const
 
 uint32_t TextureView::width() const
 {
-    return Ref { m_parentTexture }->physicalMiplevelSpecificTextureExtent(baseMipLevel()).width;
+    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).width;
 }
 
 uint32_t TextureView::height() const
 {
-    return Ref { m_parentTexture }->physicalMiplevelSpecificTextureExtent(baseMipLevel()).height;
+    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).height;
 }
 
 uint32_t TextureView::depthOrArrayLayers() const
 {
-    return Ref { m_parentTexture }->physicalMiplevelSpecificTextureExtent(baseMipLevel()).depthOrArrayLayers;
+    return m_parentTexture->physicalMiplevelSpecificTextureExtent(baseMipLevel()).depthOrArrayLayers;
 }
 
 WGPUTextureUsageFlags TextureView::usage() const

--- a/Source/WebGPU/WebGPU/XRBinding.h
+++ b/Source/WebGPU/WebGPU/XRBinding.h
@@ -63,14 +63,12 @@ public:
     Ref<XRProjectionLayer> createXRProjectionLayer(WGPUTextureFormat, WGPUTextureFormat*, WGPUTextureUsageFlags, double);
     RefPtr<XRSubImage> getViewSubImage(XRProjectionLayer&);
     Device& device() { return m_device; }
-    Ref<Device> protectedDevice() { return m_device; }
-
 
 private:
     XRBinding(bool, Device&);
     XRBinding(Device&);
 
-    Ref<Device> m_device;
+    const Ref<Device> m_device;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRProjectionLayer.h
+++ b/Source/WebGPU/WebGPU/XRProjectionLayer.h
@@ -75,7 +75,7 @@ private:
     std::pair<id<MTLSharedEvent>, uint64_t> m_sharedEvent;
     size_t m_reusableTextureIndex { 0 };
 
-    Ref<Device> m_device;
+    const Ref<Device> m_device;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRProjectionLayer.mm
+++ b/Source/WebGPU/WebGPU/XRProjectionLayer.mm
@@ -117,7 +117,7 @@ Ref<XRProjectionLayer> XRBinding::createXRProjectionLayer(WGPUTextureFormat colo
     UNUSED_PARAM(flags);
     UNUSED_PARAM(scale);
 
-    return XRProjectionLayer::create(protectedDevice().get());
+    return XRProjectionLayer::create(device());
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRSubImage.mm
+++ b/Source/WebGPU/WebGPU/XRSubImage.mm
@@ -134,7 +134,7 @@ Texture* XRSubImage::depthTexture()
 
 RefPtr<XRSubImage> XRBinding::getViewSubImage(XRProjectionLayer& projectionLayer)
 {
-    return protectedDevice()->getXRViewSubImage(projectionLayer);
+    return device().getXRViewSubImage(projectionLayer);
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRView.h
+++ b/Source/WebGPU/WebGPU/XRView.h
@@ -56,14 +56,14 @@ public:
 
     void setLabel(String&&);
 
-    bool isValid() const;
-    Device& device();
+    bool isValid() const { return true; }
+    Device& device() { return m_device; }
 
 private:
     XRView(bool, Device&);
     XRView(Device&);
 
-    Ref<Device> m_device;
+    const Ref<Device> m_device;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/XRView.mm
+++ b/Source/WebGPU/WebGPU/XRView.mm
@@ -57,16 +57,6 @@ void XRView::setLabel(String&&)
 {
 }
 
-bool XRView::isValid() const
-{
-    return true;
-}
-
-Device& XRView::device()
-{
-    return m_device;
-}
-
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs


### PR DESCRIPTION
#### 4fd36911c233673bdac8a2ecff13a8c42c7a9b44
<pre>
Make more Ref member variables const in WebCore and WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=296177">https://bugs.webkit.org/show_bug.cgi?id=296177</a>
<a href="https://rdar.apple.com/156413691">rdar://156413691</a>

Reviewed by Mike Wyrzykowski.

This landed as 297742@main but got backed out in 297754@main because it
broke an internal build. We now exclude the changes to
DynamicContentScalingDisplayList.

Apply <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

Canonical link: <a href="https://commits.webkit.org/297784@main">https://commits.webkit.org/297784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90805685ef2cf1f89aee73cc54ccddcb8b2f5eca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85870 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19635 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62796 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122259 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94735 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24117 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39600 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45296 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->