### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::ConcurrentPtrHashSet

### DIFF
--- a/Source/WTF/wtf/ConcurrentPtrHashSet.cpp
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include <wtf/ConcurrentPtrHashSet.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 ConcurrentPtrHashSet::ConcurrentPtrHashSet()
@@ -74,8 +72,9 @@ bool ConcurrentPtrHashSet::addSlow(Table* table, unsigned mask, unsigned startIn
     if (table->load.exchangeAdd(1) >= table->maxLoad())
         return resizeAndAdd(ptr);
     
+    auto span = table->span();
     for (;;) {
-        void* oldEntry = table->array[index].compareExchangeStrong(nullptr, ptr);
+        void* oldEntry = span[index].compareExchangeStrong(nullptr, ptr);
         if (!oldEntry) {
             if (m_table.load() != table) {
                 // We added an entry to an old table! We need to reexecute the add on the new table.
@@ -128,17 +127,18 @@ void ConcurrentPtrHashSet::resizeIfNecessary()
     m_table.store(&m_stubTable);
 
     std::unique_ptr<Table> newTable = Table::create(table->size * 2);
+    auto newTableSpan = newTable->span();
     unsigned mask = newTable->mask;
     unsigned load = 0;
-    for (unsigned i = 0; i < table->size; ++i) {
-        void* ptr = table->array[i].loadRelaxed();
+    for (auto& item : table->span()) {
+        void* ptr = item.loadRelaxed();
         if (!ptr)
             continue;
         
         unsigned startIndex = hash(ptr) & mask;
         unsigned index = startIndex;
         for (;;) {
-            Atomic<void*>& entryRef = newTable->array[index];
+            auto& entryRef = newTableSpan[index];
             void* entry = entryRef.loadRelaxed();
             if (!entry) {
                 entryRef.storeRelaxed(ptr);
@@ -185,12 +185,12 @@ bool ConcurrentPtrHashSet::resizeAndAdd(void* ptr)
 
 std::unique_ptr<ConcurrentPtrHashSet::Table> ConcurrentPtrHashSet::Table::create(unsigned size)
 {
-    std::unique_ptr<ConcurrentPtrHashSet::Table> result(new (fastMalloc(OBJECT_OFFSETOF(Table, array) + sizeof(Atomic<void*>) * size)) Table());
+    std::unique_ptr<ConcurrentPtrHashSet::Table> result(new (fastMalloc(OBJECT_OFFSETOF(Table, m_array) + sizeof(Atomic<void*>) * size)) Table());
     result->size = size;
     result->mask = size - 1;
     result->load.storeRelaxed(0);
-    for (unsigned i = 0; i < size; ++i)
-        result->array[i].storeRelaxed(nullptr);
+    for (auto& item : result->span())
+        item.storeRelaxed(nullptr);
     return result;
 }
 
@@ -203,9 +203,7 @@ void ConcurrentPtrHashSet::Table::initializeStub()
     size = 0;
     mask = 0;
     load.storeRelaxed(stubDefaultLoadValue);
-    array[0].storeRelaxed(nullptr);
+    span()[0].storeRelaxed(nullptr);
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/ConcurrentPtrHashSet.h
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.h
@@ -32,8 +32,6 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 // This is a concurrent hash-based set for pointers. It's optimized for:
@@ -107,7 +105,11 @@ private:
         unsigned size; // This is immutable.
         unsigned mask; // This is immutable.
         Atomic<unsigned> load;
-        Atomic<void*> array[1];
+
+        std::span<Atomic<void*>> span() { return unsafeMakeSpan(m_array, std::max(size, 1u)); }
+
+    private:
+        Atomic<void*> m_array[1];
     };
     
     static unsigned hash(const void* ptr)
@@ -139,8 +141,9 @@ private:
         unsigned mask = table->mask;
         unsigned startIndex = hash(ptr) & mask;
         unsigned index = startIndex;
+        auto span = table->span();
         for (;;) {
-            void* entry = table->array[index].loadRelaxed();
+            void* entry = span[index].loadRelaxed();
             if (!entry)
                 return false;
             if (entry == ptr)
@@ -157,8 +160,9 @@ private:
         unsigned mask = table->mask;
         unsigned startIndex = hash(ptr) & mask;
         unsigned index = startIndex;
+        auto span = table->span();
         for (;;) {
-            void* entry = table->array[index].loadRelaxed();
+            void* entry = span[index].loadRelaxed();
             if (!entry)
                 return addSlow(table, mask, startIndex, index, ptr);
             if (entry == ptr)
@@ -184,5 +188,3 @@ private:
 } // namespace WTF
 
 using WTF::ConcurrentPtrHashSet;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### e9964b3919ec010cfbbea9ba57ad7953fbd5f809
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF::ConcurrentPtrHashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=296432">https://bugs.webkit.org/show_bug.cgi?id=296432</a>

Reviewed by NOBODY (OOPS!).

This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/ConcurrentPtrHashSet.cpp:
(WTF::ConcurrentPtrHashSet::addSlow):
(WTF::ConcurrentPtrHashSet::resizeIfNecessary):
(WTF::ConcurrentPtrHashSet::Table::create):
(WTF::ConcurrentPtrHashSet::Table::initializeStub):
* Source/WTF/wtf/ConcurrentPtrHashSet.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9964b3919ec010cfbbea9ba57ad7953fbd5f809

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86033 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41471 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19810 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63000 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105555 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122463 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111654 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94882 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94625 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36241 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40002 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45501 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/135884 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39643 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36488 "Found 2 new JSC stress test failures: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->