### PR TITLE
[Flex] getComputedStyle should reflect that first-letter and first-line cannot be applied to flexboxes.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_first-letter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox_first-letter-expected.txt
@@ -1,4 +1,4 @@
 Triceratops
 
-FAIL flexbox | first-letter assert_not_equals: got disallowed value "2"
+PASS flexbox | first-letter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/getcomputedstyle/first-line-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/getcomputedstyle/first-line-computed-style-expected.txt
@@ -1,0 +1,4 @@
+Triceratops
+
+PASS first-line-computed-style
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/getcomputedstyle/first-line-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/getcomputedstyle/first-line-computed-style.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta name="assert" content="::first-line style cannot be applied to a flexbox since it does not contribute a first formatted line. Checks via getComputedStyle">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-containers">
+<style>
+  div { display: flex; }
+  div::first-line { vertical-align: top; }
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div>Triceratops</div>
+
+<script>
+  test(function() {
+    let verticalAlign = getComputedStyle(document.querySelector('div'), '::first-line').verticalAlign;
+    assert_not_equals(verticalAlign, "top");
+  });
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3173,14 +3173,18 @@ std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets
     SetForScope change(m_ignorePendingStylesheets, true);
     Ref resolver = element.styleResolver();
 
+    auto elementStyle = resolver->styleForElement(element, { parentStyle });
     if (pseudoElementIdentifier) {
+        auto pseudoId = pseudoElementIdentifier->pseudoId;
+        if ((pseudoId == PseudoId::FirstLetter || pseudoId == PseudoId::FirstLine) && elementStyle.style && !Style::supportsFirstLineAndLetterPseudoElement(*elementStyle.style))
+            return { };
+
         auto style = resolver->styleForPseudoElement(element, { *pseudoElementIdentifier }, { parentStyle });
         if (!style)
             return nullptr;
         return WTFMove(style->style);
     }
 
-    auto elementStyle = resolver->styleForElement(element, { parentStyle });
     if (elementStyle.relations) {
         Style::Update emptyUpdate(*this);
         Style::commitRelations(WTFMove(elementStyle.relations), emptyUpdate);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -395,17 +395,6 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     return { WTFMove(update), descendantsToResolve };
 }
 
-inline bool supportsFirstLineAndLetterPseudoElement(const RenderStyle& style)
-{
-    auto display = style.display();
-    return display == DisplayType::Block
-        || display == DisplayType::ListItem
-        || display == DisplayType::InlineBlock
-        || display == DisplayType::TableCell
-        || display == DisplayType::TableCaption
-        || display == DisplayType::FlowRoot;
-};
-
 std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element, const PseudoElementIdentifier& pseudoElementIdentifier, const ElementUpdate& elementUpdate, IsInDisplayNoneTree isInDisplayNoneTree, const RenderStyle* existingStyle)
 {
     if (elementUpdate.style->display() == DisplayType::None)

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -231,6 +231,17 @@ private:
 void deprecatedQueuePostResolutionCallback(Function<void()>&&);
 bool postResolutionCallbacksAreSuspended();
 
+inline bool supportsFirstLineAndLetterPseudoElement(const RenderStyle& style)
+{
+    auto display = style.display();
+    return display == DisplayType::Block
+        || display == DisplayType::ListItem
+        || display == DisplayType::InlineBlock
+        || display == DisplayType::TableCell
+        || display == DisplayType::TableCaption
+        || display == DisplayType::FlowRoot;
+}
+
 class PostResolutionCallbackDisabler {
 public:
     enum class DrainCallbacks : bool { No, Yes };


### PR DESCRIPTION
#### 02a339f40c687d1ce5b504eea903ab94cf8b40ca
<pre>
[Flex] getComputedStyle should reflect that first-letter and first-line cannot be applied to flexboxes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=210474">https://bugs.webkit.org/show_bug.cgi?id=210474</a>
<a href="https://rdar.apple.com/94163778">rdar://94163778</a>

Reviewed by Tim Nguyen.

first-letter and first-line cannot be applied to flexboxes since these
boxes do not generate a first formatted line. However, if you attempt to
query the respective pseudo element&apos;s style via getComputedStyle you
will end up with the value that was specified even though it should not
have been applied.

(WebCore::Document::styleForElementIgnoringPendingStylesheets):
Instead of just trying to resolve the style for the pseudo element
immediately, we should first resolve the style with the associated
element and check whether or not it can have the associated pseudo
content.

Canonical link: <a href="https://commits.webkit.org/298706@main">https://commits.webkit.org/298706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b02aae86372c30d7303f1fe5e31d043d0a6b757

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66796 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2af4638a-61ec-43a3-b41f-51e955072631) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88301 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42817 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67221192-0761-43c3-83d5-c01b0220c09f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68712 "Passed tests") | | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22396 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65974 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125442 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97019 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96804 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39077 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45819 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->