### PR TITLE
Web Extension

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2074,6 +2074,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionBookmark {
+    header "_WKWebExtensionBookmarks.h"
+    export *
+  }
+
   explicit module WKWebExtensionCommandPrivate {
     header "WKWebExtensionCommandPrivate.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2980,6 +2980,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionBookmark {
+    header "_WKWebExtensionBookmarks.h"
+    export *
+  }
+  
   explicit module WKWebExtensionCommandPrivate {
     header "WKWebExtensionCommandPrivate.h"
     export *

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -26,6 +26,9 @@
 #import <WebKit/WKWebExtensionControllerDelegate.h>
 
 @class _WKWebExtensionSidebar;
+@class _WKWebExtensionBookmark;
+@protocol _WKWebExtensionBookmark;
+
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
@@ -111,6 +114,33 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller didUpdateSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context;
 
+/*!
+ @abstract Called when the root-level bookmarks are needed to begin building the bookmark tree.
+ @param controller The web extension controller initiating the request.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes an array of objects conforming to
+ the `_WKWebExtensionBookmark` protocol and an optional error argument.
+ @discussion This method is the entry point for the `bookmarks.getTree` API. The delegate is responsible for
+ translating its native bookmark objects into objects that conform to the `_WKWebExtensionBookmark` protocol and
+ represent the top-level nodes of the bookmark hierarchy.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller getBookmarksForExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> * _Nullable, NSError * _Nullable))completionHandler;
+
+/*!
+ @abstract Called when a new bookmark or folder is requested to be created.
+ @param controller The web extension controller initiating the request.
+ @param parentId The string identifier of the parent folder. Can be nil or "0" for a top-level item.
+ @param index The desired index for the new bookmark within its parent. Can be nil.
+ @param url The URL for the new bookmark. Should be nil if creating a folder.
+ @param title The title for the new bookmark or folder.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes the newly created bookmark node
+ (as an object conforming to the `_WKWebExtensionBookmark` protocol) and an optional error argument.
+ @discussion This method is the entry point for the `bookmarks.create` API. The delegate is responsible for
+ taking the 4 parameters, creating the bookmark in its data store, and returning a new object that
+ represents the created item.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller createBookmarkWithParentIdentifier:(nullable NSString *)parentId index:(nullable NSNumber *)index url:(nullable NSString *)url title:(NSString * _Nonnull)title forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> * _Nullable, NSError * _Nullable))completionHandler;
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
@@ -1,0 +1,79 @@
+// Copyright © 2025  All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+
+@class WKWebExtensionContext;
+@protocol _WKWebExtensionBookmark;
+
+WK_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+/*!
+ @abstract Constants used by ``_WKWebExtensionBookmark`` to indicate the type of a bookmark node.
+ @constant _WKWebExtensionBookmarkTypeBookmark  Indicates the node is a bookmark with a URL.
+ @constant _WKWebExtensionBookmarkTypeFolder  Indicates the node is a folder that can contain other bookmarks or folders.
+ @constant _WKWebExtensionBookmarkTypeSeparator  Indicates the node is a separator.
+ */
+typedef NS_ENUM(NSInteger, _WKWebExtensionBookmarkType) {
+    _WKWebExtensionBookmarkTypeBookmark,
+    _WKWebExtensionBookmarkTypeFolder,
+} NS_SWIFT_NAME(_WKWebExtension.BookmarkType) WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
+
+/*! @abstract A class conforming to the ``_WKWebExtensionBookmark`` protocol represents a single bookmark node (a bookmark, folder, or separator) to web extensions. */
+WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4)) WK_SWIFT_UI_ACTOR
+@protocol _WKWebExtensionBookmark <NSObject>
+@optional
+
+/*!
+ @abstract Called when the unique identifier for the bookmark node is needed.
+ @param context The context in which the web extension is running.
+ @return A string uniquely identifying this bookmark node.
+ */
+- (NSString *)identifierForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(identifier(for:));
+
+/*!
+ @abstract Called when the identifier of the parent folder is needed.
+ @param context The context in which the web extension is running.
+ @return The unique identifier of the parent folder, or `nil` if the node is at the root level.
+ */
+- (nullable NSString *)parentIdentifierForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(parentIdentifier(for:));
+
+/*!
+ @abstract Called when the title of the bookmark node is needed.
+ @param context The context in which the web extension is running.
+ @return The user-visible title of the bookmark or folder.
+ */
+- (nullable NSString *)titleForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(title(for:));
+
+/*!
+ @abstract Called when the URL of the bookmark is needed.
+ @param context The context in which the web extension is running.
+ @return The URL the bookmark points to. This should be `nil` for folders.
+ */
+- (nullable NSString *)urlForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(url(for:));
+
+/*!
+ @abstract Called when the type of the bookmark node is needed.
+ @param context The context in which the web extension is running.
+ @return The type of the bookmark node.
+ */
+- (_WKWebExtensionBookmarkType)bookmarkTypeForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(bookmarkType(for:));
+
+/*!
+ @abstract Called when the children of a folder are needed.
+ @param context The context in which the web extension is running.
+ @return An array of bookmark nodes contained within this folder. Should be `nil` if the node is not a folder.
+ */
+- (nullable NSArray<id <_WKWebExtensionBookmark>> *)childrenForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(children(for:));
+
+/*!
+ @abstract Called when the zero-based index of this node within its parent folder is needed.
+ @param context The context in which the web extension is running.
+ @return The index of the bookmark node.
+ */
+- (NSInteger)indexForWebExtensionContext:(WKWebExtensionContext *)context NS_SWIFT_NAME(index(for:));
+
+@end
+
+WK_HEADER_AUDIT_END(nullability, sendability)
+

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
@@ -66,7 +66,44 @@ static Vector<WebExtensionBookmarksParameters> createParametersFromProtocolObjec
     return parameters;
 }
 
