### PR TITLE
[visionOS] Fix race condition between playerIdentifier and videoReceiverTarget with externalPlayback

### DIFF
--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -81,7 +81,7 @@ public:
     void modelDestroyed() override;
 
     std::optional<MediaPlayerIdentifier> playerIdentifier() const;
-    void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
+    virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
     void setVideoPresentationInterface(WeakPtr<VideoPresentationInterfaceIOS>);
 
     virtual void startObservingNowPlayingMetadata();

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -113,7 +113,7 @@ public:
     WEBCORE_EXPORT virtual void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)>&&, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT virtual void exitExternalPlayback();
     virtual bool cleanupExternalPlayback() { return false; }
-
+    virtual void didSetPlayerIdentifier() { }
 
     enum class ExitFullScreenReason {
         DoneButtonTapped,

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -56,6 +56,7 @@ public:
     void audioMediaSelectionIndexChanged(uint64_t) final;
     void legibleMediaSelectionIndexChanged(uint64_t) final;
     void externalPlaybackChanged(bool, WebCore::PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
+    void setPlayerIdentifier(std::optional<WebCore::MediaPlayerIdentifier>) final;
     void wirelessVideoPlaybackDisabledChanged(bool) final { }
     void mutedChanged(bool) final;
     void volumeChanged(double) final;

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -294,6 +294,14 @@ WKSLinearMediaPlayer *PlaybackSessionInterfaceLMK::linearMediaPlayer() const
     return m_player.get();
 }
 
+void PlaybackSessionInterfaceLMK::setPlayerIdentifier(std::optional<WebCore::MediaPlayerIdentifier> identifier)
+{
+    PlaybackSessionInterfaceIOS::setPlayerIdentifier(identifier);
+
+    if (RefPtr videoPresentationInterface = m_videoPresentationInterface.get())
+        videoPresentationInterface->didSetPlayerIdentifier();
+}
+
 void PlaybackSessionInterfaceLMK::durationChanged(double duration)
 {
     [m_player setStartTime:0];
@@ -393,8 +401,9 @@ void PlaybackSessionInterfaceLMK::supportsLinearMediaPlayerChanged(bool supports
         if (m_playbackSessionModel)
             m_playbackSessionModel->exitFullscreen();
         break;
+    case WKSLinearMediaPresentationStateEnteringExternal:
     case WKSLinearMediaPresentationStateExternal:
-        // If the player is in external presentation (which uses LinearMediaPlayer) but the current
+        // If the player is in (or entering) external presentation (which uses LinearMediaPlayer) but the current
         // media engine does not support it, exit external presentation.
         if (RefPtr videoPresentationInterface = m_videoPresentationInterface.get())
             videoPresentationInterface->exitExternalPlayback();

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -68,6 +68,7 @@ private:
     void enterExternalPlayback(CompletionHandler<void(bool, UIViewController *)> &&, CompletionHandler<void(bool)>&&) final;
     void exitExternalPlayback() final;
     bool cleanupExternalPlayback() final;
+    void didSetPlayerIdentifier() final;
     void didSetVideoReceiverEndpoint() final;
     void tryToStartPictureInPicture() final { }
     void stopPictureInPicture() final { }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -5320,7 +5320,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return;
     }
 
-    _page->setPlayerIdentifierForVideoElement();
     _page->enterExternalPlaybackForNowPlayingMediaSession([handler = makeBlockPtr(enterHandler)](bool entered, UIViewController *viewController) {
         if (entered)
             handler(viewController, nil);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8821,23 +8821,6 @@ void WebPageProxy::enterFullscreen()
     playbackSessionModel->enterFullscreen();
 }
 
-void WebPageProxy::setPlayerIdentifierForVideoElement()
-{
-    RefPtr playbackSessionManager = m_playbackSessionManager;
-    if (!playbackSessionManager)
-        return;
-
-    RefPtr controlsManagerInterface = playbackSessionManager->controlsManagerInterface();
-    if (!controlsManagerInterface)
-        return;
-
-    CheckedPtr playbackSessionModel = controlsManagerInterface->playbackSessionModel();
-    if (!playbackSessionModel)
-        return;
-
-    playbackSessionModel->setPlayerIdentifierForVideoElement();
-}
-
 void WebPageProxy::willEnterFullscreen(PlaybackSessionContextIdentifier identifier)
 {
     m_uiClient->willEnterFullscreen(this);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2353,7 +2353,6 @@ public:
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    void setPlayerIdentifierForVideoElement();
     bool canEnterFullscreen();
     void enterFullscreen();
 

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -197,6 +197,8 @@ extension WKSLinearMediaPresentationState: CustomStringConvertible {
             return "fullscreen"
         case .exitingFullscreen:
             return "exitingFullscreen"
+        case .enteringExternal:
+            return "enteringExternal"
         case .external:
             return "external"
         @unknown default:

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -157,8 +157,9 @@ NS_SWIFT_UI_ACTOR
 - (WKSPlayableViewControllerHost *)makeViewController;
 - (void)enterFullscreenWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL, NSError * _Nullable))completionHandler;
 - (void)exitFullscreenWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL, NSError * _Nullable))completionHandler;
-- (void)enterExternalPresentationWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL, NSError * _Nullable))completionHandler;
-- (void)exitExternalPresentationWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL, NSError * _Nullable))completionHandler;
+- (void)enterExternalPlaybackWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL, NSError * _Nullable))completionHandler;
+- (void)completeEnterExternalPlayback;
+- (void)exitExternalPlaybackWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL, NSError * _Nullable))completionHandler;
 @end
 
 NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h
