### PR TITLE
JavaScriptEvaluationResult's conversion to NSArrays should map null and undefined to NSNull

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -74,6 +74,8 @@ RetainPtr<id> JavaScriptEvaluationResult::toID()
         for (auto identifier : vector) {
             if (RetainPtr element = m_instantiatedNSObjects.get(identifier))
                 [array addObject:element.get()];
+            else
+                [array addObject:NSNull.null];
         }
     }
     for (auto [map, dictionary] : std::exchange(m_nsDictionaries, { })) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -949,6 +949,13 @@ TEST(EvaluateJavaScript, ReturnTypes)
         EXPECT_EQ([dict objectForKey:@"blob"], [NSNull null]);
     }];
 
+    NSString *containersWithNullAndUndefined = @"(function(){return [{'a':null, 'b':undefined}, [null, undefined, 0]]})()";
+    [webView evaluateJavaScript:containersWithNullAndUndefined completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(error);
+        NSArray *expected = @[@{ @"a":NSNull.null }, @[NSNull.null, NSNull.null, @0]];
+        EXPECT_TRUE([value isEqual:expected]);
+    }];
+
     NSString *jsWithNestedObjects = @""
     "(function(){"
     "    let aBool = true;\n"


### PR DESCRIPTION
#### 6613381ed551833ffcaa32fc90c70bfab4f13dd7
<pre>
JavaScriptEvaluationResult&apos;s conversion to NSArrays should map null and undefined to NSNull
<a href="https://bugs.webkit.org/show_bug.cgi?id=296401">https://bugs.webkit.org/show_bug.cgi?id=296401</a>
<a href="https://rdar.apple.com/156540084">rdar://156540084</a>

Reviewed by Abrar Rahman Protyasha.

When returning a value from JS and converting it to ObjC, null maps to NSNull and undefined maps to nil.
However, when it is the content of a JS array, both map to NSNull.  This matches the behavior of a function
in JavaScriptCore named containerValueToObject that was implemented that way in 2013 in 124088@main.
Confusingly, conversion to NSDictionary does not have this behavior.
I accidentally change this in 297201@main which was fixed in <a href="https://rdar.apple.com/156177377">rdar://156177377</a> by reverting it.
This brings the behavior to how it was for 12 years to maintain compatibility, and I add a test so
we won&apos;t miss it again in the future.

* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toID):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(ReturnTypes)):

Canonical link: <a href="https://commits.webkit.org/297811@main">https://commits.webkit.org/297811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ec2c21b0563d3db66a6bb1a63262e8886f8f254

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85941 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66248 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19711 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/95983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122355 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94797 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94536 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39667 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36121 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18178 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45393 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39535 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->