### PR TITLE
[ews-app] Add few more users to approved user list for cibuilds - part 2

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -221,8 +221,9 @@ class GitHubEWS(GitHub):
                           ['', 'watch', '', '', ''],
                           ['', 'watch-sim', '', '', '']]
     # FIXME: fetch below user list dynamically and expand it appropriately
-    approved_user_list_for_cibuilds = ['adetaylor', 'aj062', 'briannafan', 'JonWBedard', 'ryanhaddad',
-                                       'hortont424', 'aprotyas', 'pxlcoder', 'jesxilin', 'lilyspiniolas', 'megangardner', 'rr-codes', 'whsieh']
+    approved_user_list_for_cibuilds = ['aj062', 'aproskuryakov', 'briannafan', 'emw-apple', 'gsnedders', 'JonWBedard', 'ryanhaddad',
+                                       'aprotyas', 'hortont424', 'jesxilin', 'lilyspiniolas', 'megangardner', 'pxlcoder', 'rr-codes', 'whsieh',
+                                       'adetaylor', 'aestes', 'annevk', 'beidson', 'etiennesegonzac', 'zakariaridouh']
 
     @classmethod
     def generate_updated_pr_description(self, description, ews_comment):


### PR DESCRIPTION
#### fe1132fb454219048c4d526e24d22bc7962f768d
<pre>
[ews-app] Add few more users to approved user list for cibuilds - part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=296400">https://bugs.webkit.org/show_bug.cgi?id=296400</a>
<a href="https://rdar.apple.com/156539788">rdar://156539788</a>

Reviewed by Brianna Fan.

* Tools/CISupport/ews-app/ews/common/github.py:

Canonical link: <a href="https://commits.webkit.org/297807@main">https://commits.webkit.org/297807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edb8b6313754780a79ecd63eda538fa1d4ed0486

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112931 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/32666 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/23144 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/119135 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114893 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/33318 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/41229 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/119135 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/63468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115878 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/33318 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/23144 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/119135 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/33318 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/23144 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/62893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/33318 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/23144 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/122356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40009 "Build is in progress. Recent messages:") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/41229 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/122356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/40393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/23144 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/122356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/23144 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18175 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/39895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/39536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/42869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/41273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->