### PR TITLE
Annotate Media Stream endpoints with MediaDevicesEnabled

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4825,6 +4825,7 @@ MediaDevicesEnabled:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
   disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
 
 MediaEnabled:
   type: bool

--- a/Source/WebCore/Modules/mediastream/MediaDevices.idl
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.idl
@@ -37,10 +37,10 @@ typedef (MediaDeviceInfo or InputDeviceInfo) DeviceInfo;
     Exposed=Window
 ] interface MediaDevices : EventTarget {
     attribute EventHandler ondevicechange;
-    Promise<sequence<DeviceInfo>> enumerateDevices();
+    [EnabledBySetting=MediaDevicesEnabled] Promise<sequence<DeviceInfo>> enumerateDevices();
 
     MediaTrackSupportedConstraints getSupportedConstraints();
-    [PrivateIdentifier, PublicIdentifier] Promise<MediaStream> getUserMedia(optional MediaStreamConstraints constraints);
+    [PrivateIdentifier, PublicIdentifier, EnabledBySetting=MediaDevicesEnabled] Promise<MediaStream> getUserMedia(optional MediaStreamConstraints constraints);
     [EnabledBySetting=ScreenCaptureEnabled] Promise<MediaStream> getDisplayMedia(optional DisplayMediaStreamConstraints constraints);
 };
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -26,7 +26,7 @@
 [
     DispatchedFrom=WebContent,
     DispatchedTo=GPU,
-    EnabledBy=UseGPUProcessForMediaEnabled
+    EnabledBy=MediaDevicesEnabled || SpeechRecognitionEnabled
 ]
 messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager {
     CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceID) -> (std::optional<WebCore::CAAudioStreamDescription> description, uint64_t frameChunkSize)

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
@@ -30,6 +30,7 @@
 #include "Connection.h"
 #include "MessageReceiver.h"
 #include "RemoteVideoFrameObjectHeap.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "UserMediaCaptureManager.h"
 #include <WebCore/CaptureDevice.h>
 #include <WebCore/IntDegrees.h>

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in
@@ -26,7 +26,7 @@
 // rdar://140690546 - Can currently be dispatchedTo UI & GPU
 [
     DispatchedFrom=WebContent,
-    ExceptionForEnabledBy
+    EnabledBy=MediaDevicesEnabled || SpeechRecognitionEnabled
 ]
 messages -> UserMediaCaptureManagerProxy {
     CreateMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier id, WebCore::CaptureDevice device, struct WebCore::MediaDeviceHashSalts hashSalts, struct WebCore::MediaConstraints constraints, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier pageIdentifier) -> (struct WebCore::CaptureSourceError error, WebCore::RealtimeMediaSourceSettings settings, WebCore::RealtimeMediaSourceCapabilities capabilities) Async

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1785,6 +1785,10 @@ void NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedP
     m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess);
     if (CheckedPtr session = networkSession())
         session->storageManager().updateSharedPreferencesForConnection(m_connection, m_sharedPreferencesForWebProcess);
+#if USE(LIBWEBRTC)
+    if (RefPtr rtcProvider = m_rtcProvider)
+        rtcProvider->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+#endif
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3119,7 +3119,7 @@ RTCDataChannelRemoteManagerProxy& NetworkProcess::rtcDataChannelProxy()
 {
     ASSERT(isMainRunLoop());
     if (!m_rtcDataChannelProxy)
-        m_rtcDataChannelProxy = RTCDataChannelRemoteManagerProxy::create();
+        m_rtcDataChannelProxy = RTCDataChannelRemoteManagerProxy::create(*this);
     return *m_rtcDataChannelProxy;
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -207,6 +207,15 @@ PAL::SessionID NetworkMDNSRegister::sessionID() const
     return m_connection->sessionID();
 }
 
+std::optional<SharedPreferencesForWebProcess> NetworkMDNSRegister::sharedPreferencesForWebProcess() const
+{
+    RefPtr connectionToWebProcess = m_connection.get();
+    if (!connectionToWebProcess)
+        return std::nullopt;
+
+    return connectionToWebProcess->sharedPreferencesForWebProcess();
+}
+
 } // namespace WebKit
 
 #undef MDNS_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "RTCNetwork.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/CheckedRef.h>
