### PR TITLE
Enable `Math.sumPrecise` by default

### DIFF
--- a/LayoutTests/js/Object-getOwnPropertyNames-expected.txt
+++ b/LayoutTests/js/Object-getOwnPropertyNames-expected.txt
@@ -60,7 +60,7 @@ PASS getSortedOwnPropertyNames(RegExp) is ['$&', "$'", '$*', '$+', '$1', '$2', '
 PASS getSortedOwnPropertyNames(RegExp.prototype) is ['compile', 'constructor', 'dotAll', 'exec', 'flags', 'global', 'hasIndices', 'ignoreCase', 'multiline', 'source', 'sticky', 'test', 'toString', 'unicode', 'unicodeSets']
 PASS getSortedOwnPropertyNames(Error) is ['captureStackTrace', 'isError', 'length', 'name', 'prototype', 'stackTraceLimit']
 PASS getSortedOwnPropertyNames(Error.prototype) is ['constructor', 'message', 'name', 'toString']
-PASS getSortedOwnPropertyNames(Math) is ['E','LN10','LN2','LOG10E','LOG2E','PI','SQRT1_2','SQRT2','abs','acos','acosh','asin','asinh','atan','atan2','atanh','cbrt','ceil','clz32','cos','cosh','exp','expm1','f16round','floor','fround','hypot','imul','log','log10','log1p','log2','max','min','pow','random','round','sign','sin','sinh','sqrt','tan','tanh','trunc']
+PASS getSortedOwnPropertyNames(Math) is ['E','LN10','LN2','LOG10E','LOG2E','PI','SQRT1_2','SQRT2','abs','acos','acosh','asin','asinh','atan','atan2','atanh','cbrt','ceil','clz32','cos','cosh','exp','expm1','f16round','floor','fround','hypot','imul','log','log10','log1p','log2','max','min','pow','random','round','sign','sin','sinh','sqrt','sumPrecise','tan','tanh','trunc']
 PASS getSortedOwnPropertyNames(JSON) is ['isRawJSON', 'parse', 'rawJSON', 'stringify']
 PASS getSortedOwnPropertyNames(Symbol) is ['asyncIterator','for', 'hasInstance', 'isConcatSpreadable', 'iterator', 'keyFor', 'length', 'match', 'matchAll', 'name', 'prototype', 'replace', 'search', 'species', 'split', 'toPrimitive', 'toStringTag', 'unscopables']
 PASS getSortedOwnPropertyNames(Symbol.prototype) is ['constructor', 'description', 'toString', 'valueOf']

--- a/LayoutTests/js/script-tests/Object-getOwnPropertyNames.js
+++ b/LayoutTests/js/script-tests/Object-getOwnPropertyNames.js
@@ -69,7 +69,7 @@ var expectedPropertyNamesSet = {
     "RegExp.prototype": "['compile', 'constructor', 'dotAll', 'exec', 'flags', 'global', 'hasIndices', 'ignoreCase', 'multiline', 'source', 'sticky', 'test', 'toString', 'unicode', 'unicodeSets']",
     "Error": "['captureStackTrace', 'isError', 'length', 'name', 'prototype', 'stackTraceLimit']",
     "Error.prototype": "['constructor', 'message', 'name', 'toString']",
-    "Math": "['E','LN10','LN2','LOG10E','LOG2E','PI','SQRT1_2','SQRT2','abs','acos','acosh','asin','asinh','atan','atan2','atanh','cbrt','ceil','clz32','cos','cosh','exp','expm1','f16round','floor','fround','hypot','imul','log','log10','log1p','log2','max','min','pow','random','round','sign','sin','sinh','sqrt','tan','tanh','trunc']",
+    "Math": "['E','LN10','LN2','LOG10E','LOG2E','PI','SQRT1_2','SQRT2','abs','acos','acosh','asin','asinh','atan','atan2','atanh','cbrt','ceil','clz32','cos','cosh','exp','expm1','f16round','floor','fround','hypot','imul','log','log10','log1p','log2','max','min','pow','random','round','sign','sin','sinh','sqrt','sumPrecise','tan','tanh','trunc']",
     "JSON": "['isRawJSON', 'parse', 'rawJSON', 'stringify']",
     "Symbol": "['asyncIterator','for', 'hasInstance', 'isConcatSpreadable', 'iterator', 'keyFor', 'length', 'match', 'matchAll', 'name', 'prototype', 'replace', 'search', 'species', 'split', 'toPrimitive', 'toStringTag', 'unscopables']",
     "Symbol.prototype": "['constructor', 'description', 'toString', 'valueOf']",

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -643,7 +643,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorSequencing, false, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useMapGetOrInsert, false, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
-    v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
+    v(Bool, useMathSumPreciseMethod, true, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \

--- a/Source/WTF/wtf/PreciseSum.h
+++ b/Source/WTF/wtf/PreciseSum.h
@@ -106,8 +106,8 @@ private:
 } // namespace Xsum
 
 // Threshold for PreciseSum to determine whether to use XsumSmall or XsumLarge
-// if expected array size if more than PRECISE_SUM_THRESHOLD, use Xsum::XsumLarge
-// otherwise, use Xsum::XsumSmall
+// If the expected array length is greater than PRECISE_SUM_THRESHOLD, use Xsum::XsumLarge;
+// otherwise use Xsum::XsumSmall
 constexpr uint64_t PRECISE_SUM_THRESHOLD = 1'000;
 
 template<std::derived_from<Xsum::XsumInterface> T = Xsum::XsumSmall>


### PR DESCRIPTION
#### b21d2072809e9d5f30797756469cec5e22fb6820
<pre>
Enable `Math.sumPrecise` by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=295806">https://bugs.webkit.org/show_bug.cgi?id=295806</a>

Reviewed by Keith Miller.

All implementations and tests of `Math.sumPrecise` have been completed [1][2][3][4].
This patch enables `Math.sumPrecise` by default.
The feature flag is retained as a safeguard because the proposal is still at Stage 3 [5],
and potential issues may still arise.

[1]: <a href="https://github.com/WebKit/WebKit/commit/f49d6a41fb8d93f9c7e6758d87a06a9eea3e9698">https://github.com/WebKit/WebKit/commit/f49d6a41fb8d93f9c7e6758d87a06a9eea3e9698</a>
[2]: <a href="https://github.com/WebKit/WebKit/commit/2682d2ab17a40851f7e6bcff35126e810b0646fd">https://github.com/WebKit/WebKit/commit/2682d2ab17a40851f7e6bcff35126e810b0646fd</a>
[3]: <a href="https://github.com/WebKit/WebKit/commit/d95d6a80355e27cd4091e806e21019e4bc557a1e">https://github.com/WebKit/WebKit/commit/d95d6a80355e27cd4091e806e21019e4bc557a1e</a>
[4]: <a href="https://github.com/WebKit/WebKit/commit/480ea278f6add966e8b2c073c832989ace517bd0">https://github.com/WebKit/WebKit/commit/480ea278f6add966e8b2c073c832989ace517bd0</a>
[5]: <a href="https://github.com/tc39/proposal-math-sum/blob/4f621a637fb61baa61359e4c05e7c6d7e9629890/README.md?plain=1#L11">https://github.com/tc39/proposal-math-sum/blob/4f621a637fb61baa61359e4c05e7c6d7e9629890/README.md?plain=1#L11</a>

* LayoutTests/js/Object-getOwnPropertyNames-expected.txt:
* LayoutTests/js/script-tests/Object-getOwnPropertyNames.js:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/PreciseSum.h:

Canonical link: <a href="https://commits.webkit.org/297839@main">https://commits.webkit.org/297839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9373e0b3b1a9bf68fb87d073e0fddca1160046c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63584 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85964 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36667 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62916 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105471 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122379 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111570 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24155 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39693 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17506 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36145 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39918 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45417 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135800 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39559 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36472 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->