+static id<_WKWebExtensionBookmark> findBookmarkNodeInTree(NSArray<id<_WKWebExtensionBookmark>> *nodes, const String& targetId, WKWebExtensionContext *context)
+{
+    for (id<_WKWebExtensionBookmark> node in nodes) {
+        if (String([node identifierForWebExtensionContext:context]) == targetId)
+            return node;
 
+        if (NSArray *children = [node childrenForWebExtensionContext:context]) {
+            id<_WKWebExtensionBookmark> foundInChild = findBookmarkNodeInTree(children, targetId, context);
+            if (foundInChild)
+                return foundInChild;
+        }
+    }
+
+    return nil;
+}
+
+static Vector<WebExtensionBookmarksParameters> createShallowParametersFromProtocolObjects(NSArray<id<_WKWebExtensionBookmark>> *bookmarkNodes, WKWebExtensionContext *context)
+{
+    if (!bookmarkNodes)
+        return { };
+
+    Vector<WebExtensionBookmarksParameters> parameters;
+    parameters.reserveInitialCapacity(bookmarkNodes.count);
+
+    for (id<_WKWebExtensionBookmark> bookmark in bookmarkNodes) {
+        WebExtensionBookmarksParameters node;
+
+        node.nodeId = [bookmark identifierForWebExtensionContext:context];
+        node.parentId = [bookmark parentIdentifierForWebExtensionContext:context];
+        node.index = [bookmark indexForWebExtensionContext:context];
+        node.title = [bookmark titleForWebExtensionContext:context];
+        node.url = [bookmark urlForWebExtensionContext:context];
+
+        parameters.append(WTFMove(node));
+    }
+
+    return parameters;
+}
 
 void WebExtensionContext::bookmarksCreate(const std::optional<String>& parentId, const std::optional<uint64_t>& index, const std::optional<String>& url, const std::optional<String>& title, CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&& completionHandler)
 {
@@ -147,15 +184,155 @@ void WebExtensionContext::bookmarksGetTree(CompletionHandler<void(Expected<WebEx
 }
 void WebExtensionContext::bookmarksGetSubTree(const String& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"bookmarks.getSubtree()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    id controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:getBookmarksForExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+
+    [controllerDelegate _webExtensionController:controllerWrapper getBookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            return;
+        }
+
+        if (!allTopLevelNodes) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"returned array of bookmarks was invalid"));
+            return;
+        }
+        id<_WKWebExtensionBookmark> foundNode = findBookmarkNodeInTree(allTopLevelNodes, bookmarkId, contextWrapper);
+
+        std::optional<WebExtensionBookmarksParameters> singleNodeParameters = createParametersFromProtocolObject(foundNode, contextWrapper);
+
+        if (!singleNodeParameters.has_value()) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"bookmark was null or invalid"));
+            return;
+        }
+
+        Vector<WebExtensionBookmarksParameters> resultVector;
+        resultVector.append(WTFMove(singleNodeParameters.value()));
+
+        completionHandler(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError> { WTFMove(resultVector) });
+    }];
 }
 void WebExtensionContext::bookmarksGet(const Vector<String>& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString *const apiName = @"bookmarks.get()";
 
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
+
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:getBookmarksForExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+    Vector<String> capturedBookmarkIds = bookmarkId;
+
+    [controllerDelegate _webExtensionController:controllerWrapper getBookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            return;
+        }
+
+        if (!allTopLevelNodes) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"returned array of bookmarks was invalid"));
+            return;
+        }
+        NSMutableArray<id<_WKWebExtensionBookmark>> *foundNodes = [NSMutableArray arrayWithCapacity:capturedBookmarkIds.size()];
+
+        for (const String& targetId : capturedBookmarkIds) {
+            NSString *targetIdNSString = targetId.createNSString().autorelease();
+            id<_WKWebExtensionBookmark> foundNode = findBookmarkNodeInTree(allTopLevelNodes, targetIdNSString, contextWrapper);
+
+            if (!foundNode) {
+                completionHandler(toWebExtensionError(apiName, nullString(), @"A Bookmark ID was not found"));
+                return;
+            }
+            [foundNodes addObject:foundNode];
+        }
+
+        Vector<WebExtensionBookmarksParameters> foundNodeParameters = createShallowParametersFromProtocolObjects(foundNodes, contextWrapper);
+        completionHandler(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError> { WTFMove(foundNodeParameters) });
+    }];
 }
 void WebExtensionContext::bookmarksGetChildren(const String& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString *const apiName = @"bookmarks.getChildren()";
 
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
+
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    id controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:getBookmarksForExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    NSString *bookmarkIdNSString = bookmarkId.createNSString().autorelease();
+
+    [controllerDelegate _webExtensionController:controllerWrapper getBookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            return;
+        }
+
+        if (!allTopLevelNodes) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"returned array of bookmarks was invalid"));
+            return;
+        }
+
+        id<_WKWebExtensionBookmark> parentNode = findBookmarkNodeInTree(allTopLevelNodes, bookmarkIdNSString, contextWrapper);
+
+        if (!parentNode) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"bookmark Id was not found"));
+            return;
+        }
+
+        if ([parentNode bookmarkTypeForWebExtensionContext:contextWrapper] != _WKWebExtensionBookmarkTypeFolder) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"bookmark Id is not a folder"));
+            return;
+        }
+
+        NSArray<id<_WKWebExtensionBookmark>> *directChildren = [parentNode childrenForWebExtensionContext:contextWrapper];
+
+        if (!directChildren) {
+            completionHandler(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError> { Vector<WebExtensionBookmarksParameters>() });
+            return;
+        }
+
+        Vector<WebExtensionBookmarksParameters> childrenParameters = createShallowParametersFromProtocolObjects(directChildren, contextWrapper);
+        completionHandler(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError> { WTFMove(childrenParameters) });
+    }];
 }
 void WebExtensionContext::bookmarksGetRecent(uint64_t count, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
@@ -6,6 +6,10 @@
 #import "config.h"
 #import "WebExtensionContext.h"
 
+#include "WebExtensionBookmarksParameters.h"
+#include "WebExtensionController.h"
+#include "_WKWebExtensionBookmarks.h"
+
 #include <wtf/Vector.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
@@ -20,13 +24,126 @@ bool WebExtensionContext::isBookmarksMessageAllowed(IPC::Decoder& message)
     return false;
 }
 
+static Vector<WebExtensionBookmarksParameters> createParametersFromProtocolObjects(NSArray<id<_WKWebExtensionBookmark>> *, WKWebExtensionContext *);
+
+static std::optional<WebExtensionBookmarksParameters> createParametersFromProtocolObject(id<_WKWebExtensionBookmark> bookmark, WKWebExtensionContext *context)
+{
+    if (!bookmark)
+        return std::nullopt;
+
+    WebExtensionBookmarksParameters parameters;
+
+    NSString *nodeId = [bookmark identifierForWebExtensionContext:context];
+    if (!nodeId)
+        return std::nullopt;
+    parameters.nodeId = nodeId;
+
+    parameters.parentId = [bookmark parentIdentifierForWebExtensionContext:context];
+    parameters.index = [bookmark indexForWebExtensionContext:context];
+    parameters.title = [bookmark titleForWebExtensionContext:context];
+    parameters.url = [bookmark urlForWebExtensionContext:context];
+
+    if (NSArray *children = [bookmark childrenForWebExtensionContext:context])
+        parameters.children = createParametersFromProtocolObjects(children, context);
+
+    return parameters;
+}
+
+static Vector<WebExtensionBookmarksParameters> createParametersFromProtocolObjects(NSArray<id<_WKWebExtensionBookmark>> *bookmarkNodes, WKWebExtensionContext *context)
+{
+    if (!bookmarkNodes)
+        return { };
+
+    Vector<WebExtensionBookmarksParameters> parameters;
+    parameters.reserveInitialCapacity(bookmarkNodes.count);
+
+    for (id<_WKWebExtensionBookmark> bookmark in bookmarkNodes) {
+        auto parametersOptional = createParametersFromProtocolObject(bookmark, context);
+        if (parametersOptional)
+            parameters.append(WTFMove(*parametersOptional));
+    }
+
+    return parameters;
+}
+
+
+
 void WebExtensionContext::bookmarksCreate(const std::optional<String>& parentId, const std::optional<uint64_t>& index, const std::optional<String>& url, const std::optional<String>& title, CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"bookmarks.create()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:createBookmarkWithParentIdentifier:index:url:title:forExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    NSString *parentIdString = parentId ? parentId->createNSString().get() : nil;
+    NSNumber *indexNumber = index ? @(index.value()) : nil;
+    NSString *urlString = url ? url->createNSString().get() : nil;
+    NSString *titleString = title ? title->createNSString().get() : @"";
+
+    [controllerDelegate _webExtensionController:controllerWrapper createBookmarkWithParentIdentifier:parentIdString index:indexNumber url:urlString title:titleString forExtensionContext:contextWrapper completionHandler:^(NSObject<_WKWebExtensionBookmark> *newBookmark, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"error was reported"));
+            return;
+        }
+        auto parametersOptional = createParametersFromProtocolObject(newBookmark, contextWrapper);
+        if (!parametersOptional.has_value()) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"bookmark was null or invalid"));
+            return;
+        }
+
+        completionHandler(Expected<WebExtensionBookmarksParameters, WebExtensionError> { WTFMove(parametersOptional.value()) });
+    }];
 }
 void WebExtensionContext::bookmarksGetTree(CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"bookmarks.getTree()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:getBookmarksForExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    [controllerDelegate _webExtensionController:controllerWrapper getBookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *bookmarkNodes, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            return;
+        }
+
+        if (!bookmarkNodes) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"returned array of bookmarks was invalid"));
+            return;
+        }
+        Vector<WebExtensionBookmarksParameters> topLevelNodes = createParametersFromProtocolObjects(bookmarkNodes, contextWrapper);
+        WebExtensionBookmarksParameters rootNode;
+
+        rootNode.nodeId = @"testBookmarksRoot";
+        rootNode.children = WTFMove(topLevelNodes);
+        completionHandler(Expected<WebExtensionBookmarksParameters, WebExtensionError> { WTFMove(rootNode) });
+    }];
 }
 void WebExtensionContext::bookmarksGetSubTree(const String& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&& completionHandler)
 {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1853,6 +1853,7 @@
 		9565083A26D87A2B00E15CB7 /* AppleMediaServicesUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 9565083826D87A2B00E15CB7 /* AppleMediaServicesUISPI.h */; };
 		9593675F252E5E3100D3F0A0 /* WKStylusDeviceObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */; };
 		95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C943902523C0D00054F3D5 /* BaseBoardSPI.h */; };
