### PR TITLE
Suppress scrollend events for scroll snap

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollend-event-scroll-snap-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-scroll-snap-expected.txt
@@ -1,0 +1,8 @@
+
+Test scroll over content
+PASS scrollendEventFired is true
+PASS scrollendEventWasFiredDuringScroll is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-scroll-snap.html
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-scroll-snap.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+        }
+        .scroller {
+            scroll-snap-type: both mandatory;
+            position: absolute;
+            top: 310px;
+            left: 10px;
+            height: 300px;
+            width: 300px;
+            border: 20px solid gray;
+            overflow: scroll;
+        }
+        .content {
+            width: 200%;
+            height: 300%;
+        }
+        .target {
+            width: 200px;
+            height: 800px;
+            scroll-snap-align: start;
+        }
+        #space {
+            width: 2000px;
+            height: 2000px;
+        }
+        
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var scroller;
+        var scrollendEventFired = false;
+        var scrollendEventWasFiredDuringScroll = false;
+
+        async function resetScrollPositions()
+        {
+            window.scrollTo(0, 300);
+            
+            // Wait for scroll events to fire.
+            await UIHelper.ensurePresentationUpdate();
+        }
+        
+        async function testScrollOverContent()
+        {
+            debug('');
+            debug('Test scroll over content');
+            await resetScrollPositions();
+            scrollendEventFired = false;
+            scrollendEventWasFiredDuringScroll = false
+            await UIHelper.startMonitoringWheelEvents();
+
+            scroller.scrollTo({top: 750, behavior: 'smooth'});
+            await UIHelper.waitForScrollCompletion();
+
+            await UIHelper.ensurePresentationUpdate();
+            await UIHelper.renderingUpdate();
+
+            shouldBe('scrollendEventFired', 'true');
+            shouldBe('scrollendEventWasFiredDuringScroll', 'false');
+        }
+
+        async function scrollTest()
+        {
+            await testScrollOverContent();
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            scroller = document.querySelector('.scroller');
+            scroller.addEventListener('scrollend', () => {
+                scrollendEventFired = true;
+            }, false);
+
+            scroller.addEventListener('scroll', () => {
+                if (scrollendEventFired) {
+                    scrollendEventWasFiredDuringScroll = true;
+                }
+            }, false);
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="target" style="left: 0px; top: 0px; background-color: blue;"></div>
+        <div class="target" style="left: 80px; top: 80px; background-color: red;"></div>
+        <div class="target" style="left: 200px; top: 200px; background-color: yellow;"></div>    
+    </div>
+    <div class="overlapper"></div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -254,7 +254,11 @@ TextStream& operator<<(TextStream& ts, const RequestedScrollData& requestedScrol
 
 TextStream& operator<<(TextStream& ts, const ScrollUpdate& update)
 {
-    ts << "updateType: " << update.updateType << " nodeID: " << update.nodeID << " scrollPosition: " << update.scrollPosition << " layoutViewportOrigin: " << update.layoutViewportOrigin << " updateLayerPositionAction: " << update.updateLayerPositionAction;
+    if (update.updateType == ScrollUpdateType::PositionUpdate)
+        ts << "updateType: " << update.updateType << " nodeID: " << update.nodeID << " scrollPosition: " << update.scrollPosition << " layoutViewportOrigin: " << update.layoutViewportOrigin << " updateLayerPositionAction: " << update.updateLayerPositionAction;
+    else
+        ts << "updateType: " << update.updateType << " nodeID: " << update.nodeID;
+
     return ts;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -318,8 +318,10 @@ void ScrollingTreeScrollingNode::willStartAnimatedScroll()
 
 void ScrollingTreeScrollingNode::didStopAnimatedScroll()
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
-    scrollingTree()->scrollingTreeNodeDidStopAnimatedScroll(*this);
+    if (!isScrollSnapInProgress()) {
+        LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
+        scrollingTree()->scrollingTreeNodeDidStopAnimatedScroll(*this);
+    }
 }
 
 void ScrollingTreeScrollingNode::willStartWheelEventScroll()
@@ -329,7 +331,8 @@ void ScrollingTreeScrollingNode::willStartWheelEventScroll()
 
 void ScrollingTreeScrollingNode::didStopWheelEventScroll()
 {
-    scrollingTree()->scrollingTreeNodeDidStopWheelEventScroll(*this);
+    if (!isScrollSnapInProgress())
+        scrollingTree()->scrollingTreeNodeDidStopWheelEventScroll(*this);
 }
 
 bool ScrollingTreeScrollingNode::startAnimatedScrollToPosition(FloatPoint destinationPosition)
@@ -341,6 +344,12 @@ void ScrollingTreeScrollingNode::stopAnimatedScroll()
 {
     if (m_delegate)
         m_delegate->stopAnimatedScroll();
+}
+
+void ScrollingTreeScrollingNode::didStopProgrammaticScroll()
+{
+    if (!isScrollSnapInProgress())
+        scrollingTree()->scrollingTreeNodeDidStopProgrammaticScroll(*this);
 }
 
 void ScrollingTreeScrollingNode::serviceScrollAnimation(MonotonicTime currentTime)
@@ -404,7 +413,7 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
     }
 
     scrollTo(destinationPosition, requestedScrollData.scrollType, requestedScrollData.clamping);
-    scrollingTree()->scrollingTreeNodeDidStopProgrammaticScroll(*this);
+    didStopProgrammaticScroll();
 }
 
 FloatPoint ScrollingTreeScrollingNode::adjustedScrollPosition(const FloatPoint& scrollPosition, ScrollClamping clamping) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -155,6 +155,7 @@ protected:
     void didStopAnimatedScroll();
     void willStartWheelEventScroll();
     void didStopWheelEventScroll();
+    void didStopProgrammaticScroll();
 
     void setScrollAnimationInProgress(bool);
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -178,6 +178,7 @@ void ThreadedScrollingTreeScrollingNodeDelegate::willStartScrollSnapAnimation()
 void ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation()
 {
     protectedScrollingNode()->setScrollSnapInProgress(false);
+    didStopAnimatedScroll();
 }
 
 ScrollExtents ThreadedScrollingTreeScrollingNodeDelegate::scrollExtents() const


### PR DESCRIPTION
#### e4957b99d3ef54a0e9bab240b4ef13071146797c
<pre>
Suppress scrollend events for scroll snap
<a href="https://bugs.webkit.org/show_bug.cgi?id=296404">https://bugs.webkit.org/show_bug.cgi?id=296404</a>
<a href="https://rdar.apple.com/156549223">rdar://156549223</a>

Reviewed by Simon Fraser.

Prevent sending scrollend events if there is an ongoing scroll snap.

* LayoutTests/fast/scrolling/mac/scrollend-event-scroll-snap-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrollend-event-scroll-snap.html: Added.
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::didStopAnimatedScroll):
(WebCore::ScrollingTreeScrollingNode::didStopWheelEventScroll):
(WebCore::ScrollingTreeScrollingNode::didStopProgrammaticScroll):
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::didStopScrollSnapAnimation):

Canonical link: <a href="https://commits.webkit.org/298089@main">https://commits.webkit.org/298089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be50e2a12360eef03d4f5746a3cd99850597b5bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64838 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115956 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86696 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20578 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63940 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123463 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95312 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18255 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46477 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->