### PR TITLE
[Refactor] Plumb "readyState" up from AVTrackPrivateAVFObjC

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2316,6 +2316,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/TrackBuffer.h
     platform/graphics/TrackPrivateBase.h
     platform/graphics/TrackPrivateBaseClient.h
+    platform/graphics/TrackPrivateBaseEnums.h
     platform/graphics/VP9Utilities.h
     platform/graphics/VelocityData.h
     platform/graphics/VideoLayerManager.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5452,6 +5452,8 @@
 		CD722A132D693CFF00F2E1E7 /* SpatialAudioExperienceHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = CD722A0D2D6917B400F2E1E7 /* SpatialAudioExperienceHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD7D33441C7A123F00041293 /* PixelBufferConformerCV.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7D33421C7A123F00041293 /* PixelBufferConformerCV.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD7D33481C7A16BF00041293 /* CoreVideoSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7D33461C7A16BF00041293 /* CoreVideoSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CD7D5E0D2E21871400F6CAB4 /* AVTrackPrivateAVFObjCImplClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7D5E0C2E21871400F6CAB4 /* AVTrackPrivateAVFObjCImplClient.h */; };
+		CD7D5E0F2E21FB3A00F6CAB4 /* TrackPrivateBaseEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7D5E0E2E21FB3A00F6CAB4 /* TrackPrivateBaseEnums.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD7DBB2918CA19C600C11066 /* CSSGridLineNamesValue.h in Headers */ = {isa = PBXBuildFile; fileRef = CD7DBB2718CA11FF00C11066 /* CSSGridLineNamesValue.h */; };
 		CD814C2B2996B903005A780A /* ElementIteratorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = CD814C2A2996B903005A780A /* ElementIteratorInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD814C2D2996BAD2005A780A /* ElementAncestorIteratorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = CD814C2C2996BAD2005A780A /* ElementAncestorIteratorInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19458,6 +19460,8 @@
 		CD7D33421C7A123F00041293 /* PixelBufferConformerCV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PixelBufferConformerCV.h; sourceTree = "<group>"; };
 		CD7D33451C7A16BF00041293 /* CoreVideoSoftLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CoreVideoSoftLink.cpp; sourceTree = "<group>"; };
 		CD7D33461C7A16BF00041293 /* CoreVideoSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreVideoSoftLink.h; sourceTree = "<group>"; };
+		CD7D5E0C2E21871400F6CAB4 /* AVTrackPrivateAVFObjCImplClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVTrackPrivateAVFObjCImplClient.h; sourceTree = "<group>"; };
+		CD7D5E0E2E21FB3A00F6CAB4 /* TrackPrivateBaseEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackPrivateBaseEnums.h; sourceTree = "<group>"; };
 		CD7DBB2618CA11FF00C11066 /* CSSGridLineNamesValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSGridLineNamesValue.cpp; sourceTree = "<group>"; };
 		CD7DBB2718CA11FF00C11066 /* CSSGridLineNamesValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSGridLineNamesValue.h; sourceTree = "<group>"; };
 		CD7E05201651A84100C1201F /* WebCoreAVFResourceLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCoreAVFResourceLoader.h; sourceTree = "<group>"; };
@@ -22542,6 +22546,7 @@
 				CDE3A85217F5FCE600C5BE20 /* AudioTrackPrivateAVF.h */,
 				CD336F6017F9F64700DDDCD0 /* AVTrackPrivateAVFObjCImpl.h */,
 				CD336F5F17F9F64700DDDCD0 /* AVTrackPrivateAVFObjCImpl.mm */,
+				CD7D5E0C2E21871400F6CAB4 /* AVTrackPrivateAVFObjCImplClient.h */,
 				CDB704591F7465A1003923DF /* CDMFairPlayStreaming.cpp */,
 				CDB704581F7465A1003923DF /* CDMFairPlayStreaming.h */,
 				CD318621199F1E2A0030A0F7 /* CDMPrivateMediaSourceAVFObjC.h */,
@@ -34577,6 +34582,7 @@
 				076E11BE1F683E0D00177395 /* TrackPrivateBase.cpp */,
 				BE913D7F181EF8E500DCB09E /* TrackPrivateBase.h */,
 				CD1F9B1B27024BC100617EB6 /* TrackPrivateBaseClient.h */,
+				CD7D5E0E2E21FB3A00F6CAB4 /* TrackPrivateBaseEnums.h */,
 				7209C47E2931C86400633C0D /* TransparencyLayerContextSwitcher.cpp */,
 				7209C47F2931C86400633C0D /* TransparencyLayerContextSwitcher.h */,
 				E4AFCFA40DAF29A300F5F55C /* UnitBezier.h */,
@@ -40794,6 +40800,7 @@
 				070363E2181A1CDC00C074A5 /* AVCaptureDeviceManager.h in Headers */,
 				41F898F628ED702A0070549C /* AvcEncoderConfig.h in Headers */,
 				CD336F6217F9F64700DDDCD0 /* AVTrackPrivateAVFObjCImpl.h in Headers */,
+				CD7D5E0D2E21871400F6CAB4 /* AVTrackPrivateAVFObjCImplClient.h in Headers */,
 				41C7678C2D004D030014EB38 /* AVVideoCaptureSource.h in Headers */,
 				2936BF5C21D69E4B004A8FC9 /* AXCoreObject.h in Headers */,
 				486B8DC72A043C0600E00E73 /* AXGeometryManager.h in Headers */,
@@ -45696,6 +45703,7 @@
 				BE88E0C21715CE2600658D98 /* TrackListBase.h in Headers */,
 				BE913D80181EF92400DCB09E /* TrackPrivateBase.h in Headers */,
 				CD1F9B1C27024BC200617EB6 /* TrackPrivateBaseClient.h in Headers */,
+				CD7D5E0F2E21FB3A00F6CAB4 /* TrackPrivateBaseEnums.h in Headers */,
 				FFAC30FE184FB145008C4F1E /* TrailingObjects.h in Headers */,
 				516071321BD8308B00DBC4F2 /* TransactionOperation.h in Headers */,
 				CD3EEF4125799FD9006563BB /* TransferFunction.h in Headers */,

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4995,7 +4995,7 @@ void HTMLMediaElement::mediaPlayerDidAddTextTrack(InbandTextTrackPrivate& track)
     //   - Thess are all done by the media engine.
 
     // 6. Set the new text track's readiness state to loaded.
-    textTrack->setReadinessState(TextTrack::Loaded);
+    textTrack->setReadyState(TextTrack::ReadyState::Loaded);
 
     // 7. Set the new text track's mode to the mode consistent with the user's preferences and the requirements of
     // the relevant specification for the data.
