### PR TITLE
[CSS ZOOM] Apply zoom factor during cascade build time

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7784,7 +7784,6 @@ imported/w3c/web-platform-tests/css/css-viewport/zoom/svg.html [ ImageOnlyFailur
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-indent.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-shadow.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/text-stroke-width.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/word-spacing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/border.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/bottom.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/container-queries.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/length-implicit-and-explicit-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/length-implicit-and-explicit-inheritance-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL width: inherit from 100px assert_equals: expected "100px" but got "50px"
 FAIL height: inherit from 100px assert_equals: expected "100px" but got "50px"
-FAIL word-spacing: inherit from 100px assert_equals: expected "100px" but got "50px"
-FAIL word-spacing: unset from 100px assert_equals: expected "100px" but got "50px"
-FAIL word-spacing:  from 100px assert_equals: expected "100px" but got "50px"
+PASS word-spacing: inherit from 100px
+PASS word-spacing: unset from 100px
+PASS word-spacing:  from 100px
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8435,7 +8435,7 @@
                 "animation-wrapper": "LengthWrapper",
                 "animation-wrapper-requires-additional-parameters": ["{ LengthWrapper::Flags::IsLengthPercentage }"],
                 "animation-wrapper-requires-computed-getter": true,
-                "style-builder-custom": "Inherit",
+                "style-builder-custom": "Inherit|Value",
                 "style-builder-converter": "TextLengthOrNormal",
                 "style-extractor-custom": true,
                 "sink-priority": true,

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -94,6 +94,8 @@ void PropertyCascade::buildCascade()
             cascadeLevelsWithImportant.add(cascadeLevel);
     }
 
+    injectUnsetForZoomAffectedProperties();
+
     if (m_positionTryFallbackProperties)
         addPositionTryFallbackProperties();
 
@@ -104,6 +106,30 @@ void PropertyCascade::buildCascade()
     }
 
     sortLogicalGroupPropertyIDs();
+}
+
+void PropertyCascade::injectUnsetForZoomAffectedProperties()
+{
+    static const CSSPropertyID zoomAffectedProperties[] = {
+        CSSPropertyWordSpacing,
+    };
+
+    auto unsetValue = CSSPrimitiveValue::create(CSSValueUnset);
+    auto properties = MutableStyleProperties::create();
+
+    for (auto propertyID : zoomAffectedProperties) {
+        if (!CSSProperty::isInheritedProperty(propertyID))
+            continue;
+
+        if (hasNormalProperty(propertyID))
+            continue;
+
+        properties->setProperty(propertyID, unsetValue);
+    }
+
+    MatchedProperties matchedProperties { properties.get() };
+
+    addMatch(matchedProperties, CascadeLevel::UserAgent, IsImportant::No);
 }
 
 void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, CascadeLevel cascadeLevel)

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -104,6 +104,7 @@ public:
 
 private:
     void buildCascade();
