### PR TITLE
[build-webkit] Add option to pass output to `filter-build-webkit`

### DIFF
--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -83,6 +83,7 @@ my $startTime = time();
 my $archs32bit = 0;
 my $useCCache = -1;
 my $exportCompileCommands = 0;
+my $filterOutput = $ENV{'WEBKIT_FILTER_OUTPUT'} ? 1 : 0;
 
 my @features = getFeatureOptionList();
 
@@ -153,6 +154,7 @@ Usage: $programName [options] [options to pass to build system]
   --[no-]use-ccache                 Enable (or disable) CCache, if available
 
   --export-compile-commands         Generate compile_commands.json (Xcode builds only)
+  --[no-]filter-output              Filter build output through filter-build-webkit (can be set via WEBKIT_FILTER_OUTPUT)
 
 EOF
 
@@ -173,7 +175,8 @@ my %options = (
     'no-experimental-features' => \$noExperimentalFeatures,
     'lto-mode=s' => \$ltoMode,
     'use-ccache!' => \$useCCache,
-    'export-compile-commands' => \$exportCompileCommands
+    'export-compile-commands' => \$exportCompileCommands,
+    'filter-output!' => \$filterOutput
 );
 
 # Build usage text and options list from features
@@ -188,6 +191,24 @@ GetOptions(%options);
 if ($showHelp) {
    print STDERR $usage;
    exit 1;
+}
+
+# Check if we should pipe the entire script output through filter-build-webkit
+# Do this early, before any output is generated
+if ($filterOutput) {
+    my $filterPath = File::Spec->catfile($FindBin::Bin, "filter-build-webkit");
+    if (-x $filterPath) {
+        # Prepare arguments for re-execution, removing --filter-output and adding --no-filter-output
+        my @newArgs = ();
+        for my $arg (@ARGV) {
+            next if $arg eq '--filter-output';
+            push @newArgs, $arg;
+        }
+        push @newArgs, '--no-filter-output';
+
+        # Re-execute this script and pipe through filter
+        exec "$^X $0 " . join(' ', map { /\s/ ? "'$_'" : $_ } @newArgs) . " | '$filterPath'";
+    }
 }
 
 $ENV{'VERBOSE'} = 1 if $verbose;


### PR DESCRIPTION
#### 26989de7d86180ebcd5606fc82c8810572a73296
<pre>
[build-webkit] Add option to pass output to `filter-build-webkit`
<a href="https://bugs.webkit.org/show_bug.cgi?id=296395">https://bugs.webkit.org/show_bug.cgi?id=296395</a>

Reviewed by NOBODY (OOPS!).

Add --[no-]filter-output option and WEBKIT_FILTER_OUTPUT environment variable support to
atomatically pipe build output through `filter-build-webkit` for better readability.

This eliminates the need to manually type &quot;| filter-build-webkit&quot; for every build command.

* Tools/Scripts/build-webkit:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26989de7d86180ebcd5606fc82c8810572a73296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36702 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101571 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66240 "Found 137 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19704 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62879 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105434 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122342 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111533 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/39995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94792 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94530 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39661 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36108 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39881 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135763 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39522 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36466 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->