### PR TITLE
AX: Legacy YouTube embed elements create infinite loops in accessibility

### DIFF
--- a/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt
+++ b/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt
@@ -1,0 +1,6 @@
+Blocked access to external URL https://www.youtube.com/embed/UF8uR6Z6KLc
+This test verifies that we don't hang when building the accessibility tree with a YouTube embed.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html
+++ b/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="plugin-types application/x-shockwave-flash">
+</head>
+<body>
+
+<embed id="youtube-embed" src="https://www.youtube.com/v/UF8uR6Z6KLc" type="application/x-shockwave-flash" width="425" height="350">
+
+<script>
+var output = "This test verifies that we don't hang when building the accessibility tree with a YouTube embed.";
+
+if (window.accessibilityController) {
+    // Just getting the embed shouldn't cause a hang.
+    var embed = accessibilityController.accessibleElementById("youtube-embed");
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/dom/html/youtube-embed-rendering-expected.txt
+++ b/LayoutTests/dom/html/youtube-embed-rendering-expected.txt
@@ -1,0 +1,15 @@
+Blocked access to external URL https://www.youtube.com/embed/UF8uR6Z6KLc
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x370
+  RenderBlock {HTML} at (0,0) size 800x370
+    RenderBody {BODY} at (8,8) size 784x354
+      RenderInline {EMBED} at (0,336) size 300x18
+        RenderBlock {DIV} at (0,0) size 300x354
+          RenderIFrame {IFRAME} at (0,0) size 300x350
+            layer at (0,0) size 300x350
+              RenderView at (0,0) size 300x350
+            layer at (0,0) size 300x350
+              RenderBlock {HTML} at (0,0) size 300x350
+                RenderBody {BODY} at (8,8) size 284x334
+      RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/dom/html/youtube-embed-rendering.html
+++ b/LayoutTests/dom/html/youtube-embed-rendering.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="plugin-types application/x-shockwave-flash">
+</head>
+<body>
+
+<embed id="youtube-embed" src="https://www.youtube.com/v/UF8uR6Z6KLc" type="application/x-shockwave-flash" width="425" height="350">
+
+</body>
+</html>

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -241,10 +241,10 @@ bool HTMLPlugInElement::supportsFocus() const
     return renderer && !renderer->isPluginUnavailable();
 }
 
-RenderPtr<RenderElement> HTMLPlugInElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
+RenderPtr<RenderElement> HTMLPlugInElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
     if (m_pluginReplacement && m_pluginReplacement->willCreateRenderer())
-        return m_pluginReplacement->createElementRenderer(*this, WTFMove(style), insertionPosition);
+        return RenderElement::createFor(*this, WTFMove(style));
 
     return createRenderer<RenderEmbeddedObject>(*this, WTFMove(style));
 }


### PR DESCRIPTION
#### 91308c79ea565d27e36bf9aeacb1f2ed3ccdef89
<pre>
AX: Legacy YouTube embed elements create infinite loops in accessibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=296387">https://bugs.webkit.org/show_bug.cgi?id=296387</a>
<a href="https://rdar.apple.com/156331833">rdar://156331833</a>

Reviewed by NOBODY (OOPS!).

Accessibility elements are (in most cases) based off of the renderer. For
YouTube embed elements, due to some special-casing, the Embed parent and
the shadow dom child share the same renderer (see
HTMLPlugInElement::createElementRenderer). This breaks accessibility
assumptions. Instead, if we create a separate renderer for the plug in when
applicable, we can fix the broken accessibility structure while also
creating any renderering regressions.

This patch adds two new tests. The accessibility test verififes that we
no longer hang when buidling the accessibility tree. The layout test verifies
that the renderers for the embed and its child are unique.

* LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt: Added.
* LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html: Added.
* LayoutTests/dom/html/youtube-embed-rendering-expected.txt: Added.
* LayoutTests/dom/html/youtube-embed-rendering.html: Added.
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::createElementRenderer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91308c79ea565d27e36bf9aeacb1f2ed3ccdef89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119446 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64481 "Failed to checkout and rebase branch from PR 48427") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41536 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86184 "Found 14 new test failures: accessibility/youtube-embed-accessibility-hierarchy.html dom/html/youtube-embed-rendering.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41405 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116185 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26855 "Found 1 new test failure: dom/html/youtube-embed-rendering.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101858 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66506 "Found 145 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26126 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19985 "Exiting early after 10 failures. 38 tests run. 1 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96236 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20059 "Exiting early after 10 failures. 40 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30082 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95034 "Found 2 new test failures: accessibility/youtube-embed-accessibility-hierarchy.html dom/html/youtube-embed-rendering.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40701 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98071 "Exiting early after 10 failures. 63 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94776 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39922 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17733 "1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36452 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45701 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->