### PR TITLE
[Skia] Incorrect font rendering of composed characters with skia and certain fonts

### DIFF
--- a/LayoutTests/platform/glib/fast/text/combining-enclosing-keycap-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/combining-enclosing-keycap-expected.txt
@@ -3,57 +3,57 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x34
   RenderBlock {HTML} at (0,0) size 800x34
     RenderBody {BODY} at (8,8) size 784x18
-      RenderInline {SPAN} at (0,0) size 24x17
-        RenderText {#text} at (0,0) size 24x17
-          text run at (0,0) width 24: "#\x{20E3}"
+      RenderInline {SPAN} at (0,0) size 10x17
+        RenderText {#text} at (0,0) size 10x17
+          text run at (0,0) width 10: "#\x{20E3}"
+      RenderText {#text} at (10,0) size 4x17
+        text run at (10,0) width 4: " "
+      RenderInline {SPAN} at (14,0) size 10x17
+        RenderText {#text} at (14,0) size 10x17
+          text run at (14,0) width 10: "0\x{20E3}"
       RenderText {#text} at (24,0) size 4x17
         text run at (24,0) width 4: " "
-      RenderInline {SPAN} at (28,0) size 24x17
-        RenderText {#text} at (28,0) size 24x17
-          text run at (28,0) width 24: "0\x{20E3}"
+      RenderInline {SPAN} at (28,0) size 10x17
+        RenderText {#text} at (28,0) size 10x17
+          text run at (28,0) width 10: "1\x{20E3}"
+      RenderText {#text} at (38,0) size 4x17
+        text run at (38,0) width 4: " "
+      RenderInline {SPAN} at (42,0) size 10x17
+        RenderText {#text} at (42,0) size 10x17
+          text run at (42,0) width 10: "2\x{20E3}"
       RenderText {#text} at (52,0) size 4x17
         text run at (52,0) width 4: " "
-      RenderInline {SPAN} at (56,0) size 24x17
-        RenderText {#text} at (56,0) size 24x17
-          text run at (56,0) width 24: "1\x{20E3}"
+      RenderInline {SPAN} at (56,0) size 10x17
+        RenderText {#text} at (56,0) size 10x17
+          text run at (56,0) width 10: "3\x{20E3}"
+      RenderText {#text} at (66,0) size 4x17
+        text run at (66,0) width 4: " "
+      RenderInline {SPAN} at (70,0) size 10x17
+        RenderText {#text} at (70,0) size 10x17
+          text run at (70,0) width 10: "4\x{20E3}"
       RenderText {#text} at (80,0) size 4x17
         text run at (80,0) width 4: " "
-      RenderInline {SPAN} at (84,0) size 24x17
-        RenderText {#text} at (84,0) size 24x17
-          text run at (84,0) width 24: "2\x{20E3}"
+      RenderInline {SPAN} at (84,0) size 10x17
+        RenderText {#text} at (84,0) size 10x17
+          text run at (84,0) width 10: "5\x{20E3}"
+      RenderText {#text} at (94,0) size 4x17
+        text run at (94,0) width 4: " "
+      RenderInline {SPAN} at (98,0) size 10x17
+        RenderText {#text} at (98,0) size 10x17
+          text run at (98,0) width 10: "6\x{20E3}"
       RenderText {#text} at (108,0) size 4x17
         text run at (108,0) width 4: " "
-      RenderInline {SPAN} at (112,0) size 24x17
-        RenderText {#text} at (112,0) size 24x17
-          text run at (112,0) width 24: "3\x{20E3}"
+      RenderInline {SPAN} at (112,0) size 10x17
+        RenderText {#text} at (112,0) size 10x17
+          text run at (112,0) width 10: "7\x{20E3}"
+      RenderText {#text} at (122,0) size 4x17
+        text run at (122,0) width 4: " "
+      RenderInline {SPAN} at (126,0) size 10x17
+        RenderText {#text} at (126,0) size 10x17
+          text run at (126,0) width 10: "8\x{20E3}"
       RenderText {#text} at (136,0) size 4x17
         text run at (136,0) width 4: " "
-      RenderInline {SPAN} at (140,0) size 24x17
-        RenderText {#text} at (140,0) size 24x17
-          text run at (140,0) width 24: "4\x{20E3}"
-      RenderText {#text} at (164,0) size 4x17
-        text run at (164,0) width 4: " "
-      RenderInline {SPAN} at (168,0) size 24x17
-        RenderText {#text} at (168,0) size 24x17
-          text run at (168,0) width 24: "5\x{20E3}"
-      RenderText {#text} at (192,0) size 4x17
-        text run at (192,0) width 4: " "
-      RenderInline {SPAN} at (196,0) size 24x17
-        RenderText {#text} at (196,0) size 24x17
-          text run at (196,0) width 24: "6\x{20E3}"
-      RenderText {#text} at (220,0) size 4x17
-        text run at (220,0) width 4: " "
-      RenderInline {SPAN} at (224,0) size 24x17
-        RenderText {#text} at (224,0) size 24x17
-          text run at (224,0) width 24: "7\x{20E3}"
-      RenderText {#text} at (248,0) size 4x17
-        text run at (248,0) width 4: " "
-      RenderInline {SPAN} at (252,0) size 24x17
-        RenderText {#text} at (252,0) size 24x17
-          text run at (252,0) width 24: "8\x{20E3}"
-      RenderText {#text} at (276,0) size 4x17
-        text run at (276,0) width 4: " "
-      RenderInline {SPAN} at (280,0) size 24x17
-        RenderText {#text} at (280,0) size 24x17
-          text run at (280,0) width 24: "9\x{20E3}"
+      RenderInline {SPAN} at (140,0) size 10x17
+        RenderText {#text} at (140,0) size 10x17
+          text run at (140,0) width 10: "9\x{20E3}"
       RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -20,6 +20,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaRecordingResult.h
     platform/graphics/skia/SkiaReplayCanvas.h
     platform/graphics/skia/SkiaSpanExtras.h
+    platform/graphics/skia/SkiaSystemFallbackFontCache.h
 )
 
 list(APPEND WebCore_LIBRARIES

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -63,5 +63,6 @@ platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
 platform/graphics/skia/SkiaPaintingEngine.cpp
 platform/graphics/skia/SkiaRecordingResult.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp
+platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -82,6 +82,9 @@ struct IDWriteFontCollection;
 #if USE(SKIA)
 #include "SkiaHarfBuzzFontCache.h"
 #include <skia/core/SkFontMgr.h>
+#if !OS(ANDROID) && !PLATFORM(WIN)
+#include "SkiaSystemFallbackFontCache.h"
+#endif
 #endif
 
 namespace WebCore {
@@ -281,6 +284,9 @@ private:
 #if USE(SKIA)
     mutable sk_sp<SkFontMgr> m_fontManager;
     SkiaHarfBuzzFontCache m_harfBuzzFontCache;
+#if !OS(ANDROID) && !PLATFORM(WIN)
+    SkiaSystemFallbackFontCache m_skiaSystemFallbackFontCache;
+#endif
 #endif
 
 #if PLATFORM(WIN) && USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaSystemFallbackFontCache.h"
+
+#if USE(SKIA) && !OS(ANDROID) && !PLATFORM(WIN)
+#include "FontCache.h"
+#include <fontconfig/fontconfig.h>
+#include <wtf/FileSystem.h>
+#include <wtf/HashTraits.h>
+#include <wtf/Hasher.h>
+#include <wtf/text/CharacterProperties.h>
+
+namespace WebCore {
+
+static void fontconfigStyle(const SkFontStyle& style, int& weight, int& width, int& slant)
+{
+    struct MapRanges {
+        SkScalar oldValue;
+        SkScalar newValue;
+    };
+
+    auto mapRanges = [](SkScalar value, MapRanges const ranges[], int rangesCount) -> SkScalar {
+        if (value < ranges[0].oldValue)
+            return ranges[0].newValue;
+
+        for (int i = 0; i < rangesCount - 1; ++i) {
+            if (value < ranges[i + 1].oldValue)
+                return ranges[i].newValue + ((value - ranges[i].oldValue) * (ranges[i + 1].newValue - ranges[i].newValue) / (ranges[i + 1].oldValue - ranges[i].oldValue));
+        }
+        return ranges[rangesCount - 1].newValue;
+    };
+
+    static constexpr MapRanges weightRanges[] = {
+        { SkFontStyle::kThin_Weight,       FC_WEIGHT_THIN },
+        { SkFontStyle::kExtraLight_Weight, FC_WEIGHT_EXTRALIGHT },
+        { SkFontStyle::kLight_Weight,      FC_WEIGHT_LIGHT },
+        { 350,                             FC_WEIGHT_DEMILIGHT },
+        { 380,                             FC_WEIGHT_BOOK },
+        { SkFontStyle::kNormal_Weight,     FC_WEIGHT_REGULAR },
+        { SkFontStyle::kMedium_Weight,     FC_WEIGHT_MEDIUM },
+        { SkFontStyle::kSemiBold_Weight,   FC_WEIGHT_DEMIBOLD },
+        { SkFontStyle::kBold_Weight,       FC_WEIGHT_BOLD },
+        { SkFontStyle::kExtraBold_Weight,  FC_WEIGHT_EXTRABOLD },
+        { SkFontStyle::kBlack_Weight,      FC_WEIGHT_BLACK },
+        { SkFontStyle::kExtraBlack_Weight, FC_WEIGHT_EXTRABLACK },
+    };
+    weight = mapRanges(style.weight(), weightRanges, std::size(weightRanges));
+
+    static constexpr MapRanges widthRanges[] = {
+        { SkFontStyle::kUltraCondensed_Width, FC_WIDTH_ULTRACONDENSED },
+        { SkFontStyle::kExtraCondensed_Width, FC_WIDTH_EXTRACONDENSED },
+        { SkFontStyle::kCondensed_Width,      FC_WIDTH_CONDENSED },
+        { SkFontStyle::kSemiCondensed_Width,  FC_WIDTH_SEMICONDENSED },
+        { SkFontStyle::kNormal_Width,         FC_WIDTH_NORMAL },
+        { SkFontStyle::kSemiExpanded_Width,   FC_WIDTH_SEMIEXPANDED },
+        { SkFontStyle::kExpanded_Width,       FC_WIDTH_EXPANDED },
+        { SkFontStyle::kExtraExpanded_Width,  FC_WIDTH_EXTRAEXPANDED },
+        { SkFontStyle::kUltraExpanded_Width,  FC_WIDTH_ULTRAEXPANDED },
+    };
+    width = mapRanges(style.width(), widthRanges, std::size(widthRanges));
+
+    slant = FC_SLANT_ROMAN;
+    switch (style.slant()) {
+    case SkFontStyle::kUpright_Slant:
+        slant = FC_SLANT_ROMAN;
+        break;
+    case SkFontStyle::kItalic_Slant:
+        slant = FC_SLANT_ITALIC;
+        break;
+    case SkFontStyle::kOblique_Slant:
+        slant = FC_SLANT_OBLIQUE;
+        break;
+    }
+}
+
+static String filePathFromPattern(FcPattern* pattern)
+{
+    FcChar8* filename = nullptr;
+    if (FcPatternGetString(pattern, FC_FILE, 0, &filename) != FcResultMatch || !filename)
+        return { };
+
+    const char* sysroot = reinterpret_cast<const char*>(FcConfigGetSysRoot(nullptr));
+    if (!sysroot)
+        return String::fromUTF8(reinterpret_cast<const char*>(filename));
+
+    return FileSystem::pathByAppendingComponent(String::fromUTF8(sysroot), String::fromUTF8(reinterpret_cast<const char*>(filename)));
+}
+
+struct FontSetCacheKey {
+    FontSetCacheKey() = default;
+
+    FontSetCacheKey(int weight, int width, int slant)
+        : weight(weight)
+        , width(width)
+        , slant(slant)
+    {
+    }
+
+    explicit FontSetCacheKey(WTF::HashTableDeletedValueType)
+        : weight(-1)
+        , width(-1)
+        , slant(-1)
+    {
+    }
+
+    bool isHashTableDeletedValue() const { return weight == -1 && width == -1 && slant == -1; }
+
+    bool operator==(const FontSetCacheKey&) const = default;
+
+    int weight { 0 };
+    int width { 0 };
+    int slant { 0 };
+};
+
+inline void add(Hasher& hasher, const FontSetCacheKey& key)
+{
+    add(hasher, key.weight, key.width, key.slant);
+}
+
+struct FontSetCacheKeyHash {
+    static unsigned hash(const FontSetCacheKey& key) { return computeHash(key); }
+    static bool equal(const FontSetCacheKey& a, const FontSetCacheKey& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = true;
+};
+
+class FontSetCache {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FontSetCache);
+    WTF_MAKE_NONCOPYABLE(FontSetCache);
+public:
+    FontSetCache() = default;
+    ~FontSetCache() = default;
+
+    struct Font {
+        Font(String&& path, int ttcIndex, FcCharSet* charSet)
+            : path(WTFMove(path))
+            , ttcIndex(ttcIndex)
+            , charSet(charSet)
+        {
+        }
+
+        String path;
+        int ttcIndex { 0 };
+        FcCharSet* charSet { nullptr }; // Owned by FcFontSet.
+    };
+
+    const FontSetCache::Font* fontForCharacterCluster(const SkFontStyle& style, const String& locale, FcCharSet* charSet)
+    {
+        int weight, width, slant;
+        fontconfigStyle(style, weight, width, slant);
+
+        auto& fontSet = m_cache.ensure(FontSetCacheKey(weight, width, slant), [&] {
+            return FontSet::create(locale, weight, width, slant);
+        }).iterator->value;
+        if (!fontSet)
+            return nullptr;
+
+        return fontSet->bestForCharacterCluster(charSet);
+    }
+
+private:
+    class FontSet {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FontSet);
+    public:
+        static std::unique_ptr<FontSet> create(const String& locale, int weight, int width, int slant)
+        {
+            auto* pattern = FcPatternCreate();
+            if (!locale.isNull()) {
+                FcLangSet* langSet = FcLangSetCreate();
+                FcLangSetAdd(langSet, reinterpret_cast<const FcChar8*>(locale.utf8().data()));
+                FcPatternAddLangSet(pattern, FC_LANG, langSet);
+                FcLangSetDestroy(langSet);
+            }
+
+            FcPatternAddInteger(pattern, FC_WEIGHT, weight);
+            FcPatternAddInteger(pattern, FC_WIDTH, width);
+            FcPatternAddInteger(pattern, FC_SLANT, slant);
+
+            FcPatternAddBool(pattern, FC_SCALABLE, FcTrue);
+
+            FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
+            FcDefaultSubstitute(pattern);
+
+            FcResult result;
+            FcFontSet* fontSet = FcFontSort(nullptr, pattern, FcFalse, nullptr, &result);
+            FcPatternDestroy(pattern);
+
+            if (!fontSet)
+                return nullptr;
+
+            return makeUnique<FontSet>(fontSet);
+        }
+
+        FontSet(FcFontSet* fontSet)
+            : m_fontSet(fontSet)
+        {
+            for (int i = 0; i < m_fontSet->nfont; ++i) {
+                FcPattern* pattern = m_fontSet->fonts[i];
+                if (!pattern)
+                    continue;
+
+                FcCharSet* charSet = nullptr;
+                if (FcPatternGetCharSet(pattern, FC_CHARSET, 0, &charSet) != FcResultMatch)
+                    continue;
+
+                auto filepath = filePathFromPattern(pattern);
+                if (filepath.isEmpty() || !FileSystem::fileExists(filepath))
+                    continue;
+
+                int ttcIndex;
+                if (FcPatternGetInteger(pattern, FC_INDEX, 0, &ttcIndex) != FcResultMatch)
+                    ttcIndex = 0;
+
+                m_fallbackList.append(Font(WTFMove(filepath), ttcIndex, charSet));
+            }
+        }
+
+        ~FontSet()
+        {
+            FcFontSetDestroy(m_fontSet);
+        }
+
+        const FontSetCache::Font* bestForCharacterCluster(FcCharSet* charSet)
+        {
+            if (m_fallbackList.isEmpty())
+                return nullptr;
+
+            const FontSetCache::Font* bestFont = nullptr;
+            int minScore = std::numeric_limits<int>::max();
+            for (const auto& font : m_fallbackList) {
+                int score = FcCharSetSubtractCount(charSet, font.charSet);
+                if (!score) {
+                    bestFont = &font;
+                    break;
+                }
+
+                if (score < minScore) {
+                    bestFont = &font;
+                    minScore = score;
+                }
+            }
+
+            return bestFont;
+        }
+
+    private:
+        FcFontSet* m_fontSet { nullptr };
+        Vector<FontSetCache::Font> m_fallbackList;
+
+    };
+    HashMap<FontSetCacheKey, std::unique_ptr<FontSet>, FontSetCacheKeyHash, SimpleClassHashTraits<FontSetCacheKey>> m_cache;
+};
+
+SkiaSystemFallbackFontCache::SkiaSystemFallbackFontCache() = default;
+
+SkiaSystemFallbackFontCache::~SkiaSystemFallbackFontCache() = default;
+
+sk_sp<SkTypeface> SkiaSystemFallbackFontCache::fontForCharacterCluster(const SkFontStyle& style, const String& locale, StringView stringView)
+{
+    FcCharSet* charSet = FcCharSetCreate();
+    bool hasNonIgnorableCharacters = false;
+    for (char32_t character : stringView.codePoints()) {
+        if (!isDefaultIgnorableCodePoint(character)) {
+            FcCharSetAddChar(charSet, character);
+            hasNonIgnorableCharacters = true;
+        }
+    }
+
+    if (!hasNonIgnorableCharacters) {
+        FcCharSetDestroy(charSet);
+        return nullptr;
+    }
+
+    auto& fontSetCache = m_cache.ensure(locale.isNull() ? emptyString() : locale, [] {
+        return makeUnique<FontSetCache>();
+    }).iterator->value;
+
+    const auto* font = fontSetCache->fontForCharacterCluster(style, locale, charSet);
+    FcCharSetDestroy(charSet);
+    if (!font)
+        return nullptr;
+
+    return m_typefaceCache.ensure({ font->path, font->ttcIndex }, [font] -> sk_sp<SkTypeface> {
+        return FontCache::forCurrentThread()->fontManager().makeFromFile(font->path.utf8().data(), font->ttcIndex);
+    }).iterator->value;
+}
+
+void SkiaSystemFallbackFontCache::clear()
+{
+    m_cache.clear();
+    m_typefaceCache.clear();
+}
+
+} // namepsace WebCore
+
+#endif // USE(SKIA) && !OS(ANDROID) && !PLATFORM(WIN)

--- a/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA) && !OS(ANDROID) && !PLATFORM(WIN)
+#include <skia/core/SkFontStyle.h>
+#include <skia/core/SkTypeface.h>
+#include <wtf/HashMap.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+class FontSetCache;
+
+class SkiaSystemFallbackFontCache {
+    WTF_MAKE_NONCOPYABLE(SkiaSystemFallbackFontCache);
+public:
+    SkiaSystemFallbackFontCache();
+    ~SkiaSystemFallbackFontCache();
+
+    sk_sp<SkTypeface> fontForCharacterCluster(const SkFontStyle&, const String& locale, StringView);
+    void clear();
+private:
+    HashMap<String, std::unique_ptr<FontSetCache>> m_cache;
+    HashMap<std::pair<String, int>, sk_sp<SkTypeface>> m_typefaceCache;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA) && !OS(ANDROID) && !PLATFORM(WIN)


### PR DESCRIPTION
#### d00fe9e28b11e77857afbe966094a3c23c1cf306
<pre>
[Skia] Incorrect font rendering of composed characters with skia and certain fonts
<a href="https://bugs.webkit.org/show_bug.cgi?id=291272">https://bugs.webkit.org/show_bug.cgi?id=291272</a>

Reviewed by Adrian Perez de Castro.

The problem happens with some sequences like &quot;R̥g&quot;
which is composed of characters (#x0052 #x0325)
LATIN CAPITAL LETTER R with COMBINING RING BELOW. Since the system
fallback only allows to check for a single character, if we find a font
that contains a glyph for &apos;R&apos; but that can&apos;t render the combining
sequence we end up falling back to the last resort fallback font, which
depending in the system might not be able to render the sequence either.
So, when we fail to find a font that can render the sequence, we should
try to find another font in the system that contains all other
characters in the sequence as we do with cairo. But Skia API doesn&apos;t
allow to query a set of characters, we would need to call the
matchFamilyStyleCharacter() for every character which would be very
slow. We need to use fontconfig API for that, looking for a font that
contains all characters in the sequence or at least the one having more
charcter coverage. We can take advantage that we have to use fontconfig
API directly for system fallbacks to being back the FontSet cache that
will make it even faster. See <a href="https://bugs.webkit.org/show_bug.cgi?id=203544">https://bugs.webkit.org/show_bug.cgi?id=203544</a>

Canonical link: <a href="https://commits.webkit.org/298033@main">https://commits.webkit.org/298033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a70599c28a0aaa7401206cee998e5e6376994b00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86004 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41410 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19782 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62971 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96044 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122434 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94854 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36200 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18276 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45472 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->