### PR TITLE
Align macOS and iPadOS fullscreen keyboard behavior

### DIFF
--- a/Source/WebCore/PAL/pal/system/ios/Device.cpp
+++ b/Source/WebCore/PAL/pal/system/ios/Device.cpp
@@ -36,6 +36,12 @@
 
 namespace PAL {
 
+bool deviceClassIsDesktop()
+{
+    static auto deviceClass = MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);
+    return deviceClass == MGDeviceClassiPad || deviceClass == MGDeviceClassMac;
+}
+
 bool deviceClassIsSmallScreen()
 {
 #if ENABLE(FORCE_DEVICE_CLASS_SMALL_SCREEN)

--- a/Source/WebCore/PAL/pal/system/ios/Device.h
+++ b/Source/WebCore/PAL/pal/system/ios/Device.h
@@ -33,6 +33,8 @@ namespace PAL {
 
 String deviceName(); // Thread-safe.
 
+PAL_EXPORT bool deviceClassIsDesktop();
+
 // Returns true only for iPhone, iPod, Apple Watch.
 // Few callers should be making any decisions based on device class.
 // If a check like this is needed, often currentUserInterfaceIdiomIsSmallScreen is preferred.

--- a/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.h
+++ b/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.h
@@ -31,10 +31,12 @@ namespace PAL {
 
 enum class UserInterfaceIdiom : uint8_t {
     Default,
+    Desktop,
     SmallScreen,
     Vision
 };
 
+PAL_EXPORT bool currentUserInterfaceIdiomIsDesktop();
 PAL_EXPORT bool currentUserInterfaceIdiomIsSmallScreen();
 PAL_EXPORT bool currentUserInterfaceIdiomIsVision();
 

--- a/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
+++ b/Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
@@ -50,6 +50,14 @@ static bool shouldForceUserInterfaceIdiomSmallScreen(std::optional<UIUserInterfa
 }
 #endif
 
+bool currentUserInterfaceIdiomIsDesktop()
+{
+    if (!s_currentUserInterfaceIdiom.load())
+        updateCurrentUserInterfaceIdiom();
+    auto idiom = *s_currentUserInterfaceIdiom.load();
+    return idiom == UserInterfaceIdiom::Desktop;
+}
+
 bool currentUserInterfaceIdiomIsSmallScreen()
 {
     if (!s_currentUserInterfaceIdiom.load())
@@ -86,12 +94,16 @@ bool updateCurrentUserInterfaceIdiom()
     // but is not sufficient in the application case.
     UserInterfaceIdiom newIdiom = [&] {
         if (![PAL::getUIApplicationClass() sharedApplication]) {
+            if (PAL::deviceClassIsDesktop())
+                return UserInterfaceIdiom::Desktop;
             if (PAL::deviceClassIsSmallScreen() || shouldForceUserInterfaceIdiomSmallScreen())
                 return UserInterfaceIdiom::SmallScreen;
             if (PAL::deviceClassIsVision())
                 return UserInterfaceIdiom::Vision;
         } else {
             auto idiom = [[PAL::getUIDeviceClass() currentDevice] userInterfaceIdiom];
+            if (idiom == UIUserInterfaceIdiomPad || idiom == UIUserInterfaceIdiomMac)
+                return UserInterfaceIdiom::Desktop;
             if (idiom == UIUserInterfaceIdiomPhone || idiom == UIUserInterfaceIdiomWatch || shouldForceUserInterfaceIdiomSmallScreen(idiom))
                 return UserInterfaceIdiom::SmallScreen;
 #if HAVE(UI_USER_INTERFACE_IDIOM_VISION)

--- a/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
@@ -25,6 +25,7 @@
 header: <pal/system/ios/UserInterfaceIdiom.h>
 enum class PAL::UserInterfaceIdiom : uint8_t {
     Default,
+    Desktop,
     SmallScreen,
     Vision
 };

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -55,6 +55,10 @@
 #include <WebCore/UserGestureIndicator.h>
 #include <wtf/LoggerHelper.h>
 
+#if PLATFORM(IOS_FAMILY)
+#include <pal/system/ios/UserInterfaceIdiom.h>
+#endif
+
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 #include "PlaybackSessionManager.h"
 #include "VideoPresentationManager.h"
@@ -179,7 +183,7 @@ bool WebFullScreenManager::supportsFullScreenForElement(const WebCore::Element& 
         return false;
 
 #if PLATFORM(IOS_FAMILY)
-    return !withKeyboard;
+    return PAL::currentUserInterfaceIdiomIsDesktop() || !withKeyboard;
 #else
     return true;
 #endif


### PR DESCRIPTION
#### 2ae1d5df810a01cd2246fc5c5bdd85184855ff6c
<pre>
Align macOS and iPadOS fullscreen keyboard behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=296391">https://bugs.webkit.org/show_bug.cgi?id=296391</a>
<a href="https://rdar.apple.com/problem/156522008">rdar://problem/156522008</a>

Reviewed by Brent Fulgham.

There has been a difference between keyboard behavior on macOS and iPadOS in fullscreen mode.
This patch brings these two back into alignment.

* Source/WebCore/PAL/pal/system/ios/Device.cpp
* Source/WebCore/PAL/pal/system/ios/Device.h
* Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.h
* Source/WebCore/PAL/pal/system/ios/UserInterfaceIdiom.mm
* Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp

Canonical link: <a href="https://commits.webkit.org/297962@main">https://commits.webkit.org/297962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07d33b34cc4c5ff6b7ad8db26f869df3e34eff61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123003 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95251 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24246 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17938 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45986 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40142 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->