@@ -5186,7 +5186,7 @@ ExceptionOr<Ref<TextTrack>> HTMLMediaElement::addTextTrack(const AtomString& kin
     addTextTrack(track.copyRef());
 
     // ... its text track readiness state to the text track loaded state ...
-    track->setReadinessState(TextTrack::Loaded);
+    track->setReadyState(TextTrack::ReadyState::Loaded);
 
     // ... its text track mode to the text track hidden mode, and its text track list of cues to an empty list ...
     track->setMode(TextTrack::Mode::Hidden);
@@ -7721,7 +7721,7 @@ bool HTMLMediaElement::hasClosedCaptions() const
 
     for (unsigned i = 0; i < m_textTracks->length(); ++i) {
         auto& track = *m_textTracks->item(i);
-        if (track.readinessState() == TextTrack::FailedToLoad)
+        if (track.readyState() == TextTrack::ReadyState::Error)
             continue;
         if (track.kind() == TextTrack::Kind::Captions || track.kind() == TextTrack::Kind::Subtitles)
             return true;
@@ -7743,25 +7743,25 @@ bool HTMLMediaElement::textTracksAreReady() const
     // in the disabled state when the element's resource selection algorithm last started now
     // have a text track readiness state of loaded or failed to load.
     for (unsigned i = 0; i < m_textTracksWhenResourceSelectionBegan.size(); ++i) {
-        if (m_textTracksWhenResourceSelectionBegan[i]->readinessState() == TextTrack::Loading
-            || m_textTracksWhenResourceSelectionBegan[i]->readinessState() == TextTrack::NotLoaded)
+        if (m_textTracksWhenResourceSelectionBegan[i]->readyState() == TextTrack::ReadyState::Loading
+            || m_textTracksWhenResourceSelectionBegan[i]->readyState() == TextTrack::ReadyState::None)
             return false;
     }
 
     return true;
 }
 
-void HTMLMediaElement::textTrackReadyStateChanged(TextTrack* track)
+void HTMLMediaElement::textTrackReadyStateChanged(TextTrack& track, TrackPrivateBaseReadyState readyState)
 {
-    if (track->readinessState() != TextTrack::Loading
-        && track->mode() != TextTrack::Mode::Disabled) {
+    if (readyState != TextTrack::ReadyState::Loading
+        && track.mode() != TextTrack::Mode::Disabled) {
         // The display trees exist as long as the track is active, in this case,
         // and if the same track is loaded again (for example if the src attribute was changed),
         // cues can be accumulated with the old ones, that's why they needs to be flushed
         updateTextTrackDisplay();
     }
-    if (m_player && m_textTracksWhenResourceSelectionBegan.contains(track)) {
-        if (track->readinessState() != TextTrack::Loading)
+    if (m_player && m_textTracksWhenResourceSelectionBegan.contains(&track)) {
+        if (track.readyState() != TextTrack::ReadyState::Loading)
             setReadyState(m_player->readyState());
     }
 }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -485,7 +485,7 @@ public:
 
     void captionPreferencesChanged();
     using HTMLMediaElementEnums::TextTrackVisibilityCheckType;
-    void textTrackReadyStateChanged(TextTrack*);
+    void textTrackReadyStateChanged(TextTrack&, TrackBaseReadyState) override;
     void updateTextTrackRepresentationImageIfNeeded();
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -269,22 +269,23 @@ void HTMLTrackElement::didCompleteLoad(LoadStatus status)
     dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-// NOTE: The values in the TextTrack::ReadinessState enum must stay in sync with those in HTMLTrackElement::ReadyState.
-static_assert(HTMLTrackElement::NONE == static_cast<HTMLTrackElement::ReadyState>(TextTrack::NotLoaded), "TextTrackEnumNotLoaded is wrong. Should be HTMLTrackElementEnumNONE");
-static_assert(HTMLTrackElement::LOADING == static_cast<HTMLTrackElement::ReadyState>(TextTrack::Loading), "TextTrackEnumLoading is wrong. Should be HTMLTrackElementEnumLOADING");
-static_assert(HTMLTrackElement::LOADED == static_cast<HTMLTrackElement::ReadyState>(TextTrack::Loaded), "TextTrackEnumLoaded is wrong. Should be HTMLTrackElementEnumLOADED");
-static_assert(HTMLTrackElement::TRACK_ERROR == static_cast<HTMLTrackElement::ReadyState>(TextTrack::FailedToLoad), "TextTrackEnumFailedToLoad is wrong. Should be HTMLTrackElementEnumTRACK_ERROR");
+// NOTE: The values in the TextTrack::ReadyState enum must stay in sync with those in HTMLTrackElement::ReadyState.
+static_assert(HTMLTrackElement::NONE == static_cast<HTMLTrackElement::ReadyState>(TextTrack::ReadyState::None), "TextTrackEnumNotLoaded is wrong. Should be HTMLTrackElementEnumNONE");
+static_assert(HTMLTrackElement::LOADING == static_cast<HTMLTrackElement::ReadyState>(TextTrack::ReadyState::Loading), "TextTrackEnumLoading is wrong. Should be HTMLTrackElementEnumLOADING");
+static_assert(HTMLTrackElement::LOADED == static_cast<HTMLTrackElement::ReadyState>(TextTrack::ReadyState::Loaded), "TextTrackEnumLoaded is wrong. Should be HTMLTrackElementEnumLOADED");
+static_assert(HTMLTrackElement::TRACK_ERROR == static_cast<HTMLTrackElement::ReadyState>(TextTrack::ReadyState::Error), "TextTrackEnumFailedToLoad is wrong. Should be HTMLTrackElementEnumTRACK_ERROR");
 
 void HTMLTrackElement::setReadyState(ReadyState state)
 {
-    track().setReadinessState(static_cast<TextTrack::ReadinessState>(state));
+    TextTrack::ReadyState readyState = static_cast<TextTrack::ReadyState>(state);
+    track().setReadyState(readyState);
     if (auto parent = mediaElement())
-        parent->textTrackReadyStateChanged(m_track.ptr());
+        parent->textTrackReadyStateChanged(m_track, readyState);
 }
 
 HTMLTrackElement::ReadyState HTMLTrackElement::readyState() const
 {
-    return static_cast<ReadyState>(m_track->readinessState());
+    return static_cast<ReadyState>(m_track->readyState());
 }
 
 const AtomString& HTMLTrackElement::mediaElementCrossOriginAttribute() const

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -196,6 +196,14 @@ void AudioTrack::willRemove()
     });
 }
 
