### PR TITLE
Fix extension sidebar code

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -105,6 +105,14 @@ inline std::optional<RetainPtr<T>> toOptional(T *maybeNil)
     return std::nullopt;
 }
 
+template<typename T>
+inline std::optional<Ref<T>> toOptional(RefPtr<T> maybeNull)
+{
+    if (maybeNull)
+        return maybeNull.releaseNonNull();
+    return std::nullopt;
+}
+
 inline std::optional<String> toOptional(NSString *maybeNil)
 {
     if (maybeNil)

--- a/Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp
@@ -97,12 +97,12 @@ String WebExtensionPermission::scripting()
     return "scripting"_s;
 }
 
-#if ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 String WebExtensionPermission::sidePanel()
 {
     return "sidePanel"_s;
 }
-#endif // ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 String WebExtensionPermission::storage()
 {

--- a/Source/WebKit/Shared/Extensions/WebExtensionPermission.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPermission.h
@@ -49,9 +49,9 @@ public:
     static String nativeMessaging();
     static String notifications();
     static String scripting();
-#if ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     static String sidePanel();
-#endif // ENABLE(WK_WEB_EXTENSION_SIDEBAR)
+#endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     static String storage();
     static String tabs();
     static String unlimitedStorage();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm
@@ -53,12 +53,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionSidebar, WebExtensionSideba
 
 - (NSString *)title
 {
-    return _webExtensionSidebar->title();
+    return _webExtensionSidebar->title().createNSString().get();
 }
 
 - (CocoaImage *)iconForSize:(CGSize)size
 {
-    return WebKit::toCocoaImage(_webExtensionSidebar->icon(WebCore::FloatSize(size)));
+    return _webExtensionSidebar->icon(WebCore::FloatSize(size))
+        .transform([](Ref<WebCore::Icon> icon) { return WebKit::toCocoaImage(icon.ptr()); })
+        .value_or(nullptr);
 }
 
 - (SidebarViewControllerType *)viewController

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm
@@ -158,7 +158,7 @@ using WTF::WeakPtr;
 
     _webExtensionSidebar = sidebar;
     self.view = sidebar.webView();
-    self.title = extensionContext.value()->extension().displayName();
+    self.title = extensionContext.value()->extension().displayName().createNSString().get();
 
     return self;
 }