+		960C47F52E1CB1BB00B8D2D1 /* _WKWebExtensionBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 960C47F42E1C861C00B8D2D1 /* _WKWebExtensionBookmarks.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		961A72D02E17270900DD2AF9 /* WebExtensionBookmarksParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 96CC7DBF2E15EC2800233E69 /* WebExtensionBookmarksParameters.h */; };
 		96418A5E2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */; };
 		96CC7DBE2E15DA4200233E69 /* WebExtensionContextAPIBookmarksCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96CC7DBD2E15DA2900233E69 /* WebExtensionContextAPIBookmarksCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -7166,6 +7167,7 @@
 		9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKStylusDeviceObserver.h; path = ios/WKStylusDeviceObserver.h; sourceTree = "<group>"; };
 		9593675E252E5E3100D3F0A0 /* WKStylusDeviceObserver.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKStylusDeviceObserver.mm; path = ios/WKStylusDeviceObserver.mm; sourceTree = "<group>"; };
 		95C943902523C0D00054F3D5 /* BaseBoardSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseBoardSPI.h; sourceTree = "<group>"; };
+		960C47F42E1C861C00B8D2D1 /* _WKWebExtensionBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionBookmarks.h; sourceTree = "<group>"; };
 		96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIBookmarks.h; sourceTree = "<group>"; };
 		96418A5F2DFA4BA900C19CDC /* JSWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
 		966F42B3BF3CA9AFEE64F9BF /* RemoteSerializedImageBufferIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteSerializedImageBufferIdentifier.h; sourceTree = "<group>"; };
@@ -12246,6 +12248,7 @@
 				574728D023456E98001700AF /* _WKWebAuthenticationPanel.mm */,
 				5790A6512565DE6A0077C5A7 /* _WKWebAuthenticationPanelForTesting.h */,
 				574728D3234570AE001700AF /* _WKWebAuthenticationPanelInternal.h */,
+				960C47F42E1C861C00B8D2D1 /* _WKWebExtensionBookmarks.h */,
 				028D30862C62FA8A004F4FC6 /* _WKWebExtensionSidebar.h */,
 				028D30892C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm */,
 				028D308D2C63E3B3004F4FC6 /* _WKWebExtensionSidebarInternal.h */,
@@ -16986,6 +16989,7 @@
 				574728D4234570AE001700AF /* _WKWebAuthenticationPanelInternal.h in Headers */,
 				1CC5CA6D2C5ACB8500DF3B94 /* _WKWebExtension.h in Headers */,
 				1CC5CA722C5ACB8500DF3B94 /* _WKWebExtensionAction.h in Headers */,