+void AudioTrack::readyStateChanged(ReadyState readyState)
+{
+    setReadyState(readyState);
+    m_clients.forEach([this, readyState] (auto& client) {
+        client.audioTrackReadyStateChanged(*this, readyState);
+    });
+}
+
 void AudioTrack::updateKindFromPrivate()
 {
     switch (m_private->kind()) {

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -85,6 +85,7 @@ private:
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;
+    void readyStateChanged(ReadyState) final;
 
     void updateKindFromPrivate();
     void updateConfigurationFromPrivate();

--- a/Source/WebCore/html/track/AudioTrackClient.h
+++ b/Source/WebCore/html/track/AudioTrackClient.h
@@ -41,6 +41,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::AudioTrackCl
 namespace WebCore {
 
 class AudioTrack;
+enum class TrackPrivateBaseReadyState : uint8_t;
 
 class AudioTrackClient : public CanMakeWeakPtr<AudioTrackClient> {
 public:
@@ -52,6 +53,7 @@ public:
     virtual void audioTrackLanguageChanged(AudioTrack&) { }
     virtual void audioTrackConfigurationChanged(AudioTrack&) { }
     virtual void willRemoveAudioTrack(AudioTrack&) { }
+    virtual void audioTrackReadyStateChanged(AudioTrack&, TrackPrivateBaseReadyState) { }
 };
 
 }

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -173,6 +173,14 @@ void InbandTextTrack::willRemove()
     });
 }
 
+void InbandTextTrack::readyStateChanged(ReadyState readyState)
+{
+    setReadyState(readyState);
+    m_clients.forEach([this, readyState] (auto& client) {
+        client.textTrackReadyStateChanged(*this, readyState);
+    });
+}
+
 void InbandTextTrack::updateKindFromPrivate()
 {
     switch (m_private->kind()) {

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -70,6 +70,7 @@ private:
     void labelChanged(const AtomString&) override;
     void languageChanged(const AtomString&) override;
     void willRemove() override;
+    void readyStateChanged(ReadyState) override;
 
     void addDataCue(const MediaTime&, const MediaTime&, std::span<const uint8_t>) override { ASSERT_NOT_REACHED(); }
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -78,10 +78,6 @@ public:
     Mode mode() const;
     virtual void setMode(Mode);
 
-    enum ReadinessState { NotLoaded = 0, Loading = 1, Loaded = 2, FailedToLoad = 3 };
-    ReadinessState readinessState() const { return m_readinessState; }
-    void setReadinessState(ReadinessState state) { m_readinessState = state; }
-
     TextTrackCueList* cues();
     RefPtr<TextTrackCueList> protectedCues();
     TextTrackCueList* activeCues() const;
@@ -179,7 +175,6 @@ private:
     Mode m_mode { Mode::Disabled };
     Kind m_kind;
     TextTrackType m_trackType;
-    ReadinessState m_readinessState { NotLoaded };
     std::optional<int> m_trackIndex;
     std::optional<int> m_renderedTrackIndex;
     bool m_hasBeenConfigured { false };

--- a/Source/WebCore/html/track/TextTrackClient.h
+++ b/Source/WebCore/html/track/TextTrackClient.h
@@ -43,6 +43,7 @@ namespace WebCore {
 class TextTrack;
 class TextTrackCue;
 class TextTrackCueList;
+enum class TrackPrivateBaseReadyState : uint8_t;
 
 class TextTrackClient : public CanMakeWeakPtr<TextTrackClient> {
 public:
@@ -57,6 +58,7 @@ public:
     virtual void textTrackAddCue(TextTrack&, TextTrackCue&) { }
     virtual void textTrackRemoveCue(TextTrack&, TextTrackCue&) { }
     virtual void willRemoveTextTrack(TextTrack&) { }
+    virtual void textTrackReadyStateChanged(TextTrack&, TrackPrivateBaseReadyState) { }
 };
 
 }

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include "ContextDestructionObserver.h"
+#include "TrackPrivateBaseEnums.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMalloc.h>
@@ -41,6 +42,7 @@ class TrackListBase;
 class TrackPrivateBase;
 class TrackPrivateBaseClient;
 using TrackID = uint64_t;
+using TrackBaseReadyState = TrackPrivateBaseReadyState;
 
 class TrackBase
     : public RefCounted<TrackBase>
@@ -78,6 +80,10 @@ public:
 
     virtual bool enabled() const = 0;
 
+    using ReadyState = TrackBaseReadyState;
+    ReadyState readyState() const { return m_readyState; }
+    void setReadyState(ReadyState readyState) { m_readyState = readyState; }
+
 #if !RELEASE_LOG_DISABLED
     virtual void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
@@ -108,6 +114,7 @@ private:
     int m_uniqueId;
     AtomString m_id;
     TrackID m_trackId { 0 };
+    ReadyState m_readyState { ReadyState::None };
     AtomString m_label;
     AtomString m_language;
     AtomString m_validBCP47Language;

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -175,6 +175,14 @@ void VideoTrack::willRemove()
     });
 }
 
+void VideoTrack::readyStateChanged(ReadyState readyState)
+{
+    setReadyState(readyState);
+    m_clients.forEach([this, readyState] (auto& client) {
+        client.videoTrackReadyStateChanged(*this, readyState);
+    });
+}
+
 void VideoTrack::setKind(const AtomString& kind)
 {
     // 10.1 kind, on setting:

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -87,6 +87,7 @@ private:
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;
+    void readyStateChanged(ReadyState) final;
 
     bool enabled() const final { return selected(); }
 

--- a/Source/WebCore/html/track/VideoTrackClient.h
+++ b/Source/WebCore/html/track/VideoTrackClient.h
@@ -41,6 +41,7 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::VideoTrackCl
 namespace WebCore {
 
 class VideoTrack;
+enum class TrackPrivateBaseReadyState : uint8_t;
 
 class VideoTrackClient : public CanMakeWeakPtr<VideoTrackClient> {
 public:
@@ -52,6 +53,7 @@ public:
     virtual void videoTrackSelectedChanged(VideoTrack&) { }
     virtual void videoTrackConfigurationChanged(VideoTrack&) { }
     virtual void willRemoveVideoTrack(VideoTrack&) { }
+    virtual void videoTrackReadyStateChanged(VideoTrack&, TrackPrivateBaseReadyState) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.cpp
@@ -145,4 +145,21 @@ WTFLogChannel& TrackPrivateBase::logChannel() const
 
 } // namespace WebCore
 
+namespace WTF {
+
+template<> bool isValidEnum<WebCore::TrackPrivateBaseReadyState>(std::underlying_type_t<WebCore::TrackPrivateBaseReadyState> value)
+{
+    switch (value) {
+    case enumToUnderlyingType(WebCore::TrackPrivateBaseReadyState::None):
+    case enumToUnderlyingType(WebCore::TrackPrivateBaseReadyState::Loading):
+    case enumToUnderlyingType(WebCore::TrackPrivateBaseReadyState::Loaded):
+    case enumToUnderlyingType(WebCore::TrackPrivateBaseReadyState::Error):
+        return true;
+    default:
+        return false;
+    }
+}
+
+}
+
 #endif

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -31,6 +31,8 @@
 
 #include "ScriptExecutionContextIdentifier.h"
 #include "TrackPrivateBaseClient.h"
+#include "TrackPrivateBaseEnums.h"
+#include <wtf/EnumTraits.h>
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
@@ -80,6 +82,18 @@ public:
     enum class Type { Video, Audio, Text };
     virtual Type type() const = 0;
 
+    using ReadyState = TrackPrivateBaseReadyState;
+    void setReadyState(ReadyState readyState)
+    {
+        if (m_readyState == readyState)
+            return;
+        m_readyState = readyState;
+        notifyClients([readyState](auto& client) {
+            client.readyStateChanged(readyState);
+        });
+    }
+    ReadyState readyState() const { return m_readyState; };
+
 #if !RELEASE_LOG_DISABLED
     virtual void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
@@ -115,6 +129,8 @@ protected:
     using ClientRecord = std::tuple<RefPtr<SharedDispatcher>, WeakPtr<TrackPrivateBaseClient>, bool /* is main thread */>;
     Vector<ClientRecord> m_clients WTF_GUARDED_BY_LOCK(m_lock);
 
+    ReadyState m_readyState { ReadyState::Loaded };
+
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };
@@ -122,5 +138,9 @@ protected:
 };
 
 } // namespace WebCore
