### PR TITLE
[Form Control Refresh] Date inputs should be pill-shaped on iOS

### DIFF
--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -871,11 +871,9 @@ static RoundedShape shapeForButton(const RenderObject& box, const FloatRect& rec
     const auto boxLogicalHeight = isVertical ? rect.width() : rect.height();
     const auto minDimension = std::min(rect.width(), rect.height());
 
-    const auto radiusForNonDateRelatedLargeButton = minDimension * largeButtonRadiusRatio;
-    if (nodeIsDateOrTimeRelatedInput(box.node()))
-        controlRadius = 5 * zoomScale;
-    else if (boxLogicalHeight >= largeButtonHeight * zoomScale)
-        controlRadius = radiusForNonDateRelatedLargeButton;
+    const auto radiusForLargeButton = minDimension * largeButtonRadiusRatio;
+    if (boxLogicalHeight >= largeButtonHeight * zoomScale)
+        controlRadius = radiusForLargeButton;
     else {
         controlRadius = minDimension / 2;
 
@@ -884,7 +882,7 @@ static RoundedShape shapeForButton(const RenderObject& box, const FloatRect& rec
         const auto sizeRatio = rect.width() / rect.height();
         const auto limitingRatio = 1.5f;
         if (limitingRatio > sizeRatio && sizeRatio > 1 / limitingRatio)
-            controlRadius = radiusForNonDateRelatedLargeButton;
+            controlRadius = radiusForLargeButton;
     }
 #endif
 


### PR DESCRIPTION
#### 8d362fa79de47b1c592e401e8b6c9cb0c5bfde26
<pre>
[Form Control Refresh] Date inputs should be pill-shaped on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=296385">https://bugs.webkit.org/show_bug.cgi?id=296385</a>
<a href="https://rdar.apple.com/156474450">rdar://156474450</a>

Reviewed by Aditya Keerthi.

On iOS, date-related inputs (time, week, month, datetime-local, date)
are now pill-shaped at the default height and at other low-height values.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::shapeForButton):

Canonical link: <a href="https://commits.webkit.org/297799@main">https://commits.webkit.org/297799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8759190fe4704c4817639396c846ef42c3ef0bc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63413 "Built successfully") | ✅ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85909 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66214 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19672 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122308 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94772 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94510 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39640 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36074 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45345 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39487 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->