### PR TITLE
[ macOS ] media/media-source/media-source-rvfc-paused-offscreen.html is a flakey text failure

### DIFF
--- a/LayoutTests/media/media-source/media-source-rvfc-paused-offscreen.html
+++ b/LayoutTests/media/media-source/media-source-rvfc-paused-offscreen.html
@@ -25,6 +25,7 @@
         let video = document.createElement('video');
 
         let rvfcPromise = waitForVideoFrame(video);
+        let loadedDataPromise = waitFor(video, 'loadeddata', true);
         await setupMSE(video, "content/test-fragmented-video.mp4", "video/mp4; codecs=avc1.4d401e");
         const frame1 = await rvfcPromise;
 
@@ -33,18 +34,18 @@
         testExpected(frame1[1].width, 640);
         testExpected(frame1[1].height, 480);
 
+        await loadedDataPromise;
+        rvfcPromise = waitForVideoFrame(video);
         // FIXME: Last frame has a time of 9.958333, seeking on B-Framce webkit.org/b/283564
         // location of the last frame.
         video.currentTime = 9.916667;
 
-        const seekPromise = waitFor(video, 'seeked');
-        const frame2 = await waitForVideoFrame(video);
+        await waitFor(video, 'seeked');
+        const frame2 = await rvfcPromise;
         testExpectedEqualWithTolerance(video.currentTime, 9.916667, 0.000001);
         testExpectedEqualWithTolerance(frame2[1].mediaTime, 9.916667, 0.000001);
         testExpected(frame2[1].width, 640);
         testExpected(frame2[1].height, 480);
-
-        await seekPromise;
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/media/media-source/media-source-rvfc-paused.html
+++ b/LayoutTests/media/media-source/media-source-rvfc-paused.html
@@ -33,18 +33,17 @@
         testExpected(frame1[1].width, 640);
         testExpected(frame1[1].height, 480);
 
+        rvfcPromise = waitForVideoFrame(video);
         // FIXME: Last frame has a time of 9.958333, seeking on B-Framce webkit.org/b/283564
         // location of the last frame.
         video.currentTime = 9.916667;
 
-        const seekPromise = waitFor(video, 'seeked');
-        const frame2 = await waitForVideoFrame(video);
+        await waitFor(video, 'seeked');
+        const frame2 = await rvfcPromise;
         testExpectedEqualWithTolerance(video.currentTime, 9.916667, 0.000001);
         testExpectedEqualWithTolerance(frame2[1].mediaTime, 9.916667, 0.000001);
         testExpected(frame2[1].width, 640);
         testExpected(frame2[1].height, 480);
-
-        await seekPromise;
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2502,8 +2502,6 @@ webkit.org/b/296138 compositing/transforms/transformed-replaced-with-shadow-chil
 # Test seems to pass on WPT dashboard but fails on macOS
 imported/w3c/web-platform-tests/css/css-tables/paint/table-border-paint-caption-change.html [ Skip ]
 
-webkit.org/b/296334 media/media-source/media-source-rvfc-paused-offscreen.html [ Pass Failure ]
-
 webkit.org/b/296017 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-022.html [ Pass ImageOnlyFailure ]
 
 [ x86_64 ] imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-central-large-font-size.svg [ Skip ]

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -197,6 +197,8 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
     clearDecodeQueue();
     m_enqueueDiscontinuityBoundary = time + m_discontinuityTolerance;
 
+    m_needsReenqueueing = false;
+
     if (m_samples.empty())
         return false;
 
@@ -260,8 +262,6 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
                 m_hasOutOfOrderFrames = true;
         }
     }
-
-    m_needsReenqueueing = false;
 
     return true;
 }


### PR DESCRIPTION
#### 086d3a732eae0da936324c6452e1f91693b4d9f3
<pre>
[ macOS ] media/media-source/media-source-rvfc-paused-offscreen.html is a flakey text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=296334">https://bugs.webkit.org/show_bug.cgi?id=296334</a>
<a href="https://rdar.apple.com/156415981">rdar://156415981</a>

Reviewed by Youenn Fablet.

The test exposed two issues:
1- If the seeked event was fired after the requestVideoFrameCallback resolved,
   it would have lead to an expectation failure due to the ordering of messages varying.
2- From time to time, the rVFC would be resolved for the same frame (here the first) even though time progressed.

Issue 1 is resolved by amending the test so that we wait for the seeked event
before checking the rVFC result.

Issue 2 occurred because whenever we set the TrackBuffer&apos;s needsReenqueueing flag
we would only ever clear it if we did actually need to re-enqueue.
As such, on playback startup, or after a seek, samples were always unnecessarily
enqueued and decoded twice.
This regression was introduced a long time ago in 251376@main.

As the rVFC is resolved whenever we have a new frame to display, when
decoding the same frame a second time and it was still in time for display
the rVFC would be resolved with that same frame again.

The TrackBuffer shouldn&apos;t be managing its state and how frames should be enqueued to it,
the SourceBufferPrivate should and treat the TrackBuffer as a container only.
We will address this issue in a follow-up change.

* LayoutTests/media/media-source/media-source-rvfc-paused-offscreen.html:
* LayoutTests/media/media-source/media-source-rvfc-paused.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::reenqueueMediaForTime): Clear the needsReenqueueing flag as soon
as the method is called: there&apos;s nothing to re-enqueue in the future.

Canonical link: <a href="https://commits.webkit.org/297924@main">https://commits.webkit.org/297924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5259394399f3498bae13958802a71264e4a028d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/112994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/114956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/85991 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36700 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 48466") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19768 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122419 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94843 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94586 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17531 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36185 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45457 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42932 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->