+
+namespace WTF {
+template<> WEBCORE_EXPORT bool isValidEnum<WebCore::TrackPrivateBaseReadyState>(std::underlying_type_t<WebCore::TrackPrivateBaseReadyState>);
+} // namespace WTF
 
 #endif

--- a/Source/WebCore/platform/graphics/TrackPrivateBaseEnums.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBaseEnums.h
@@ -27,36 +27,14 @@
 
 #if ENABLE(VIDEO)
 
-#include "TrackPrivateBaseEnums.h"
-#include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
-
-namespace WebCore {
-class TrackPrivateBaseClient;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::TrackPrivateBaseClient> : std::true_type { };
-}
 
 namespace WebCore {
 
-using TrackID = uint64_t;
-
-class TrackPrivateBaseClient : public CanMakeWeakPtr<TrackPrivateBaseClient> {
-public:
-    using Task = Function<void()>;
-    using Dispatcher = Function<void(Task&&)>;
-
-    virtual ~TrackPrivateBaseClient() = default;
-    enum Type { Text, Audio, Video };
-    virtual constexpr Type type() const = 0;
-    virtual void idChanged(TrackID) = 0;
-    virtual void labelChanged(const AtomString&) = 0;
-    virtual void languageChanged(const AtomString&) = 0;
-    virtual void willRemove() = 0;
-    virtual void readyStateChanged(TrackPrivateBaseReadyState) = 0;
+enum class TrackPrivateBaseReadyState : uint8_t {
+    None,
+    Loading,
+    Loaded,
+    Error,
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -28,12 +28,12 @@
 
 #if ENABLE(VIDEO)
 
+#include "AVTrackPrivateAVFObjCImplClient.h"
 #include "AudioTrackPrivate.h"
 #include "InbandTextTrackPrivate.h"
 #include "PlatformVideoColorSpace.h"
 #include "SpatialVideoMetadata.h"
 #include "VideoTrackPrivate.h"
-#include <wtf/Observer.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
@@ -72,6 +72,9 @@ public:
     static Ref<AVTrackPrivateAVFObjCImpl> create(MediaSelectionOptionAVFObjC& option) { return adoptRef(*new AVTrackPrivateAVFObjCImpl(option)); }
     ~AVTrackPrivateAVFObjCImpl();
 
+    void setVideoTrackClient(WeakPtr<AVTrackPrivateAVFObjCImplVideoClient>&& client) { m_videoTrackClient = WTFMove(client); }
+    void setAudioTrackClient(WeakPtr<AVTrackPrivateAVFObjCImplAudioClient>&& client) { m_audioTrackClient = WTFMove(client); }
+
     AVPlayerItemTrack* playerItemTrack() const { return m_playerItemTrack.get(); }
     AVAssetTrack* assetTrack() const { return m_assetTrack.get(); }
     MediaSelectionOptionAVFObjC* mediaSelectionOption() const { return m_mediaSelectionOption.get(); }
@@ -95,12 +98,10 @@ public:
     static String languageForAVMediaSelectionOption(AVMediaSelectionOption *);
 
     PlatformVideoTrackConfiguration videoTrackConfiguration() const;
-    using VideoTrackConfigurationObserver = Observer<void()>;
-    void setVideoTrackConfigurationObserver(VideoTrackConfigurationObserver& observer) { m_videoTrackConfigurationObserver = observer; }
-
     PlatformAudioTrackConfiguration audioTrackConfiguration() const;
-    using AudioTrackConfigurationObserver = Observer<void()>;
-    void setAudioTrackConfigurationObserver(AudioTrackConfigurationObserver& observer) { m_audioTrackConfigurationObserver = observer; }
+
+    using ReadyState = TrackPrivateBase::ReadyState;
+    ReadyState readyState() const;
 
 private:
     AVTrackPrivateAVFObjCImpl(AVPlayerItemTrack*);
@@ -124,8 +125,8 @@ private:
     const RetainPtr<AVPlayerItemTrack> m_playerItemTrack;
     const RefPtr<MediaSelectionOptionAVFObjC> m_mediaSelectionOption;
     const RetainPtr<AVAssetTrack> m_assetTrack;
-    WeakPtr<VideoTrackConfigurationObserver> m_videoTrackConfigurationObserver;
-    WeakPtr<AudioTrackConfigurationObserver> m_audioTrackConfigurationObserver;
+    WeakPtr<AVTrackPrivateAVFObjCImplVideoClient> m_videoTrackClient;
+    WeakPtr<AVTrackPrivateAVFObjCImplAudioClient> m_audioTrackClient;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -57,7 +57,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AVTrackPrivateAVFObjCImpl);
 
-static NSArray* assetTrackConfigurationKeyNames()
+static NSArray<NSString *> *assetTrackConfigurationKeyNames()
 {
     static NSArray* keys = [[NSArray alloc] initWithObjects:@"formatDescriptions", @"estimatedDataRate", @"nominalFrameRate", nil];
     return keys;
@@ -111,10 +111,16 @@ void AVTrackPrivateAVFObjCImpl::initializeAssetTrack()
 
 void AVTrackPrivateAVFObjCImpl::initializationCompleted()
 {
-    if (m_audioTrackConfigurationObserver)
-        (*m_audioTrackConfigurationObserver)();
-    if (m_videoTrackConfigurationObserver)
-        (*m_videoTrackConfigurationObserver)();
+    Ref protectedThis = *this;
+    if (RefPtr audioClient = m_audioTrackClient.get()) {
+        audioClient->trackReadyStateChanged(protectedThis, ReadyState::Loaded);
+        audioClient->audioTrackConfigurationChanged(protectedThis, audioTrackConfiguration());
+    }
+
+    if (RefPtr videoClient = m_videoTrackClient.get()) {
+        videoClient->trackReadyStateChanged(protectedThis, ReadyState::Loaded);
+        videoClient->videoTrackConfigurationChanged(protectedThis, videoTrackConfiguration());
+    }
 }
 
 bool AVTrackPrivateAVFObjCImpl::enabled() const
@@ -468,6 +474,25 @@ std::optional<SpatialVideoMetadata> AVTrackPrivateAVFObjCImpl::spatialVideoMetad
 std::optional<VideoProjectionMetadata> AVTrackPrivateAVFObjCImpl::videoProjectionMetadata() const
 {
     return videoProjectionMetadataFromFormatDescription(formatDescriptionFor(*this).get());
+}
+
+auto AVTrackPrivateAVFObjCImpl::readyState() const -> ReadyState
+{
+    RetainPtr assetTrack = assetTrackFor(*this);
+    bool anyLoading = false;
+    for (NSString *keyName in assetTrackConfigurationKeyNames()) {
+        auto status = [assetTrack statusOfValueForKey:keyName error:nil];
+        if (status == AVKeyValueStatusUnknown || status == AVKeyValueStatusCancelled)
+            return ReadyState::None;
+        if (status == AVKeyValueStatusFailed)
+            return ReadyState::Error;
+        if (status == AVKeyValueStatusLoading) {
+            anyLoading = true;
+            continue;
+        }
+        ASSERT(status == AVKeyValueStatusLoaded);
+    }
+    return anyLoading ? ReadyState::Loading : ReadyState::Loaded;
 }
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImplClient.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImplClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,49 +25,36 @@
 
 #pragma once
 
-#include "AVTrackPrivateAVFObjCImplClient.h"
-#include "AudioTrackPrivateAVF.h"
-#include <wtf/TZoneMalloc.h>
+#if ENABLE(VIDEO)
 
-#if ENABLE(MEDIA_SOURCE)
-
-OBJC_CLASS AVAssetTrack;
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class AVTrackPrivateAVFObjCImpl;
-class SourceBufferPrivateAVFObjC;
+struct PlatformAudioTrackConfiguration;
+struct PlatformVideoTrackConfiguration;
+enum class TrackPrivateBaseReadyState : uint8_t;
 
-class AudioTrackPrivateMediaSourceAVFObjC final
-    : public AudioTrackPrivateAVF
-    , public AVTrackPrivateAVFObjCImplAudioClient {
-    WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateMediaSourceAVFObjC);
-    WTF_MAKE_NONCOPYABLE(AudioTrackPrivateMediaSourceAVFObjC)
+class AVTrackPrivateAVFObjCImplClient : public AbstractRefCountedAndCanMakeWeakPtr<AVTrackPrivateAVFObjCImplClient> {
 public:
-    static Ref<AudioTrackPrivateMediaSourceAVFObjC> create(AVAssetTrack *track)
-    {
-        return adoptRef(*new AudioTrackPrivateMediaSourceAVFObjC(track));
-    }
+    virtual ~AVTrackPrivateAVFObjCImplClient() = default;
 
-    virtual ~AudioTrackPrivateMediaSourceAVFObjC();
-
-    void setEnabled(bool) final;
-
-    AVAssetTrack* assetTrack();
-
-    void ref() const final { AudioTrackPrivateAVF::ref(); }
-    void deref() const final { AudioTrackPrivateAVF::deref(); }
-
-private:
-    explicit AudioTrackPrivateMediaSourceAVFObjC(AVAssetTrack*);
-    
-    void resetPropertiesFromTrack();
-    void trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState) final;
-    void audioTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformAudioTrackConfiguration&&) final;
-
-    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
+    using ReadyState = TrackPrivateBaseReadyState;
+    virtual void trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState) = 0;
 };
 