@@ -78,6 +79,8 @@ public:
 #endif
 
     bool hasRegisteredName(const String&) const;
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
     void unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(WEB_RTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -541,6 +541,12 @@ void NetworkRTCMonitor::deref()
     m_rtcProvider->deref();
 }
 
+std::optional<SharedPreferencesForWebProcess> NetworkRTCMonitor::sharedPreferencesForWebProcess(IPC::Connection& connection) const
+{
+    Ref protectedProvider = m_rtcProvider.get();
+    return protectedProvider->sharedPreferencesForWebProcess(connection);
+}
+
 } // namespace WebKit
 
 #undef RTC_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 
 #include "RTCNetwork.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -63,6 +64,8 @@ public:
 
     void ref();
     void deref();
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
 
 private:
     void startUpdatingIfNeeded();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
@@ -23,9 +23,10 @@
 #if USE(LIBWEBRTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
 ]
 messages -> NetworkRTCMonitor {
     void StartUpdatingIfNeeded()

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -63,6 +63,7 @@ NetworkRTCProvider::NetworkRTCProvider(NetworkConnectionToWebProcess& connection
     : m_connection(&connection)
     , m_ipcConnection(connection.connection())
     , m_rtcMonitor(*this)
+    , m_sharedPreferences(connection.sharedPreferencesForWebProcessValue())
 #if PLATFORM(COCOA)
     , m_sourceApplicationAuditToken(connection.networkProcess().sourceApplicationAuditToken())
     , m_rtcNetworkThreadQueue(WorkQueue::create("NetworkRTCProvider Queue"_s, WorkQueue::QOS::UserInitiated))
@@ -390,6 +391,18 @@ void NetworkRTCProvider::signalSocketIsClosed(LibWebRTCSocketIdentifier identifi
 Ref<NetworkRTCMonitor> NetworkRTCProvider::protectedRTCMonitor()
 {
     return m_rtcMonitor;
+}
+
+std::optional<SharedPreferencesForWebProcess> NetworkRTCProvider::sharedPreferencesForWebProcess(IPC::Connection& connection)
+{
+    Locker locker { m_sharedPreferencesLock };
+    return m_sharedPreferences;
+}
+
+void NetworkRTCProvider::updateSharedPreferencesForWebProcess(const SharedPreferencesForWebProcess& preferences)
+{
+    Locker locker { m_sharedPreferencesLock };
+    m_sharedPreferences = preferences;
 }
 
 #undef RTC_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -125,6 +125,9 @@ public:
     const char* applicationBundleIdentifier() const { return m_applicationBundleIdentifier.data(); }
 #endif
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&);
+    void updateSharedPreferencesForWebProcess(const SharedPreferencesForWebProcess&);
+
 private:
     explicit NetworkRTCProvider(NetworkConnectionToWebProcess&);
     void startListeningForIPC();
@@ -167,6 +170,8 @@ private:
     bool m_isStarted { true };
 
     NetworkRTCMonitor m_rtcMonitor;
+    mutable Lock m_sharedPreferencesLock;
+    SharedPreferencesForWebProcess m_sharedPreferences WTF_GUARDED_BY_LOCK(m_sharedPreferencesLock);
 
 #if PLATFORM(COCOA)
     HashMap<WebPageProxyIdentifier, String> m_attributedBundleIdentifiers;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
@@ -23,9 +23,10 @@
 #if USE(LIBWEBRTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
 ]
 messages -> NetworkRTCProvider {
     CreateUDPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::WebRTCNetwork::SocketAddress localAddress, uint16_t minPort, uint16_t maxPort, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp
@@ -30,28 +30,32 @@
 #include "NetworkConnectionToWebProcess.h"
 #include "RTCDataChannelRemoteManagerMessages.h"
 #include "RTCDataChannelRemoteManagerProxyMessages.h"
+#include <wtf/RefPtr.h>
 
 namespace WebKit {
 
-RTCDataChannelRemoteManagerProxy::RTCDataChannelRemoteManagerProxy()
+RTCDataChannelRemoteManagerProxy::RTCDataChannelRemoteManagerProxy(NetworkProcess& networkProcess)
     : m_queue(WorkQueue::create("RTCDataChannelRemoteManagerProxy"_s))
+    , m_networkProcess(networkProcess)
 {
 }
 
 void RTCDataChannelRemoteManagerProxy::registerConnectionToWebProcess(NetworkConnectionToWebProcess& connectionToWebProcess)
 {
-    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier(), connectionID = connectionToWebProcess.connection().uniqueID()]() mutable {
+    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier(), connectionID = connectionToWebProcess.connection().uniqueID(), sharedPreferences = connectionToWebProcess.sharedPreferencesForWebProcessValue()]() mutable {
         ASSERT(!m_webProcessConnections.contains(identifier));
         m_webProcessConnections.add(identifier, connectionID);
+        m_sharedPreferencesForConnections.add(connectionID, WTFMove(sharedPreferences));
     });
     connectionToWebProcess.connection().addWorkQueueMessageReceiver(Messages::RTCDataChannelRemoteManagerProxy::messageReceiverName(), m_queue, *this);
 }
 
 void RTCDataChannelRemoteManagerProxy::unregisterConnectionToWebProcess(NetworkConnectionToWebProcess& connectionToWebProcess)
 {
-    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier()] {
+    m_queue->dispatch([this, protectedThis = Ref { *this }, identifier = connectionToWebProcess.webProcessIdentifier(), connectionID = connectionToWebProcess.connection().uniqueID()] {
         ASSERT(m_webProcessConnections.contains(identifier));
         m_webProcessConnections.remove(identifier);
+        m_sharedPreferencesForConnections.remove(connectionID);
     });
     connectionToWebProcess.connection().removeWorkQueueMessageReceiver(Messages::RTCDataChannelRemoteManagerProxy::messageReceiverName());
 }
@@ -90,6 +94,16 @@ void RTCDataChannelRemoteManagerProxy::bufferedAmountIsDecreasing(WebCore::RTCDa
 {
     if (auto connectionID = m_webProcessConnections.getOptional(identifier.processIdentifier()))
         IPC::Connection::send(*connectionID, Messages::RTCDataChannelRemoteManager::BufferedAmountIsDecreasing { identifier, amount }, 0);
+}
+
+std::optional<SharedPreferencesForWebProcess> RTCDataChannelRemoteManagerProxy::sharedPreferencesForWebProcess(const IPC::Connection& connection)
+{
+    auto iterator = m_sharedPreferencesForConnections.find(connection.uniqueID());
+    if (iterator != m_sharedPreferencesForConnections.end())
+        return iterator->value;
+
+    // Connection not found - this can happen during connection teardown or if called before registration
+    return std::nullopt;
 }
 
 }

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -27,6 +27,8 @@
 #if ENABLE(WEB_RTC)
 
 #include "Connection.h"
+#include "NetworkProcess.h"
+#include "SharedPreferencesForWebProcess.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/RTCDataChannelRemoteHandlerConnection.h>
 #include <WebCore/RTCDataChannelRemoteSourceConnection.h>
@@ -38,13 +40,14 @@ class NetworkConnectionToWebProcess;
 
 class RTCDataChannelRemoteManagerProxy final : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any> {
 public:
-    static Ref<RTCDataChannelRemoteManagerProxy> create() { return adoptRef(*new RTCDataChannelRemoteManagerProxy); }
+    static Ref<RTCDataChannelRemoteManagerProxy> create(NetworkProcess& networkProcess) { return adoptRef(*new RTCDataChannelRemoteManagerProxy(networkProcess)); }
 
     void registerConnectionToWebProcess(NetworkConnectionToWebProcess&);
     void unregisterConnectionToWebProcess(NetworkConnectionToWebProcess&);
 
 private:
-    RTCDataChannelRemoteManagerProxy();
+    RTCDataChannelRemoteManagerProxy(NetworkProcess&);
+
 
     // IPC::WorkQueueMessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -59,8 +62,12 @@ private:
     void detectError(WebCore::RTCDataChannelIdentifier, WebCore::RTCErrorDetailType, const String&);
     void bufferedAmountIsDecreasing(WebCore::RTCDataChannelIdentifier, uint64_t amount);
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&);
+
     const Ref<WorkQueue> m_queue;
     HashMap<WebCore::ProcessIdentifier, IPC::Connection::UniqueID> m_webProcessConnections;
+    HashMap<IPC::Connection::UniqueID, SharedPreferencesForWebProcess> m_sharedPreferencesForConnections;
+    const Ref<NetworkProcess> m_networkProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
@@ -23,9 +23,10 @@
 #if ENABLE(WEB_RTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
 ]
 messages -> RTCDataChannelRemoteManagerProxy {
     // To source

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2626,6 +2626,38 @@ void WebProcess::didReceiveRemoteCommand(PlatformMediaSession::RemoteControlComm
         page->didReceiveRemoteCommand(type, argument);
 }
 
+#if ENABLE(MEDIA_STREAM)
+bool WebProcess::anyPageHasMediaDevicesEnabled() const
+{
+    for (auto& page : m_pageMap.values()) {
+        RefPtr protectedPage = page.get();
+        if (!protectedPage)
+            continue;
+
+        if (RefPtr corePage = protectedPage->corePage()) {
+            if (corePage->settings().mediaDevicesEnabled())
+                return true;
+        }
+    }
+    return false;
+}
+
+bool WebProcess::anyPageHasSpeechRecognitionEnabled() const
+{
+    for (auto& page : m_pageMap.values()) {
+        RefPtr protectedPage = page.get();
+        if (!protectedPage)
+            continue;
+
+        if (RefPtr corePage = protectedPage->corePage()) {
+            if (corePage->settings().speechRecognitionEnabled())
+                return true;
+        }
+    }
+    return false;
+}
+#endif
+
 } // namespace WebKit
 
 #undef RELEASE_LOG_SESSION_ID

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -509,6 +509,11 @@ public:
 
     bool mediaPlaybackEnabled() const { return m_mediaPlaybackEnabled; }
 
