### PR TITLE
[Flex] crossAxisDirection should take directionality into consideration

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-rtl-direction-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-rtl-direction-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-rtl-direction.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-rtl-direction.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Baseline aligned item should be aligned towards the start of the inline axis (right side)."
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
+<style>
+.flexbox {
+  display: flex;
+  width: 100px;
+  height: 100px;
+  align-items: baseline;
+  flex-direction: column;
+  direction: rtl;
+  position: relative;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+}
+.abspos {
+  position: absolute;
+  right: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="flexbox">
+  <div class="abspos item"></div>
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-lr-rtl-wrap-reverse-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-lr-rtl-wrap-reverse-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-lr-rtl-wrap-reverse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-lr-rtl-wrap-reverse.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Baseline aligned item should be aligned towards the start of the inline axis (bottom side)."
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
+<style>
+.flexbox {
+  display: flex;
+  width: 100px;
+  height: 100px;
+  align-items: baseline;
+  flex-direction: column;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  flex-wrap: wrap-reverse;
+  position: relative;
+}
+.item {
+  width: 100px;
+  height: 50px;
+  background-color: green;
+}
+.abspos {
+  position: absolute;
+  bottom: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="flexbox">
+  <div class="abspos item"></div>
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-rl-rtl-wrap-reverse-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-rl-rtl-wrap-reverse-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-rl-rtl-wrap-reverse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-column-vert-rl-rtl-wrap-reverse.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Baseline aligned item should be aligned towards the start of the inline axis (bottom side)."
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-wrap-property">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
+<style>
+.flexbox {
+  display: flex;
+  width: 100px;
+  height: 100px;
+  align-items: baseline;
+  flex-direction: column;
+  writing-mode: vertical-rl;
+  direction: rtl;
+  flex-wrap: wrap-reverse;
+  position: relative;
+}
+.item {
+  width: 100px;
+  height: 50px;
+  background-color: green;
+}
+.abspos {
+  position: absolute;
+  bottom: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="flexbox">
+  <div class="abspos item"></div>
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/multiline-align-self-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/multiline-align-self-expected.txt
@@ -53,84 +53,16 @@ PASS .flexbox 3
 PASS .flexbox 4
 PASS .flexbox 5
 PASS .flexbox 6
-FAIL .flexbox 7 assert_equals:
-<div class="flexbox horizontal-tb rtl column wrap" style="height: 70px" data-expected-width="600" data-expected-height="70">
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="590" data-offset-y="0"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="580" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="570" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="585" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="585" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="570" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="570" data-offset-y="60"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="560" data-offset-y="0"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="550" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="540" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="555" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="555" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="540" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="540" data-offset-y="60"></div>
-  </div>
-offsetLeft expected 585 but got 570
-FAIL .flexbox 8 assert_equals:
-<div class="flexbox horizontal-tb rtl column wrap-reverse" style="height: 70px" data-expected-width="600" data-expected-height="70">
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="0" data-offset-y="0"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="10" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="20" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="0" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="0" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="0" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="0" data-offset-y="60"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="30" data-offset-y="0"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="40" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="50" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="30" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="30" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="30" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="30" data-offset-y="60"></div>
-  </div>
-offsetLeft expected 0 but got 15
+PASS .flexbox 7
+PASS .flexbox 8
 PASS .flexbox 9
 PASS .flexbox 10
 PASS .flexbox 11
 PASS .flexbox 12
 PASS .flexbox 13
 PASS .flexbox 14
-FAIL .flexbox 15 assert_equals:
-<div class="flexbox horizontal-tb rtl column-reverse wrap" style="height: 70px" data-expected-width="600" data-expected-height="70">
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="590" data-offset-y="60"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="580" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="570" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="585" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="585" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="570" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="570" data-offset-y="0"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="560" data-offset-y="60"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="550" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="540" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="555" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="555" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="540" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="540" data-offset-y="0"></div>
-  </div>
-offsetLeft expected 585 but got 570
-FAIL .flexbox 16 assert_equals:
-<div class="flexbox horizontal-tb rtl column-reverse wrap-reverse" style="height: 70px" data-expected-width="600" data-expected-height="70">
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="0" data-offset-y="60"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="10" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="20" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="0" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="0" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="0" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="0" data-offset-y="0"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-start" data-expected-width="10" data-expected-height="10" data-offset-x="30" data-offset-y="60"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: center" data-expected-width="10" data-expected-height="10" data-offset-x="40" data-offset-y="50"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: flex-end" data-expected-width="10" data-expected-height="10" data-offset-x="50" data-offset-y="40"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline" data-expected-width="10" data-expected-height="10" data-offset-x="30" data-offset-y="30"></div>
-    <div style="flex: 1 10px;width: 10px;align-self: baseline; margin-inline-start: 5px;" data-expected-width="10" data-expected-height="10" data-offset-x="30" data-offset-y="20"></div>
-    <div style="flex: 1 10px;width: auto;align-self: stretch" data-expected-width="30" data-expected-height="10" data-offset-x="30" data-offset-y="10"></div>
-    <div style="flex: 1 10px;width: 30px;align-self: flex-start" data-expected-width="30" data-expected-height="10" data-offset-x="30" data-offset-y="0"></div>
-  </div>
-offsetLeft expected 0 but got 15
+PASS .flexbox 15
+PASS .flexbox 16
 PASS .flexbox 17
 PASS .flexbox 18
 PASS .flexbox 19

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -541,6 +541,24 @@ bool RenderFlexibleBox::isLeftToRightFlow() const
     return writingMode().isLogicalLeftInlineStart() ^ (style().flexDirection() == FlexDirection::RowReverse);
 }
 
+RenderFlexibleBox::Direction RenderFlexibleBox::crossAxisDirection() const
+{
+    auto crossAxisDirection = style().isRowFlexDirection() ? writingMode().blockDirection() : writingMode().inlineDirection();
+    switch (crossAxisDirection) {
+    case FlowDirection::TopToBottom:
+        return style().flexWrap() == FlexWrap::Reverse ? Direction::BottomToTop : Direction::TopToBottom;
+    case FlowDirection::BottomToTop:
+        return style().flexWrap() == FlexWrap::Reverse ? Direction::TopToBottom : Direction::BottomToTop;
+    case FlowDirection::LeftToRight:
+        return style().flexWrap() == FlexWrap::Reverse ? Direction::RightToLeft : Direction::LeftToRight;
+    case FlowDirection::RightToLeft:
+        return style().flexWrap() == FlexWrap::Reverse ? Direction::LeftToRight : Direction::RightToLeft;
+    default:
+        ASSERT_NOT_REACHED();
+        return Direction::TopToBottom;
+    }
+}
+
 bool RenderFlexibleBox::isMultiline() const
 {
     return style().flexWrap() != FlexWrap::NoWrap;

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -64,30 +64,7 @@ public:
     void paintChildren(PaintInfo& forSelf, const LayoutPoint&, PaintInfo& forChild, bool usePrintRect) override;
 
     bool isHorizontalFlow() const;
-    inline Direction crossAxisDirection() const
-    {
-        switch (writingMode().blockDirection()) {
-        case FlowDirection::TopToBottom:
-            if (style().isRowFlexDirection())
-                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
-            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
-        case FlowDirection::BottomToTop:
-            if (style().isRowFlexDirection())
-                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::TopToBottom : Direction::BottomToTop;
-            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
-        case FlowDirection::LeftToRight:
-            if (style().isRowFlexDirection())
-                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
-            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
-        case FlowDirection::RightToLeft:
-            if (style().isRowFlexDirection())
-                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::LeftToRight : Direction::RightToLeft;
-            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
-        default:
-            ASSERT_NOT_REACHED();
-            return Direction::TopToBottom;
-        }
-    }
+    Direction crossAxisDirection() const;
 
     const OrderIterator& orderIterator() const { return m_orderIterator; }
 


### PR DESCRIPTION
#### b1e5deb5bcdaf804514b00519e75a5d9affacb5e
<pre>
[Flex] crossAxisDirection should take directionality into consideration
<a href="https://bugs.webkit.org/show_bug.cgi?id=296402">https://bugs.webkit.org/show_bug.cgi?id=296402</a>
<a href="https://rdar.apple.com/156540996">rdar://156540996</a>

Reviewed by Alan Baradlay.

The goal of crossAxisDirection, as the name implies, is to map the
direction in which the flexbox&apos;s cross axis flows to a physical direction.
It correctly looks at flex-wrap since flex-wrap: wrap-reverse can flip
the direction of the cross axis.

However, there is an issue when the cross axis is in the same axis as
the flexbox&apos;s inline axis. In this case, the start and end of the inline
axis can be affected by the direction property. In those cases, we need
to look at which way the inline direction flows in order to determine
whether the cross axis is simply that direction or needs to be flipped
in the case of flex-wrap: wrap-reverse. This can be done by taking
writingMode().inlineDirection() instead of writingMode().blockDirection()
when the cross axis is in the inline axis and passing it into the switch
statement.

I also decided to move this function definition from the header to the
source since it is not clear to me why I decided to make it inline as I
do not think there is an obvious benefit that outweighs the - albeit
likely small - build time increase.

Canonical link: <a href="https://commits.webkit.org/297876@main">https://commits.webkit.org/297876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ef9a3a3fec313b89a76e4c305d25487c44835c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86049 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36707 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19824 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122479 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94893 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94636 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24180 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36257 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45517 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->