+class AVTrackPrivateAVFObjCImplVideoClient : public AVTrackPrivateAVFObjCImplClient {
+public:
+    virtual ~AVTrackPrivateAVFObjCImplVideoClient() = default;
+    virtual void videoTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformVideoTrackConfiguration&&) = 0;
+};
+
+class AVTrackPrivateAVFObjCImplAudioClient : public AVTrackPrivateAVFObjCImplClient {
+public:
+    virtual ~AVTrackPrivateAVFObjCImplAudioClient() = default;
+    virtual void audioTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformAudioTrackConfiguration&&) = 0;
+};
 }
 
-#endif // ENABLE(MEDIA_SOURCE)
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -28,8 +28,8 @@
 
 #if ENABLE(VIDEO)
 
+#include "AVTrackPrivateAVFObjCImplClient.h"
 #include "AudioTrackPrivateAVF.h"
-#include <wtf/Observer.h>
 #include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVAssetTrack;
@@ -42,8 +42,11 @@ namespace WebCore {
 
 class AVTrackPrivateAVFObjCImpl;
 class MediaSelectionOptionAVFObjC;
+struct PlatformAudioTrackConfiguration;
 
-class AudioTrackPrivateAVFObjC : public AudioTrackPrivateAVF {
+class AudioTrackPrivateAVFObjC
+    : public AudioTrackPrivateAVF
+    , public AVTrackPrivateAVFObjCImplAudioClient {
     WTF_MAKE_TZONE_ALLOCATED(AudioTrackPrivateAVFObjC);
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateAVFObjC)
 public:
@@ -72,6 +75,9 @@ public:
 
     MediaSelectionOptionAVFObjC* mediaSelectionOption();
 
+    void ref() const final { AudioTrackPrivateAVF::ref(); }
+    void deref() const final { AudioTrackPrivateAVF::deref(); }
+
 private:
     friend class MediaPlayerPrivateAVFoundationObjC;
     AudioTrackPrivateAVFObjC(AVPlayerItemTrack*);
@@ -80,11 +86,10 @@ private:
     AudioTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&&);
 
     void resetPropertiesFromTrack();
-    void audioTrackConfigurationChanged();
-    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
+    void trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState) final;
+    void audioTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformAudioTrackConfiguration&&) final;
 
-    using AudioTrackConfigurationObserver = Observer<void()>;
-    AudioTrackConfigurationObserver m_audioTrackConfigurationObserver;
+    const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -52,9 +52,9 @@ AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC& 
 
 AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&& impl)
     : m_impl(WTFMove(impl))
-    , m_audioTrackConfigurationObserver([this] { audioTrackConfigurationChanged(); })
 {
-    m_impl->setAudioTrackConfigurationObserver(m_audioTrackConfigurationObserver);
+    m_readyState = m_impl->readyState();
+    m_impl->setAudioTrackClient(this);
     resetPropertiesFromTrack();
 }
 
@@ -85,11 +85,6 @@ void AudioTrackPrivateAVFObjC::resetPropertiesFromTrack()
     setConfiguration(WTFMove(newConfiguration));
 }
 
