### PR TITLE
Use builtin __builtin_arm_jcvt instead of inline asm when available

### DIFF
--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -179,9 +179,7 @@ ALWAYS_INLINE Int toIntImpl(double number)
 ALWAYS_INLINE int32_t toInt32(double number)
 {
 #if HAVE(FJCVTZS_INSTRUCTION)
-    int32_t result = 0;
-    __asm__ ("fjcvtzs %w0, %d1" : "=r" (result) : "w" (number) : "cc");
-    return result;
+    return __builtin_arm_jcvt(number);
 #else
     return toIntImpl<int32_t>(number);
 #endif


### PR DESCRIPTION
#### 0f857e32274d4d51ea4d6aec4461e1f74cdac3e5
<pre>
Use builtin __builtin_arm_jcvt instead of inline asm when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=296382">https://bugs.webkit.org/show_bug.cgi?id=296382</a>
<a href="https://rdar.apple.com/156494767">rdar://156494767</a>

Reviewed by Yusuke Suzuki.

Seems a bit cleaner to use the intrinsic now that it exists (since 2019) rather than inline asm when possible.

Canonical link: <a href="https://commits.webkit.org/297789@main">https://commits.webkit.org/297789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67682871b4042d57b24df5d7b5f8e97c66986eba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62815 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105370 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122278 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111469 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29775 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39817 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45315 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135699 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39457 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36447 "Found 18 new JSC stress test failures: stress/arrowfunction-constructor.js.bytecode-cache, stress/arrowfunction-constructor.js.default, stress/arrowfunction-constructor.js.dfg-eager, stress/arrowfunction-constructor.js.dfg-eager-no-cjit-validate, stress/arrowfunction-constructor.js.eager-jettison-no-cjit, stress/arrowfunction-constructor.js.mini-mode, stress/arrowfunction-constructor.js.no-cjit-collect-continuously, stress/arrowfunction-constructor.js.no-cjit-validate-phases, stress/arrowfunction-constructor.js.no-llint, stress/builtin-function-is-construct-type-none.js.bytecode-cache ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->