@@ -228,17 +228,7 @@ namespace WebKit {
 static NSString * const fallbackPath = @"about:blank";
 static NSString * const fallbackTitle = @"";
 
-static std::optional<String> getDefaultSidebarTitleFromExtension(WebExtension& extension)
-{
-    return toOptional(extension.sidebarTitle());
-}
-
-static std::optional<String> getDefaultSidebarPathFromExtension(WebExtension& extension)
-{
-    return toOptional(extension.sidebarDocumentPath());
-}
-
-static std::optional<RefPtr<JSON::Value>> getDefaultIconsDictFromExtension(WebExtension& extensions)
+static std::optional<Ref<JSON::Object>> getDefaultIconsDictFromExtension(WebExtension& extensions)
 {
     // FIXME: <https://webkit.org/b/276833> implement this
     return std::nullopt;
@@ -258,8 +248,8 @@ WebExtensionSidebar::WebExtensionSidebar(WebExtensionContext& context, std::opti
     // if this is the default action, initialize with default sidebar path / title if present
     if (isDefaultSidebar()) {
         auto& extension = context.extension();
-        m_titleOverride = getDefaultSidebarTitleFromExtension(extension);
-        m_sidebarPathOverride = getDefaultSidebarPathFromExtension(extension);
+        m_titleOverride = extension.sidebarTitle();
+        m_sidebarPathOverride = extension.sidebarDocumentPath();
         m_iconsOverride = getDefaultIconsDictFromExtension(extension);
         m_isEnabled = true;
     }
@@ -309,37 +299,40 @@ void WebExtensionSidebar::propertiesDidChange()
         notifyDelegateOfPropertyUpdate();
 }
 
-RefPtr<WebCore::Icon> WebExtensionSidebar::icon(WebCore::FloatSize size)
+std::optional<Ref<WebCore::Icon>> WebExtensionSidebar::icon(WebCore::FloatSize size)
 {
     if (!extensionContext())
-        return nil;
+        return std::nullopt;
 
     auto& context = extensionContext().value().get();
     return m_iconsOverride
-        .and_then([&](RefPtr<JSON::Value> icons) -> std::optional<RefPtr<WebCore::Icon>> {
-            return toOptional(context.extension().bestIcon(icons, size, [](NSError *error) { }));
+        .and_then([&](Ref<JSON::Object> icons) -> std::optional<Ref<WebCore::Icon>> {
+            return toOptional(context.extension().bestIcon(icons.ptr(), size, [](Ref<API::Error> error) { }));
         })
-        .or_else([&] -> std::optional<RefPtr<WebCore::Icon>> {
-            return parent().transform([&](auto const& parent) { return parent.get().icon(size); });
+        .or_else([&] -> std::optional<Ref<WebCore::Icon>> {
+            return parent().and_then([&](auto const& parent) {
+                return parent.get().icon(size);
+            });
         })
         // using .or_else(..).value() is more efficient than value_or, since value_or will evaluate its argument
         // regardless of whether or not it's used. by switching to or_else(..).value() we instead lazily evaluate
         // the fallback value
-        .or_else([&] { return std::optional { context.extension().actionIcon(size) }; })
-        .value();
+        .or_else([&] {
+            return toOptional(context.extension().actionIcon(size));
+        });
 }
 
-void WebExtensionSidebar::setIconsDictionary(RefPtr<JSON::Object> icons)
+void WebExtensionSidebar::setIconsDictionary(std::optional<Ref<JSON::Object>> icons)
 {
-    if (!icons || !icons.count) {
+    if (!icons || !icons.value()->size()) {
         m_iconsOverride = std::nullopt;
         return;
     }
 
-    if (m_iconsOverride && m_iconsOverride.value() == icons)
+    if (m_iconsOverride && m_iconsOverride.value() == icons.value())
         return;
 
-    m_iconsOverride = icons;
+    m_iconsOverride = WTFMove(icons);
     propertiesDidChange();
 }
 
@@ -353,7 +346,7 @@ String WebExtensionSidebar::title() const
 void WebExtensionSidebar::setTitle(std::optional<String> titleOverride)
 {
     if (!titleOverride && isDefaultSidebar() && extensionContext())
-        m_titleOverride = getDefaultSidebarTitleFromExtension(extensionContext().value()->extension());
+        m_titleOverride = extensionContext().value()->extension().sidebarTitle();
     else
         m_titleOverride = titleOverride;
 
@@ -383,7 +376,7 @@ String WebExtensionSidebar::sidebarPath() const
 void WebExtensionSidebar::setSidebarPath(std::optional<String> sidebarPath)
 {
     if (!sidebarPath && isDefaultSidebar() && extensionContext())
-        m_sidebarPathOverride = getDefaultSidebarPathFromExtension(extensionContext().value()->extension());
+        m_sidebarPathOverride = extensionContext().value()->extension().sidebarDocumentPath();
     else
         m_sidebarPathOverride = sidebarPath;
 
@@ -482,7 +475,7 @@ WKWebView *WebExtensionSidebar::webView()
     auto *webViewConfiguration = context->webViewConfiguration(WebExtensionContext::WebViewPurpose::Sidebar);
     m_webView = [[_WKWebExtensionSidebarWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration webExtensionSidebar:*this];
     m_webView.get().inspectable = context->isInspectable();
-    m_webView.get().accessibilityLabel = title();
+    m_webView.get().accessibilityLabel = title().createNSString().get();
     m_webViewDelegate = [[_WKWebExtensionSidebarWebViewDelegate alloc] initWithWebExtensionSidebar:*this];
     m_webView.get().navigationDelegate = m_webViewDelegate.get();
 
@@ -545,7 +538,7 @@ void WebExtensionSidebar::reloadWebView()
         return;
 
     auto url = URL { extensionContext().value()->baseURL(), sidebarPath() };
-    [m_webView loadRequest:[NSURLRequest requestWithURL:url]];
+    [m_webView loadRequest:[NSURLRequest requestWithURL:url.createNSURL().get()]];
 }
 
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1533,13 +1533,13 @@ RefPtr<WebCore::Icon> WebExtension::sidebarIcon(WebCore::FloatSize idealSize)
     return nullptr;
 }
 
-const String& WebExtension::sidebarDocumentPath()
+const std::optional<String>& WebExtension::sidebarDocumentPath()
 {
     populateSidebarPropertiesIfNeeded();
     return m_sidebarDocumentPath;
 }
 
-const String& WebExtension::sidebarTitle()
+const std::optional<String>& WebExtension::sidebarTitle()
 {
     populateSidebarPropertiesIfNeeded();
     return m_sidebarTitle;
@@ -1561,27 +1561,27 @@ void WebExtension::populateSidebarPropertiesIfNeeded()
     // sidebarAction documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action
 
     if (RefPtr sidebarActionObject = manifestObject->getObject(sidebarActionManifestKey)) {
-        populateSidebarActionProperties(sidebarActionObject);
+        populateSidebarActionProperties(*sidebarActionObject);
         return;
     }
 
     if (RefPtr sidePanelObject = manifestObject->getObject(sidePanelManifestKey))
-        populateSidePanelProperties(sidePanelObject);
+        populateSidePanelProperties(*sidePanelObject);
 }
 
 void WebExtension::populateSidebarActionProperties(const JSON::Object& sidebarActionObject)
 {
     // FIXME: <https://webkit.org/b/276833> implement sidebar icon parsing
-    m_sidebarIconsCache = nullptr;
+    m_sidebarIconsCache = std::nullopt;
     m_sidebarTitle = sidebarActionObject.getString(sidebarActionTitleManifestKey);
     m_sidebarDocumentPath = sidebarActionObject.getString(sidebarActionPathManifestKey);
 }
 
 void WebExtension::populateSidePanelProperties(const JSON::Object& sidePanelObject)
 {
-    // Since sidePanel cannot set a default title or icon from the manifest, setting these to null here is intentional.
-    m_sidebarIconsCache = nullptr;
-    m_sidebarTitle = nullString();
+    // Since sidePanel cannot set a default title or icon from the manifest, setting these to nullopt here is intentional.
+    m_sidebarIconsCache = std::nullopt;
+    m_sidebarTitle = std::nullopt;
     m_sidebarDocumentPath = sidePanelObject.getString(sidePanelPathManifestKey);
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -273,8 +273,8 @@ public:
     bool hasSidePanel();
     bool hasAnySidebar();
     RefPtr<WebCore::Icon> sidebarIcon(WebCore::FloatSize idealSize);
-    const Sring& sidebarDocumentPath();
-    const String& sidebarTitle();
+    const std::optional<String>& sidebarDocumentPath();
+    const std::optional<String>& sidebarTitle();
 #endif
 
     RefPtr<WebCore::Icon> iconForPath(const String&, RefPtr<API::Error>&, WebCore::FloatSize sizeForResizing = { }, std::optional<double> displayScale = std::nullopt);
@@ -375,8 +375,8 @@ private:
     void populateExternallyConnectableIfNeeded();
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     void populateSidebarPropertiesIfNeeded();
-    void populateSidebarActionProperties(RetainPtr<NSDictionary>);
-    void populateSidePanelProperties(RetainPtr<NSDictionary>);
+    void populateSidebarActionProperties(const JSON::Object&);
+    void populateSidePanelProperties(const JSON::Object&);
 #endif
 
     URL resourceFileURLForPath(const String&);
@@ -427,9 +427,9 @@ private:
     String m_actionPopupPath;
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-    IconsCache m_sidebarIconsCache;
-    String m_sidebarDocumentPath;
-    String m_sidebarTitle;
+    std::optional<IconsCache> m_sidebarIconsCache;
+    std::optional<String> m_sidebarDocumentPath;
+    std::optional<String> m_sidebarTitle;
 #endif
 
     String m_contentSecurityPolicy;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h
@@ -38,6 +38,7 @@ using SidebarViewControllerType = NSViewController;
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
 #include "APIObject.h"
+#include <WebCore/Icon.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -81,8 +82,8 @@ public:
     void propertiesDidChange();
 
     /// `icon()` will return the overridden icon of this sidebar, or the icon of the first parent sidebar in which the icon is set
-    RefPtr<WebCore::Icon> icon(WebCore::FloatSize);
-    void setIconsDictionary(RefPtr<JSON::Object>);
+    std::optional<Ref<WebCore::Icon>> icon(WebCore::FloatSize);
+    void setIconsDictionary(std::optional<Ref<JSON::Object>>);
 
     /// `title()` will return the overridden title of this sidebar, or the title of the first parent sidebar in which the title is set
     String title() const;
@@ -130,7 +131,7 @@ private:
 
     void reloadWebView();
 
-    std::optional<RefPtr<JSON::Object>> m_iconsOverride;
+    std::optional<Ref<JSON::Object>> m_iconsOverride;
     std::optional<String> m_titleOverride;
     std::optional<String> m_sidebarPathOverride;
     std::optional<bool> m_isEnabled;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
@@ -37,6 +37,7 @@
 #import "WebExtensionAPISidebarAction.h"
 #import "WebExtensionActionClickBehavior.h"
 #import "WebExtensionContextMessages.h"
+#import "WebExtensionPermission.h"
 #import "WebProcess.h"
 
 namespace WebKit {
@@ -45,37 +46,41 @@ static NSString * const tabIdKey = @"tabId";
 static NSString * const windowIdKey = @"windowId";
 static NSString * const actionClickBehaviorKey = @"openPanelOnActionClick";
 
-static ParseResult parseTabIdentifier(NSDictionary *options)
+static Expected<std::optional<WebExtensionTabIdentifier>, WebExtensionError> parseTabIdentifier(NSDictionary *options)
 {
     id maybeTabId = [options objectForKey:tabIdKey];
 
     if (!maybeTabId || [maybeTabId isKindOfClass:NSNull.class])
-        return std::monostate();
+        return std::optional<WebExtensionTabIdentifier> { };
 
     if ([maybeTabId isKindOfClass:NSNumber.class]) {
         auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
-        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nullString(), @"options", @"'tabId' is invalid"));
+        if (!isValid(tabId))
+            return makeUnexpected(toErrorString(nullString(), @"options", @"'tabId' is invalid"));
+        return std::optional(tabId.value());
     }
 
-    return toErrorString(nullString(), @"options", @"'tabId' must be a number");
+    return makeUnexpected(toErrorString(nullString(), @"options", @"'tabId' must be a number"));
 }
 
-static ParseResult parseWindowIdentifier(NSDictionary *options)
+static Expected<std::optional<WebExtensionWindowIdentifier>, WebExtensionError> parseWindowIdentifier(NSDictionary *options)
 {
     id maybeWindowId = [options objectForKey:windowIdKey];
 
     if (!maybeWindowId || [maybeWindowId isKindOfClass:NSNull.class])
-        return std::monostate();
+        return std::optional<WebExtensionWindowIdentifier> { };
 
     if ([maybeWindowId isKindOfClass:NSNumber.class]) {
         auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
-        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nullString(), @"options", @"'windowId' is invalid"));
+        if (!isValid(windowId))
+            return makeUnexpected(toErrorString(nullString(), @"options", @"'windowId' is invalid"));
+        return std::optional(windowId.value());
     }
 
-    return toErrorString(nullString(), @"options", @"'windowId' must be a number");
+    return makeUnexpected(toErrorString(nullString(), @"options", @"'windowId' must be a number"));
 }
 
-static Variant<WebExtensionActionClickBehavior, SidebarError> parseActionClickBehavior(NSDictionary *behavior)
+static Expected<WebExtensionActionClickBehavior, WebExtensionError> parseActionClickBehavior(NSDictionary *behavior)
 {
     static NSDictionary<NSString *, id> *types = @{
         actionClickBehaviorKey: @YES.class,
@@ -83,7 +88,7 @@ static Variant<WebExtensionActionClickBehavior, SidebarError> parseActionClickBe
 
     NSString *exceptionString;
     if (!validateDictionary(behavior, @"behavior", nil, types, &exceptionString))
-        return exceptionString;
+        return makeUnexpected(exceptionString);
 
     NSNumber *actionClickBehavior = behavior[actionClickBehaviorKey];
     if (actionClickBehavior.boolValue)
@@ -96,7 +101,7 @@ static NSDictionary<NSString *, id> *serializeSidebarParameters(WebExtensionSide
     NSMutableDictionary *serializedParameters = [NSMutableDictionary new];
 
     serializedParameters[@"enabled"] = @(parameters.enabled);
-    serializedParameters[@"path"] = parameters.panelPath;
+    serializedParameters[@"path"] = parameters.panelPath.createNSString().get();
 
     if (parameters.tabIdentifier)
         serializedParameters[@"tabId"] = @(toWebAPI(parameters.tabIdentifier.value()));
@@ -116,8 +121,8 @@ static Expected<WebExtensionSidebarParameters, WebExtensionError> deserializeSid
 
     auto tabIdentifierResult = parseTabIdentifier(serializedParameters);
     if (NSString *error = indicatesError(tabIdentifierResult).get())
-        return toWebExtensionError(nil, @"details", error);
-    parameters.tabIdentifier = toOptional<WebExtensionTabIdentifier>(tabIdentifierResult);
+        return toWebExtensionError(nullString(), @"details", error);
+    parameters.tabIdentifier = WTFMove(tabIdentifierResult.value());
 
     return parameters;
 }
@@ -128,12 +133,12 @@ void WebExtensionAPISidePanel::getOptions(NSDictionary *options, Ref<WebExtensio
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto tabId = toOptional<WebExtensionTabIdentifier>(result);
+    const auto tabId = WTFMove(result.value());
 
     WebProcess::singleton()
         .sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetOptions(std::nullopt, tabId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionSidebarParameters, WebExtensionError>&& result) {
             if (!result) {
-                callback->reportError(result.error());
+                callback->reportError(result.error().createNSString().get());
                 return;
             }
 
@@ -145,7 +150,7 @@ void WebExtensionAPISidePanel::setOptions(NSDictionary *options, Ref<WebExtensio
 {
     auto result = deserializeSidebarParameters(options);
     if (!result) {
-        *outExceptionString = result.error();
+        *outExceptionString = result.error().createNSString().get();
         return;
     }
 
@@ -153,7 +158,7 @@ void WebExtensionAPISidePanel::setOptions(NSDictionary *options, Ref<WebExtensio
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(std::nullopt, result->tabIdentifier, panelPath, result->enabled), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -165,7 +170,7 @@ void WebExtensionAPISidePanel::getPanelBehavior(Ref<WebExtensionCallbackHandler>
 {
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetActionClickBehavior(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionActionClickBehavior, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -182,11 +187,11 @@ void WebExtensionAPISidePanel::setPanelBehavior(NSDictionary *behavior, Ref<WebE
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    auto actionClickBehavior = std::get<WebExtensionActionClickBehavior>(result);
+    auto actionClickBehavior = WTFMove(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetActionClickBehavior(actionClickBehavior), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -197,8 +202,8 @@ void WebExtensionAPISidePanel::setPanelBehavior(NSDictionary *behavior, Ref<WebE
 void WebExtensionAPISidePanel::open(NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        // In chrome, this error manifests as a rejected promise, so match this behavior
-        callback->reportError(toErrorString(@"sidePanel.open()", nil, @"it must be called during a user gesture"));
+        // In Chrome, this error manifests as a rejected promise, so match this behavior.
+        callback->reportError(toErrorString(@"sidePanel.open()", nullString(), @"it must be called during a user gesture").createNSString().get());
         return;
     }
 
@@ -206,22 +211,22 @@ void WebExtensionAPISidePanel::open(NSDictionary *options, Ref<WebExtensionCallb
     if ((*outExceptionString = indicatesError(tabResult).get()))
         return;
 
-    auto tabId = toOptional<WebExtensionTabIdentifier>(tabResult);
+    auto tabId = WTFMove(tabResult.value());
 
     auto windowResult = parseWindowIdentifier(options);
     if ((*outExceptionString = indicatesError(windowResult).get()))
         return;
 
-    auto windowId = toOptional<WebExtensionWindowIdentifier>(windowResult);
+    auto windowId = WTFMove(windowResult.value());
 
     if (!windowId && !tabId) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify at least one of 'tabId' or 'windowId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify at least one of 'tabId' or 'windowId'").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarOpen(windowId, tabId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -52,54 +52,59 @@ static ParseResult parseSidebarActionDetails(NSDictionary *details)
     id maybeWindowId = [details objectForKey:windowIdKey];
 
     if (maybeTabId && maybeWindowId)
-        return toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowId'");
+        return makeUnexpected(toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowId'"));
 
     if (maybeTabId && ![maybeTabId isKindOfClass:NSNumber.class])
-        return toErrorString(nullString(), @"details", @"'tabId' must be a number");
+        return makeUnexpected(toErrorString(nullString(), @"details", @"'tabId' must be a number"));
 
     if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class])
-        return toErrorString(nullString(), @"details", @"'windowId' must be a number");
+        return makeUnexpected(toErrorString(nullString(), @"details", @"'windowId' must be a number"));
 
     if (maybeTabId) {
         auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
-        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nullString(), @"details", @"'tabId' is invalid"));
+        return isValid(tabId) ? ParseResult(tabId.value()) : makeUnexpected(toErrorString(nullString(), @"details", @"'tabId' is invalid"));
     }
 
     if (maybeWindowId) {
         auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
-        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nullString(), @"details", @"'windowId' is invalid"));
+        return isValid(windowId) ? ParseResult(windowId.value()) : makeUnexpected(toErrorString(nullString(), @"details", @"'windowId' is invalid"));
     }
 
-    return std::monostate();
+    return ParseResult(std::nullopt);
 }
 
-static Variant<std::monostate, String, SidebarError> parseDetailsStringFromKey(NSDictionary *dict, NSString *key, bool required = false)
+static Expected<std::optional<String>, WebExtensionError> parseDetailsStringFromKey(NSDictionary *dict, NSString *key, bool required = false)
 {
     RetainPtr<id> maybeValue = [dict objectForKey:key];
     if (!maybeValue && required)
-        return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+        return makeUnexpected(toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]));
 
     if ([maybeValue isKindOfClass:NSNull.class]) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' is required", key]).get()) };
-        return std::monostate();
+            return makeUnexpected(toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]));
+        return std::optional<String> { };
     }
 
     RetainPtr nsStringValue = dynamic_objc_cast<NSString>(maybeValue.get());
-    if (!nsStringValue]) {
+    if (!nsStringValue) {
         if (required)
-            return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string'", key]).get()) };
-        return SidebarError { toErrorString(nullString(), @"details", adoptNS([[NSString alloc] initWithFormat:@"'%@' must be of type 'string' or 'null'", key]).get()) };
+            return makeUnexpected(toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string'", key]));
+        return makeUnexpected(toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]));
     }
 
-    return String(nsStringValue.get());
+    return std::optional<String> { String(nsStringValue.get()) };
 }
 
 template<typename VariantType>
-static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>> getIdentifiers(VariantType& variant)
+static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<WebExtensionTabIdentifier>> getIdentifiers(std::optional<VariantType>& maybeVariant)
 {
     static_assert(isVariantMember<WebExtensionWindowIdentifier, VariantType>::value);
     static_assert(isVariantMember<WebExtensionTabIdentifier, VariantType>::value);
+
+    if (!maybeVariant.has_value())
+        return std::make_tuple(std::nullopt, std::nullopt);
+
+    auto variant = maybeVariant.value();
 
     return std::make_tuple(WTFMove(toOptional<WebExtensionWindowIdentifier>(variant)), WTFMove(toOptional<WebExtensionTabIdentifier>(variant)));
 }
@@ -107,13 +112,13 @@ static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<Web
 void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callback , NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it must be called during a user gesture").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarOpen(std::nullopt, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -124,13 +129,13 @@ void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callb
 void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it must be called during a user gesture").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarClose(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -141,13 +146,13 @@ void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& call
 void WebExtensionAPISidebarAction::toggle(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"it must be called during a user gesture").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarToggle(), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -160,19 +165,19 @@ void WebExtensionAPISidebarAction::isOpen(NSDictionary *details, Ref<WebExtensio
     // we don't use parseSidebarActionDetails here because we only need windowId for isOpen
     id maybeWindowId = details[windowIdKey];
     if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class]) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' must be a number");
+        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' must be a number").createNSString().get();
         return;
     }
 
     std::optional<WebExtensionWindowIdentifier> windowId = maybeWindowId ? toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue) : std::nullopt;
     if (windowId && !isValid(windowId)) {
-        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' is invalid");
+        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' is invalid").createNSString().get();
         return;
     }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarIsOpen(windowId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<bool, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -187,15 +192,15 @@ void WebExtensionAPISidebarAction::getPanel(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetOptions(windowId, tabId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionSidebarParameters, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value().panelPath);
+        callback->call(result.value().panelPath.createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -205,17 +210,17 @@ void WebExtensionAPISidebarAction::setPanel(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(panelResult).get()))
         return;
 
-    const auto panelPath = toOptional<String>(panelResult);
+    const auto panelPath = panelResult.value();
 
     auto result = parseSidebarActionDetails(details);
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetOptions(windowId, tabId, panelPath, std::nullopt), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
@@ -229,15 +234,15 @@ void WebExtensionAPISidebarAction::getTitle(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarGetTitle(windowId, tabId), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 
-        callback->call(result.value());
+        callback->call(result.value().createNSString().get());
     }, extensionContext().identifier());
 }
 
@@ -247,17 +252,17 @@ void WebExtensionAPISidebarAction::setTitle(NSDictionary *details, Ref<WebExtens
     if ((*outExceptionString = indicatesError(titleResult).get()))
         return;
 
-    const auto title = toOptional<String>(titleResult);
+    const auto title = WTFMove(titleResult.value());
 
     auto result = parseSidebarActionDetails(details);
     if ((*outExceptionString = indicatesError(result).get()))
         return;
 
-    const auto [windowId, tabId] = getIdentifiers(result);
+    const auto [windowId, tabId] = getIdentifiers(result.value());
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::SidebarSetTitle(windowId, tabId, title), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {
-            callback->reportError(result.error());
+            callback->reportError(result.error().createNSString().get());
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h
@@ -35,9 +35,7 @@ OBJC_CLASS NSString;
 
 namespace WebKit {
 
-using SidebarError = RetainPtr<NSString>;
-// In this variant, `monostate` indicates that we have neither a window or tab identifier, but no error
-using ParseResult = Variant<std::monostate, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, SidebarError>;
+using ParseResult = Expected<std::optional<Variant<WebExtensionTabIdentifier, WebExtensionWindowIdentifier>>, WebExtensionError>;
 
 template<typename T, typename VARIANT_T>
 struct isVariantMember;
@@ -52,14 +50,31 @@ std::optional<OptType> toOptional(Variant<Types...>& variant)
     return std::nullopt;
 }
 
-template<typename VariantType>
-SidebarError indicatesError(const VariantType& variant)
+template<typename OptType, typename ErrorType, typename... Types>
+std::optional<OptType> toOptional(Expected<Variant<Types...>, ErrorType>& expected)
 {
-    static_assert(isVariantMember<SidebarError, VariantType>::value);
+    if (!expected.has_value())
+        return std::nullopt;
+    auto variant = WTFMove(expected.value());
+    if (std::holds_alternative<OptType>(variant))
+        return WTFMove(std::get<OptType>(variant));
+    return std::nullopt;
+}
 
-    if (std::holds_alternative<SidebarError>(variant))
-        return WTFMove(std::get<SidebarError>(variant));
-    return nil;
+template<typename OptType, typename ErrorType>
+std::optional<OptType> toOptional(Expected<OptType, ErrorType>& expected)
+{
+    if (!expected.has_value())
+        return std::nullopt;
+    return WTFMove(expected.value());
+}
+
+template<typename SuccessType>
+RetainPtr<NSString> indicatesError(const Expected<SuccessType, WebExtensionError>& result)
+{
+    if (result.has_value())
+        return nil;
+    return WTFMove(result.error().createNSString());
 }
 
 class WebExtensionAPISidebarAction : public WebExtensionAPIObject, public JSWebExtensionWrappable {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm
@@ -132,7 +132,7 @@ class WKWebExtensionAPISidebar : public testing::Test {
 protected:
     WKWebExtensionAPISidebar()
     {
-        sidebarConfig = WKWebExtensionControllerConfiguration.nonPersistantConfiguration;
+        sidebarConfig = WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
         if (!sidebarConfig.webViewConfiguration)
             sidebarConfig.webViewConfiguration = [[WKWebViewConfiguration alloc] init];
 


### PR DESCRIPTION
#### 55bc92f4fd0a7b3173aaa39723fedc12bd6216f6
<pre>
Fix extension sidebar code
<a href="https://rdar.apple.com/156534472">rdar://156534472</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296398">https://bugs.webkit.org/show_bug.cgi?id=296398</a>

Reviewed by NOBODY (OOPS!).

This patch fixes a myriad of compiler errors which prevent Webkit from building with
ENABLE_WK_WEB_EXTENSIONS_SIDEBAR turned on. It also somewhat simplifies some of the parsing logic in
WebExtensionAPISidePanelCocoa.mm and WebExtensionAPISidebarActionCocoa.mm.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::toOptional): Add implementation of RefPtr&lt;T&gt; -&gt; std::optional&lt;Ref&lt;T&gt;&gt;
* Source/WebKit/Shared/Extensions/WebExtensionPermission.cpp: Fix feature guard
* Source/WebKit/Shared/Extensions/WebExtensionPermission.h: Fix feature guard
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebar.mm:
(-[_WKWebExtensionSidebar title]): Convert String to NSString
(-[_WKWebExtensionSidebar iconForSize:]): Handle WebExtensionSidebar::icon returning an optional
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionSidebarCocoa.mm:
(-[_WKWebExtensionSidebarViewController initWithWebExtensionSidebar:]): Convert String to NSString
(WebKit::getDefaultIconsDictFromExtension): Fix return type
(WebKit::WebExtensionSidebar::WebExtensionSidebar): Remove helper functions, directly get title and
document path since these are now returned as optionals.
(WebKit::WebExtensionSidebar::icon): Return optional&lt;Ref&gt; rather than nullable RefPtr, fix types
(WebKit::WebExtensionSidebar::setIconsDictionary): Take optional&lt;Ref&gt; rather than nullable RefPtr
(WebKit::WebExtensionSidebar::setTitle): Remove helper function, directly get optional title
(WebKit::WebExtensionSidebar::setSidebarPath): Remove helper function, directly get optional path
(WebKit::WebExtensionSidebar::webView): Convert String to NSString for accessibility label
(WebKit::WebExtensionSidebar::reloadWebView): Convert URL to NSURL for loadRequest
(WebKit::getDefaultSidebarTitleFromExtension): Deleted.
(WebKit::getDefaultSidebarPathFromExtension): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::sidebarDocumentPath): Return optional&lt;String&gt; rather than nullable String
(WebKit::WebExtension::sidebarTitle): Return optional&lt;String&gt; rather than nullable String
(WebKit::WebExtension::populateSidebarPropertiesIfNeeded): Dereference sidebarActionObject and
sidePanelObject to pass reference directly
(WebKit::WebExtension::populateSidebarActionProperties): Use nullopt instead of null
(WebKit::WebExtension::populateSidePanelProperties): Use nullopt instead of null
* Source/WebKit/UIProcess/Extensions/WebExtension.h: Fix types, make many things optional
instead of nullable.
* Source/WebKit/UIProcess/Extensions/WebExtensionSidebar.h: Fix types, make many things optional
instead of nullable.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::parseTabIdentifier): Simplify parsing, remove SidebarError, use Expected&lt;optional&lt;...&gt;, ...&gt;
instead of Variant.
(WebKit::parseWindowIdentifier): Simplify parsing, remove SidebarError, use Expected&lt;optional&lt;...&gt;, ...&gt;
instead of Variant.
(WebKit::parseActionClickBehavior): Miscellaneous type fixes.
(WebKit::serializeSidebarParameters): Miscellaneous type fixes.
(WebKit::deserializeSidebarParameters): Miscellaneous type fixes.
(WebKit::WebExtensionAPISidePanel::getOptions): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::setOptions): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::getPanelBehavior): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::setPanelBehavior): Convert String to NSString.
(WebKit::WebExtensionAPISidePanel::open): Convert String to NSString, remove uses of toOptional.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseSidebarActionDetails): Use Expected instead of Variant, miscellaneous fixes.
(WebKit::parseDetailsStringFromKey): Use Expected instead of Variant, miscellaneous fixes.
(WebKit::getIdentifiers): Take parameter which is an optional variant instead of just variant
(WebKit::WebExtensionAPISidebarAction::open): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::close): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::toggle): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::isOpen): Convert String to NSString.
(WebKit::WebExtensionAPISidebarAction::getPanel): Convert String to NSString, use Expected instead
of Variant.
(WebKit::WebExtensionAPISidebarAction::setPanel): Convert String to NSString, use Expected instead
of Variant.
(WebKit::WebExtensionAPISidebarAction::getTitle): Convert String to NSString, use Expected instead
of Variant.
(WebKit::WebExtensionAPISidebarAction::setTitle): Convert String to NSString, use Expected instead
of Variant.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPISidebarAction.h:
(WebKit::toOptional): Add implementations of toOptional taking Expected&lt;Variant, ...&gt; and Expected
(WebKit::indicatesError): Utility function which checks if an Expected contains an error, and
returns it as a RetainPtr&lt;NSString&gt; if so.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPISidebar.mm:
(TestWebKitAPI::WKWebExtensionAPISidebar::WKWebExtensionAPISidebar): Fix typo
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55bc92f4fd0a7b3173aaa39723fedc12bd6216f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63633 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86041 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36699 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101686 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66352 "Found 140 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19817 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94631 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17576 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36250 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40011 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45510 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->