-void AudioTrackPrivateAVFObjC::audioTrackConfigurationChanged()
-{
-    setConfiguration(m_impl->audioTrackConfiguration());
-}
-
 AVPlayerItemTrack* AudioTrackPrivateAVFObjC::playerItemTrack()
 {
     return m_impl->playerItemTrack();
@@ -109,6 +104,16 @@ void AudioTrackPrivateAVFObjC::setEnabled(bool enabled)
 {
     AudioTrackPrivateAVF::setEnabled(enabled);
     m_impl->setEnabled(enabled);
+}
+
+void AudioTrackPrivateAVFObjC::trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState readyState)
+{
+    setReadyState(readyState);
+}
+
+void AudioTrackPrivateAVFObjC::audioTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformAudioTrackConfiguration&& configuration)
+{
+    setConfiguration(WTFMove(configuration));
 }
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -38,6 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioTrackPrivateMediaSourceAVFObjC);
 AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
     : m_impl(AVTrackPrivateAVFObjCImpl::create(track))
 {
+    m_readyState = m_impl->readyState();
     resetPropertiesFromTrack();
 }
 
@@ -62,6 +63,16 @@ void AudioTrackPrivateMediaSourceAVFObjC::setEnabled(bool enabled)
         return;
 
     AudioTrackPrivateAVF::setEnabled(enabled);
+}
+
+void AudioTrackPrivateMediaSourceAVFObjC::trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState readyState)
+{
+    setReadyState(readyState);
+}
+
+void AudioTrackPrivateMediaSourceAVFObjC::audioTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformAudioTrackConfiguration&& configuration)
+{
+    setConfiguration(WTFMove(configuration));
 }
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -54,9 +54,9 @@ VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(MediaSelectionOptionAVFObjC& 
 
 VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&& impl)
     : m_impl(WTFMove(impl))
-    , m_videoTrackConfigurationObserver([this] { videoTrackConfigurationChanged(); })
 {
-    m_impl->setVideoTrackConfigurationObserver(m_videoTrackConfigurationObserver);
+    m_readyState = m_impl->readyState();
+    m_impl->setVideoTrackClient(this);
     resetPropertiesFromTrack();
 }
 
@@ -85,11 +85,6 @@ void VideoTrackPrivateAVFObjC::resetPropertiesFromTrack()
     setConfiguration(WTFMove(newConfiguration));
 }
 
-void VideoTrackPrivateAVFObjC::videoTrackConfigurationChanged()
-{
-    setConfiguration(m_impl->videoTrackConfiguration());
-}
-
 AVPlayerItemTrack* VideoTrackPrivateAVFObjC::playerItemTrack()
 {
     return m_impl->playerItemTrack();
@@ -110,7 +105,17 @@ void VideoTrackPrivateAVFObjC::setSelected(bool enabled)
     VideoTrackPrivateAVF::setSelected(enabled);
     m_impl->setEnabled(enabled);
 }
-    
+
+void VideoTrackPrivateAVFObjC::trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState readyState)
+{
+    setReadyState(readyState);
+}
+
+void VideoTrackPrivateAVFObjC::videoTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformVideoTrackConfiguration&& configuration)
+{
+    setConfiguration(WTFMove(configuration));
+}
+
 }
 
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
@@ -28,8 +28,8 @@
 
 #if ENABLE(VIDEO)
 
+#include "AVTrackPrivateAVFObjCImplClient.h"
 #include "VideoTrackPrivateAVF.h"
-#include <wtf/Observer.h>
 #include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS AVAssetTrack;
@@ -42,8 +42,11 @@ namespace WebCore {
 
 class AVTrackPrivateAVFObjCImpl;
 class MediaSelectionOptionAVFObjC;
+struct PlatformVideoTrackConfiguration;
 
-class VideoTrackPrivateAVFObjC final : public VideoTrackPrivateAVF {
+class VideoTrackPrivateAVFObjC final
+    : public VideoTrackPrivateAVF
+    , public AVTrackPrivateAVFObjCImplVideoClient {
     WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateAVFObjC);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateAVFObjC)
 public:
@@ -70,6 +73,9 @@ public:
 
     MediaSelectionOptionAVFObjC* mediaSelectionOption();
 
+    void ref() const final { VideoTrackPrivateAVF::ref(); }
+    void deref() const final { VideoTrackPrivateAVF::deref(); }
+
 private:
     friend class MediaPlayerPrivateAVFoundationObjC;
     explicit VideoTrackPrivateAVFObjC(AVPlayerItemTrack*);
@@ -78,11 +84,9 @@ private:
     explicit VideoTrackPrivateAVFObjC(Ref<AVTrackPrivateAVFObjCImpl>&&);
 
     void resetPropertiesFromTrack();
-    void videoTrackConfigurationChanged();
+    void trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState) final;
+    void videoTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformVideoTrackConfiguration&&) final;
     const Ref<AVTrackPrivateAVFObjCImpl> m_impl;
-
-    using VideoTrackConfigurationObserver = Observer<void()>;
-    VideoTrackConfigurationObserver m_videoTrackConfigurationObserver;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
@@ -26,6 +26,7 @@
 #ifndef VideoTrackPrivateMediaSourceAVFObjC_h
 #define VideoTrackPrivateMediaSourceAVFObjC_h
 
+#include "AVTrackPrivateAVFObjCImplClient.h"
 #include "IntSize.h"
 #include "VideoTrackPrivateAVF.h"
 #include <wtf/TZoneMalloc.h>
