### PR TITLE
AX: Voice Control number/name overlays don't label content in iframe

### DIFF
--- a/LayoutTests/accessibility/mac/visible-content-search-in-iframe-expected.txt
+++ b/LayoutTests/accessibility/mac/visible-content-search-in-iframe-expected.txt
@@ -1,0 +1,18 @@
+This test ensures we consider content inside iframes accessible from searches done via AXUIElementsForSearchPredicate with the AXVisibleOnly search key.
+
+
+{#outside-iframe-button AXRole: AXButton}
+
+{AXRole: AXScrollArea}
+
+{AXRole: AXWebArea}
+
+{#inside-iframe-button AXRole: AXButton}
+PASS: output.includes('#outside-iframe-button') === true
+PASS: output.includes('#inside-iframe-button') === true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Outside iframe

--- a/LayoutTests/accessibility/mac/visible-content-search-in-iframe.html
+++ b/LayoutTests/accessibility/mac/visible-content-search-in-iframe.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="outside-iframe-button">Outside iframe</button>
+<iframe id="iframe" onload="runTest()" srcdoc="<button id='inside-iframe-button'>Inside iframe</button>"></iframe>
+
+<script>
+var output = "This test ensures we consider content inside iframes accessible from searches done via AXUIElementsForSearchPredicate with the AXVisibleOnly search key.\n\n";
+
+window.jsTestIsAsync = true;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    // We should find the button inside the iframe too.
+    output += dumpAXSearchTraversal(webArea, { visibleOnly: true });
+    output += expect("output.includes('#outside-iframe-button')", "true");
+    output += expect("output.includes('#inside-iframe-button')", "true");
+
+    // Make the button inside the iframe invisible.
+    document.getElementById("iframe").contentDocument.getElementById("inside-iframe-button").style.display = "none";
+    output += "\n";
+    setTimeout(async function() {
+        await waitFor(() => {
+            const traversalOutput = dumpAXSearchTraversal(webArea, { visibleOnly: true });
+            return traversalOutput.includes("#outside-iframe-button") && !traversalOutput.includes("#inside-iframe-button");
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/mac/visible-content-search-in-scrolled-iframe-expected.txt
+++ b/LayoutTests/accessibility/mac/visible-content-search-in-scrolled-iframe-expected.txt
@@ -1,0 +1,11 @@
+This test ensures we properly consider content inside iframes accessible or non-accessible from searches
+done via AXUIElementsForSearchPredicate with the AXVisibleOnly search key, particularly after a scroll has been performed.
+
+PASS: traversalOutput.includes('#outside-iframe-button') === true
+PASS: traversalOutput.includes('#inside-iframe-button') === true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Outside iframe

--- a/LayoutTests/accessibility/mac/visible-content-search-in-scrolled-iframe.html
+++ b/LayoutTests/accessibility/mac/visible-content-search-in-scrolled-iframe.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body style="height: 2000px;">
+
+<button id="outside-iframe-button">Outside iframe</button>
+<iframe id="iframe" style="overflow: scroll" onload="runTest()" srcdoc="
+<div style='height: 500px'>
+    <button id='inside-iframe-button'>Inside iframe</button>
+</div>
+"></iframe>
+
+<script>
+var output = `This test ensures we properly consider content inside iframes accessible or non-accessible from searches 
+done via AXUIElementsForSearchPredicate with the AXVisibleOnly search key, particularly after a scroll has been performed.\n\n`;
+
+window.jsTestIsAsync = true;
+var traversalOutput;
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    // The button inside the iframe should be initially visible.
+    traversalOutput = dumpAXSearchTraversal(webArea, { visibleOnly: true });
+    output += expect("traversalOutput.includes('#outside-iframe-button')", "true");
+    output += expect("traversalOutput.includes('#inside-iframe-button')", "true");
+
+    var iframeWindow = document.getElementById("iframe").contentWindow;
+    // Scroll to make the button invisible.
+    iframeWindow.scroll(0, 100);
+    output += "\n";
+    setTimeout(async function() {
+        await waitFor(() => {
+            traversalOutput = dumpAXSearchTraversal(webArea, { visibleOnly: true });
+            return traversalOutput.includes("#outside-iframe-button") && !traversalOutput.includes("#inside-iframe-button");
+        });
+
+        // Scroll the button back into view. Only about half the button is visible at 20px y-scroll, which should be enough.
+        iframe.contentWindow.scroll(0, 20);
+
+        await waitFor(() => {
+            traversalOutput = dumpAXSearchTraversal(webArea, { visibleOnly: true });
+            return traversalOutput.includes("#outside-iframe-button") && traversalOutput.includes("#inside-iframe-button");
+        });
+
+        // Scroll the outer window. Nothing should be visible.
+        window.scroll(0, 1000);
+
+        await waitFor(() => {
+            traversalOutput = dumpAXSearchTraversal(webArea, { visibleOnly: true });
+            return !traversalOutput.includes("#outside-iframe-button") && !traversalOutput.includes("#inside-iframe-button");
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/accessibility/mac/visible-content-search-in-iframe-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/mac/visible-content-search-in-iframe-expected.txt
@@ -1,0 +1,16 @@
+This test ensures we consider content inside iframes accessible from searches done via AXUIElementsForSearchPredicate with the AXVisibleOnly search key.
+
+
+{#outside-iframe-button AXRole: AXButton}
+
+{AXRole: AXWebArea}
+
+{#inside-iframe-button AXRole: AXButton}
+PASS: output.includes('#outside-iframe-button') === true
+PASS: output.includes('#inside-iframe-button') === true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Outside iframe

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -25,13 +25,17 @@ function dumpAXTable(axElement, options) {
 
 // Dumps the result of a traversal via the UI element search API (which is what some ATs use).
 // `options` is an object with these keys:
+//
 //   * `excludeRoles`: Array of strings representing roles you don't want to include in the output.
 //                     Case insensitive, partial match is fine, e.g. "scrollbar" will exclude "AXScrollBar".
+//
+//   * `visibleOnly`: True if only elements in the viewport should be returned.
 function dumpAXSearchTraversal(axElement, options = { }) {
     let output = "";
     let searchResult = null;
+    const { visibleOnly = false } = options;
     while (true) {
-        searchResult = axElement.uiElementForSearchPredicate(searchResult, true, "AXAnyTypeSearchKey", "", false);
+        searchResult = axElement.uiElementForSearchPredicate(searchResult, /* directionIsNext */ true, "AXAnyTypeSearchKey", /* searchText */ "", visibleOnly);
         if (!searchResult)
             break;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -69,6 +69,7 @@ public:
 
     std::optional<AXID> treeID() const final;
     String dbgInternal(bool, OptionSet<AXDebugStringOption>) const final;
+    virtual String extraDebugInfo() const { return emptyString(); }
 
     // After constructing an AccessibilityObject, it must be given a
     // unique ID, then added to AXObjectCache, and finally init() must

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -70,7 +70,7 @@ String AccessibilityScrollView::ownerDebugDescription() const
     }
 
     CheckedPtr renderer = m_frameOwnerElement->renderer();
-    return renderer ? renderer->debugDescription() : m_frameOwnerElement->debugDescription();
+    return makeString("owned by: "_s, renderer ? renderer->debugDescription() : m_frameOwnerElement->debugDescription());
 }
 
 void AccessibilityScrollView::detachRemoteParts(AccessibilityDetachmentType detachmentType)

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -50,6 +50,7 @@ public:
     RefPtr<AXRemoteFrame> remoteFrame() const { return m_remoteFrame; }
 
     String ownerDebugDescription() const;
+    String extraDebugInfo() const final { return ownerDebugDescription(); }
 
 private:
     explicit AccessibilityScrollView(AXID, ScrollView&);
@@ -82,6 +83,7 @@ private:
     Document* document() const final;
     LocalFrameView* documentFrameView() const final;
     LayoutRect elementRect() const final;
+    LayoutRect boundingBoxRect() const final { return elementRect(); }
     AccessibilityObject* parentObject() const final;
 
     AccessibilityObject* firstChild() const final { return webAreaObject(); }


### PR DESCRIPTION
#### 250a3ab845c5672c4579c6fcc406ffdf5d800c7d
<pre>
AX: Voice Control number/name overlays don&apos;t label content in iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=285188">https://bugs.webkit.org/show_bug.cgi?id=285188</a>
<a href="https://rdar.apple.com/142096466">rdar://142096466</a>

Reviewed by Joshua Hoffman.

This happened for two reasons:

  1. AccessibilityScrollView did not implement boundingBoxRect(), which AccessibilityObject::isOnScreen relied on.
     It did implement elementRect(), so implement boundingBoxRect() in terms of elementRect. In the future, we should
     consider only having one method to return an element&apos;s rect.

  2. The rect of elements within non-root scrollables (like iframes) needs to be normalized to the root view. Otherwise,
     the rect would be relative to the containing scrollable, e.g. a button at x=8 y=8 in an iframe that is x=300 y=300
     should be considered to have a position of x=308 y=308, but this wasn&apos;t happening, so we were considering the button
     to not be visible.

Two new tests added.

* LayoutTests/accessibility/mac/visible-content-search-in-iframe-expected.txt: Added.
* LayoutTests/accessibility/mac/visible-content-search-in-iframe.html: Added.
* LayoutTests/accessibility/mac/visible-content-search-in-scrolled-iframe-expected.txt: Added.
* LayoutTests/accessibility/mac/visible-content-search-in-scrolled-iframe.html: Added.
* LayoutTests/resources/accessibility-helper.js:
(dumpAXSearchTraversal):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::dbgInternal const):
(WebCore::AccessibilityObject::isOnScreen const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::extraDebugInfo const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::ownerDebugDescription const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:

Canonical link: <a href="https://commits.webkit.org/297816@main">https://commits.webkit.org/297816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/770dfc8142da417ea6c1c2ade0b3236201e368bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85976 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40045 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/29856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94824 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94564 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36158 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39931 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45430 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->