+#if ENABLE(MEDIA_STREAM)
+    bool anyPageHasMediaDevicesEnabled() const;
+    bool anyPageHasSpeechRecognitionEnabled() const;
+#endif
+
 #if PLATFORM(COCOA)
     void registerAdditionalFonts(AdditionalFonts&&);
     void registerFontMap(HashMap<String, URL>&&, HashMap<String, Vector<String>>&&, Vector<SandboxExtension::Handle>&& sandboxExtensions);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
@@ -61,6 +61,9 @@ void RemoteRealtimeAudioSource::remoteAudioSamplesAvailable(const MediaTime& tim
 
 void RemoteRealtimeAudioSource::setIsInBackground(bool value)
 {
+    if (!WebProcess::singleton().anyPageHasMediaDevicesEnabled() && !WebProcess::singleton().anyPageHasSpeechRecognitionEnabled())
+        return;
+
     connection().send(Messages::UserMediaCaptureManagerProxy::SetIsInBackground { identifier(), value }, 0);
 }
 

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -94,8 +94,10 @@ void UserMediaCaptureManager::setupCaptureProcesses(bool shouldCaptureAudioInUIP
     m_videoFactory.setShouldCaptureInGPUProcess(shouldCaptureVideoInGPUProcess);
     m_displayFactory.setShouldCaptureInGPUProcess(shouldCaptureDisplayInGPUProcess);
 
-    if (shouldCaptureAudioInUIProcess || shouldCaptureAudioInGPUProcess)
-        WebCore::AudioMediaStreamTrackRendererInternalUnit::setCreateFunction(createRemoteAudioMediaStreamTrackRendererInternalUnitProxy);
+    if (shouldCaptureAudioInUIProcess || shouldCaptureAudioInGPUProcess) {
+        if (m_process->anyPageHasMediaDevicesEnabled() || m_process->anyPageHasSpeechRecognitionEnabled())
+            WebCore::AudioMediaStreamTrackRendererInternalUnit::setCreateFunction(createRemoteAudioMediaStreamTrackRendererInternalUnitProxy);
+    }
 
     if (shouldCaptureAudioInUIProcess || shouldCaptureAudioInGPUProcess)
         RealtimeMediaSourceCenter::singleton().setAudioCaptureFactory(m_audioFactory);
@@ -210,6 +212,9 @@ CaptureSourceOrError UserMediaCaptureManager::AudioFactory::createAudioCaptureSo
         return CaptureSourceOrError { "Audio capture in GPUProcess is not implemented"_s };
 #endif
 
+    if (m_shouldCaptureInGPUProcess && !m_manager->m_process->anyPageHasMediaDevicesEnabled() && !m_manager->m_process->anyPageHasSpeechRecognitionEnabled())
+        return CaptureSourceOrError { CaptureSourceError { "MediaDevices and SpeechRecognition are disabled - cannot create remote audio capture source"_s, MediaAccessDenialReason::UserMediaDisabled } };
+
 #if PLATFORM(IOS_FAMILY) || ENABLE(ROUTING_ARBITRATION)
     // FIXME: Remove disabling of the audio session category management once we move all media playing to GPUProcess.
     if (m_shouldCaptureInGPUProcess)
@@ -235,6 +240,10 @@ CaptureSourceOrError UserMediaCaptureManager::VideoFactory::createVideoCaptureSo
     if (m_shouldCaptureInGPUProcess)
         return CaptureSourceOrError { "Video capture in GPUProcess is not implemented"_s };
 #endif
+
+    if (m_shouldCaptureInGPUProcess && !m_manager->m_process->anyPageHasMediaDevicesEnabled() && !m_manager->m_process->anyPageHasSpeechRecognitionEnabled())
+        return CaptureSourceOrError { CaptureSourceError { "MediaDevices and SpeechRecognition are disabled - cannot create remote video capture source"_s, MediaAccessDenialReason::UserMediaDisabled } };
+
     if (m_shouldCaptureInGPUProcess)
         m_manager->m_remoteCaptureSampleManager.setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureGPUProcessConnection().videoFrameObjectHeapProxy());
 
@@ -247,6 +256,10 @@ CaptureSourceOrError UserMediaCaptureManager::DisplayFactory::createDisplayCaptu
     if (m_shouldCaptureInGPUProcess)
         return CaptureSourceOrError { "Display capture in GPUProcess is not implemented"_s };
 #endif
+
+    if (m_shouldCaptureInGPUProcess && !m_manager->m_process->anyPageHasMediaDevicesEnabled() && !m_manager->m_process->anyPageHasSpeechRecognitionEnabled())
+        return CaptureSourceOrError { CaptureSourceError { "MediaDevices and SpeechRecognition are disabled - cannot create remote display capture source"_s, MediaAccessDenialReason::UserMediaDisabled } };
+
     if (m_shouldCaptureInGPUProcess) {
         Ref videoFrameObjectHeapProxy = WebProcess::singleton().ensureGPUProcessConnection().videoFrameObjectHeapProxy();
         m_manager->m_remoteCaptureSampleManager.setVideoFrameObjectHeapProxy(WTFMove(videoFrameObjectHeapProxy));


### PR DESCRIPTION
#### 63c515a99f14ff20cea263edc954ca34fbf9cb29
<pre>
Annotate Media Stream endpoints with MediaDevicesEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=296429">https://bugs.webkit.org/show_bug.cgi?id=296429</a>
<a href="https://rdar.apple.com/156599811">rdar://156599811</a>

Reviewed by NOBODY (OOPS!).

Guard Media Stream and Capture endpoints with correct runtime flags

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/MediaDevices.idl:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h:
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.messages.in:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::rtcDataChannelProxy):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::NetworkMDNSRegister::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkRTCMonitor::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::NetworkRTCProvider):
(WebKit::NetworkRTCProvider::sharedPreferencesForWebProcess):
(WebKit::NetworkRTCProvider::updateSharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp:
(WebKit::RTCDataChannelRemoteManagerProxy::RTCDataChannelRemoteManagerProxy):
(WebKit::RTCDataChannelRemoteManagerProxy::registerConnectionToWebProcess):
(WebKit::RTCDataChannelRemoteManagerProxy::unregisterConnectionToWebProcess):
(WebKit::RTCDataChannelRemoteManagerProxy::sharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::anyPageHasMediaDevicesEnabled const):
(WebKit::WebProcess::anyPageHasSpeechRecognitionEnabled const):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp:
(WebKit::RemoteRealtimeAudioSource::setIsInBackground):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::setupCaptureProcesses):
(WebKit::UserMediaCaptureManager::AudioFactory::createAudioCaptureSource):
(WebKit::UserMediaCaptureManager::VideoFactory::createVideoCaptureSource):
(WebKit::UserMediaCaptureManager::DisplayFactory::createDisplayCaptureSource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c515a99f14ff20cea263edc954ca34fbf9cb29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120230 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65054 "Failed to checkout and rebase branch from PR 48476") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86693 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41691 "Unable to confirm if test failures are introduced by change, retrying build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102443 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67101 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20571 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63934 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106489 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123457 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112624 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95525 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95308 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40440 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18248 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37251 "Failed to checkout and rebase branch from PR 48476") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40969 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46471 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136825 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40594 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36635 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->