@@ -40,7 +41,9 @@ namespace WebCore {
 class AVTrackPrivateAVFObjCImpl;
 class SourceBufferPrivateAVFObjC;
 
-class VideoTrackPrivateMediaSourceAVFObjC final : public VideoTrackPrivateAVF {
+class VideoTrackPrivateMediaSourceAVFObjC final
+    : public VideoTrackPrivateAVF
+    , public AVTrackPrivateAVFObjCImplVideoClient {
     WTF_MAKE_TZONE_ALLOCATED(VideoTrackPrivateMediaSourceAVFObjC);
     WTF_MAKE_NONCOPYABLE(VideoTrackPrivateMediaSourceAVFObjC)
 public:
@@ -55,9 +58,14 @@ public:
 
     FloatSize naturalSize() const;
 
+    void ref() const final { VideoTrackPrivateAVF::ref(); }
+    void deref() const final { VideoTrackPrivateAVF::deref(); }
+
 private:
     explicit VideoTrackPrivateMediaSourceAVFObjC(AVAssetTrack*);
-    
+
+    void trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState);
+    void videoTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformVideoTrackConfiguration&&);
     void resetPropertiesFromTrack();
 
     const Ref<AVTrackPrivateAVFObjCImpl> m_impl;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -40,6 +40,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(VideoTrackPrivateMediaSourceAVFObjC);
 VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC(AVAssetTrack* track)
     : m_impl(AVTrackPrivateAVFObjCImpl::create(track))
 {
+    m_readyState = m_impl->readyState();
+    m_impl->setVideoTrackClient(this);
     resetPropertiesFromTrack();
 }
 
@@ -63,6 +65,16 @@ AVAssetTrack* VideoTrackPrivateMediaSourceAVFObjC::assetTrack() const
 FloatSize VideoTrackPrivateMediaSourceAVFObjC::naturalSize() const
 {
     return FloatSize([assetTrack() naturalSize]);
+}
+
+void VideoTrackPrivateMediaSourceAVFObjC::trackReadyStateChanged(const AVTrackPrivateAVFObjCImpl&, ReadyState readyState)
+{
+    setReadyState(readyState);
+}
+
+void VideoTrackPrivateMediaSourceAVFObjC::videoTrackConfigurationChanged(const AVTrackPrivateAVFObjCImpl&, PlatformVideoTrackConfiguration&& configuration)
+{
+    setConfiguration(WTFMove(configuration));
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp
@@ -69,6 +69,7 @@ AudioTrackPrivateRemoteConfiguration RemoteAudioTrackProxy::configuration()
             m_trackPrivate->language(),
             m_trackPrivate->startTimeVariance(),
             m_trackPrivate->trackIndex(),
+            m_trackPrivate->readyState(),
         },
         m_trackPrivate->enabled(),
         m_trackPrivate->kind(),
@@ -87,6 +88,11 @@ void RemoteAudioTrackProxy::configurationChanged()
 void RemoteAudioTrackProxy::willRemove()
 {
     ASSERT_NOT_REACHED();
+}
+
+void RemoteAudioTrackProxy::readyStateChanged(WebCore::TrackPrivateBaseReadyState)
+{
+    configurationChanged();
 }
 
 void RemoteAudioTrackProxy::enabledChanged(bool enabled)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -79,6 +79,7 @@ private:
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;
+    void readyStateChanged(WebCore::TrackPrivateBaseReadyState) final;
 
     AudioTrackPrivateRemoteConfiguration configuration();
     void configurationChanged();

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -61,27 +61,25 @@ RemoteTextTrackProxy::~RemoteTextTrackProxy()
     m_trackPrivate->removeClient(m_clientId);
 }
 
-TextTrackPrivateRemoteConfiguration& RemoteTextTrackProxy::configuration()
+TextTrackPrivateRemoteConfiguration RemoteTextTrackProxy::configuration()
 {
-    static NeverDestroyed<TextTrackPrivateRemoteConfiguration> configuration;
-
-    configuration->trackId = m_trackPrivate->id();
-    configuration->label = m_trackPrivate->label();
-    configuration->language = m_trackPrivate->language();
-    configuration->trackIndex = m_trackPrivate->trackIndex();
-    configuration->inBandMetadataTrackDispatchType = m_trackPrivate->inBandMetadataTrackDispatchType();
-    configuration->startTimeVariance = m_trackPrivate->startTimeVariance();
-
-    configuration->cueFormat = m_trackPrivate->cueFormat();
-    configuration->isClosedCaptions = m_trackPrivate->isClosedCaptions();
-    configuration->isSDH = m_trackPrivate->isSDH();
-    configuration->containsOnlyForcedSubtitles = m_trackPrivate->containsOnlyForcedSubtitles();
-    configuration->isMainProgramContent = m_trackPrivate->isMainProgramContent();
-    configuration->isEasyToRead = m_trackPrivate->isEasyToRead();
-    configuration->isDefault = m_trackPrivate->isDefault();
-    configuration->kind = m_trackPrivate->kind();
-
-    return configuration.get();
+    return {
+        m_trackPrivate->id(),
+        m_trackPrivate->label(),
+        m_trackPrivate->language(),
+        m_trackPrivate->inBandMetadataTrackDispatchType(),
+        m_trackPrivate->startTimeVariance(),
+        m_trackPrivate->trackIndex(),
+        m_trackPrivate->readyState(),
+        m_trackPrivate->cueFormat(),
+        m_trackPrivate->kind(),
+        m_trackPrivate->isClosedCaptions(),
+        m_trackPrivate->isSDH(),
+        m_trackPrivate->containsOnlyForcedSubtitles(),
+        m_trackPrivate->isMainProgramContent(),
+        m_trackPrivate->isEasyToRead(),
+        m_trackPrivate->isDefault(),
+    };
 }
 
 void RemoteTextTrackProxy::configurationChanged()
@@ -93,6 +91,11 @@ void RemoteTextTrackProxy::configurationChanged()
 void RemoteTextTrackProxy::willRemove()
 {
     ASSERT_NOT_REACHED();
+}
+
+void RemoteTextTrackProxy::readyStateChanged(WebCore::TrackPrivateBaseReadyState)
+{
+    configurationChanged();
 }
 
 void RemoteTextTrackProxy::idChanged(TrackID)

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -88,8 +88,9 @@ private:
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;
+    void readyStateChanged(WebCore::TrackPrivateBaseReadyState) final;
 
-    TextTrackPrivateRemoteConfiguration& configuration();
+    TextTrackPrivateRemoteConfiguration configuration();
     void configurationChanged();
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp
@@ -68,6 +68,7 @@ VideoTrackPrivateRemoteConfiguration RemoteVideoTrackProxy::configuration()
             m_trackPrivate->language(),
             m_trackPrivate->startTimeVariance(),
             m_trackPrivate->trackIndex(),
+            m_trackPrivate->readyState(),
         },
         m_trackPrivate->selected(),
         m_trackPrivate->kind(),
@@ -84,6 +85,11 @@ void RemoteVideoTrackProxy::updateConfiguration()
 void RemoteVideoTrackProxy::willRemove()
 {
     ASSERT_NOT_REACHED();
+}
+
+void RemoteVideoTrackProxy::readyStateChanged(WebCore::TrackPrivateBaseReadyState)
+{
+    updateConfiguration();
 }
 
 void RemoteVideoTrackProxy::selectedChanged(bool selected)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -79,6 +79,7 @@ private:
     void labelChanged(const AtomString&) final;
     void languageChanged(const AtomString&) final;
     void willRemove() final;
+    void readyStateChanged(WebCore::TrackPrivateBaseReadyState) final;
 
     VideoTrackPrivateRemoteConfiguration configuration();
     void updateConfiguration();

