### PR TITLE
[Navigation API] Fix frame navigation.entries() using wrong history.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation - traverse from a non-contiguous same-origin url assert_equals: expected 1 but got 3
+PASS navigation.activation - traverse from a non-contiguous same-origin url
 

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -186,6 +186,17 @@ Vector<Ref<HistoryItem>> BackForwardController::allItems()
     return historyItems;
 }
 
+Vector<Ref<HistoryItem>> BackForwardController::itemsForFrame(FrameIdentifier frameID)
+{
+    Vector<Ref<HistoryItem>> historyItems;
+    for (Ref item : allItems()) {
+        if (item->frameID() == frameID)
+            historyItems.append(WTFMove(item));
+    }
+
+    return historyItems;
+}
+
 void BackForwardController::close()
 {
     m_client->close();

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -75,6 +75,7 @@ public:
     WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem(std::optional<FrameIdentifier> = std::nullopt);
 
     Vector<Ref<HistoryItem>> allItems();
+    Vector<Ref<HistoryItem>> itemsForFrame(FrameIdentifier);
 
 private:
     Ref<Page> protectedPage() const;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -170,7 +170,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries-for-the-navigation-api
     Vector<Ref<HistoryItem>> items;
-    auto rawEntries = page->checkedBackForward()->allItems();
+    auto rawEntries = page->backForward().itemsForFrame(frame()->frameID());
     auto startingIndex = rawEntries.find(*currentItem);
     if (startingIndex != notFound) {
         Ref startingOrigin = SecurityOrigin::create(Ref { rawEntries[startingIndex] }->url());


### PR DESCRIPTION
#### 9a84ed303598e77c99cd5bb047272511c63501b0
<pre>
[Navigation API] Fix frame navigation.entries() using wrong history.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296403">https://bugs.webkit.org/show_bug.cgi?id=296403</a>
<a href="https://rdar.apple.com/156538817">rdar://156538817</a>

Reviewed by Tim Nguyen.

Frames including main frame were incorrectly using the main frame&apos;s navigation history
instead of their own, causing navigation.entries() to return incorrect results after
cross-origin navigations.

Now all frames only expose their current entry with same-origin filtering.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::itemsForFrame):
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):

Canonical link: <a href="https://commits.webkit.org/297926@main">https://commits.webkit.org/297926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77e6b5d2e4d10fd0e50890e332e1c453c0b16b37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86042 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36701 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19818 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122473 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94889 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94632 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36251 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45511 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42986 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->