+    void injectUnsetForZoomAffectedProperties();
     bool addNormalMatches(CascadeLevel);
     void addImportantMatches(CascadeLevel);
     bool addMatch(const MatchedProperties&, CascadeLevel, IsImportant);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -155,6 +155,18 @@ inline WebkitLineGrid forwardInheritedValue(const WebkitLineGrid& value) { auto 
 inline BorderImageSource forwardInheritedValue(const BorderImageSource& value) { auto copy = value; return copy; }
 inline MaskBorderSource forwardInheritedValue(const MaskBorderSource& value) { auto copy = value; return copy; }
 
+inline WebCore::Length adjustInheritedLengthForZoom(const WebCore::Length& parentValue, const BuilderState& builderState)
+{
+    float parentZoom = builderState.parentStyle().usedZoom();
+    float currentZoom = builderState.style().usedZoom();
+
+    if (currentZoom == parentZoom)
+        return parentValue;
+
+    float zoomRatio = currentZoom / parentZoom;
+    return WebCore::Length(parentValue.value() * zoomRatio, parentValue.type());
+}
+
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {
 public:
@@ -211,6 +223,8 @@ public:
     static void applyValueWebkitTextZoom(BuilderState&, CSSValue&);
     static void applyValueWritingMode(BuilderState&, CSSValue&);
     static void applyValueFontSizeAdjust(BuilderState&, CSSValue&);
+    static void applyValueWordSpacing(BuilderState&, CSSValue&);
+
 
 #if ENABLE(DARK_MODE_CSS)
     static void applyValueColorScheme(BuilderState&, CSSValue&);
@@ -393,7 +407,7 @@ DEFINE_BORDER_IMAGE_MODIFIER_HANDLER(MaskBorder, Width)
 
 inline void BuilderCustom::applyInheritWordSpacing(BuilderState& builderState)
 {
-    builderState.style().setWordSpacing(forwardInheritedValue(builderState.parentStyle().computedWordSpacing()));
+    builderState.style().setWordSpacing(adjustInheritedLengthForZoom(builderState.parentStyle().computedWordSpacing(), builderState));
 }
 
 inline void BuilderCustom::applyInheritLetterSpacing(BuilderState& builderState)
@@ -437,6 +451,23 @@ inline void BuilderCustom::applyValueLetterSpacing(BuilderState& builderState, C
 {
     maybeUpdateFontForLetterSpacing(builderState, value);
     builderState.style().setLetterSpacing(BuilderConverter::convertTextLengthOrNormal(builderState, value));
+}
+
+inline void BuilderCustom::applyValueWordSpacing(BuilderState& builderState, CSSValue& value)
+{
+    auto length = BuilderConverter::convertTextLengthOrNormal(builderState, value);
+
+    // computeNonCalcLengthDouble skips zoom for all relative units
+    // We need to manually apply zoom here to ensure consistent behavior with px units
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->isFontRelativeLength()) {
+            float zoom = builderState.style().usedZoom();
+            if (zoom != 1.0f)
+                length = WebCore::Length(length.value() * zoom, length.type());
+        }
+    }
+
+    builderState.style().setWordSpacing(WTFMove(length));
 }
 
 #if ENABLE(TEXT_AUTOSIZING)


### PR DESCRIPTION
#### cd60099499eb
<pre>
Make word-spacing zoom aware
<a href="https://bugs.webkit.org/show_bug.cgi?id=296165">https://bugs.webkit.org/show_bug.cgi?id=296165</a>
<a href="https://rdar.apple.com/156118978">rdar://156118978</a>

Reviewed by NOBODY (OOPS!).

This PR applies zoom to the word-spacing property;
other properties will follow.

When zoom changes occur between parent and child elements, the
used values of inherited length properties must be adjusted.
However, the automatic inheritance mechanism simply copies values
and cannot apply these adjustments.

To address this, the following changes have been introduced:

- During cascade building, we inject &apos;unset&apos; values for zoom-affected
inherited properties. This forces these properties to follow an
explicit inheritance path, allowing us to handle zoom
adjustments properly.

- Relative units require additional handling, as zoom is not applied
during their conversion. To ensure consistency with absolute units,
zoom adjustments are applied manually.

All zoom adjustments are now performed at style-resolution time.

Please note that this is a workaround and will be removed in the future.
Ideally, these adjustments should occur during layout time,
when effective values also known as &quot;used values&quot; are computed.

LayoutTests/TestExpectations:
LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/length-implicit-and-explicit-inheritance-expected.txt:
Source/WebCore/css/CSSProperties.json:
Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::buildCascade):
(WebCore::Style::PropertyCascade::injectUnsetForZoomAffectedProperties):
Source/WebCore/style/PropertyCascade.h:
Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::adjustInheritedLengthForZoom):
(WebCore::Style::BuilderCustom::applyInheritWordSpacing):
(WebCore::Style::BuilderCustom::applyValueWordSpacing):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd60099499eba6f163a473a3c1e8a6f6486c4efc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65885 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f30e6196-ca46-40c9-9e86-9c0e8f978a1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87585 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42324 "Too many flaky failures: compositing/transforms/transformed-replaced-with-shadow-children.html, fast/dom/HTMLTemplateElement/no-form-association-2.html, fast/dom/microtask-reverse.html, fast/events/page-visibility-null-view.html, fast/forms/change-input-type-in-focus-handler.html, js/arrowfunction-call.html, js/arrowfunction-constructor.html, js/call-apply-crash.html, js/caller-property.html, js/dom/array-with-double-push.html, js/dom/assign.html, js/dom/call-link-info-recursion.html, js/dom/callback-function-with-handle-event.html, js/dom/scheduled-action-exception-checks.html, performance-api/paint-timing/paint-timing-frames.html, performance-api/paint-timing/paint-timing-with-worker.html, resize-observer/element-leak.html, storage/domstorage/sessionstorage/set-item-synchronous-keydown.html, storage/indexeddb/cursor-continue-add-failure.html, storage/indexeddb/cursor-finished.html, storage/indexeddb/dont-wedge-private.html, storage/indexeddb/modern/index-1-private.html, storage/indexeddb/mozilla/readwrite-transactions.html, streams/readable-stream-default-controller-error.html, transforms/2d/scale-composited.html, webgl/2.0.y/conformance2/extensions/ext-color-buffer-float.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2d515f8-a712-401e-b2cc-cab196ee1b0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67981 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65042 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124558 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96378 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96163 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19239 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42114 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41631 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43357 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->