--- a/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h
@@ -40,6 +40,7 @@ struct TextTrackPrivateRemoteConfiguration {
     String inBandMetadataTrackDispatchType;
     MediaTime startTimeVariance { MediaTime::zeroTime() };
     int trackIndex;
+    WebCore::TrackPrivateBase::ReadyState readyState { WebCore::TrackPrivateBase::ReadyState::None };
 
     WebCore::InbandTextTrackPrivate::CueFormat cueFormat { WebCore::InbandTextTrackPrivate::CueFormat::Generic };
     WebCore::InbandTextTrackPrivate::Kind kind { WebCore::InbandTextTrackPrivate::Kind::None };

--- a/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::TextTrackPrivateRemoteConfiguration {
     String inBandMetadataTrackDispatchType;
     MediaTime startTimeVariance;
     int trackIndex;
+    WebCore::TrackPrivateBase::ReadyState readyState;
 
     WebCore::InbandTextTrackPrivate::CueFormat cueFormat;
     WebCore::InbandTextTrackPrivate::Kind kind;

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
 #include <WebCore/TrackBase.h>
+#include <WebCore/TrackPrivateBase.h>
 #include <wtf/MediaTime.h>
 
 namespace WebKit {
@@ -38,6 +39,8 @@ struct TrackPrivateRemoteConfiguration {
     String language;
     MediaTime startTimeVariance { MediaTime::zeroTime() };
     int trackIndex;
+    WebCore::TrackPrivateBaseReadyState readyState { WebCore::TrackPrivateBaseReadyState::None };
+
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
@@ -92,6 +92,8 @@ void AudioTrackPrivateRemote::updateConfiguration(AudioTrackPrivateRemoteConfigu
     m_trackIndex = configuration.trackIndex;
     m_startTimeVariance = configuration.startTimeVariance;
     m_kind = configuration.kind;
+
+    setReadyState(configuration.readyState);
     setConfiguration(WTFMove(configuration.trackConfiguration));
     
     AudioTrackPrivate::setEnabled(configuration.enabled);

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -103,6 +103,8 @@ void TextTrackPrivateRemote::updateConfiguration(TextTrackPrivateRemoteConfigura
     m_isMainProgramContent = configuration.isMainProgramContent;
     m_isEasyToRead = configuration.isEasyToRead;
     m_isDefault = configuration.isDefault;
+
+    setReadyState(configuration.readyState);
 }
 
 void TextTrackPrivateRemote::addGenericCue(Ref<InbandGenericCue> cue)

--- a/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp
@@ -92,6 +92,7 @@ void VideoTrackPrivateRemote::updateConfiguration(VideoTrackPrivateRemoteConfigu
     m_trackIndex = configuration.trackIndex;
     m_startTimeVariance = configuration.startTimeVariance;
     m_kind = configuration.kind;
+    setReadyState(configuration.readyState);
     setConfiguration(WTFMove(configuration.trackConfiguration));
     VideoTrackPrivate::setSelected(configuration.selected);
 }


### PR DESCRIPTION
#### b8bb7f542ec5e85d97fa569410b88101dac3ad05
<pre>
[Refactor] Plumb &quot;readyState&quot; up from AVTrackPrivateAVFObjC
<a href="https://bugs.webkit.org/show_bug.cgi?id=296390">https://bugs.webkit.org/show_bug.cgi?id=296390</a>
&lt;<a href="https://rdar.apple.com/problem/156521213">rdar://problem/156521213</a>&gt;

Reviewed by Eric Carlson.

Most in-band tracks are fully &quot;ready&quot; once the main media metadata is parsed. For
streaming formats like HLS, tracks can come and go, and may not be fully &quot;ready&quot;
when initially parsed.

TextTrack already has the concept of &quot;readiness&quot; as a fully out-of-band media format.
Bring this concept down to the level of TrackPrivateBase and expose a mechanism to
pass &quot;readyState&quot; upwards to AudioTrack, VideoTrack, and InbandTextTrack.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerDidAddTextTrack):
(WebCore::HTMLMediaElement::addTextTrack):
(WebCore::HTMLMediaElement::hasClosedCaptions const):
(WebCore::HTMLMediaElement::textTracksAreReady const):
(WebCore::HTMLMediaElement::textTrackReadyStateChanged):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::setReadyState):
(WebCore::HTMLTrackElement::readyState const):
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::readyStateChanged):
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/AudioTrackClient.h:
(WebCore::AudioTrackClient::audioTrackReadyStateChanged):
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::readyStateChanged):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
(WebCore::TextTrack::readinessState const): Deleted.
(WebCore::TextTrack::setReadinessState): Deleted.
* Source/WebCore/html/track/TextTrackClient.h:
(WebCore::TextTrackClient::textTrackReadyStateChanged):
* Source/WebCore/html/track/TrackBase.h:
(WebCore::TrackBase::readyState const):
(WebCore::TrackBase::setReadyState):
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::readyStateChanged):
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/html/track/VideoTrackClient.h:
(WebCore::VideoTrackClient::videoTrackReadyStateChanged):
* Source/WebCore/platform/graphics/TrackPrivateBase.cpp:
(WTF::isValidEnum&lt;WebCore::TrackPrivateBaseReadyState&gt;):
* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/TrackPrivateBaseClient.h:
* Source/WebCore/platform/graphics/TrackPrivateBaseEnums.h: Copied from Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h.
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h:
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::AVTrackPrivateAVFObjCImpl::initializationCompleted):
(WebCore::AVTrackPrivateAVFObjCImpl::videoProjectionMetadata const):
(WebCore::assetTrackConfigurationKeyNames): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImplClient.h: Copied from Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h.
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
(WebCore::AudioTrackPrivateAVFObjC::AudioTrackPrivateAVFObjC):
(WebCore::AudioTrackPrivateAVFObjC::trackReadyStateChanged):
(WebCore::AudioTrackPrivateAVFObjC::audioTrackConfigurationChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::AudioTrackPrivateMediaSourceAVFObjC):
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::trackReadyStateChanged):
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::audioTrackConfigurationChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC):
(WebCore::VideoTrackPrivateAVFObjC::trackReadyStateChanged):
(WebCore::VideoTrackPrivateAVFObjC::videoTrackConfigurationChanged):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::VideoTrackPrivateMediaSourceAVFObjC):
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::trackReadyStateChanged):
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::videoTrackConfigurationChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.cpp:
(WebKit::RemoteAudioTrackProxy::configuration):
(WebKit::RemoteAudioTrackProxy::readyStateChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::configuration):
(WebKit::RemoteTextTrackProxy::readyStateChanged):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.cpp:
(WebKit::RemoteVideoTrackProxy::configuration):
(WebKit::RemoteVideoTrackProxy::readyStateChanged):
* Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h:
* Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.h:
* Source/WebKit/GPUProcess/media/TextTrackPrivateRemoteConfiguration.serialization.in:
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteConfiguration.h:
* Source/WebKit/WebProcess/GPU/media/AudioTrackPrivateRemote.cpp:
(WebKit::AudioTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp:
(WebKit::TextTrackPrivateRemote::updateConfiguration):
* Source/WebKit/WebProcess/GPU/media/VideoTrackPrivateRemote.cpp:
(WebKit::VideoTrackPrivateRemote::updateConfiguration):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8bb7f542ec5e85d97fa569410b88101dac3ad05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113179 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86149 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41454 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101816 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66469 "Found 139 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies, /WPE/TestResources:/webkit/WebKitWebResource/suggested-filename ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19946 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122604 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40257 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30035 "Found 1 new test failure: ipc/serialized-type-info.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94998 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94740 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45642 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->