### PR TITLE
Partially revert 296380@main

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -677,13 +677,11 @@ void VideoPresentationManagerProxy::applicationDidBecomeActive()
 
 void VideoPresentationManagerProxy::requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier contextId, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&& callback)
 {
-    RefPtr page = m_page.get();
-    if (!page)
-        return callback({ }, { });
-    RefPtr process = WebProcessProxy::processForIdentifier(contextId.processIdentifier());
-    if (!process)
-        return callback({ }, { });
-    process->sendWithAsyncReply(Messages::VideoPresentationManager::RequestRouteSharingPolicyAndContextUID(contextId.object()), WTFMove(callback), page->webPageIDInProcess(*process));
+    // FIXME: This needs to be implemented for site isolation in a way that doesn't re-introduce rdar://155266545
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::VideoPresentationManager::RequestRouteSharingPolicyAndContextUID(contextId.object()), WTFMove(callback), page->webPageIDInMainFrameProcess());
+    else
+        callback({ }, { });
 }
 
 static Ref<PlatformVideoPresentationInterface> videoPresentationInterface(WebPageProxy& page, PlatformPlaybackSessionInterface& playbackSessionInterface)

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
@@ -100,6 +100,7 @@ void WebFramePolicyListenerProxy::download()
 
 void WebFramePolicyListenerProxy::ignore(WasNavigationIntercepted wasNavigationIntercepted)
 {
+    WTFReportBacktrace();
     if (m_reply)
         m_reply(WebCore::PolicyAction::Ignore, nullptr, ProcessSwapRequestedByClient::No, { }, wasNavigationIntercepted);
 }


### PR DESCRIPTION
#### d9e38f6e964e771d4196059110cf46cea288149f
<pre>
Partially revert 296380@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=296411">https://bugs.webkit.org/show_bug.cgi?id=296411</a>
<a href="https://rdar.apple.com/155266545">rdar://155266545</a>

Reviewed by Eric Carlson.

Sending Messages::VideoPresentationManager::RequestRouteSharingPolicyAndContextUID to the process
with the media element in it keeps waking it up, causing HLS buffering to continue in the background.
Partially revert for now.

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::requestRouteSharingPolicyAndContextUID):

Canonical link: <a href="https://commits.webkit.org/297956@main">https://commits.webkit.org/297956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dad974d1b4a725183599a6412d032fe00b0f63a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85975 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36683 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115919 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101831 "Found 3 new API test failures: TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigationRetainBundlePage, TestWebKitAPI.ProcessSwap.ReuseSuspendedProcessForRegularNavigation, TestWebKitAPI.ContentRuleList.RequestMethods (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66401 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62934 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122397 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94827 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94568 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36163 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45435 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->