@@ -49,6 +49,7 @@ typedef NS_ENUM(NSInteger, WKSLinearMediaPresentationState) {
     WKSLinearMediaPresentationStateEnteringFullscreen,
     WKSLinearMediaPresentationStateFullscreen,
     WKSLinearMediaPresentationStateExitingFullscreen,
+    WKSLinearMediaPresentationStateEnteringExternal,
     WKSLinearMediaPresentationStateExternal
 };
 


### PR DESCRIPTION
#### 2cd725727d17c4d27dd52eb8804bfa1cea148b4c
<pre>
[visionOS] Fix race condition between playerIdentifier and videoReceiverTarget with externalPlayback
<a href="https://bugs.webkit.org/show_bug.cgi?id=296407">https://bugs.webkit.org/show_bug.cgi?id=296407</a>
<a href="https://rdar.apple.com/155573225">rdar://155573225</a>

Reviewed by Andy Estes.

Safari sometimes has missing content in the player in Spatial Browsing. This is
due to a race condition between the playerIdentifier being set and the
videoReceiverTarget being set.

The existing flow is this:
1. Safari calls enterExternalPlayback
2. WebPageProxy kicks off the request to set the playerIdentifier
3. WebPageProxy also asks the controls manager VideoPresentationInterface to
   enter external playback.
4. VPI puts LinearMediaPlayer into `external` state and notifies Safari.
5. Safari adds the LMPlayableViewController to its scene.
6. AVKit gets notified from REKit about this newly created videoReceiverEndpoint.
7. AVKit informs LinearMediaPlayer who informs the PlaybackSessionInterface.
8. The interface attempts to retrieve the playerIdentifier from the model
   and pipe it (together with the endpoint) to the WebGPU process.

The problem with the above flow is that Step 2 needs to be completed before
Step 8, but Step 2 has to roundtrip from the UIP to the WCP and back for Step 8
to work (for the playerIdentifier to be set on the model in the UIP).

And Steps 3-7 do not require sending messages to the WCP and waiting for the
result. There is *some* async aspects (Step 5 -&gt; 6 takes some time), so this has
worked for the most part, but *sometimes* it happens quicker than the player id.

In the logs, this issue looks like:
17:12:13.397 PlaybackSessionManagerProxy::setVideoReceiverEndpoint(CF500F83) no player identifier
17:12:13.475 WebContent[1270] HTMLMediaElement::setPlayerIdentifierForVideoElement(CD087073AA0B5226)

To fix this race condition, we move Step 2 into Step 4, and VPI does not call the
handler for Safari until after the player identifier is set. Because this introduces
a non-synchronous flow from when VPI attempts to enter external playback to when it
completes, we add a new state on LinearMediaPlayer:

`enteringExternal`

This is to allow for a &quot;lock&quot; on the state so that other states (like fullscreen)
do not interfere (and the reverse) during this transitional period while VPI is
waiting for the playerIdenfitifer to be set. It also allows cleanup to work if
the video were to be cleaned up during this brief period of time.

* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm:
(WebCore::PlaybackSessionInterfaceIOS::setPlayerIdentifier):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::didSetPlayerIdentifier):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::supportsLinearMediaPlayerChanged):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::enterExternalPlayback):
(WebKit::VideoPresentationInterfaceLMK::exitExternalPlayback):
(WebKit::VideoPresentationInterfaceLMK::cleanupExternalPlayback):
(WebKit::VideoPresentationInterfaceLMK::didSetPlayerIdentifier):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _enterExternalPlaybackForNowPlayingMediaSessionWithEnterCompletionHandler:exitCompletionHandler:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setPlayerIdentifierForVideoElement): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.enterExternalCompletionHandler):
(WKSLinearMediaPlayer.enterExternalPlayback(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.completeEnterExternalPlayback):
(WKSLinearMediaPlayer.exitExternalPlayback(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.enterFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.exitFullscreen(_:(any Error)?) -&gt; Void:)):
(WKSLinearMediaPlayer.presentationStateChanged(_:)):
(WKSLinearMediaPlayer.toggleInlineMode):
(WKSLinearMediaPlayer.willEnterFullscreen):
(WKSLinearMediaPlayer.willExitFullscreen):
(WKSLinearMediaPlayer.enterExternalPresentation(_:(any Error)?) -&gt; Void:)): Deleted.
(WKSLinearMediaPlayer.exitExternalPresentation(_:(any Error)?) -&gt; Void:)): Deleted.
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSLinearMediaPresentationState.description):
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h:

Canonical link: <a href="https://commits.webkit.org/297873@main">https://commits.webkit.org/297873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cb7475dfdd07844f52ddb7c18300bcbd115cb49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86069 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36730 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63044 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94917 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36285 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45545 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->