### PR TITLE
[WPEPlatform][Wayland] Support asking the compositor for server-side decorations

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -176,8 +176,32 @@ add_custom_command(
     COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/unstable/linux-explicit-synchronization/linux-explicit-synchronization-unstable-v1.xml ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-explicit-synchronization-unstable-v1-client-protocol.h
     VERBATIM)
 
+set(WPEPlatformWayland_DEFINITIONS "")
+if (EXISTS "${WAYLAND_PROTOCOLS_DATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml")
+    add_custom_command(
+        OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-decoration-unstable-v1-protocol.c
+        MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
+        DEPENDS ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-decoration-unstable-v1-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER} private-code
+            ${WAYLAND_PROTOCOLS_DATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
+            ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-decoration-unstable-v1-protocol.c
+        VERBATIM)
+
+    add_custom_command(
+        OUTPUT ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-decoration-unstable-v1-client-protocol.h
+        MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
+        COMMAND ${WAYLAND_SCANNER} client-header
+            ${WAYLAND_PROTOCOLS_DATADIR}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml
+            ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-decoration-unstable-v1-client-protocol.h
+        VERBATIM)
+
+    list(APPEND WPEPlatformWayland_SOURCES ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/xdg-decoration-unstable-v1-protocol.c)
+    list(APPEND WPEPlatformWayland_DEFINITIONS USE_XDG_DECORATION_UNSTABLE_V1=1)
+endif ()
+
 add_library(WPEPlatformWayland OBJECT ${WPEPlatformWayland_SOURCES})
 add_dependencies(WPEPlatformWayland WPEPlatformGeneratedEnumTypesHeader)
+target_compile_definitions(WPEPlatformWayland PRIVATE ${WPEPlatformWayland_DEFINITIONS})
 target_include_directories(WPEPlatformWayland PRIVATE ${WPEPlatformWayland_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatformWayland SYSTEM PRIVATE ${WPEPlatformWayland_SYSTEM_INCLUDE_DIRECTORIES})
 target_link_libraries(WPEPlatformWayland ${WPEPlatformWayland_LIBRARIES})

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -94,6 +94,9 @@ struct _WPEDisplayWaylandPrivate {
 #if USE(SYSPROF_CAPTURE)
     struct wp_presentation* presentation;
 #endif
+#if USE(XDG_DECORATION_UNSTABLE_V1)
+    struct zxdg_decoration_manager_v1* xdgDecorationManager;
+#endif
     Vector<std::pair<uint32_t, uint64_t>> linuxDMABufFormats;
     std::unique_ptr<WPE::WaylandSeat> wlSeat;
     std::unique_ptr<WPE::WaylandCursor> wlCursor;
@@ -228,6 +231,9 @@ static void wpeDisplayWaylandDispose(GObject* object)
 #if USE(SYSPROF_CAPTURE)
     g_clear_pointer(&priv->presentation, wp_presentation_destroy);
 #endif
+#if USE(XDG_DECORATION_UNSTABLE_V1)
+    g_clear_pointer(&priv->xdgDecorationManager, zxdg_decoration_manager_v1_destroy);
+#endif
 #if USE(LIBDRM)
     g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
 #endif
@@ -283,6 +289,10 @@ const struct wl_registry_listener registryListener = {
 #if USE(SYSPROF_CAPTURE)
         else if (interfaceName == "wp_presentation"_s)
             priv->presentation = static_cast<struct wp_presentation*>(wl_registry_bind(registry, name, &wp_presentation_interface, 1));
+#endif
+#if USE(XDG_DECORATION_UNSTABLE_V1)
+        else if (interfaceName == "zxdg_decoration_manager_v1"_s)
+            priv->xdgDecorationManager = static_cast<struct zxdg_decoration_manager_v1*>(wl_registry_bind(registry, name, &zxdg_decoration_manager_v1_interface, 1));
 #endif
     },
     // global_remove
@@ -633,6 +643,13 @@ struct wp_presentation* wpeDisplayWaylandGetPresentation(WPEDisplayWayland* disp
     return display->priv->presentation;
 }
 #endif
+
+#if USE(XDG_DECORATION_UNSTABLE_V1)
+struct zxdg_decoration_manager_v1* wpeDisplayWaylandGetXDGDecorationManager(WPEDisplayWayland* display)
+{
+    return display->priv->xdgDecorationManager;
+}
+#endif // USE(XDG_DECORATION_UNSTABLE_V1)
 
 struct zwp_linux_explicit_synchronization_v1* wpeDisplayWaylandGetLinuxExplicitSync(WPEDisplayWayland* display)
 {

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h
@@ -30,6 +30,10 @@
 #include "WPEWaylandCursor.h"
 #include "WPEWaylandSeat.h"
 
+#if USE(XDG_DECORATION_UNSTABLE_V1)
+#include "xdg-decoration-unstable-v1-client-protocol.h"
+#endif
+
 struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
 WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
 WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
@@ -42,3 +46,4 @@ struct zwp_text_input_v3* wpeDisplayWaylandGetTextInputV3(WPEDisplayWayland*);
 struct zwp_pointer_constraints_v1* wpeDisplayWaylandGetPointerConstraints(WPEDisplayWayland*);
 struct zwp_relative_pointer_manager_v1* wpeDisplayWaylandGetRelativePointerManager(WPEDisplayWayland*);
 struct wp_presentation* wpeDisplayWaylandGetPresentation(WPEDisplayWayland*);
+struct zxdg_decoration_manager_v1* wpeDisplayWaylandGetXDGDecorationManager(WPEDisplayWayland*);


### PR DESCRIPTION
#### f7162bfa01cb4e605bf553e3b6500febf0c0d195
<pre>
[WPEPlatform][Wayland] Support asking the compositor for server-side decorations
<a href="https://bugs.webkit.org/show_bug.cgi?id=296425">https://bugs.webkit.org/show_bug.cgi?id=296425</a>

Reviewed by Patrick Griffis.

Optionally use the XDG Decoration protocol (xdg-decoration-unstable-v1)
to request Wayland compositors to use server-side decorations for toplevels.

* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandGetXDGDecorationManager):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:
(wpeToplevelWaylandConstructed):
(wpeToplevelWaylandDispose):

Canonical link: <a href="https://commits.webkit.org/297865@main">https://commits.webkit.org/297865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15a533c47c4c87a43ed6289db742478745b44bb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86008 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36660 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (failure); Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101652 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66321 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25936 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/62974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94859 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94602 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24172 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39738 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/39976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45475 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->