### PR TITLE
Add IPC validation for WebCore::DestinationColorSpace

### DIFF
--- a/LayoutTests/ipc/invalid-platform-color-space-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-platform-color-space-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-platform-color-space-crash.html
+++ b/LayoutTests/ipc/invalid-platform-color-space-crash.html
@@ -1,0 +1,46 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    window.setTimeout(async () => {
+        if (!window.IPC)
+            return window.testRunner?.notifyDone();
+
+        const { CoreIPC } = await import('./coreipc.js');
+
+        const renderingBackendIdentifier = randomIPCID();
+        const connection = CoreIPC.newStreamConnection();
+        CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, { renderingBackendIdentifier: renderingBackendIdentifier, connectionHandle: connection });
+        const remoteBackend = connection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+        const didInitializeReply = connection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+        connection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+        remoteBackend.CreateImageBuffer(
+            {
+                logicalSize: { width: 34, height: 103 },
+                renderingMode: 0,
+                renderingPurpose: 5,
+                resolutionScale: 41,
+                colorSpace: {
+                    serializableColorSpace: {
+                        alias: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: 'RetainPtr<CFStringRef>', variant: 'A'
+                                }
+                            }
+                        }
+                    }
+                }, pixelFormat: 2, identifier: 393235, contextIdentifier: 393236
+            });;
+
+        connection.connection.invalidate();
+        window.testRunner?.notifyDone();
+    }, 10);
+</script>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2173,7 +2173,7 @@ using WebCore::PlatformColorSpace = sk_sp<SkColorSpace>;
 #endif
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::DestinationColorSpace {
-        WebCore::PlatformColorSpace serializableColorSpace();
+        [Validator='*serializableColorSpace'] WebCore::PlatformColorSpace serializableColorSpace();
 };
 
 struct WebCore::WindowFeatures {


### PR DESCRIPTION
#### 9266cff4be4dfc24f779c93d6a6afac24f194cf2
<pre>
Add IPC validation for WebCore::DestinationColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=296375">https://bugs.webkit.org/show_bug.cgi?id=296375</a>
<a href="https://rdar.apple.com/156486637">rdar://156486637</a>

Reviewed by NOBODY (OOPS!).

Avoids ASSERT in constructor after unsuccessful deserialisation.

* LayoutTests/ipc/invalid-platform-color-space-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-platform-color-space-crash.html: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9266cff4be4dfc24f779c93d6a6afac24f194cf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86360 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41437 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20156 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63407 "Hash 9266cff4 for PR 48417 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40513 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30278 "Found 1 new test failure: ipc/invalid-platform-color-space-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95216 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94962 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17896 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36676 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45915 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->