+				960C47F52E1CB1BB00B8D2D1 /* _WKWebExtensionBookmarks.h in Headers */,
 				1CC5CA702C5ACB8500DF3B94 /* _WKWebExtensionCommand.h in Headers */,
 				1CC5CA922C5ACD5700DF3B94 /* _WKWebExtensionCommandPrivate.h in Headers */,
 				1CC5CA6E2C5ACB8500DF3B94 /* _WKWebExtensionContext.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
@@ -31,6 +31,10 @@
 #include "config.h"
 #import "WebExtensionAPIBookmarks.h"
 #import "CocoaHelpers.h"
+#import "MessageSenderInlines.h"
+#import "WebExtensionBookmarksParameters.h"
+#import "WebExtensionContextMessages.h"
+#import "WebProcess.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
 
@@ -63,6 +67,31 @@ static NSString *toWebAPI(WebExtensionAPIBookmarks::BookmarkTreeNodeType type, N
 
     return folderKey;
 }
+static NSDictionary *toAPI(const WebExtensionBookmarksParameters& node)
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+
+    dictionary[idKey] = node.nodeId.createNSString().get();
+    dictionary[indexKey] = @(node.index);
+    dictionary[titleKey] = node.title.createNSString().get();
+
+    if (node.parentId)
+        dictionary[parentIdKey] = node.parentId->createNSString().get();
+    dictionary[typeKey] = @"folder";
+    if (node.url && !node.url->isEmpty()) {
+        dictionary[urlKey] = node.url->createNSString().get();
+        dictionary[typeKey] = @"bookmark";
+    }
+
+    if (node.children) {
+        NSMutableArray *childrenArray = [NSMutableArray array];
+        for (const auto& childNode : *node.children)
+            [childrenArray addObject:toAPI(childNode)];
+        dictionary[childrenKey] = childrenArray;
+    }
+
+    return dictionary;
+}
 
 static NSDictionary *toWebAPI(const WebExtensionAPIBookmarks::MockBookmarkNode& node)
 {
@@ -76,7 +105,7 @@ static NSDictionary *toWebAPI(const WebExtensionAPIBookmarks::MockBookmarkNode& 
         typeKey: toWebAPI(node.type, node.url.createNSString().get())
     };
 
-    NSMutableDictionary *tempNode = baseNodeDict.mutableCopy;
+    NSMutableDictionary *tempNode = baseNodeDictionary.mutableCopy;
 
     NSMutableArray *childrenArray = [NSMutableArray array];
     if (node.type == WebExtensionAPIBookmarks::BookmarkTreeNodeType::Folder) {
@@ -140,6 +169,8 @@ void WebExtensionAPIBookmarks::initializeMockBookmarksInternal()
     }
 }
 
+static int s_nextInternalBookmarkNodeId = 100;
+
 void WebExtensionAPIBookmarks::createBookmark(NSDictionary *bookmark, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (m_mockBookmarks.isEmpty())
@@ -176,7 +207,7 @@ void WebExtensionAPIBookmarks::createBookmark(NSDictionary *bookmark, Ref<WebExt
     }
 
     Ref newNode = MockBookmarkNode::create();
-    newNode->id = bookmark[idKey];
+    newNode->id = String::number(s_nextInternalBookmarkNodeId++);
     newNode->url = bookmark[urlKey];
     newNode->title = bookmark[titleKey];
     newNode->parentId = bookmark[parentIdKey] ? bookmark[parentIdKey] : bookmarksRootId;
@@ -208,7 +239,24 @@ void WebExtensionAPIBookmarks::createBookmark(NSDictionary *bookmark, Ref<WebExt
         [](const Ref<MockBookmarkNode>& a, const Ref<MockBookmarkNode>& b) {
             return a->index < b->index;
         });
-    callback->call(toWebAPI(newNode));
+    const std::optional<String>& parentmockId = parentId;
+    const std::optional<String>& title = newNode->title;
+    const std::optional<String>& url = newNode->url;
+
+    std::optional<uint64_t> index = (newNode->index);
+    WebProcess::singleton().sendWithAsyncReply(
+        Messages::WebExtensionContext::BookmarksCreate(parentmockId, index, url, title),
+        [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionBookmarksParameters, WebExtensionError>&& result) {
+            if (!result) {
+                callback->reportError(result.error().createNSString().get());
+                return;
+            }
+            auto createdNode = result.value();
+            NSDictionary* newNodeDictionary = toAPI(createdNode);
+            callback->call(newNodeDictionary);
+        },
+        extensionContext().identifier()
+    );
 }
 
 void WebExtensionAPIBookmarks::getChildren(NSString *bookmarkIdentifier, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
@@ -251,22 +299,20 @@ void WebExtensionAPIBookmarks::getSubTree(NSString *bookmarkIdentifier, Ref<WebE
 
 void WebExtensionAPIBookmarks::getTree(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    if (m_mockBookmarks.isEmpty())
-        initializeMockBookmarksInternal();
+    WebProcess::singleton().sendWithAsyncReply(
+        Messages::WebExtensionContext::BookmarksGetTree(),
+        [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<WebExtensionBookmarksParameters, WebExtensionError>&& result) {
+            if (!result) {
+                callback->reportError(result.error().createNSString().get());
+                return;
+            }
 
-    auto rootNodeOptional = m_mockBookmarks.getOptional(bookmarksRootId);
-    if (!rootNodeOptional) {
-        if (outExceptionString)
-            *outExceptionString = toErrorString(nullString(), nullString(), @"root not found").createNSString().autorelease();
-        return;
-    }
-
-    if (auto rootOptional = m_mockBookmarks.getOptional(bookmarksRootId)) {
-        Ref finalTreeRoot = rootOptional.value();
-        NSDictionary *rootDict = toWebAPI(finalTreeRoot);
-        NSArray* resultArray = [NSArray arrayWithObject:rootDict];
-        callback->call(resultArray);
-    }
+            auto rootNode = result.value();
+            NSDictionary* rootDictionary = toAPI(rootNode);
+            callback->call(rootDictionary);
+        },
+        extensionContext().identifier()
+    );
 }
 
 void WebExtensionAPIBookmarks::get(NSObject *idOrIdList, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
@@ -31,7 +31,111 @@
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
 
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebExtensionControllerDelegatePrivate.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKWebExtensionBookmarks.h>
+
+
+@interface _MockBookmarkNode : NSObject <_WKWebExtensionBookmark>
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+@property (nonatomic, strong) NSMutableDictionary *dictionary;
+@end
+
+@implementation _MockBookmarkNode
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
+{
+    self = [super init];
+    if (self)
+        _dictionary = [dictionary mutableCopy];
+    return self;
+}
+- (NSString *)identifierForWebExtensionContext:(WKWebExtensionContext *)context { return _dictionary[@"id"]; }
+- (NSString *)parentIdentifierForWebExtensionContext:(WKWebExtensionContext *)context { return _dictionary[@"parentId"]; }
+- (NSString *)titleForWebExtensionContext:(WKWebExtensionContext *)context { return _dictionary[@"title"]; }
+- (NSString *)urlForWebExtensionContext:(WKWebExtensionContext *)context { return _dictionary[@"url"]; }
+- (NSInteger)indexForWebExtensionContext:(WKWebExtensionContext *)context { return [_dictionary[@"index"] integerValue]; }
+- (NSArray<id<_WKWebExtensionBookmark>> *)childrenForWebExtensionContext:(WKWebExtensionContext *)context {
+    NSArray *childDictionaries = _dictionary[@"children"];
+    if (!childDictionaries)
+        return nil;
+    NSMutableArray<id<_WKWebExtensionBookmark>> *children = [NSMutableArray array];
+    for (NSDictionary *childDict in childDictionaries)
+        [children addObject:[[_MockBookmarkNode alloc] initWithDictionary:childDict]];
+    return children;
+}
+@end
+
+
+@interface TestBookmarksDelegate : NSObject <WKWebExtensionControllerDelegatePrivate>
+@property (nonatomic, strong) NSMutableArray<NSMutableDictionary *> *mockBookmarks;
+@property (nonatomic) NSInteger nextMockBookmarkId;
+@end
+
+static NSMutableDictionary *findParentInMockTree(NSMutableArray<NSMutableDictionary *> *tree, NSString *parentId)
+{
+    for (NSMutableDictionary *node in tree) {
+        if ([node[@"id"] isEqualToString:parentId])
+            return node;
+        id children = node[@"children"];
+        if (children && [children isKindOfClass:[NSMutableArray class]]) {
+            NSMutableDictionary *found = findParentInMockTree(children, parentId);
+            if (found)
+                return found;
+        }
+    }
+    return nil;
+}
+
+
+@implementation TestBookmarksDelegate
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _mockBookmarks = [NSMutableArray array];
+        _nextMockBookmarkId = 100;
+    }
+    return self;
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller getBookmarksForExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *))completionHandler
+{
+    NSMutableArray<NSObject<_WKWebExtensionBookmark> *> *results = [NSMutableArray array];
+    for (NSDictionary *bookmarkDict in self.mockBookmarks)
+        [results addObject:[[_MockBookmarkNode alloc] initWithDictionary:bookmarkDict]];
+    completionHandler(results, nil);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller createBookmarkWithParentIdentifier:(NSString *)parentId index:(NSNumber *)index url:(NSString *)url title:(NSString *)title forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler
+{
+    NSMutableDictionary *newBookmark = [NSMutableDictionary dictionary];
+    newBookmark[@"title"] = title;
+    if (url)
+        newBookmark[@"url"] = url;
+    NSString *newId = [NSString stringWithFormat:@"%ld", (long)self.nextMockBookmarkId];
+    _nextMockBookmarkId++;
+    newBookmark[@"id"] = newId;
+
+    if (parentId && ![parentId isEqualToString:@"0"]) {
+        NSMutableDictionary *parentDict = findParentInMockTree(self.mockBookmarks, parentId);
+        if (parentDict) {
+            NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+            newBookmark[@"parentId"] = parentId;
+            newBookmark[@"index"] = index ?: @(children.count);
+            [children addObject:newBookmark];
+            parentDict[@"children"] = children;
+
+            completionHandler([[_MockBookmarkNode alloc] initWithDictionary:newBookmark], nil);
+            return;
+        }
+    }
+
+    newBookmark[@"parentId"] = @"0";
+    newBookmark[@"index"] = index ?: @(self.mockBookmarks.count);
+    [self.mockBookmarks addObject:newBookmark];
+
+    completionHandler([[_MockBookmarkNode alloc] initWithDictionary:newBookmark], nil);
+}
+@end
 
 namespace TestWebKitAPI {
 
@@ -51,7 +155,7 @@ static constexpr auto *bookmarkOffManifest = @{
     },
 };
 
-static auto *bookmarkOnManifest = @{
+static constexpr auto *bookmarkOnManifest = @{
     @"manifest_version": @3,
     @"name": @"bookmarkpermission on Test",
     @"description": @"bookmarkpermission on Test",
@@ -189,27 +293,63 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICheckgetRecent)
 
 TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)
 {
+    auto uiProcessMockBookmarks = adoptNS([NSMutableArray new]);
+    __block NSInteger nextMockBookmarkId = 100;
     auto *script = @[
         @"browser.bookmarks.create({id: 'id_old', title: 'Oldest Bookmark', url: 'http://example.com/1', dateAdded: 1000})",
         @"browser.bookmarks.create({id: 'id_new', title: 'Newest Bookmark', url: 'http://example.com/3', dateAdded: 3000})",
         @"browser.bookmarks.create({id: 'id_mid', title: 'Middle Bookmark', url: 'http://example.com/2', dateAdded: 2000})",
         @"let recent = await browser.bookmarks.getRecent(2)",
         @"browser.test.assertEq(2, recent.length, 'Should return exactly 2 bookmarks')",
-        @"browser.test.assertEq('id_new', recent[0].id, 'First result should be the newest bookmark')",
-        @"browser.test.assertEq('id_mid', recent[1].id, 'Second result should be the middle bookmark')",
+        @"browser.test.assertEq('Newest Bookmark', recent[0].title, 'First result should be the newest bookmark')",
+        @"browser.test.assertEq('Middle Bookmark', recent[1].title, 'Second result should be the middle bookmark')",
         @"let recent2 = await browser.bookmarks.getRecent(5)",
         @"browser.test.assertEq(3, recent2.length, 'Should adapt and return the max available which is 3')",
-        @"browser.test.assertEq('id_new', recent2[0].id, 'First result should be the newest bookmark')",
-        @"browser.test.assertEq('id_mid', recent2[1].id, 'Second result should be the middle bookmark')",
-        @"browser.test.assertEq('id_old', recent2[2].id, 'Second result should be the middle bookmark')",
+        @"browser.test.assertEq('Newest Bookmark', recent2[0].title, 'First result should be the newest bookmark')",
+        @"browser.test.assertEq('Middle Bookmark', recent2[1].title, 'Second result should be the middle bookmark')",
+        @"browser.test.assertEq('Oldest Bookmark', recent2[2].title, 'Second result should be the middle bookmark')",
         @"browser.test.notifyPass()",
     ];
 
-    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    manager.get().internalDelegate.createBookmarkWithParentIdentifier = ^(NSString * parentId, NSNumber * index, NSString * url, NSString * title, void (^completionHandler)(NSObject<_WKWebExtensionBookmark> *, NSError *)) {
+        NSMutableDictionary *newBookmarkData = [NSMutableDictionary dictionary];
+        newBookmarkData[@"title"] = title;
+        if (url)
+            newBookmarkData[@"url"] = url;
+        NSString *newId = [NSString stringWithFormat:@"%ld", (long)nextMockBookmarkId];
+        nextMockBookmarkId++;
+        newBookmarkData[@"id"] = newId;
+
+        newBookmarkData[@"parentId"] = parentId;
+        if (parentId && ![parentId isEqualToString:@"0"]) {
+            NSMutableDictionary *parentDict = findParentInMockTree(uiProcessMockBookmarks.get(), parentId);
+            if (parentDict) {
+                NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+                newBookmarkData[@"parentId"] = parentId;
+                newBookmarkData[@"index"] = index ?: @(children.count);
+                [children addObject:newBookmarkData];
+                parentDict[@"children"] = children;
+                completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+                return;
+            }
+        }
+
+        newBookmarkData[@"index"] = index ?: @(uiProcessMockBookmarks.get().count);
+        [uiProcessMockBookmarks addObject:newBookmarkData];
+        completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+    };
+
+    [manager loadAndRun];
 }
 
 TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)
 {
+    auto uiProcessMockBookmarks = adoptNS([NSMutableArray new]);
+    __block NSInteger nextMockBookmarkId = 100;
     auto *script = @[
         @"let createdNode = await browser.bookmarks.create({id: 'test1', title: 'My Test Bookmark', url: 'https://example.com/test1'})",
         @"browser.test.assertEq('My Test Bookmark', createdNode.title, 'Title should match');",
@@ -218,37 +358,67 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)
         @"let createdNode2 = await browser.bookmarks.create({id: 'test2', title: 'My Test Folder', parentId: 'testFavorites'})",
         @"browser.test.assertEq('My Test Folder', createdNode2.title, 'Title should match');",
         @"browser.test.assertEq('folder', createdNode2.type, 'type should be folder because url is not specified');",
-        @"browser.test.assertEq('testfav', createdNode2.parentId, 'parentId should match');",
+        @"browser.test.assertEq('testFavorites', createdNode2.parentId, 'parentId should match');",
         @"browser.test.notifyPass()",
     ];
 
-    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    manager.get().internalDelegate.createBookmarkWithParentIdentifier = ^(NSString * parentId, NSNumber * index, NSString * url, NSString * title, void (^completionHandler)(NSObject<_WKWebExtensionBookmark> *, NSError *)) {
+        NSMutableDictionary *newBookmarkData = [NSMutableDictionary dictionary];
+        newBookmarkData[@"title"] = title;
+        if (url)
+            newBookmarkData[@"url"] = url;
+        NSString *newId = [NSString stringWithFormat:@"%ld", (long)nextMockBookmarkId];
+        nextMockBookmarkId++;
+        newBookmarkData[@"id"] = newId;
+
+        newBookmarkData[@"parentId"] = parentId;
+        if (parentId && ![parentId isEqualToString:@"0"]) {
+            NSMutableDictionary *parentDict = findParentInMockTree(uiProcessMockBookmarks.get(), parentId);
+            if (parentDict) {
+                NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+                newBookmarkData[@"parentId"] = parentId;
+                newBookmarkData[@"index"] = index ?: @(children.count);
+                [children addObject:newBookmarkData];
+                parentDict[@"children"] = children;
+                completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+                return;
+            }
+        }
+
+        newBookmarkData[@"index"] = index ?: @(uiProcessMockBookmarks.get().count);
+        [uiProcessMockBookmarks addObject:newBookmarkData];
+        completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+    };
+
+    [manager loadAndRun];
+
 }
 
 TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)
 {
+    auto uiProcessMockBookmarks = adoptNS([NSMutableArray new]);
+    __block NSInteger nextMockBookmarkId = 100;
     auto *script = @[
         @"let bookmark1 = await browser.bookmarks.create({type: 'bookmark', id: 'bookmark1', title: 'Top Bookmark 1', url: 'http://example.com/bm1'});",
         @"let folder1 = await browser.bookmarks.create({id: 'folder1', type: 'folder', title: 'Top Folder 1'});",
         @"let bookmark2 = await browser.bookmarks.create({id: 'bookmark2', title: 'Child Bookmark 2', url: 'http://example.com/bm2', parentId: folder1.id});",
         @"let bookmark3 = await browser.bookmarks.create({id: 'bookmark3', title: 'Top Bookmark 3', url: 'http://example.com/bm3'});",
-        @"let tree = await browser.bookmarks.getTree();",
-        @"browser.test.assertEq(1, tree.length, 'Tree should have one root node');",
-        @"let root = tree[0];",
+        @"let root = await browser.bookmarks.getTree();",
         @"browser.test.assertEq('testBookmarksRoot', root.id, 'Root node ID should be root');",
-        @"browser.test.assertEq('folder', root.type, 'Root node type should be folder');",
         @"browser.test.assertTrue(root.children.length >= 1, 'Root should have at least one child (default folder)');",
-        @"let foundBookmark1 = root.children.find(n => n.id === bookmark1.id);",
+        @"let foundBookmark1 = root.children.find(n => n.title === bookmark1.title);",
         @"browser.test.assertEq('Top Bookmark 1', foundBookmark1.title, 'Bm1 title matches');",
         @"browser.test.assertEq('http://example.com/bm1', foundBookmark1.url, 'Bm1 URL matches');",
         @"browser.test.assertEq('bookmark', foundBookmark1.type, 'Bm1 type is bookmark');",
-        @"browser.test.assertEq(root.id, foundBookmark1.parentId, 'Bm1 parentId matches default folder');",
-        @"let foundFolder1 = root.children.find(n => n.id === folder1.id);",
+        @"let foundFolder1 = root.children.find(n => n.title === folder1.title);",
         @"browser.test.assertEq('Top Folder 1', foundFolder1.title, 'Folder1 title matches');",
         @"browser.test.assertEq('folder', foundFolder1.type, 'Folder1 type is folder');",
-        @"browser.test.assertEq(root.id, foundFolder1.parentId, 'Folder1 parentId matches default folder');",
-        @"browser.test.assertEq(bookmark2.id, foundFolder1.children[0].id, 'Folder1 should have children array');",
-        @"let foundBookmark2 = foundFolder1.children.find(n => n.id === bookmark2.id);",
+        @"browser.test.assertEq(bookmark2.title, foundFolder1.children[0].title, 'Folder1 should have children array');",
+        @"let foundBookmark2 = foundFolder1.children.find(n => n.title === bookmark2.title);",
         @"browser.test.assertEq('Child Bookmark 2', foundBookmark2.title, 'Bm2 title matches');",
         @"browser.test.assertEq('http://example.com/bm2', foundBookmark2.url, 'Bm2 URL matches');",
         @"browser.test.assertEq('bookmark', foundBookmark2.type, 'Bm2 type is bookmark');",
@@ -256,10 +426,122 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)
         @"browser.test.notifyPass()",
     ];
 
-    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    manager.get().internalDelegate.createBookmarkWithParentIdentifier = ^(NSString * parentId, NSNumber * index, NSString * url, NSString * title, void (^completionHandler)(NSObject<_WKWebExtensionBookmark> *, NSError *)) {
+        NSMutableDictionary *newBookmarkData = [NSMutableDictionary dictionary];
+        newBookmarkData[@"title"] = title;
+        if (url)
+            newBookmarkData[@"url"] = url;
+        NSString *newId = [NSString stringWithFormat:@"%ld", (long)nextMockBookmarkId];
+        nextMockBookmarkId++;
+        newBookmarkData[@"id"] = newId;
+
+        newBookmarkData[@"parentId"] = parentId;
+        if (parentId && ![parentId isEqualToString:@"0"]) {
+            NSMutableDictionary *parentDict = findParentInMockTree(uiProcessMockBookmarks.get(), parentId);
+            if (parentDict) {
+                NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+                newBookmarkData[@"parentId"] = parentId;
+                newBookmarkData[@"index"] = index ?: @(children.count);
+                [children addObject:newBookmarkData];
+                parentDict[@"children"] = children;
+                completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+                return;
+            }
+        }
+
+        newBookmarkData[@"index"] = index ?: @(uiProcessMockBookmarks.get().count);
+        [uiProcessMockBookmarks addObject:newBookmarkData];
+        completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+    };
+
+    manager.get().internalDelegate.getBookmarksForExtensionContext = ^(void (^completionHandler)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *)) {
+        NSMutableArray<NSObject<_WKWebExtensionBookmark> *> *results = [NSMutableArray array];
+        for (NSDictionary *dict in uiProcessMockBookmarks.get()) {
+            auto mockNode = adoptNS([_MockBookmarkNode new]);
+            mockNode.get().dictionary = [dict mutableCopy];
+            [results addObject:mockNode.get()];
+        }
+        completionHandler(results, nil);
+    };
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)
+{
+    auto uiProcessMockBookmarks = adoptNS([NSMutableArray new]);
+    __block NSInteger nextMockBookmarkId = 100;
+    auto *script = @[
+        @"let folder = await browser.bookmarks.create({ id: 'testFolder', title: 'Test Folder' });",
+        @"browser.test.assertEq(folder.title, 'Test Folder', 'Folder title should be correct');",
+        @"browser.test.assertTrue(!!folder.id, 'Folder should have an ID');",
+        @"let bookmark = await browser.bookmarks.create({ id: 'testbookmark1', parentId: folder.id, title: 'WebKit.org', url: 'https://webkit.org/' });",
+        @"browser.test.assertEq(bookmark.title, 'WebKit.org', 'Bookmark title should be correct');",
+        @"browser.test.assertEq(bookmark.url, 'https://webkit.org/', 'Bookmark URL should be correct');",
+        @"let rootNode = await browser.bookmarks.getTree();",
+        @"browser.test.assertTrue(Array.isArray(rootNode.children), 'Root object should have a children array');",
+        @"browser.test.assertEq(rootNode.children.length, 1);",
+        @"browser.test.assertEq(rootNode.children[0].title, 'Test Folder');",
+        @"browser.test.assertTrue(Array.isArray(rootNode.children[0].children), 'Folder should have a children array');",
+        @"browser.test.assertEq(rootNode.children[0].children[0].title, 'WebKit.org', 'Child bookmark in tree should have correct title');",
+        @"browser.test.assertEq(rootNode.children[0].children[0].url, 'https://webkit.org/', 'Child bookmark in tree should have correct URL');",
+        @"let bookmark2 = await browser.bookmarks.create({ id: 'topLevelBookmark', title: 'Test Top Bookmark', url: 'https://coolbook.com/' });",
+        @"browser.test.assertEq(bookmark2.title, 'Test Top Bookmark', 'Bookmark title should be correct');",
+        @"browser.test.assertEq(bookmark2.url, 'https://coolbook.com/', 'Bookmark URL should be correct');",
+        @"let updatedRootNode = await browser.bookmarks.getTree();",
+        @"browser.test.assertEq(updatedRootNode.children.length, 2);",
+        @"browser.test.assertEq(updatedRootNode.children[0].title, 'Test Folder');",
+        @"browser.test.assertEq(updatedRootNode.children[1].title, 'Test Top Bookmark');",
+        @"browser.test.notifyPass();",
+    ];
+
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    manager.get().internalDelegate.createBookmarkWithParentIdentifier = ^(NSString * parentId, NSNumber * index, NSString * url, NSString * title, void (^completionHandler)(NSObject<_WKWebExtensionBookmark> *, NSError *)) {
+        NSMutableDictionary *newBookmarkData = [NSMutableDictionary dictionary];
+        newBookmarkData[@"title"] = title;
+        if (url)
+            newBookmarkData[@"url"] = url;
+        NSString *newId = [NSString stringWithFormat:@"%ld", (long)nextMockBookmarkId];
+        nextMockBookmarkId++;
+        newBookmarkData[@"id"] = newId;
+
+        newBookmarkData[@"parentId"] = parentId;
+        if (parentId && ![parentId isEqualToString:@"0"]) {
+            NSMutableDictionary *parentDict = findParentInMockTree(uiProcessMockBookmarks.get(), parentId);
+            if (parentDict) {
+                NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+                newBookmarkData[@"parentId"] = parentId;
+                newBookmarkData[@"index"] = index ?: @(children.count);
+                [children addObject:newBookmarkData];
+                parentDict[@"children"] = children;
+                completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+                return;
+            }
+        }
+
+        newBookmarkData[@"index"] = index ?: @(uiProcessMockBookmarks.get().count);
+        [uiProcessMockBookmarks addObject:newBookmarkData];
+        completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+    };
+
+    manager.get().internalDelegate.getBookmarksForExtensionContext = ^(void (^completionHandler)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *)) {
+        NSMutableArray<NSObject<_WKWebExtensionBookmark> *> *results = [NSMutableArray array];
+        for (NSDictionary *dict in uiProcessMockBookmarks.get()) {
+            auto mockNode = adoptNS([_MockBookmarkNode new]);
+            mockNode.get().dictionary = [dict mutableCopy];
+            [results addObject:mockNode.get()];
+        }
+        completionHandler(results, nil);
+    };
+    [manager loadAndRun];
 }
 
 }
-
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
@@ -54,6 +54,16 @@
 - (NSString *)titleForWebExtensionContext:(WKWebExtensionContext *)context { return _dictionary[@"title"]; }
 - (NSString *)urlForWebExtensionContext:(WKWebExtensionContext *)context { return _dictionary[@"url"]; }
 - (NSInteger)indexForWebExtensionContext:(WKWebExtensionContext *)context { return [_dictionary[@"index"] integerValue]; }
+- (_WKWebExtensionBookmarkType)bookmarkTypeForWebExtensionContext:(WKWebExtensionContext *)context {
+    NSString *typeString = self.dictionary[@"type"];
+    if ([typeString isEqualToString:@"folder"])
+        return _WKWebExtensionBookmarkTypeFolder;
+
+    NSString *url = self.dictionary[@"url"];
+    if (url && url.length > 0)
+        return _WKWebExtensionBookmarkTypeBookmark;
+    return _WKWebExtensionBookmarkTypeFolder;
+}
 - (NSArray<id<_WKWebExtensionBookmark>> *)childrenForWebExtensionContext:(WKWebExtensionContext *)context {
     NSArray *childDictionaries = _dictionary[@"children"];
     if (!childDictionaries)
@@ -511,6 +521,93 @@ TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)
         nextMockBookmarkId++;
         newBookmarkData[@"id"] = newId;
 
+        newBookmarkData[@"parentId"] = parentId;
+        if (parentId && ![parentId isEqualToString:@"0"]) {
+            NSMutableDictionary *parentDict = findParentInMockTree(uiProcessMockBookmarks.get(), parentId);
+            if (parentDict) {
+                NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+                newBookmarkData[@"parentId"] = parentId;
+                newBookmarkData[@"index"] = index ?: @(children.count);
+                [children addObject:newBookmarkData];
+                parentDict[@"children"] = children;
+                completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+                return;
+            }
+        }
+
+        newBookmarkData[@"index"] = index ?: @(uiProcessMockBookmarks.get().count);
+        [uiProcessMockBookmarks addObject:newBookmarkData];
+        completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+    };
+
+    manager.get().internalDelegate.getBookmarksForExtensionContext = ^(void (^completionHandler)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *)) {
+        NSMutableArray<NSObject<_WKWebExtensionBookmark> *> *results = [NSMutableArray array];
+        for (NSDictionary *dict in uiProcessMockBookmarks.get()) {
+            auto mockNode = adoptNS([_MockBookmarkNode new]);
+            mockNode.get().dictionary = [dict mutableCopy];
+            [results addObject:mockNode.get()];
+        }
+        completionHandler(results, nil);
+    };
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPIBookmarks, GetSubTree)
+{
+    auto uiProcessMockBookmarks = adoptNS([NSMutableArray new]);
+    __block NSInteger nextMockBookmarkId = 100;
+    auto *script = @[
+        @"let folder = await browser.bookmarks.create({title: 'Test Folder' });",
+        @"browser.test.assertEq(folder.title, 'Test Folder', 'Folder title should be correct');",
+        @"browser.test.assertTrue(!!folder.id, 'Folder should have an ID');",
+        @"let bookmark = await browser.bookmarks.create({parentId: folder.id, title: 'WebKit.org', url: 'https://webkit.org/' });",
+        @"browser.test.assertEq(bookmark.title, 'WebKit.org', 'Bookmark title should be correct');",
+        @"browser.test.assertEq(bookmark.url, 'https://webkit.org/', 'Bookmark URL should be correct');",
+        @"let folder2 = await browser.bookmarks.create({parentId: folder.id, title: 'Folder 2'});",
+        @"browser.test.assertEq(folder2.title, 'Folder 2', 'Bookmark title should be correct');",
+        @"browser.test.assertEq(folder2.parentId, folder.id, 'Bookmark URL should be correct');",
+        @"let bookmark2 = await browser.bookmarks.create({parentId: folder2.id, title: 'Bookmark 2', url: 'https://bookmark2.org/' });",
+        @"browser.test.log(`Starting bookmark test right before...: ${JSON.stringify(folder.id)}`);",
+        @"let subtreeFolder1 = await browser.bookmarks.getSubTree(folder.id);",
+        @"browser.test.assertTrue(Array.isArray(subtreeFolder1), 'subtreeFolder1 should be an array');",
+        @"browser.test.assertEq(2, subtreeFolder1.length, 'subtreeFolder1 array should have 2 elements');",
+        @"browser.test.assertEq('Folder 2', subtreeFolder1[1].title, 'childs title should be Folder 2');",
+        @"browser.test.assertEq('folder', subtreeFolder1[1].type, 'type should be folder');",
+        @"browser.test.assertTrue(Array.isArray(subtreeFolder1[1].children), 'Folder 2 should have children');",
+        @"browser.test.assertEq(1, subtreeFolder1[1].children.length, 'folder 2 should have 1 child');",
+        @"browser.test.assertEq(bookmark2.title, subtreeFolder1[1].children[0].title, 'bookmark2 should be child of folder2');",
+        @"browser.test.assertEq(bookmark.id, subtreeFolder1[0].id, 'Second child is bookmark');",
+        @"let subtreeBookmark = await browser.bookmarks.getSubTree(bookmark.id);",
+        @"browser.test.assertTrue(Array.isArray(subtreeBookmark), 'subtreeBookmark should be an array');",
+        @"browser.test.assertEq(0, subtreeBookmark.length, 'subtreeBookmark array should have 1 element');",
+        @"let childrenFolder1 = await browser.bookmarks.getChildren(folder.id);",
+        @"browser.test.assertTrue(Array.isArray(childrenFolder1), 'childrenFolder1 should be an array');",
+        @"browser.test.assertEq('Folder 2', childrenFolder1[1].title, 'childs title should be Folder 2');",
+        @"browser.test.log(`Starting bookmark test right before...: ${JSON.stringify(folder2.id)}`);",
+        @"let getFolder1 = await browser.bookmarks.get([folder.id, folder2.id]);",
+        @"browser.test.assertTrue(Array.isArray(getFolder1), 'getFolder1 should be an array');",
+        @"browser.test.assertEq(2, getFolder1.length, 'getFolder1 array should have 2 elements');",
+        @"browser.test.assertEq('Folder 2', getFolder1[1].title, 'childs title should be Folder 2');",
+        @"browser.test.assertEq('Test Folder', getFolder1[0].title, 'childs title should be Folder 2');",
+        @"browser.test.notifyPass();",
+    ];
+
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    manager.get().internalDelegate.createBookmarkWithParentIdentifier = ^(NSString * parentId, NSNumber * index, NSString * url, NSString * title, void (^completionHandler)(NSObject<_WKWebExtensionBookmark> *, NSError *)) {
+        NSMutableDictionary *newBookmarkData = [NSMutableDictionary dictionary];
+        newBookmarkData[@"title"] = title;
+        if (url)
+            newBookmarkData[@"url"] = url;
+        NSString *newId = [NSString stringWithFormat:@"%ld", (long)nextMockBookmarkId];
+        nextMockBookmarkId++;
+        newBookmarkData[@"id"] = newId;
+        if (!newBookmarkData[@"type"]) {
+            NSString *url = newBookmarkData[@"url"];
+            newBookmarkData[@"type"] = (url && url.length > 0) ? @"bookmark" : @"folder";
+        }
         newBookmarkData[@"parentId"] = parentId;
         if (parentId && ![parentId isEqualToString:@"0"]) {
             NSMutableDictionary *parentDict = findParentInMockTree(uiProcessMockBookmarks.get(), parentId);

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -70,6 +70,9 @@
 
 @property (nonatomic, copy) void (^didUpdateSidebar)(_WKWebExtensionSidebar *);
 
+@property (nonatomic, copy) void (^createBookmarkWithParentIdentifier)(NSString * parentId, NSNumber * index, NSString * url, NSString * title, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
+@property (nonatomic, copy) void (^getBookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *));
+
 @end
 
 #endif // __OBJC__

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -170,6 +170,23 @@
         _didUpdateSidebar(sidebar);
 }
 
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller createBookmarkWithParentIdentifier:(NSString *)parentId index:(NSNumber *)index url:(NSString *)url title:(NSString *)title forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler
+{
+    if (_createBookmarkWithParentIdentifier)
+        _createBookmarkWithParentIdentifier(parentId, index, url, title, completionHandler);
+    else if (completionHandler)
+        completionHandler(nil, nil);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller getBookmarksForExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *))completionHandler
+{
+    if (_getBookmarksForExtensionContext)
+        _getBookmarksForExtensionContext(completionHandler);
+    else if (completionHandler)
+        completionHandler(@[], nil);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 9edb20b7fedb8ba9d34ec202d0bec69dc6047c99
<pre>
Web Extension: Add implementations for get(), getSubTree(), and getChildren()
<a href="https://rdar.apple.com/152505844">rdar://152505844</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295876">https://bugs.webkit.org/show_bug.cgi?id=295876</a>

Reviewed by NOBODY (OOPS!).

Adds the WebProcess and UIProcess for get(), getSubTree(), and getChildren(). Also adds tests for these.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::findBookmarkNodeInTree):
(WebKit::createShallowParametersFromProtocolObjects):
(WebKit::WebExtensionContext::bookmarksGetSubTree):
(WebKit::WebExtensionContext::bookmarksGet):
(WebKit::WebExtensionContext::bookmarksGetChildren):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::WebExtensionAPIBookmarks::getChildren):
(WebKit::WebExtensionAPIBookmarks::getSubTree):
(WebKit::WebExtensionAPIBookmarks::get):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(-[_MockBookmarkNode bookmarkTypeForWebExtensionContext:]):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, GetSubTree)):
</pre>
----------------------------------------------------------------------
#### 6a6001177fd679fe7a11e281b5692c3d9e28fe2f
<pre>
Web Extensions: Add delegate functions for getTree()
<a href="https://rdar.apple.com/155264420">rdar://155264420</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295551">https://bugs.webkit.org/show_bug.cgi?id=295551</a>

Reviewed by NOBODY (OOPS!).

Implementation of getTree and mockNode for create bookmarks for testing. Created a delegate for getTree and create.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::createParametersFromProtocolObject):
(WebKit::createParametersFromProtocolObjects):
(WebKit::WebExtensionContext::bookmarksCreate):
(WebKit::WebExtensionContext::bookmarksGetTree):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::toAPI):
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getTree):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(-[_MockBookmarkNode initWithDictionary:]):
(-[_MockBookmarkNode childrenForWebExtensionContext:]):
(findParentInMockTree):
(-[TestBookmarksDelegate init]):
(-[TestBookmarksDelegate _webExtensionController:getBookmarksForExtensionContext:completionHandler:]):
(-[TestBookmarksDelegate _webExtensionController:createBookmarkWithParentIdentifier:index:url:title:forExtensionContext:completionHandler:]):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:createBookmarkWithParentIdentifier:index:url:title:forExtensionContext:completionHandler:]):
(-[TestWebExtensionsDelegate _webExtensionController:getBookmarksForExtensionContext:completionHandler:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9edb20b7fedb8ba9d34ec202d0bec69dc6047c99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36697 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122471 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94886 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97903 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94629 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39766 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17573 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36249 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40010 "Hash 9edb20b7 for PR 48452 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45509 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39651 "Hash 9edb20b7 for PR 48452 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42984 "Hash 9edb20b7 for PR 48452 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41388 "Hash 9edb20b7 for PR 48452 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->