### PR TITLE
[Style] Convert some OptionSet based properties to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2752,6 +2752,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/align/StyleGapGutter.h
 
     style/values/anchor-position/StyleAnchorName.h
+    style/values/anchor-position/StylePositionVisibility.h
 
     style/values/borders/StyleBorderRadius.h
     style/values/borders/StyleBoxShadow.h
@@ -2868,6 +2869,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/text/StyleTextIndent.h
 
+    style/values/text-decoration/StyleTextDecorationLine.h
     style/values/text-decoration/StyleTextDecorationThickness.h
     style/values/text-decoration/StyleTextEmphasisStyle.h
     style/values/text-decoration/StyleTextShadow.h

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -4,3 +4,5 @@ platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cv/VideoFrameCV.mm
 platform/mac/WebCoreObjCExtras.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h
+style/values/primitives/StylePrimitiveKeywordSet+Serialization.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4844,6 +4844,12 @@
 		BC0929AB2E2AA30A002ACB2C /* StyleScrollBehavior.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0929A82E2AA1D6002ACB2C /* StyleScrollBehavior.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC0929AF2E2AA652002ACB2C /* StyleWebKitTouchCallout.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0929AC2E2AA595002ACB2C /* StyleWebKitTouchCallout.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC0929B22E2AA9BA002ACB2C /* StyleWebKitOverflowScrolling.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0929B12E2AA9BA002ACB2C /* StyleWebKitOverflowScrolling.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A462E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A452E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A4B2E2EF0BC002ACB2C /* StylePositionVisibility.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A4A2E2EF0BC002ACB2C /* StylePositionVisibility.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A4D2E2EF3B4002ACB2C /* StyleTextDecorationLine.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A482E2EEB26002ACB2C /* StyleTextDecorationLine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A502E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A4F2E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A522E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A512E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC092A542E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = BC092A532E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10137C25C3624B00DC773C /* ColorModels.h in Headers */ = {isa = PBXBuildFile; fileRef = BC10137B25C3624B00DC773C /* ColorModels.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10137F25C3631600DC773C /* ColorTransferFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC10137E25C3631600DC773C /* ColorTransferFunctions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC10D76817D8EE71005E2626 /* RenderBlockFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = BCFB45F317D8E39200444446 /* RenderBlockFlow.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -18000,6 +18006,13 @@
 		BC092A042E2D5110002ACB2C /* StyleCursor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleCursor.cpp; sourceTree = "<group>"; };
 		BC092A0C2E2D75E6002ACB2C /* StyleTextDecorationThickness.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleTextDecorationThickness.cpp; sourceTree = "<group>"; };
 		BC092A1B2E2DBC36002ACB2C /* StyleViewTransitionName.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleViewTransitionName.cpp; sourceTree = "<group>"; };
+		BC092A452E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSPrimitiveKeywordSet.h; sourceTree = "<group>"; };
+		BC092A482E2EEB26002ACB2C /* StyleTextDecorationLine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleTextDecorationLine.h; sourceTree = "<group>"; };
+		BC092A4A2E2EF0BC002ACB2C /* StylePositionVisibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePositionVisibility.h; sourceTree = "<group>"; };
+		BC092A4E2E2EFBC1002ACB2C /* StylePrimitiveKeywordSet+CSSValueConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+CSSValueConversion.h"; sourceTree = "<group>"; };
+		BC092A4F2E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+CSSValueCreation.h"; sourceTree = "<group>"; };
+		BC092A512E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+Serialization.h"; sourceTree = "<group>"; };
+		BC092A532E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StylePrimitiveKeywordSet+Logging.h"; sourceTree = "<group>"; };
 		BC0CA74C264AED0A004FDC62 /* PixelBufferConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PixelBufferConversion.h; sourceTree = "<group>"; };
 		BC0CA74D264AED0A004FDC62 /* PixelBufferConversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PixelBufferConversion.cpp; sourceTree = "<group>"; };
 		BC10137B25C3624B00DC773C /* ColorModels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorModels.h; sourceTree = "<group>"; };
@@ -35028,6 +35041,7 @@
 			isa = PBXGroup;
 			children = (
 				BC2A0EF72E1214CD003CBA0E /* StyleAnchorName.h */,
+				BC092A4A2E2EF0BC002ACB2C /* StylePositionVisibility.h */,
 			);
 			path = "anchor-position";
 			sourceTree = "<group>";
@@ -35138,6 +35152,7 @@
 		BC3078E42D02884200630D75 /* text-decoration */ = {
 			isa = PBXGroup;
 			children = (
+				BC092A482E2EEB26002ACB2C /* StyleTextDecorationLine.h */,
 				BC092A0C2E2D75E6002ACB2C /* StyleTextDecorationThickness.cpp */,
 				1CB6B4F8217B83930093B9CD /* StyleTextDecorationThickness.h */,
 				BCD9EFEE2E19879200D1C3DF /* StyleTextEmphasisStyle.cpp */,
@@ -35896,6 +35911,7 @@
 				BCB271D82CC0142C00265123 /* CSSPosition.h */,
 				BC2C0C8E2D32EBCB00FCFBA0 /* CSSPrimitiveData.h */,
 				BC2C0C8D2D32EBBD00FCFBA0 /* CSSPrimitiveKeywordList.h */,
+				BC092A452E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h */,
 				BC2C0C8F2D32F35000FCFBA0 /* CSSPrimitiveNumeric.h */,
 				BCD67C112D1F10BB0079EB9C /* CSSPrimitiveNumericConcepts.h */,
 				BC2C0C902D32F3F200FCFBA0 /* CSSPrimitiveNumericOrKeyword.h */,
@@ -35953,6 +35969,10 @@
 				BC2A0F232E144E0A003CBA0E /* StylePrimitiveKeyword+CSSValueConversion.h */,
 				BC2A0D332E05D43F003CBA0E /* StylePrimitiveKeyword+CSSValueCreation.h */,
 				BC2A0D312E05D409003CBA0E /* StylePrimitiveKeyword+Serialization.h */,
+				BC092A4E2E2EFBC1002ACB2C /* StylePrimitiveKeywordSet+CSSValueConversion.h */,
+				BC092A4F2E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h */,
+				BC092A532E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h */,
+				BC092A512E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h */,
 				BC2A0E322E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h */,
 				BC2C0C912D32F46F00FCFBA0 /* StylePrimitiveNumeric.h */,
 				BC6AFC732DFE6FA10065FA1D /* StylePrimitiveNumericAdaptors.h */,
@@ -41408,6 +41428,7 @@
 				977B3863122883E900B81FF8 /* CSSPreloadScanner.h in Headers */,
 				BC2C0C972D32FCE600FCFBA0 /* CSSPrimitiveData.h in Headers */,
 				BC2C0C992D32FF3F00FCFBA0 /* CSSPrimitiveKeywordList.h in Headers */,
+				BC092A462E2EAC1A002ACB2C /* CSSPrimitiveKeywordSet.h in Headers */,
 				BC2C0C982D32FCF500FCFBA0 /* CSSPrimitiveNumeric.h in Headers */,
 				BCD67C122D1F10BB0079EB9C /* CSSPrimitiveNumericConcepts.h in Headers */,
 				BC2C0C9A2D3316C200FCFBA0 /* CSSPrimitiveNumericOrKeyword.h in Headers */,
@@ -45270,9 +45291,13 @@
 				BCD9F1782E2040DC00D1C3DF /* StylePerspectiveOrigin.h in Headers */,
 				BCB2720E2CC1F1DB00265123 /* StylePolygonFunction.h in Headers */,
 				BCB272212CC20CAC00265123 /* StylePosition.h in Headers */,
+				BC092A4B2E2EF0BC002ACB2C /* StylePositionVisibility.h in Headers */,
 				BC675B6E2DEE8BB700AD4D79 /* StylePreferredSize.h in Headers */,
 				BC2A0D342E05D43F003CBA0E /* StylePrimitiveKeyword+CSSValueCreation.h in Headers */,
 				BC2A0D322E05D409003CBA0E /* StylePrimitiveKeyword+Serialization.h in Headers */,
+				BC092A502E2EFBCE002ACB2C /* StylePrimitiveKeywordSet+CSSValueCreation.h in Headers */,
+				BC092A542E2EFBEB002ACB2C /* StylePrimitiveKeywordSet+Logging.h in Headers */,
+				BC092A522E2EFBD8002ACB2C /* StylePrimitiveKeywordSet+Serialization.h in Headers */,
 				BC2A0E332E0B6642003CBA0E /* StylePrimitiveNumeric+Forward.h in Headers */,
 				BCE434662D4320400030D140 /* StylePrimitiveNumeric.h in Headers */,
 				BC6AFC742DFE70590065FA1D /* StylePrimitiveNumericAdaptors.h in Headers */,
@@ -45325,6 +45350,7 @@
 				E46B72512B61141D00A1F9B5 /* StyleSheetContentsCache.h in Headers */,
 				A8EA800A0A19516E00A8EF5F /* StyleSheetList.h in Headers */,
 				BC5EB5E50E81BF6D00B25965 /* StyleSurroundData.h in Headers */,
+				BC092A4D2E2EF3B4002ACB2C /* StyleTextDecorationLine.h in Headers */,
 				1C73A71521857587004CCEA5 /* StyleTextDecorationThickness.h in Headers */,
 				DD1C779029354C77003BD79B /* StyleTextEdge.h in Headers */,
 				BCD9EFED2E18E5A000D1C3DF /* StyleTextEmphasisStyle.h in Headers */,

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1683,14 +1683,14 @@ LineDecorationStyle::LineDecorationStyle(RenderObject& renderer)
 {
     const auto& style = renderer.style();
     auto decor = style.textDecorationLineInEffect();
-    if (decor & TextDecorationLine::Underline || decor & TextDecorationLine::LineThrough) {
+    if (decor & CSS::Keyword::Underline { } || decor & CSS::Keyword::LineThrough { }) {
         auto decorationStyles = TextDecorationPainter::stylesForRenderer(renderer, decor);
-        if (decor & TextDecorationLine::Underline) {
+        if (decor & CSS::Keyword::Underline { }) {
             hasUnderline = true;
             underlineColor = decorationStyles.underline.color;
         }
 
-        if (decor & TextDecorationLine::LineThrough) {
+        if (decor & CSS::Keyword::LineThrough { }) {
             hasLinethrough = true;
             linethroughColor = decorationStyles.linethrough.color;
         }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2217,10 +2217,10 @@ void AXObjectCache::onStyleChange(RenderText& renderText, StyleDifference differ
 
     auto oldDecor = oldStyle->textDecorationLineInEffect();
     auto newDecor = newStyle.textDecorationLineInEffect();
-    if ((oldDecor & TextDecorationLine::Underline) != (newDecor & TextDecorationLine::Underline))
+    if ((oldDecor & CSS::Keyword::Underline { }) != (newDecor & CSS::Keyword::Underline { }))
         tree->queueNodeUpdate(object->objectID(), { AXProperty::HasUnderline });
 
-    if ((oldDecor & TextDecorationLine::LineThrough) != (newDecor & TextDecorationLine::LineThrough))
+    if ((oldDecor & CSS::Keyword::LineThrough { }) != (newDecor & CSS::Keyword::LineThrough { }))
         tree->queueNodeUpdate(object->objectID(), { AXProperty::HasLinethrough });
 
     if (oldStyle->textDecorationColor() != newStyle.textDecorationColor())

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2888,7 +2888,7 @@ bool AccessibilityRenderObject::hasUnderline() const
     if (!m_renderer)
         return false;
     
-    return m_renderer->style().textDecorationLineInEffect().contains(TextDecorationLine::Underline);
+    return m_renderer->style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { });
 }
 
 String AccessibilityRenderObject::secureFieldValue() const

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -788,8 +788,8 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::fontDPI()), "pt"_s));
         addAttributeIfNeeded("weight"_s, makeString(static_cast<float>(style.fontCascade().weight())));
         addAttributeIfNeeded("style"_s, style.fontCascade().italic() ? "italic"_s : "normal"_s);
-        addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine() & TextDecorationLine::LineThrough ? "true"_s : "false"_s);
-        addAttributeIfNeeded("underline"_s, style.textDecorationLine() & TextDecorationLine::Underline ? "single"_s : "none"_s);
+        addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine() & CSS::Keyword::LineThrough { } ? "true"_s : "false"_s);
+        addAttributeIfNeeded("underline"_s, style.textDecorationLine() & CSS::Keyword::Underline { } ? "single"_s : "none"_s);
         addAttributeIfNeeded("invisible"_s, style.visibility() == Visibility::Hidden ? "true"_s : "false"_s);
         addAttributeIfNeeded("editable"_s, m_coreObject->canSetValueAttribute() ? "true"_s : "false"_s);
         addAttributeIfNeeded("direction"_s, style.writingMode().isBidiLTR() ? "ltr"_s : "rtl"_s);

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -270,7 +270,7 @@ static void attributeStringSetStyle(NSMutableAttributedString *attrString, Rende
     attributedStringSetFont(attrString, style.fontCascade().primaryFont()->getCTFont(), range);
 
     auto decor = style.textDecorationLineInEffect();
-    if (decor & TextDecorationLine::Underline)
+    if (decor & CSS::Keyword::Underline { })
         attributedStringSetNumber(attrString, AccessibilityTokenUnderline, @YES, range);
 
     // Add code context if this node is within a <code> block.

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1221,12 +1221,6 @@ template<> constexpr TextJustify fromCSSValueID(CSSValueID valueID)
     return TextJustify::Auto;
 }
 
-#define TYPE TextDecorationLine
-#define FOR_EACH(CASE) CASE(Underline) CASE(Overline) CASE(LineThrough) CASE(Blink)
-DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
-#undef TYPE
-#undef FOR_EACH
-
 #define TYPE TextDecorationStyle
 #define FOR_EACH(CASE) CASE(Solid) CASE(Double) CASE(Dotted) CASE(Dashed) CASE(Wavy)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
@@ -2615,12 +2609,6 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 
 #define TYPE Style::PositionTryOrder
 #define FOR_EACH(CASE) CASE(Normal) CASE(MostWidth) CASE(MostHeight) CASE(MostBlockSize) CASE(MostInlineSize)
-DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
-#undef TYPE
-#undef FOR_EACH
-
-#define TYPE PositionVisibility
-#define FOR_EACH(CASE) CASE(AnchorsValid) CASE(AnchorsVisible) CASE(NoOverflow)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10273,7 +10273,7 @@
                 "initial-letter"
             ],
             "codegen-properties": {
-                "style-converter": "LineBoxContain",
+                "style-converter": "StyleType<LineBoxContain>",
                 "parser-grammar": "none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]"
             },
             "status": {
@@ -10814,10 +10814,10 @@
                 }
             ],
             "codegen-properties": {
-                "style-converter": "TextDecorationLine",
                 "aliases": [
                     "-webkit-text-decoration-line"
                 ],
+                "style-converter": "StyleType<TextDecorationLine>",
                 "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt)",
                 "parser-exported": true
             },
@@ -10959,7 +10959,7 @@
             "inherited": true,
             "codegen-properties": {
                 "skip-style-builder": true,
-                "style-extractor-converter": "TextDecorationLine",
+                "style-extractor-converter": "StyleType<TextDecorationLine>",
                 "render-style-name-for-methods": "TextDecorationLineInEffect",
                 "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt)",
                 "comment": "FIXME: Should this be an alias of text-decoration-line?"
@@ -12295,7 +12295,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssAnchorPositioningPositionVisibilityEnabled",
-                "style-converter": "PositionVisibility",
+                "style-converter": "StyleType<PositionVisibility>",
                 "parser-grammar": "always | [ anchors-valid || anchors-visible || no-overflow ]@(no-single-item-opt)"
             },
             "specification": {

--- a/Source/WebCore/css/scripts/process-css-values.py
+++ b/Source/WebCore/css/scripts/process-css-values.py
@@ -364,6 +364,7 @@ class GenerationContext:
         to.write(f"template<CSSValueID C> struct Constant {{\n")
         to.write(f"    static constexpr auto value = C;\n")
         to.write(f"    constexpr bool operator==(const Constant<C>&) const = default;\n")
+        to.write(f"    constexpr bool operator==(CSSValueID other) const {{ return value == other; }}\n")
         to.write(f"}};\n\n")
 
         to.write(f"namespace CSS::Keyword {{\n\n")

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordSet.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordSet.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordList.h"
+#include <wtf/MathExtras.h>
+
+namespace WebCore {
+namespace CSS {
+
+// `OptionSet`-like type for sets of CSS keywords.
+template<typename Derived, PrimitiveKeyword EmptyCase, PrimitiveKeyword... Ks> struct PrimitiveKeywordSet {
+    using Base = PrimitiveKeywordSet<Derived, EmptyCase, Ks...>;
+    using Keywords = PrimitiveKeywordList<Ks...>;
+
+    static constexpr auto bits = Keywords::count;
+    static_assert(bits <= 32);
+
+    using Storage = std::conditional_t<bits <= 8, uint8_t, std::conditional_t<bits <= 16, uint16_t, uint32_t>>;
+
+    static constexpr auto emptyCase = EmptyCase { };
+
+    struct Value {
+        constexpr Value(ValidKeywordForList<Keywords> auto keyword)
+            : value(static_cast<uint8_t>(Keywords::offsetForKeyword(keyword)))
+        {
+        }
+
+        PrimitiveKeywordSet toSet() const { return PrimitiveKeywordSet::fromRaw(1 << value); }
+
+        bool operator==(const Value&) const = default;
+
+    private:
+        uint8_t value;
+    };
+
+    static constexpr Derived all() { return fromRaw(-1); }
+
+    static constexpr Derived fromRaw(Storage raw) { return Derived(raw); }
+
+    constexpr PrimitiveKeywordSet() = default;
+
+    constexpr PrimitiveKeywordSet(EmptyCase)
+        : m_storage { 0 }
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(Storage storage)
+        : m_storage { storage }
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(ValidKeywordForList<Keywords> auto keyword)
+        : m_storage(toBit(keyword))
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(Value value)
+        : PrimitiveKeywordSet { value.toSet() }
+    {
+    }
+
+    constexpr PrimitiveKeywordSet(std::initializer_list<PrimitiveKeywordSet> initializerList)
+    {
+        for (auto& keywordSet : initializerList) {
+            ASSERT_UNDER_CONSTEXPR_CONTEXT(hasOneBitSet(keywordSet.m_storage));
+            m_storage |= keywordSet.m_storage;
+        }
+    }
+
+    constexpr Storage toRaw() const { return m_storage; }
+
+    constexpr bool isEmpty() const { return !m_storage; }
+    constexpr explicit operator bool() const { return !isEmpty(); }
+
+    // MARK: - Operators
+
+    constexpr friend Derived operator|(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage | rhs.m_storage);
+    }
+
+    constexpr PrimitiveKeywordSet& operator|=(const PrimitiveKeywordSet& other)
+    {
+        add(other);
+        return *this;
+    }
+
+    constexpr friend Derived operator&(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage & rhs.m_storage);
+    }
+
+    constexpr friend Derived operator-(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage & ~rhs.m_storage);
+    }
+
+    constexpr friend Derived operator^(PrimitiveKeywordSet lhs, PrimitiveKeywordSet rhs)
+    {
+        return fromRaw(lhs.m_storage ^ rhs.m_storage);
+    }
+
+    constexpr bool contains(ValidKeywordForList<Keywords> auto keyword) const
+    {
+        return containsAny(keyword);
+    }
+
+    constexpr bool contains(Value keyword) const
+    {
+        return containsAny(keyword.toSet());
+    }
+
+    constexpr bool containsAny(PrimitiveKeywordSet set) const
+    {
+        return !!(*this & set);
+    }
+
+    constexpr bool containsAll(PrimitiveKeywordSet set) const
+    {
+        return (*this & set) == set;
+    }
+
+    constexpr bool containsOnly(PrimitiveKeywordSet set) const
+    {
+        return *this == (*this & set);
+    }
+
+    constexpr void add(PrimitiveKeywordSet set)
+    {
+        m_storage |= set.m_storage;
+    }
+
+    constexpr void remove(PrimitiveKeywordSet set)
+    {
+        m_storage &= ~set.m_storage;
+    }
+
+    constexpr void set(PrimitiveKeywordSet set, bool value)
+    {
+        if (value)
+            add(set);
+        else
+            remove(set);
+    }
+
+    constexpr bool hasExactlyOneBitSet() const
+    {
+        return m_storage && !(m_storage & (m_storage - 1));
+    }
+
+    constexpr bool operator==(const PrimitiveKeywordSet&) const = default;
+
+private:
+    static constexpr Storage toBit(ValidKeywordForList<Keywords> auto keyword)
+    {
+        return static_cast<Storage>(1 << Keywords::offsetForKeyword(keyword));
+    }
+
+    Storage m_storage;
+};
+
+// MARK: - Concepts
+
+template<typename T> concept PrimitiveKeywordSetDerived = WTF::IsBaseOfTemplate<PrimitiveKeywordSet, T>::value  && VariantLike<T>;
+
+} // namespace CSS
+} // namespace WebCore

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4653,9 +4653,9 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
         }
     } else {
         auto decoration = style->textDecorationLineInEffect();
-        if (decoration & TextDecorationLine::LineThrough)
+        if (decoration & CSS::Keyword::LineThrough { })
             attributes.hasStrikeThrough = true;
-        if (decoration & TextDecorationLine::Underline)
+        if (decoration & CSS::Keyword::Underline { })
             attributes.hasUnderline = true;
     }
 

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -343,12 +343,12 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
     UNUSED_PARAM(elementQualifiesForWritingToolsPreservationCache);
 #endif
 
-    if (style.textDecorationLineInEffect() & TextDecorationLine::Underline)
+    if (style.textDecorationLineInEffect() & CSS::Keyword::Underline { })
         [attributes setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSUnderlineStyleAttributeName];
     else
         [attributes removeObjectForKey:NSUnderlineStyleAttributeName];
 
-    if (style.textDecorationLineInEffect() & TextDecorationLine::LineThrough)
+    if (style.textDecorationLineInEffect() & CSS::Keyword::LineThrough { })
         [attributes setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSStrikethroughStyleAttributeName];
     else
         [attributes removeObjectForKey:NSStrikethroughStyleAttributeName];

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -30,6 +30,7 @@
 #include "LayoutBox.h"
 #include "LayoutUnits.h"
 #include "LengthFunctions.h"
+#include "StyleLineBoxContain.h"
 #include "StyleTextEdge.h"
 #include <wtf/OptionSet.h>
 
@@ -169,7 +170,7 @@ private:
         TextBoxTrim textBoxTrim;
         TextEdge textBoxEdge;
         TextEdge lineFitEdge;
-        OptionSet<WebCore::Style::LineBoxContain> lineBoxContain;
+        WebCore::Style::LineBoxContain lineBoxContain;
         InlineLayoutUnit primaryFontSize { 0 };
         VerticalAlignment verticalAlignment { };
     };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -73,18 +73,18 @@ inline InlineLevelBox InlineLevelBox::createRootInlineBox(const Box& layoutBox, 
 inline bool InlineLevelBox::mayStretchLineBox() const
 {
     if (isRootInlineBox())
-        return m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Block, WebCore::Style::LineBoxContain::Inline }) || (hasContent() && m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::InitialLetter, WebCore::Style::LineBoxContain::Font, WebCore::Style::LineBoxContain::Glyphs }));
+        return m_style.lineBoxContain.containsAny({ CSS::Keyword::Block { }, CSS::Keyword::Inline { } }) || (hasContent() && m_style.lineBoxContain.containsAny({ CSS::Keyword::InitialLetter { }, CSS::Keyword::Font { }, CSS::Keyword::Glyphs { } }));
 
     if (isAtomicInlineBox())
-        return m_style.lineBoxContain.contains(WebCore::Style::LineBoxContain::Replaced);
+        return m_style.lineBoxContain.contains(CSS::Keyword::Replaced { });
 
     if (isInlineBox()) {
         // Either the inline box itself is included or its text content through Glyph and Font.
-        return m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Inline, WebCore::Style::LineBoxContain::InlineBox }) || (hasContent() && m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Font, WebCore::Style::LineBoxContain::Glyphs }));
+        return m_style.lineBoxContain.containsAny({ CSS::Keyword::Inline { }, CSS::Keyword::InlineBox { } }) || (hasContent() && m_style.lineBoxContain.containsAny({ CSS::Keyword::Font { }, CSS::Keyword::Glyphs { } }));
     }
 
     if (isLineBreakBox())
-        return m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Inline, WebCore::Style::LineBoxContain::InlineBox }) || (hasContent() && m_style.lineBoxContain.containsAny({ WebCore::Style::LineBoxContain::Font, WebCore::Style::LineBoxContain::Glyphs }));
+        return m_style.lineBoxContain.containsAny({ CSS::Keyword::Inline { }, CSS::Keyword::InlineBox { } }) || (hasContent() && m_style.lineBoxContain.containsAny({ CSS::Keyword::Font { }, CSS::Keyword::Glyphs { } }));
 
     return true;
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -510,7 +510,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
     // Collect layout bounds based on the contain property and set them on the inline boxes when they are applicable.
     HashMap<InlineLevelBox*, TextUtil::EnclosingAscentDescent> inlineBoxBoundsMap;
 
-    if (lineBoxContain.contains(Style::LineBoxContain::InlineBox)) {
+    if (lineBoxContain.contains(CSS::Keyword::InlineBox { })) {
         for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
             if (!inlineLevelBox.isInlineBox())
                 continue;
@@ -521,7 +521,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         }
     }
 
-    if (lineBoxContain.contains(Style::LineBoxContain::Font)) {
+    if (lineBoxContain.contains(CSS::Keyword::Font { })) {
         // Assign font based layout bounds to all inline boxes.
         auto ensureFontMetricsBasedHeight = [&] (auto& inlineBox) {
             ASSERT(inlineBox.isInlineBox());
@@ -546,7 +546,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         }
     }
 
-    if (lineBoxContain.contains(Style::LineBoxContain::Glyphs)) {
+    if (lineBoxContain.contains(CSS::Keyword::Glyphs { })) {
         // Compute text content (glyphs) hugging inline box layout bounds.
         for (auto run : lineLayoutResult().inlineContent) {
             if (!run.isText())
@@ -566,7 +566,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         }
     }
 
-    if (lineBoxContain.contains(Style::LineBoxContain::InitialLetter)) {
+    if (lineBoxContain.contains(CSS::Keyword::InitialLetter { })) {
         // Initial letter contain is based on the font metrics cap geometry and we hug descent.
         auto& rootInlineBox = lineBox.rootInlineBox();
         auto& fontMetrics = rootInlineBox.primarymetricsOfPrimaryFont();
@@ -597,7 +597,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
         auto inlineBoxLayoutBounds = inlineBox->layoutBounds();
 
         // "line-box-container: block" The extended block progression dimension of the root inline box must fit within the line box.
-        auto mayShrinkLineBox = inlineBox->isRootInlineBox() ? !lineBoxContain.contains(Style::LineBoxContain::Block) : true;
+        auto mayShrinkLineBox = inlineBox->isRootInlineBox() ? !lineBoxContain.contains(CSS::Keyword::Block { }) : true;
         auto ascent = mayShrinkLineBox ? enclosingAscentDescentForInlineBox.ascent : std::max(enclosingAscentDescentForInlineBox.ascent, inlineBoxLayoutBounds.ascent);
         auto descent = mayShrinkLineBox ? enclosingAscentDescentForInlineBox.descent : std::max(enclosingAscentDescentForInlineBox.descent, inlineBoxLayoutBounds.descent);
         inlineBox->setLayoutBounds({ ceilf(ascent), ceilf(descent) });

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -841,7 +841,7 @@ LineBuilder::RectAndFloatConstraints LineBuilder::adjustedLineRectWithCandidateI
         if (inlineItem.isText()) {
             auto& styleToUse = isFirstFormattedLine() ? inlineItem.firstLineStyle() : inlineItem.style();
             candidateContentHeight = std::max<InlineLayoutUnit>(candidateContentHeight, styleToUse.computedLineHeight());
-        } else if (inlineItem.isAtomicInlineBox() && lineBoxContain.contains(Style::LineBoxContain::Replaced))
+        } else if (inlineItem.isAtomicInlineBox() && lineBoxContain.contains(CSS::Keyword::Replaced { }))
             candidateContentHeight = std::max(candidateContentHeight, InlineLayoutUnit { formattingContext().geometryForBox(inlineItem.layoutBox()).marginBoxHeight() });
     }
     if (candidateContentHeight <= m_lineLogicalRect.height())

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -104,7 +104,7 @@ bool InlineQuirks::inlineBoxAffectsLineBox(const InlineLevelBox& inlineLevelBox)
 std::optional<LayoutUnit> InlineQuirks::initialLetterAlignmentOffset(const Box& floatBox, const RenderStyle& lineBoxStyle) const
 {
     ASSERT(floatBox.isFloatingPositioned());
-    if (!floatBox.style().lineBoxContain().contains(Style::LineBoxContain::InitialLetter))
+    if (!floatBox.style().lineBoxContain().contains(CSS::Keyword::InitialLetter { }))
         return { };
     auto& primaryFontMetrics = lineBoxStyle.fontCascade().metricsOfPrimaryFont();
     auto lineHeight = [&]() -> InlineLayoutUnit {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1020,14 +1020,14 @@ static float logicalBottomForTextDecorationContent(const InlineDisplay::Boxes& b
     for (auto& displayBox : boxes) {
         if (displayBox.isRootInlineBox())
             continue;
-        if (!displayBox.style().textDecorationLineInEffect().contains(TextDecorationLine::Underline))
+        if (!displayBox.style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { }))
             continue;
         if (displayBox.isText() || displayBox.style().textDecorationSkipInk() == TextDecorationSkipInk::None) {
             auto contentLogicalBottom = isHorizontalWritingMode ? displayBox.bottom() : displayBox.right();
             logicalBottom = logicalBottom ? std::max(*logicalBottom, contentLogicalBottom) : contentLogicalBottom;
         }
     }
-    // This function is not called unless there's at least one run on the line with TextDecorationLine::Underline.
+    // This function is not called unless there's at least one run on the line with TextDecorationLine CSS::Keyword::Underline.
     ASSERT(logicalBottom);
     return logicalBottom.value_or(0.f);
 }
@@ -1051,7 +1051,7 @@ void InlineDisplayContentBuilder::collectInkOverflowForTextDecorations(InlineDis
             continue;
 
         auto decorationOverflow = [&] {
-            if (!textDecorations.contains(TextDecorationLine::Underline))
+            if (!textDecorations.contains(CSS::Keyword::Underline { }))
                 return inkOverflowForDecorations(parentStyle);
 
             if (!logicalBottomForTextDecoration)

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -49,15 +49,15 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
     auto decorationStyle = pseudoElementStyle->textDecorationStyle();
     auto decorations = pseudoElementStyle->textDecorationLineInEffect();
 
-    if (decorations.contains(TextDecorationLine::Underline)) {
+    if (decorations.contains(CSS::Keyword::Underline { })) {
         style.textDecorationStyles.underline.color = color;
         style.textDecorationStyles.underline.decorationStyle = decorationStyle;
     }
-    if (decorations.contains(TextDecorationLine::Overline)) {
+    if (decorations.contains(CSS::Keyword::Overline { })) {
         style.textDecorationStyles.overline.color = color;
         style.textDecorationStyles.overline.decorationStyle = decorationStyle;
     }
-    if (decorations.contains(TextDecorationLine::LineThrough)) {
+    if (decorations.contains(CSS::Keyword::LineThrough { })) {
         style.textDecorationStyles.linethrough.color = color;
         style.textDecorationStyles.linethrough.decorationStyle = decorationStyle;
     }
@@ -158,15 +158,15 @@ static TextDecorationPainter::Styles computeStylesForTextDecorations(const TextD
 
     auto textDecorationStyles = previousTextDecorationStyles;
 
-    if (textDecorations.contains(TextDecorationLine::Underline)) {
+    if (textDecorations.contains(CSS::Keyword::Underline { })) {
         textDecorationStyles.underline.color = currentTextDecorationStyles.underline.color;
         textDecorationStyles.underline.decorationStyle = currentTextDecorationStyles.underline.decorationStyle;
     }
-    if (textDecorations.contains(TextDecorationLine::Overline)) {
+    if (textDecorations.contains(CSS::Keyword::Overline { })) {
         textDecorationStyles.overline.color = currentTextDecorationStyles.overline.color;
         textDecorationStyles.overline.decorationStyle = currentTextDecorationStyles.overline.decorationStyle;
     }
-    if (textDecorations.contains(TextDecorationLine::LineThrough)) {
+    if (textDecorations.contains(CSS::Keyword::LineThrough { })) {
         textDecorationStyles.linethrough.color = currentTextDecorationStyles.linethrough.color;
         textDecorationStyles.linethrough.decorationStyle = currentTextDecorationStyles.linethrough.decorationStyle;
     }

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -577,7 +577,7 @@ static inline float computedLinethroughCenter(const RenderStyle& styleToUse, flo
     return center - textDecorationThickness / 2;
 }
 
-static inline OptionSet<TextDecorationLine> computedTextDecorationType(const RenderStyle& style, const TextDecorationPainter::Styles& textDecorationStyles)
+static inline Style::TextDecorationLine computedTextDecorationType(const RenderStyle& style, const TextDecorationPainter::Styles& textDecorationStyles)
 {
     auto textDecorations = style.textDecorationLineInEffect();
     textDecorations.add(TextDecorationPainter::textDecorationsInEffectForStyle(textDecorationStyles));
@@ -606,8 +606,8 @@ static inline bool isDecoratingBoxForBackground(const InlineIterator::InlineBox&
         // <font> and <a> are always considered decorating boxes.
         return true;
     }
-    return styleToUse.textDecorationLine().containsAny({ TextDecorationLine::Underline, TextDecorationLine::Overline })
-        || (inlineBox.isRootInlineBox() && styleToUse.textDecorationLineInEffect().containsAny({ TextDecorationLine::Underline, TextDecorationLine::Overline }));
+    return styleToUse.textDecorationLine().containsAny({ CSS::Keyword::Underline { }, CSS::Keyword::Overline { } })
+        || (inlineBox.isRootInlineBox() && styleToUse.textDecorationLineInEffect().containsAny({ CSS::Keyword::Underline { }, CSS::Keyword::Overline { } }));
 }
 
 void TextBoxPainter::collectDecoratingBoxesForBackgroundPainting(DecoratingBoxList& decoratingBoxList, const InlineIterator::TextBoxIterator& textBox, FloatPoint textBoxLocation, const TextDecorationPainter::Styles& overrideDecorationStyle)
@@ -679,7 +679,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
         auto computedBackgroundDecorationGeometry = [&] {
             auto textDecorationThickness = computedTextDecorationThickness(decoratingBox.style, m_document.deviceScaleFactor());
             auto underlineOffset = [&] {
-                if (!computedTextDecorationType.contains(TextDecorationLine::Underline))
+                if (!computedTextDecorationType.contains(CSS::Keyword::Underline { }))
                     return 0.f;
                 auto baseOffset = underlineOffsetForTextBoxPainting(*decoratingBox.inlineBox, decoratingBox.style);
                 auto wavyOffset = decoratingBox.textDecorationStyles.underline.decorationStyle == TextDecorationStyle::Wavy ? wavyOffsetFromDecoration() : 0.f;
@@ -687,7 +687,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
             };
             auto autoTextDecorationThickness = computedAutoTextDecorationThickness(decoratingBox.style, m_document.deviceScaleFactor());
             auto overlineOffset = [&] {
-                if (!computedTextDecorationType.contains(TextDecorationLine::Overline))
+                if (!computedTextDecorationType.contains(CSS::Keyword::Overline { }))
                     return 0.f;
                 auto baseOffset = overlineOffsetForTextBoxPainting(*decoratingBox.inlineBox, decoratingBox.style);
                 baseOffset += (autoTextDecorationThickness - textDecorationThickness);
@@ -733,7 +733,7 @@ void TextBoxPainter::paintForegroundDecorations(TextDecorationPainter& decoratio
         return textDecorations;
     }();
 
-    if (!computedTextDecorationType.contains(TextDecorationLine::LineThrough))
+    if (!computedTextDecorationType.contains(CSS::Keyword::LineThrough { }))
         return;
 
     if (m_isCombinedText)

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -152,16 +152,16 @@ TextDecorationPainter::TextDecorationPainter(GraphicsContext& context, const Fon
 }
 
 // Paint text-shadow, underline, overline
-void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style, const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, OptionSet<TextDecorationLine> decorationType, const Styles& decorationStyle)
+void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style, const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, Style::TextDecorationLine decorationType, const Styles& decorationStyle)
 {
-    auto paintDecoration = [&] (auto decoration, auto underlineStyle, auto& color, auto& rect) {
+    auto paintDecoration = [&](Style::TextDecorationLine decoration, auto underlineStyle, auto& color, auto& rect) {
         m_context.setStrokeColor(color);
 
         auto strokeStyle = textDecorationStyleToStrokeStyle(underlineStyle);
 
         if (underlineStyle == TextDecorationStyle::Wavy)
             strokeWavyTextDecoration(m_context, rect, decorationGeometry.wavyStrokeParameters);
-        else if (decoration == TextDecorationLine::Underline || decoration == TextDecorationLine::Overline) {
+        else if (decoration == CSS::Keyword::Underline { } || decoration == CSS::Keyword::Overline { }) {
             if ((style.textDecorationSkipInk() == TextDecorationSkipInk::Auto
                 || style.textDecorationSkipInk() == TextDecorationSkipInk::All)
                 && !m_writingMode.isVerticalTypographic()) {
@@ -184,9 +184,9 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
             ASSERT_NOT_REACHED();
     };
 
-    auto areLinesOpaque = !m_isPrinting && (!decorationType.contains(TextDecorationLine::Underline) || decorationStyle.underline.color.isOpaque())
-        && (!decorationType.contains(TextDecorationLine::Overline) || decorationStyle.overline.color.isOpaque())
-        && (!decorationType.contains(TextDecorationLine::LineThrough) || decorationStyle.linethrough.color.isOpaque());
+    auto areLinesOpaque = !m_isPrinting && (!decorationType.contains(CSS::Keyword::Underline { }) || decorationStyle.underline.color.isOpaque())
+        && (!decorationType.contains(CSS::Keyword::Overline { }) || decorationStyle.overline.color.isOpaque())
+        && (!decorationType.contains(CSS::Keyword::LineThrough { }) || decorationStyle.linethrough.color.isOpaque());
 
     float extraOffset = 0.f;
     auto boxOrigin = decorationGeometry.boxOrigin;
@@ -211,19 +211,19 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
     // These decorations should match the visual overflows computed in visualOverflowForDecorations().
     auto underlineRect = FloatRect { boxOrigin, FloatSize { decorationGeometry.textBoxWidth, decorationGeometry.textDecorationThickness } };
     auto overlineRect = underlineRect;
-    if (decorationType.contains(TextDecorationLine::Underline))
+    if (decorationType.contains(CSS::Keyword::Underline { }))
         underlineRect.move(0.f, decorationGeometry.underlineOffset);
-    if (decorationType.contains(TextDecorationLine::Overline))
+    if (decorationType.contains(CSS::Keyword::Overline { }))
         overlineRect.move(0.f, decorationGeometry.overlineOffset);
 
     auto draw = [&](const Style::TextShadow* shadow) {
-        if (decorationType.contains(TextDecorationLine::Underline) && !underlineRect.isEmpty())
-            paintDecoration(TextDecorationLine::Underline, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
-        if (decorationType.contains(TextDecorationLine::Overline) && !overlineRect.isEmpty())
-            paintDecoration(TextDecorationLine::Overline, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
+        if (decorationType.contains(CSS::Keyword::Underline { }) && !underlineRect.isEmpty())
+            paintDecoration(CSS::Keyword::Underline { }, decorationStyle.underline.decorationStyle, decorationStyle.underline.color, underlineRect);
+        if (decorationType.contains(CSS::Keyword::Overline { }) && !overlineRect.isEmpty())
+            paintDecoration(CSS::Keyword::Overline { }, decorationStyle.overline.decorationStyle, decorationStyle.overline.color, overlineRect);
         // We only want to paint the shadow, hence the transparent color, not the actual line-through,
         // which will be painted in paintForegroundDecorations().
-        if (shadow && decorationType.contains(TextDecorationLine::LineThrough))
+        if (shadow && decorationType.contains(CSS::Keyword::LineThrough { }))
             paintLineThrough({ boxOrigin, decorationGeometry.textBoxWidth, decorationGeometry.textDecorationThickness, decorationGeometry.linethroughCenter, decorationGeometry.wavyStrokeParameters }, Color::transparentBlack, decorationStyle);
     };
 
@@ -275,27 +275,27 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, OptionSet<TextDecorationLine> remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, Style::TextDecorationLine remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
 {
-    auto extractDecorations = [&] (const RenderStyle& style, OptionSet<TextDecorationLine> decorations) {
+    auto extractDecorations = [&] (const RenderStyle& style, Style::TextDecorationLine decorations) {
         if (decorations.isEmpty())
             return;
 
         auto color = TextDecorationPainter::decorationColor(style, paintBehavior);
         auto decorationStyle = style.textDecorationStyle();
 
-        if (decorations.contains(TextDecorationLine::Underline)) {
-            remainingDecorations.remove(TextDecorationLine::Underline);
+        if (decorations.contains(CSS::Keyword::Underline { })) {
+            remainingDecorations.remove(CSS::Keyword::Underline { });
             result.underline.color = color;
             result.underline.decorationStyle = decorationStyle;
         }
-        if (decorations.contains(TextDecorationLine::Overline)) {
-            remainingDecorations.remove(TextDecorationLine::Overline);
+        if (decorations.contains(CSS::Keyword::Overline { })) {
+            remainingDecorations.remove(CSS::Keyword::Overline { });
             result.overline.color = color;
             result.overline.decorationStyle = decorationStyle;
         }
-        if (decorations.contains(TextDecorationLine::LineThrough)) {
-            remainingDecorations.remove(TextDecorationLine::LineThrough);
+        if (decorations.contains(CSS::Keyword::LineThrough { })) {
+            remainingDecorations.remove(CSS::Keyword::LineThrough { });
             result.linethrough.color = color;
             result.linethrough.decorationStyle = decorationStyle;
         }
@@ -345,7 +345,7 @@ Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet
     return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Style::TextDecorationLine requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
 {
     if (requestedDecorations.isEmpty())
         return { };
@@ -357,15 +357,15 @@ auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, Opti
     return result;
 }
 
-OptionSet<TextDecorationLine> TextDecorationPainter::textDecorationsInEffectForStyle(const TextDecorationPainter::Styles& style)
+Style::TextDecorationLine TextDecorationPainter::textDecorationsInEffectForStyle(const TextDecorationPainter::Styles& style)
 {
-    OptionSet<TextDecorationLine> decorations;
+    Style::TextDecorationLine decorations;
     if (style.underline.color.isValid())
-        decorations.add(TextDecorationLine::Underline);
+        decorations.add(CSS::Keyword::Underline { });
     if (style.overline.color.isValid())
-        decorations.add(TextDecorationLine::Overline);
+        decorations.add(CSS::Keyword::Overline { });
     if (style.linethrough.color.isValid())
-        decorations.add(TextDecorationLine::LineThrough);
+        decorations.add(CSS::Keyword::LineThrough { });
     return decorations;
 }
 

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -36,7 +36,11 @@ class FontCascade;
 class RenderObject;
 class RenderStyle;
 class TextRun;
-    
+
+namespace Style {
+struct TextDecorationLine;
+}
+
 class TextDecorationPainter {
 public:
     TextDecorationPainter(GraphicsContext&, const FontCascade&, const Style::TextShadows&, const FilterOperations*, bool isPrinting, WritingMode);
@@ -63,7 +67,7 @@ public:
         float clippingOffset { 0.f };
         WavyStrokeParameters wavyStrokeParameters;
     };
-    void paintBackgroundDecorations(const RenderStyle&, const TextRun&, const BackgroundDecorationGeometry&, OptionSet<TextDecorationLine>, const Styles&);
+    void paintBackgroundDecorations(const RenderStyle&, const TextRun&, const BackgroundDecorationGeometry&, Style::TextDecorationLine, const Styles&);
 
     struct ForegroundDecorationGeometry {
         FloatPoint boxOrigin;
@@ -75,8 +79,8 @@ public:
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
     static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
-    static Styles stylesForRenderer(const RenderObject&, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
-    static OptionSet<TextDecorationLine> textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
+    static Styles stylesForRenderer(const RenderObject&, Style::TextDecorationLine requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
+    static Style::TextDecorationLine textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:
     void paintLineThrough(const ForegroundDecorationGeometry&, const Color&, const Styles&);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -51,9 +51,11 @@
 #include "StyleExtractor.h"
 #include "StyleImage.h"
 #include "StyleInheritedData.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StyleResolver.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleSelfAlignmentData.h"
+#include "StyleTextDecorationLine.h"
 #include "StyleTextEdge.h"
 #include "StyleTreeResolver.h"
 #include "TransformOperationData.h"
@@ -108,7 +110,7 @@ static_assert(sizeof(RenderStyle) == sizeof(SameSizeAsRenderStyle), "RenderStyle
 
 static_assert(PublicPseudoIDBits == enumToUnderlyingType(PseudoId::FirstInternalPseudoId) - enumToUnderlyingType(PseudoId::FirstPublicPseudoId));
 
-static_assert(!(static_cast<unsigned>(maxTextDecorationLineValue) >> TextDecorationLineBits));
+static_assert(static_cast<unsigned>(Style::TextDecorationLine::bits) == TextDecorationLineBits);
 
 static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
 
@@ -3794,7 +3796,7 @@ void RenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const NonIn
     LOG_IF_DIFFERENT(usesContainerUnits);
     LOG_IF_DIFFERENT(useTreeCountingFunctions);
 
-    LOG_IF_DIFFERENT_WITH_CAST(TextDecorationLine, textDecorationLine);
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::TextDecorationLine, textDecorationLine);
 
     LOG_IF_DIFFERENT(hasExplicitlyInheritedProperties);
     LOG_IF_DIFFERENT(disallowsFastPathInheritance);
@@ -3821,7 +3823,7 @@ void RenderStyle::InheritedFlags::dumpDifferences(TextStream& ts, const Inherite
     LOG_IF_DIFFERENT_WITH_CAST(TextWrapStyle, textWrapStyle);
 
     LOG_RAW_OPTIONSET_IF_DIFFERENT(TextTransform, textTransform);
-    LOG_RAW_OPTIONSET_IF_DIFFERENT(TextDecorationLine, textDecorationLineInEffect);
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::TextDecorationLine, textDecorationLineInEffect);
 
     LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
     LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -183,7 +183,6 @@ enum class PaintOrder : uint8_t;
 enum class PaintType : uint8_t;
 enum class PointerEvents : uint8_t;
 enum class PositionType : uint8_t;
-enum class PositionVisibility : uint8_t;
 enum class PrintColorAdjust : bool;
 enum class PseudoId : uint32_t;
 enum class Resize : uint8_t;
@@ -203,7 +202,6 @@ enum class TextAlignLast : uint8_t;
 enum class TextAlignMode : uint8_t;
 enum class TextBoxTrim : uint8_t;
 enum class TextCombine : bool;
-enum class TextDecorationLine : uint8_t;
 enum class TextDecorationSkipInk : uint8_t;
 enum class TextDecorationStyle : uint8_t;
 enum class TextEmphasisPosition : uint8_t;
@@ -287,6 +285,7 @@ struct GridTemplateAreas;
 struct GridTemplateList;
 struct GridTrackSizes;
 struct InsetEdge;
+struct LineBoxContain;
 struct ListStyleType;
 struct MarginEdge;
 struct MaximumSize;
@@ -299,6 +298,7 @@ struct OffsetRotate;
 struct PaddingEdge;
 struct Perspective;
 struct Position;
+struct PositionVisibility;
 struct PositionX;
 struct PositionY;
 struct PositionTryFallback;
@@ -315,6 +315,7 @@ struct ScrollPaddingEdge;
 struct ScrollTimelines;
 struct ScrollbarColor;
 struct ScrollbarGutter;
+struct TextDecorationLine;
 struct TextDecorationThickness;
 struct TextEmphasisStyle;
 struct TextIndent;
@@ -330,7 +331,6 @@ struct ViewTransitionName;
 
 enum class Change : uint8_t;
 enum class GridTrackSizingDirection : bool;
-enum class LineBoxContain : uint8_t;
 enum class PositionTryOrder : uint8_t;
 enum class ScrollBehavior : bool;
 enum class WebkitOverflowScrolling : bool;
@@ -682,8 +682,8 @@ public:
     inline TextAlignLast textAlignLast() const;
     inline TextGroupAlign textGroupAlign() const;
     inline OptionSet<TextTransform> textTransform() const;
-    inline OptionSet<TextDecorationLine> textDecorationLineInEffect() const;
-    inline OptionSet<TextDecorationLine> textDecorationLine() const;
+    inline Style::TextDecorationLine textDecorationLineInEffect() const;
+    inline Style::TextDecorationLine textDecorationLine() const;
     inline TextDecorationStyle textDecorationStyle() const;
     inline TextDecorationSkipInk textDecorationSkipInk() const;
     inline OptionSet<TextUnderlinePosition> textUnderlinePosition() const;
@@ -1100,7 +1100,7 @@ public:
     inline const LengthSize& pageSize() const;
     inline PageSizeType pageSizeType() const;
 
-    inline OptionSet<Style::LineBoxContain> lineBoxContain() const;
+    inline Style::LineBoxContain lineBoxContain() const;
     inline const LineClampValue& lineClamp() const;
     inline const Style::BlockEllipsis& blockEllipsis() const;
     inline size_t maxLines() const;
@@ -1344,9 +1344,9 @@ public:
     void setTextAlign(TextAlignMode v) { m_inheritedFlags.textAlign = static_cast<unsigned>(v); }
     inline void setTextAlignLast(TextAlignLast);
     inline void setTextGroupAlign(TextGroupAlign);
-    inline void addToTextDecorationLineInEffect(OptionSet<TextDecorationLine>);
-    inline void setTextDecorationLineInEffect(OptionSet<TextDecorationLine>);
-    inline void setTextDecorationLine(OptionSet<TextDecorationLine>);
+    inline void addToTextDecorationLineInEffect(Style::TextDecorationLine);
+    inline void setTextDecorationLineInEffect(Style::TextDecorationLine);
+    inline void setTextDecorationLine(Style::TextDecorationLine);
     inline void setTextDecorationStyle(TextDecorationStyle);
     inline void setTextDecorationSkipInk(TextDecorationSkipInk);
     inline void setTextDecorationThickness(Style::TextDecorationThickness&&);
@@ -1647,7 +1647,7 @@ public:
     inline void setPageSizeType(PageSizeType);
     inline void resetPageSizeType();
 
-    inline void setLineBoxContain(OptionSet<Style::LineBoxContain>);
+    inline void setLineBoxContain(Style::LineBoxContain);
     inline void setLineClamp(LineClampValue);
     
     inline void setMaxLines(size_t);
@@ -1993,7 +1993,7 @@ public:
     static constexpr TextAlignMode initialTextAlign();
     static constexpr TextAlignLast initialTextAlignLast();
     static constexpr TextGroupAlign initialTextGroupAlign();
-    static constexpr OptionSet<TextDecorationLine> initialTextDecorationLine();
+    static constexpr Style::TextDecorationLine initialTextDecorationLine();
     static constexpr TextDecorationStyle initialTextDecorationStyle();
     static constexpr TextDecorationSkipInk initialTextDecorationSkipInk();
     static constexpr OptionSet<TextUnderlinePosition> initialTextUnderlinePosition();
@@ -2092,7 +2092,7 @@ public:
     static constexpr RubyPosition initialRubyPosition();
     static constexpr RubyAlign initialRubyAlign();
     static constexpr RubyOverhang initialRubyOverhang();
-    static constexpr OptionSet<Style::LineBoxContain> initialLineBoxContain();
+    static constexpr Style::LineBoxContain initialLineBoxContain();
     static constexpr ImageOrientation initialImageOrientation();
     static constexpr ImageRendering initialImageRendering();
     static StyleImage* initialBorderImageSource() { return nullptr; }
@@ -2325,9 +2325,9 @@ public:
     const FixedVector<Style::PositionTryFallback>& positionTryFallbacks() const;
     void setPositionTryFallbacks(FixedVector<Style::PositionTryFallback>&&);
 
-    static constexpr OptionSet<PositionVisibility> initialPositionVisibility();
-    inline OptionSet<PositionVisibility> positionVisibility() const;
-    inline void setPositionVisibility(OptionSet<PositionVisibility>);
+    static constexpr Style::PositionVisibility initialPositionVisibility();
+    inline Style::PositionVisibility positionVisibility() const;
+    inline void setPositionVisibility(Style::PositionVisibility);
 
     inline bool insideDefaultButton() const;
     inline void setInsideDefaultButton(bool);

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1176,17 +1176,6 @@ TextStream& operator<<(TextStream& ts, TextCombine textCombine)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, TextDecorationLine line)
-{
-    switch (line) {
-    case TextDecorationLine::Underline: ts << "underline"_s; break;
-    case TextDecorationLine::Overline: ts << "overline"_s; break;
-    case TextDecorationLine::LineThrough: ts << "line-through"_s; break;
-    case TextDecorationLine::Blink: ts << "blink"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, TextDecorationSkipInk skip)
 {
     switch (skip) {
@@ -1512,16 +1501,6 @@ TextStream& operator<<(TextStream& ts, OverflowContinue overflowContinue)
     case OverflowContinue::Discard:
         ts << "discard"_s;
         break;
-    }
-    return ts;
-}
-
-TextStream& operator<<(TextStream& ts, PositionVisibility positionVisibility)
-{
-    switch (positionVisibility) {
-    case PositionVisibility::AnchorsValid: ts << "anchors-valid"; break;
-    case PositionVisibility::AnchorsVisible: ts << "anchors-visible"; break;
-    case PositionVisibility::NoOverflow: ts << "no-overflow"; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -666,14 +666,6 @@ enum class TextTransform : uint8_t {
 };
 constexpr auto maxTextTransformValue = TextTransform::FullWidth;
 
-enum class TextDecorationLine : uint8_t {
-    Underline     = 1 << 0,
-    Overline      = 1 << 1,
-    LineThrough   = 1 << 2,
-    Blink         = 1 << 3,
-};
-constexpr auto maxTextDecorationLineValue = TextDecorationLine::Blink;
-
 enum class TextDecorationStyle : uint8_t {
     Solid,
     Double,
@@ -1233,12 +1225,6 @@ enum class FieldSizing : bool {
     Content
 };
 
-enum class PositionVisibility : uint8_t {
-    AnchorsValid   = 1 << 0,
-    AnchorsVisible = 1 << 1,
-    NoOverflow     = 1 << 2
-};
-
 CSSBoxType transformBoxToCSSBoxType(TransformBox);
 
 constexpr float defaultMiterLimit = 4;
@@ -1318,7 +1304,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, OverflowWrap);
 WTF::TextStream& operator<<(WTF::TextStream&, PaintOrder);
 WTF::TextStream& operator<<(WTF::TextStream&, PointerEvents);
 WTF::TextStream& operator<<(WTF::TextStream&, PositionType);
-WTF::TextStream& operator<<(WTF::TextStream&, PositionVisibility);
 WTF::TextStream& operator<<(WTF::TextStream&, PrintColorAdjust);
 WTF::TextStream& operator<<(WTF::TextStream&, PseudoId);
 WTF::TextStream& operator<<(WTF::TextStream&, QuoteType);
@@ -1338,7 +1323,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignMode);
 WTF::TextStream& operator<<(WTF::TextStream&, TextAlignLast);
 WTF::TextStream& operator<<(WTF::TextStream&, TextCombine);
-WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationLine);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationSkipInk);
 WTF::TextStream& operator<<(WTF::TextStream&, TextDecorationStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, TextEmphasisFill);

--- a/Source/WebCore/rendering/style/RenderStyleDifference.h
+++ b/Source/WebCore/rendering/style/RenderStyleDifference.h
@@ -42,6 +42,9 @@ namespace WebCore {
 #define LOG_IF_DIFFERENT_WITH_CAST(type, name) \
     do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), static_cast<type>(name), static_cast<type>(other.name)); } while (0)
 
+#define LOG_IF_DIFFERENT_WITH_CONSTRUCTION(type, name) \
+    do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), type(name), type(other.name)); } while (0)
+
 #define LOG_RAW_OPTIONSET_IF_DIFFERENT(type, name) \
     do { logIfDifferent(ts, ASCIILiteral::fromLiteralUnsafe(#name), OptionSet<type>::fromRaw(name), OptionSet<type>::fromRaw(other.name)); } while (0)
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -47,7 +47,6 @@
 #include "StyleGridItemData.h"
 #include "StyleGridTrackSizingDirection.h"
 #include "StyleInheritedData.h"
-#include "StyleLineBoxContain.h"
 #include "StyleMarqueeData.h"
 #include "StyleMiscNonInheritedData.h"
 #include "StyleMultiColData.h"
@@ -55,6 +54,7 @@
 #include "StyleRareInheritedData.h"
 #include "StyleRareNonInheritedData.h"
 #include "StyleSurroundData.h"
+#include "StyleTextDecorationLine.h"
 #include "StyleTransformData.h"
 #include "StyleVisitedLinkColorData.h"
 #include "UnicodeBidi.h"
@@ -413,7 +413,7 @@ inline const IntSize& RenderStyle::initialLetter() const { return m_nonInherited
 inline int RenderStyle::initialLetterDrop() const { return initialLetter().width(); }
 inline int RenderStyle::initialLetterHeight() const { return initialLetter().height(); }
 constexpr LineAlign RenderStyle::initialLineAlign() { return LineAlign::None; }
-constexpr OptionSet<Style::LineBoxContain> RenderStyle::initialLineBoxContain() { return { Style::LineBoxContain::Block, Style::LineBoxContain::Inline, Style::LineBoxContain::Replaced }; }
+constexpr Style::LineBoxContain RenderStyle::initialLineBoxContain() { return { CSS::Keyword::Block { }, CSS::Keyword::Inline { }, CSS::Keyword::Replaced { } }; }
 constexpr LineBreak RenderStyle::initialLineBreak() { return LineBreak::Auto; }
 constexpr LineClampValue RenderStyle::initialLineClamp() { return { }; }
 inline const AtomString& RenderStyle::initialLineGrid() { return nullAtom(); }
@@ -456,7 +456,7 @@ inline std::optional<Style::ScopedName> RenderStyle::initialPositionAnchor() { r
 inline std::optional<PositionArea> RenderStyle::initialPositionArea() { return { }; }
 inline FixedVector<Style::PositionTryFallback> RenderStyle::initialPositionTryFallbacks() { return { }; }
 constexpr Style::PositionTryOrder RenderStyle::initialPositionTryOrder() { return Style::PositionTryOrder::Normal; }
-constexpr OptionSet<PositionVisibility> RenderStyle::initialPositionVisibility() { return PositionVisibility::AnchorsVisible; }
+constexpr Style::PositionVisibility RenderStyle::initialPositionVisibility() { return CSS::Keyword::AnchorsVisible { }; }
 constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
 inline Style::Quotes RenderStyle::initialQuotes() { return CSS::Keyword::Auto { }; }
 constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
@@ -488,7 +488,7 @@ constexpr TextAlignLast RenderStyle::initialTextAlignLast() { return TextAlignLa
 constexpr TextBoxTrim RenderStyle::initialTextBoxTrim() { return TextBoxTrim::None; }
 constexpr TextCombine RenderStyle::initialTextCombine() { return TextCombine::None; }
 inline Style::Color RenderStyle::initialTextDecorationColor() { return Style::Color::currentColor(); }
-constexpr OptionSet<TextDecorationLine> RenderStyle::initialTextDecorationLine() { return { }; }
+constexpr Style::TextDecorationLine RenderStyle::initialTextDecorationLine() { return CSS::Keyword::None { }; }
 constexpr TextDecorationSkipInk RenderStyle::initialTextDecorationSkipInk() { return TextDecorationSkipInk::Auto; }
 constexpr TextDecorationStyle RenderStyle::initialTextDecorationStyle() { return TextDecorationStyle::Solid; }
 inline Style::TextDecorationThickness RenderStyle::initialTextDecorationThickness() { return CSS::Keyword::Auto { }; }
@@ -574,7 +574,7 @@ inline const Style::InsetEdge& RenderStyle::left() const { return m_nonInherited
 inline float RenderStyle::letterSpacing() const { return m_inheritedData->fontData->fontCascade.letterSpacing(); }
 inline const FontCascade& RenderStyle::fontCascade() const { return m_inheritedData->fontData->fontCascade; }
 inline LineAlign RenderStyle::lineAlign() const { return static_cast<LineAlign>(m_rareInheritedData->lineAlign); }
-inline OptionSet<Style::LineBoxContain> RenderStyle::lineBoxContain() const { return OptionSet<Style::LineBoxContain>::fromRaw(m_rareInheritedData->lineBoxContain); }
+inline Style::LineBoxContain RenderStyle::lineBoxContain() const { return Style::LineBoxContain::fromRaw( m_rareInheritedData->lineBoxContain); }
 inline LineBreak RenderStyle::lineBreak() const { return static_cast<LineBreak>(m_rareInheritedData->lineBreak); }
 inline const LineClampValue& RenderStyle::lineClamp() const { return m_nonInheritedData->rareData->lineClamp; }
 inline const AtomString& RenderStyle::lineGrid() const { return m_rareInheritedData->lineGrid; }
@@ -682,7 +682,7 @@ inline const Style::PerspectiveOriginY& RenderStyle::perspectiveOriginY() const 
 inline const std::optional<Style::ScopedName>& RenderStyle::positionAnchor() const { return m_nonInheritedData->rareData->positionAnchor; }
 inline std::optional<PositionArea> RenderStyle::positionArea() const { return m_nonInheritedData->rareData->positionArea; }
 inline Style::PositionTryOrder RenderStyle::positionTryOrder() const { return static_cast<Style::PositionTryOrder>(m_nonInheritedData->rareData->positionTryOrder); }
-inline OptionSet<PositionVisibility> RenderStyle::positionVisibility() const { return OptionSet<PositionVisibility>::fromRaw(m_nonInheritedData->rareData->positionVisibility); }
+inline Style::PositionVisibility RenderStyle::positionVisibility() const { return Style::PositionVisibility(m_nonInheritedData->rareData->positionVisibility); }
 inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpaceCollapse()); }
 inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
 inline const Style::Quotes& RenderStyle::quotes() const { return m_rareInheritedData->quotes; }
@@ -727,11 +727,11 @@ inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<Tex
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }
 inline TextCombine RenderStyle::textCombine() const { return static_cast<TextCombine>(m_rareInheritedData->textCombine); }
 inline const Style::Color& RenderStyle::textDecorationColor() const { return m_nonInheritedData->rareData->textDecorationColor; }
-inline OptionSet<TextDecorationLine> RenderStyle::textDecorationLine() const { return OptionSet<TextDecorationLine>::fromRaw(m_nonInheritedFlags.textDecorationLine); }
+inline Style::TextDecorationLine RenderStyle::textDecorationLine() const { return Style::TextDecorationLine(m_nonInheritedFlags.textDecorationLine); }
+inline Style::TextDecorationLine RenderStyle::textDecorationLineInEffect() const { return Style::TextDecorationLine(m_inheritedFlags.textDecorationLineInEffect); }
 inline TextDecorationSkipInk RenderStyle::textDecorationSkipInk() const { return static_cast<TextDecorationSkipInk>(m_rareInheritedData->textDecorationSkipInk); }
 inline TextDecorationStyle RenderStyle::textDecorationStyle() const { return static_cast<TextDecorationStyle>(m_nonInheritedData->rareData->textDecorationStyle); }
 inline const Style::TextDecorationThickness& RenderStyle::textDecorationThickness() const { return m_nonInheritedData->rareData->textDecorationThickness; }
-inline OptionSet<TextDecorationLine> RenderStyle::textDecorationLineInEffect() const { return OptionSet<TextDecorationLine>::fromRaw(m_inheritedFlags.textDecorationLineInEffect); }
 inline const Style::Color& RenderStyle::textEmphasisColor() const { return m_rareInheritedData->textEmphasisColor; }
 inline const Style::TextEmphasisStyle& RenderStyle::textEmphasisStyle() const { return m_rareInheritedData->textEmphasisStyle; }
 inline OptionSet<TextEmphasisPosition> RenderStyle::textEmphasisPosition() const { return OptionSet<TextEmphasisPosition>::fromRaw(m_rareInheritedData->textEmphasisPosition); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -46,7 +46,7 @@ namespace WebCore {
 
 template<typename T, typename U> inline bool compareEqual(const T& a, const U& b) { return a == b; }
 
-inline void RenderStyle::addToTextDecorationLineInEffect(OptionSet<TextDecorationLine> value) { m_inheritedFlags.textDecorationLineInEffect |= static_cast<unsigned>(value.toRaw()); }
+inline void RenderStyle::addToTextDecorationLineInEffect(Style::TextDecorationLine value) { m_inheritedFlags.textDecorationLineInEffect |= static_cast<unsigned>(value.toRaw()); }
 inline void RenderStyle::clearAnimations() { m_nonInheritedData.access().miscData.access().animations = nullptr; }
 inline void RenderStyle::clearBackgroundLayers() { m_nonInheritedData.access().backgroundData.access().background = FillLayer::create(FillLayerType::Background); }
 inline void RenderStyle::clearMaskLayers() { m_nonInheritedData.access().miscData.access().mask = FillLayer::create(FillLayerType::Mask); }
@@ -205,7 +205,7 @@ inline void RenderStyle::setJustifySelf(const StyleSelfAlignmentData& data) { SE
 inline void RenderStyle::setJustifySelfPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().justifySelf.setPosition(position); }
 inline void RenderStyle::setLeft(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.left(), WTFMove(edge)); }
 inline void RenderStyle::setLineAlign(LineAlign alignment) { SET(m_rareInheritedData, lineAlign, static_cast<unsigned>(alignment)); }
-inline void RenderStyle::setLineBoxContain(OptionSet<Style::LineBoxContain> c) { SET(m_rareInheritedData, lineBoxContain, c.toRaw()); }
+inline void RenderStyle::setLineBoxContain(Style::LineBoxContain c) { SET(m_rareInheritedData, lineBoxContain, c.toRaw()); }
 inline void RenderStyle::setLineBreak(LineBreak rule) { SET(m_rareInheritedData, lineBreak, static_cast<unsigned>(rule)); }
 inline void RenderStyle::setLineClamp(LineClampValue value) { SET_NESTED(m_nonInheritedData, rareData, lineClamp, value); }
 inline void RenderStyle::setLineGrid(const AtomString& name) { SET(m_rareInheritedData, lineGrid, name); }
@@ -264,7 +264,7 @@ inline void RenderStyle::setPerspectiveOriginY(Style::PerspectiveOriginY&& origi
 inline void RenderStyle::setPositionAnchor(const std::optional<Style::ScopedName>& anchor) { SET_NESTED(m_nonInheritedData, rareData, positionAnchor, anchor); }
 inline void RenderStyle::setPositionArea(std::optional<PositionArea> value) { SET_NESTED(m_nonInheritedData, rareData, positionArea, value); }
 inline void RenderStyle::setPositionTryOrder(Style::PositionTryOrder order) { SET_NESTED(m_nonInheritedData, rareData, positionTryOrder, static_cast<unsigned>(order)); }
-inline void RenderStyle::setPositionVisibility(OptionSet<PositionVisibility> value) { SET_NESTED(m_nonInheritedData, rareData, positionVisibility, value.toRaw()); }
+inline void RenderStyle::setPositionVisibility(Style::PositionVisibility value) { SET_NESTED(m_nonInheritedData, rareData, positionVisibility, value.toRaw()); }
 inline void RenderStyle::setResize(Resize r) { SET_NESTED(m_nonInheritedData, miscData, resize, static_cast<unsigned>(r)); }
 inline void RenderStyle::setRight(Style::InsetEdge&& edge) { SET_NESTED(m_nonInheritedData, surroundData, inset.right(), WTFMove(edge)); }
 inline void RenderStyle::setRotate(Style::Rotate&& rotate) { SET_NESTED(m_nonInheritedData, rareData, rotate, WTFMove(rotate)); }
@@ -295,11 +295,11 @@ inline void RenderStyle::setTextAlignLast(TextAlignLast value) { SET(m_rareInher
 inline void RenderStyle::setTextBoxTrim(TextBoxTrim value) { SET_NESTED(m_nonInheritedData, rareData, textBoxTrim, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextCombine(TextCombine value) { SET(m_rareInheritedData, textCombine, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, rareData, textDecorationColor, WTFMove(color)); }
-inline void RenderStyle::setTextDecorationLine(OptionSet<TextDecorationLine> value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }
+inline void RenderStyle::setTextDecorationLine(Style::TextDecorationLine value) { m_nonInheritedFlags.textDecorationLine = value.toRaw(); }
+inline void RenderStyle::setTextDecorationLineInEffect(Style::TextDecorationLine value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
 inline void RenderStyle::setTextDecorationSkipInk(TextDecorationSkipInk skipInk) { SET(m_rareInheritedData, textDecorationSkipInk, static_cast<unsigned>(skipInk)); }
 inline void RenderStyle::setTextDecorationStyle(TextDecorationStyle value) { SET_NESTED(m_nonInheritedData, rareData, textDecorationStyle, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextDecorationThickness(Style::TextDecorationThickness&& textDecorationThickness) { SET_NESTED(m_nonInheritedData, rareData, textDecorationThickness, WTFMove(textDecorationThickness)); }
-inline void RenderStyle::setTextDecorationLineInEffect(OptionSet<TextDecorationLine> value) { m_inheritedFlags.textDecorationLineInEffect = value.toRaw(); }
 inline void RenderStyle::setTextEmphasisColor(Style::Color&& c) { SET(m_rareInheritedData, textEmphasisColor, WTFMove(c)); }
 inline void RenderStyle::setTextEmphasisStyle(Style::TextEmphasisStyle&& style) { SET(m_rareInheritedData, textEmphasisStyle, style); }
 inline void RenderStyle::setTextEmphasisPosition(OptionSet<TextEmphasisPosition> position) { SET(m_rareInheritedData, textEmphasisPosition, static_cast<unsigned>(position.toRaw())); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -28,6 +28,7 @@
 #include "RenderStyleDifference.h"
 #include "StyleFilterData.h"
 #include "StyleImage.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/PointerComparison.h>
 
@@ -460,7 +461,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(TextEmphasisPosition, textEmphasisPosition);
     LOG_IF_DIFFERENT_WITH_CAST(TextUnderlinePosition, textUnderlinePosition);
 
-    LOG_RAW_OPTIONSET_IF_DIFFERENT(Style::LineBoxContain, lineBoxContain);
+    LOG_IF_DIFFERENT_WITH_CONSTRUCTION(Style::LineBoxContain, lineBoxContain);
 
     LOG_IF_DIFFERENT_WITH_CAST(ImageOrientation, imageOrientation);
     LOG_IF_DIFFERENT_WITH_CAST(ImageRendering, imageRendering);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -31,8 +31,8 @@
 #include "StyleColor.h"
 #include "StyleCursor.h"
 #include "StyleCustomPropertyData.h"
-#include "StyleLineBoxContain.h"
 #include "StyleDynamicRangeLimit.h"
+#include "StyleLineBoxContain.h"
 #include "StyleListStyleType.h"
 #include "StyleQuotes.h"
 #include "StyleScrollbarColor.h"
@@ -151,7 +151,7 @@ public:
     PREFERRED_TYPE(TextCombine) unsigned textCombine : 1;
     PREFERRED_TYPE(TextEmphasisPosition) unsigned textEmphasisPosition : 4;
     PREFERRED_TYPE(TextUnderlinePosition) unsigned textUnderlinePosition : 4;
-    PREFERRED_TYPE(OptionSet<Style::LineBoxContain>) unsigned lineBoxContain: 7;
+    PREFERRED_TYPE(Style::LineBoxContain) unsigned lineBoxContain: Style::LineBoxContain::bits;
     PREFERRED_TYPE(ImageOrientation) unsigned imageOrientation : 1;
     PREFERRED_TYPE(ImageRendering) unsigned imageRendering : 3;
     PREFERRED_TYPE(LineSnap) unsigned lineSnap : 2;

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -51,6 +51,7 @@
 #include "StyleOffsetRotate.h"
 #include "StylePerspective.h"
 #include "StylePerspectiveOrigin.h"
+#include "StylePositionVisibility.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StyleProgressTimelineAxes.h"
 #include "StyleProgressTimelineName.h"
@@ -267,7 +268,7 @@ public:
     PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
     PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
     PREFERRED_TYPE(Style::PositionTryOrder) unsigned positionTryOrder : 3;
-    PREFERRED_TYPE(OptionSet<PositionVisibility>) unsigned positionVisibility : 3;
+    PREFERRED_TYPE(Style::PositionVisibility) unsigned positionVisibility : Style::PositionVisibility::bits;
     PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
     PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
 #if HAVE(CORE_MATERIAL)

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -220,10 +220,10 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
 
         // Spec: All text decorations except line-through should be drawn before the text is filled and stroked; thus, the text is rendered on top of these decorations.
         auto decorations = style.textDecorationLineInEffect();
-        if (decorations & TextDecorationLine::Underline)
-            paintDecoration(TextDecorationLine::Underline, fragment);
-        if (decorations & TextDecorationLine::Overline)
-            paintDecoration(TextDecorationLine::Overline, fragment);
+        if (decorations & CSS::Keyword::Underline { })
+            paintDecoration(CSS::Keyword::Underline { }, fragment);
+        if (decorations & CSS::Keyword::Overline { })
+            paintDecoration(CSS::Keyword::Overline { }, fragment);
 
         for (auto type : RenderStyle::paintTypesForPaintOrder(style.paintOrder())) {
             switch (type) {
@@ -247,8 +247,8 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
         }
 
         // Spec: Line-through should be drawn after the text is filled and stroked; thus, the line-through is rendered on top of the text.
-        if (decorations & TextDecorationLine::LineThrough)
-            paintDecoration(TextDecorationLine::LineThrough, fragment);
+        if (decorations & CSS::Keyword::LineThrough { })
+            paintDecoration(CSS::Keyword::LineThrough { }, fragment);
 
         m_paintingResourceMode = { };
     }
@@ -396,23 +396,23 @@ bool mapStartEndPositionsIntoFragmentCoordinates(unsigned textBoxStart, const SV
     return true;
 }
 
-static inline float positionOffsetForDecoration(OptionSet<TextDecorationLine> decoration, const FontMetrics& fontMetrics, float thickness)
+static inline float positionOffsetForDecoration(Style::TextDecorationLine decoration, const FontMetrics& fontMetrics, float thickness)
 {
     // FIXME: For SVG Fonts we need to use the attributes defined in the <font-face> if specified.
     // Compatible with Batik/Opera.
     const float ascent = fontMetrics.ascent();
-    if (decoration == TextDecorationLine::Underline)
+    if (decoration == CSS::Keyword::Underline { })
         return ascent + thickness * 1.5f;
-    if (decoration == TextDecorationLine::Overline)
+    if (decoration == CSS::Keyword::Overline { })
         return thickness;
-    if (decoration == TextDecorationLine::LineThrough)
+    if (decoration == CSS::Keyword::LineThrough { })
         return ascent * 5 / 8.0f;
 
     ASSERT_NOT_REACHED();
     return 0.0f;
 }
 
-static inline float thicknessForDecoration(OptionSet<TextDecorationLine>, const FontCascade& font)
+static inline float thicknessForDecoration(Style::TextDecorationLine, const FontCascade& font)
 {
     // FIXME: For SVG Fonts we need to use the attributes defined in the <font-face> if specified.
     // Compatible with Batik/Opera
@@ -420,7 +420,7 @@ static inline float thicknessForDecoration(OptionSet<TextDecorationLine>, const 
 }
 
 template<typename TextBoxPath>
-void SVGTextBoxPainter<TextBoxPath>::paintDecoration(OptionSet<TextDecorationLine> decoration, const SVGTextFragment& fragment)
+void SVGTextBoxPainter<TextBoxPath>::paintDecoration(Style::TextDecorationLine decoration, const SVGTextFragment& fragment)
 {
     if (renderer().style().textDecorationLineInEffect().isEmpty())
         return;
@@ -476,7 +476,7 @@ void SVGTextBoxPainter<TextBoxPath>::paintDecoration(OptionSet<TextDecorationLin
 }
 
 template<typename TextBoxPath>
-void SVGTextBoxPainter<TextBoxPath>::paintDecorationWithStyle(OptionSet<TextDecorationLine> decoration, const SVGTextFragment& fragment, const RenderBoxModelObject& decorationRenderer)
+void SVGTextBoxPainter<TextBoxPath>::paintDecorationWithStyle(Style::TextDecorationLine decoration, const SVGTextFragment& fragment, const RenderBoxModelObject& decorationRenderer)
 {
     ASSERT(!m_legacyPaintingResource);
     ASSERT(!paintingResourceMode().isEmpty());

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.h
@@ -37,6 +37,10 @@ class RenderStyle;
 class SVGPaintServerHandling;
 struct SVGTextFragment;
 
+namespace Style {
+struct TextDecorationLine;
+}
+
 template<typename TextBoxPath>
 class SVGTextBoxPainter {
 public:
@@ -53,8 +57,8 @@ private:
     const RenderBoxModelObject& parentRenderer() const;
     OptionSet<RenderSVGResourceMode> paintingResourceMode() const { return m_paintingResourceMode; }
 
-    void paintDecoration(OptionSet<TextDecorationLine>, const SVGTextFragment&);
-    void paintDecorationWithStyle(OptionSet<TextDecorationLine>, const SVGTextFragment&, const RenderBoxModelObject&);
+    void paintDecoration(Style::TextDecorationLine, const SVGTextFragment&);
+    void paintDecorationWithStyle(Style::TextDecorationLine, const SVGTextFragment&, const RenderBoxModelObject&);
     void paintTextWithShadows(const RenderStyle&, TextRun&, const SVGTextFragment&, unsigned startPosition, unsigned endPosition);
     void paintText(const RenderStyle&, const RenderStyle& selectionStyle, const SVGTextFragment&, bool hasSelection, bool paintSelectedTextOnly);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -63,7 +63,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
         // For an N-line first-letter and for alphabetic baselines, the cap-height of the first letter needs to equal (N-1)*line-height of paragraph lines + cap-height of the paragraph
         // Mathematically we can't rely on font-size, since font().height() doesn't necessarily match. For reliability, the best approach is simply to
         // compare the final measured cap-heights of the two fonts in order to get to the closest possible value.
-        firstLetterStyle.setLineBoxContain({ Style::LineBoxContain::InitialLetter });
+        firstLetterStyle.setLineBoxContain({ CSS::Keyword::InitialLetter { } });
         int lineHeight = paragraph->style().computedLineHeight();
 
         // Set the font to be one line too big and then ratchet back to get to a precise fit. We can't just set the desired font size based off font height metrics

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -61,7 +61,7 @@ static float minLogicalTopForTextDecorationLineUnder(const InlineIterator::LineB
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
-        if (!run->style().textDecorationLineInEffect().contains(TextDecorationLine::Underline))
+        if (!run->style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { }))
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
         if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
@@ -80,7 +80,7 @@ static float maxLogicalBottomForTextDecorationLineUnder(const InlineIterator::Li
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
-        if (!run->style().textDecorationLineInEffect().contains(TextDecorationLine::Underline))
+        if (!run->style().textDecorationLineInEffect().contains(CSS::Keyword::Underline { }))
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
         if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
@@ -108,7 +108,7 @@ static const RenderElement* enclosingRendererWithTextDecoration(const RenderText
                 // <font> and <a> are always considered decorating boxes.
                 return true;
             }
-            return ancestor->style().textDecorationLine().contains(TextDecorationLine::Underline);
+            return ancestor->style().textDecorationLine().contains(CSS::Keyword::Underline { });
         };
         if (isDecoratingInlineBox())
             return ancestor;
@@ -212,7 +212,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
 
     // These metrics must match where underlines get drawn.
     // FIXME: Share the code in TextDecorationPainter::paintBackgroundDecorations() so we can just query it for the painted geometry.
-    if (decoration & TextDecorationLine::Underline) {
+    if (decoration & CSS::Keyword::Underline { }) {
         ASSERT(underlineOffset);
         if (decorationStyle == TextDecorationStyle::Wavy) {
             overflowResult.extendBottom(*underlineOffset + wavyOffset + wavyStrokeParameters.controlPointDistance + strokeThickness - height);
@@ -222,7 +222,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
             overflowResult.extendTop(-*underlineOffset);
         }
     }
-    if (decoration & TextDecorationLine::Overline) {
+    if (decoration & CSS::Keyword::Overline { }) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
         float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
         rect.move(0, autoTextDecorationThickness - strokeThickness - wavyOffset);
@@ -235,7 +235,7 @@ static GlyphOverflow computedInkOverflowForDecorations(const RenderStyle& lineSt
         overflowResult.extendTop(-rect.y());
         overflowResult.extendBottom(rect.maxY() - height);
     }
-    if (decoration & TextDecorationLine::LineThrough) {
+    if (decoration & CSS::Keyword::LineThrough { }) {
         FloatRect rect(FloatPoint(), FloatSize(1, strokeThickness));
         float autoTextDecorationThickness = Style::TextDecorationThickness { CSS::Keyword::Auto { } }.resolve(lineStyle.computedFontSize(), lineStyle.metricsOfPrimaryFont());
         auto center = 2 * lineStyle.metricsOfPrimaryFont().ascent() / 3 + autoTextDecorationThickness / 2;
@@ -279,7 +279,7 @@ GlyphOverflow inkOverflowForDecorations(const InlineIterator::LineBoxIterator& l
         textUnderlinePositionUnder = TextUnderlinePositionUnder { textBoxLogicalBottom - textBoxLogicalTop, textRunOffset };
     }
 
-    auto underlineOffset = style.textDecorationLineInEffect().contains(TextDecorationLine::Underline)
+    auto underlineOffset = style.textDecorationLineInEffect().contains(CSS::Keyword::Underline { })
         ? std::make_optional(computedUnderlineOffset({ style, textUnderlinePositionUnder }))
         : std::nullopt;
     return computedInkOverflowForDecorations(style, underlineOffset);
@@ -287,7 +287,7 @@ GlyphOverflow inkOverflowForDecorations(const InlineIterator::LineBoxIterator& l
 
 GlyphOverflow inkOverflowForDecorations(const RenderStyle& style, TextUnderlinePositionUnder textUnderlinePositionUnder)
 {
-    auto underlineOffset = style.textDecorationLineInEffect().contains(TextDecorationLine::Underline)
+    auto underlineOffset = style.textDecorationLineInEffect().contains(CSS::Keyword::Underline { })
         ? std::make_optional(computedUnderlineOffset({ style, textUnderlinePositionUnder }))
         : std::nullopt;
     return computedInkOverflowForDecorations(style, underlineOffset);
@@ -295,7 +295,7 @@ GlyphOverflow inkOverflowForDecorations(const RenderStyle& style, TextUnderlineP
 
 GlyphOverflow inkOverflowForDecorations(const RenderStyle& style)
 {
-    auto underlineOffset = style.textDecorationLineInEffect().contains(TextDecorationLine::Underline)
+    auto underlineOffset = style.textDecorationLineInEffect().contains(CSS::Keyword::Underline { })
         ? std::make_optional(computedUnderlineOffset({ style, { } }))
         : std::nullopt;
     return computedInkOverflowForDecorations(style, underlineOffset);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -78,7 +78,6 @@
 #include "StyleFlexBasis.h"
 #include "StyleInset.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
-#include "StyleLineBoxContain.h"
 #include "StyleMargin.h"
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
@@ -92,6 +91,7 @@
 #include "StylePerspective.h"
 #include "StylePreferredSize.h"
 #include "StylePrimitiveKeyword+CSSValueConversion.h"
+#include "StylePrimitiveKeywordSet+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleRayFunction.h"
@@ -134,7 +134,6 @@ public:
     static TabSize convertTabSize(BuilderState&, const CSSValue&);
     template<typename T> static T convertComputedLength(BuilderState&, const CSSValue&);
     template<typename T> static T convertLineWidth(BuilderState&, const CSSValue&);
-    static OptionSet<TextDecorationLine> convertTextDecorationLine(BuilderState&, const CSSValue&);
     static OptionSet<TextTransform> convertTextTransform(BuilderState&, const CSSValue&);
     template<typename T> static T convertNumber(BuilderState&, const CSSValue&);
     template<typename T, CSSValueID> static T convertNumberOrKeyword(BuilderState&, const CSSValue&);
@@ -159,7 +158,6 @@ public:
     static TextEdge convertTextEdge(BuilderState&, const CSSValue&);
     static IntSize convertInitialLetter(BuilderState&, const CSSValue&);
     static float convertTextStrokeWidth(BuilderState&, const CSSValue&);
-    static OptionSet<LineBoxContain> convertLineBoxContain(BuilderState&, const CSSValue&);
     static RefPtr<ShapeValue> convertShapeValue(BuilderState&, const CSSValue&);
     static ScrollSnapType convertScrollSnapType(BuilderState&, const CSSValue&);
     static ScrollSnapAlign convertScrollSnapAlign(BuilderState&, const CSSValue&);
@@ -219,7 +217,6 @@ public:
 
     static std::optional<ScopedName> convertPositionAnchor(BuilderState&, const CSSValue&);
     static std::optional<PositionArea> convertPositionArea(BuilderState&, const CSSValue&);
-    static OptionSet<PositionVisibility> convertPositionVisibility(BuilderState&, const CSSValue&);
 
     static size_t convertMaxLines(BuilderState&, const CSSValue&);
 
@@ -345,16 +342,6 @@ inline T BuilderConverter::convertLineWidth(BuilderState& builderState, const CS
         ASSERT_NOT_REACHED();
         return 0;
     }
-}
-
-inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine(BuilderState&, const CSSValue& value)
-{
-    auto result = RenderStyle::initialTextDecorationLine();
-    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
-        for (auto& currentValue : *list)
-            result.add(fromCSSValue<TextDecorationLine>(currentValue));
-    }
-    return result;
 }
 
 inline OptionSet<TextTransform> BuilderConverter::convertTextTransform(BuilderState&, const CSSValue& value)
@@ -755,68 +742,6 @@ inline float BuilderConverter::convertTextStrokeWidth(BuilderState& builderState
     }
 
     return width;
-}
-
-inline OptionSet<LineBoxContain> BuilderConverter::convertLineBoxContain(BuilderState& builderState, const CSSValue& value)
-{
-    if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        switch (primitive->valueID()) {
-        case CSSValueNone:
-            return { };
-        case CSSValueBlock:
-            return LineBoxContain::Block;
-        case CSSValueInline:
-            return LineBoxContain::Inline;
-        case CSSValueFont:
-            return LineBoxContain::Font;
-        case CSSValueGlyphs:
-            return LineBoxContain::Glyphs;
-        case CSSValueReplaced:
-            return LineBoxContain::Replaced;
-        case CSSValueInlineBox:
-            return LineBoxContain::InlineBox;
-        case CSSValueInitialLetter:
-            return LineBoxContain::InitialLetter;
-        default:
-            builderState.setCurrentPropertyInvalidAtComputedValueTime();
-            return { };
-        }
-    }
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    OptionSet<LineBoxContain> result;
-    for (Ref primitive : *list) {
-        switch (primitive->valueID()) {
-        case CSSValueBlock:
-            result.add(LineBoxContain::Block);
-            break;
-        case CSSValueInline:
-            result.add(LineBoxContain::Inline);
-            break;
-        case CSSValueFont:
-            result.add(LineBoxContain::Font);
-            break;
-        case CSSValueGlyphs:
-            result.add(LineBoxContain::Glyphs);
-            break;
-        case CSSValueReplaced:
-            result.add(LineBoxContain::Replaced);
-            break;
-        case CSSValueInlineBox:
-            result.add(LineBoxContain::InlineBox);
-            break;
-        case CSSValueInitialLetter:
-            result.add(LineBoxContain::InitialLetter);
-            break;
-        default:
-            builderState.setCurrentPropertyInvalidAtComputedValueTime();
-            return { };
-        }
-    }
-    return result;
 }
 
 inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& builderState, const CSSValue& value)
@@ -1857,23 +1782,6 @@ inline std::optional<PositionArea> BuilderConverter::convertPositionArea(Builder
     }
 
     return area;
-}
-
-inline OptionSet<PositionVisibility> BuilderConverter::convertPositionVisibility(BuilderState& builderState, const CSSValue& value)
-{
-    if (value.valueID() == CSSValueAlways)
-        return { };
-
-    auto maybeList = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!maybeList)
-        return { };
-    auto list = *maybeList;
-
-    OptionSet<PositionVisibility> result;
-    for (const auto& value : list)
-        result.add(fromCSSValue<PositionVisibility>(value));
-
-    return result;
 }
 
 inline size_t BuilderConverter::convertMaxLines(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -91,7 +91,6 @@
 #include "StyleFilterProperty.h"
 #include "StyleFlexBasis.h"
 #include "StyleInset.h"
-#include "StyleLineBoxContain.h"
 #include "StyleMargin.h"
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
@@ -101,6 +100,7 @@
 #include "StylePerspective.h"
 #include "StylePreferredSize.h"
 #include "StylePrimitiveKeyword+CSSValueCreation.h"
+#include "StylePrimitiveKeywordSet+CSSValueCreation.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleReflection.h"
@@ -193,12 +193,10 @@ public:
     static Ref<CSSValue> convertTabSize(ExtractorState&, const TabSize&);
     static Ref<CSSValue> convertScrollSnapType(ExtractorState&, const ScrollSnapType&);
     static Ref<CSSValue> convertScrollSnapAlign(ExtractorState&, const ScrollSnapAlign&);
-    static Ref<CSSValue> convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain>);
     static Ref<CSSValue> convertWebkitRubyPosition(ExtractorState&, RubyPosition);
     static Ref<CSSValue> convertPosition(ExtractorState&, const LengthPoint&);
     static Ref<CSSValue> convertTouchAction(ExtractorState&, OptionSet<TouchAction>);
     static Ref<CSSValue> convertTextTransform(ExtractorState&, OptionSet<TextTransform>);
-    static Ref<CSSValue> convertTextDecorationLine(ExtractorState&, OptionSet<TextDecorationLine>);
     static Ref<CSSValue> convertTextUnderlinePosition(ExtractorState&, OptionSet<TextUnderlinePosition>);
     static Ref<CSSValue> convertTextEmphasisPosition(ExtractorState&, OptionSet<TextEmphasisPosition>);
     static Ref<CSSValue> convertSpeakAs(ExtractorState&, OptionSet<SpeakAs>);
@@ -214,7 +212,6 @@ public:
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const PositionArea&);
     static Ref<CSSValue> convertPositionArea(ExtractorState&, const std::optional<PositionArea>&);
     static Ref<CSSValue> convertNameScope(ExtractorState&, const NameScope&);
-    static Ref<CSSValue> convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility>);
 
     // MARK: FillLayer conversions
 
@@ -913,29 +910,6 @@ inline Ref<CSSValue> ExtractorConverter::convertScrollSnapAlign(ExtractorState& 
     );
 }
 
-inline Ref<CSSValue> ExtractorConverter::convertLineBoxContain(ExtractorState&, OptionSet<Style::LineBoxContain> lineBoxContain)
-{
-    if (!lineBoxContain)
-        return CSSPrimitiveValue::create(CSSValueNone);
-
-    CSSValueListBuilder list;
-    if (lineBoxContain.contains(LineBoxContain::Block))
-        list.append(CSSPrimitiveValue::create(CSSValueBlock));
-    if (lineBoxContain.contains(LineBoxContain::Inline))
-        list.append(CSSPrimitiveValue::create(CSSValueInline));
-    if (lineBoxContain.contains(LineBoxContain::Font))
-        list.append(CSSPrimitiveValue::create(CSSValueFont));
-    if (lineBoxContain.contains(LineBoxContain::Glyphs))
-        list.append(CSSPrimitiveValue::create(CSSValueGlyphs));
-    if (lineBoxContain.contains(LineBoxContain::Replaced))
-        list.append(CSSPrimitiveValue::create(CSSValueReplaced));
-    if (lineBoxContain.contains(LineBoxContain::InlineBox))
-        list.append(CSSPrimitiveValue::create(CSSValueInlineBox));
-    if (lineBoxContain.contains(LineBoxContain::InitialLetter))
-        list.append(CSSPrimitiveValue::create(CSSValueInitialLetter));
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
 inline Ref<CSSValue> ExtractorConverter::convertWebkitRubyPosition(ExtractorState&, RubyPosition position)
 {
     return CSSPrimitiveValue::create([&] {
@@ -997,21 +971,6 @@ inline Ref<CSSValue> ExtractorConverter::convertTextTransform(ExtractorState&, O
     if (textTransform.contains(TextTransform::FullSizeKana))
         list.append(CSSPrimitiveValue::create(CSSValueFullSizeKana));
 
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueNone);
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertTextDecorationLine(ExtractorState&, OptionSet<TextDecorationLine> textDecorationLine)
-{
-    // Blink value is ignored.
-    CSSValueListBuilder list;
-    if (textDecorationLine & TextDecorationLine::Underline)
-        list.append(CSSPrimitiveValue::create(CSSValueUnderline));
-    if (textDecorationLine & TextDecorationLine::Overline)
-        list.append(CSSPrimitiveValue::create(CSSValueOverline));
-    if (textDecorationLine & TextDecorationLine::LineThrough)
-        list.append(CSSPrimitiveValue::create(CSSValueLineThrough));
     if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
     return CSSValueList::createSpaceSeparated(WTFMove(list));
@@ -1379,22 +1338,6 @@ inline Ref<CSSValue> ExtractorConverter::convertNameScope(ExtractorState&, const
 
     ASSERT_NOT_REACHED();
     return CSSPrimitiveValue::create(CSSValueNone);
-}
-
-inline Ref<CSSValue> ExtractorConverter::convertPositionVisibility(ExtractorState&, OptionSet<PositionVisibility> positionVisibility)
-{
-    CSSValueListBuilder list;
-    if (positionVisibility & PositionVisibility::AnchorsValid)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsValid));
-    if (positionVisibility & PositionVisibility::AnchorsVisible)
-        list.append(CSSPrimitiveValue::create(CSSValueAnchorsVisible));
-    if (positionVisibility & PositionVisibility::NoOverflow)
-        list.append(CSSPrimitiveValue::create(CSSValueNoOverflow));
-
-    if (list.isEmpty())
-        return CSSPrimitiveValue::create(CSSValueAlways);
-
-    return CSSValueList::createSpaceSeparated(WTFMove(list));
 }
 
 // MARK: - FillLayer conversions

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -32,6 +32,7 @@
 #include "ColorSerialization.h"
 #include "StyleExtractorConverter.h"
 #include "StylePrimitiveKeyword+Serialization.h"
+#include "StylePrimitiveKeywordSet+Serialization.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
 #include <wtf/text/StringBuilder.h>
 
@@ -114,12 +115,10 @@ public:
     static void serializeTabSize(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const TabSize&);
     static void serializeScrollSnapType(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollSnapType&);
     static void serializeScrollSnapAlign(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const ScrollSnapAlign&);
-    static void serializeLineBoxContain(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<Style::LineBoxContain>);
     static void serializeWebkitRubyPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, RubyPosition);
     static void serializePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const LengthPoint&);
     static void serializeTouchAction(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TouchAction>);
     static void serializeTextTransform(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextTransform>);
-    static void serializeTextDecorationLine(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextDecorationLine>);
     static void serializeTextUnderlinePosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextUnderlinePosition>);
     static void serializeTextEmphasisPosition(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<TextEmphasisPosition>);
     static void serializeSpeakAs(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<SpeakAs>);
@@ -134,7 +133,6 @@ public:
     static void serializePositionAnchor(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<ScopedName>&);
     static void serializePositionArea(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const std::optional<PositionArea>&);
     static void serializeNameScope(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const NameScope&);
-    static void serializePositionVisibility(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, OptionSet<PositionVisibility>);
 
     // MARK: FillLayer serializations
 
@@ -1106,31 +1104,6 @@ inline void ExtractorSerializer::serializeScrollSnapAlign(ExtractorState& state,
     serialize(state, builder, context, alignment.inlineAlign);
 }
 
-inline void ExtractorSerializer::serializeLineBoxContain(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<Style::LineBoxContain> lineBoxContain)
-{
-    if (!lineBoxContain) {
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-        return;
-    }
-
-    bool listEmpty = true;
-    auto appendOption = [&](LineBoxContain test, CSSValueID value) {
-        if (lineBoxContain.contains(test)) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(LineBoxContain::Block, CSSValueBlock);
-    appendOption(LineBoxContain::Inline, CSSValueInline);
-    appendOption(LineBoxContain::Font, CSSValueFont);
-    appendOption(LineBoxContain::Glyphs, CSSValueGlyphs);
-    appendOption(LineBoxContain::Replaced, CSSValueReplaced);
-    appendOption(LineBoxContain::InlineBox, CSSValueInlineBox);
-    appendOption(LineBoxContain::InitialLetter, CSSValueInitialLetter);
-}
-
 inline void ExtractorSerializer::serializeWebkitRubyPosition(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, RubyPosition position)
 {
     switch (position) {
@@ -1213,26 +1186,6 @@ inline void ExtractorSerializer::serializeTextTransform(ExtractorState& state, S
     };
     appendOption(TextTransform::FullWidth, CSSValueFullWidth);
     appendOption(TextTransform::FullSizeKana, CSSValueFullSizeKana);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
-}
-
-inline void ExtractorSerializer::serializeTextDecorationLine(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextDecorationLine> textDecorationLine)
-{
-    // Blink value is ignored.
-    bool listEmpty = true;
-    auto appendOption = [&](TextDecorationLine test, CSSValueID value) {
-        if (textDecorationLine & test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(TextDecorationLine::Underline, CSSValueUnderline);
-    appendOption(TextDecorationLine::Overline, CSSValueOverline);
-    appendOption(TextDecorationLine::LineThrough, CSSValueLineThrough);
 
     if (listEmpty)
         serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
@@ -1509,25 +1462,6 @@ inline void ExtractorSerializer::serializeNameScope(ExtractorState& state, Strin
     }
 
     RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline void ExtractorSerializer::serializePositionVisibility(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<PositionVisibility> positionVisibility)
-{
-    bool listEmpty = true;
-    auto appendOption = [&](PositionVisibility test, CSSValueID value) {
-        if (positionVisibility & test) {
-            if (!listEmpty)
-                builder.append(' ');
-            builder.append(nameLiteralForSerialization(value));
-            listEmpty = false;
-        }
-    };
-    appendOption(PositionVisibility::AnchorsValid, CSSValueAnchorsValid);
-    appendOption(PositionVisibility::AnchorsVisible, CSSValueAnchorsVisible);
-    appendOption(PositionVisibility::NoOverflow, CSSValueNoOverflow);
-
-    if (listEmpty)
-        serializationForCSS(builder, context, state.style, CSS::Keyword::Always { });
 }
 
 // MARK: - FillLayer serializations

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -37,6 +37,7 @@
 #include "AnimationMalloc.h"
 #include "StyleInterpolationFunctions.h"
 #include "StyleInterpolationWrapperBase.h"
+#include "StylePrimitiveKeywordSet+Logging.h"
 #include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1613,7 +1613,7 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
         if (!anchored)
             return false;
 
-        if (style.positionVisibility().contains(PositionVisibility::AnchorsVisible)) {
+        if (style.positionVisibility().contains(CSS::Keyword::AnchorsVisible { })) {
             // "If the box has a default anchor box but that anchor box is invisible or clipped by intervening boxes, the box’s visibility property computes to force-hidden."
             if (AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(*anchored))
                 return true;

--- a/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
+++ b/Source/WebCore/style/values/anchor-position/StylePositionVisibility.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,14 +32,14 @@
 namespace WebCore {
 namespace Style {
 
-// <'-webkit-line-box-contain'> = none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]
-// Non-standard
-struct LineBoxContain : CSS::PrimitiveKeywordSet<LineBoxContain, CSS::Keyword::None, CSS::Keyword::Block, CSS::Keyword::Inline, CSS::Keyword::Font, CSS::Keyword::Glyphs, CSS::Keyword::Replaced, CSS::Keyword::InlineBox, CSS::Keyword::InitialLetter> {
+// <'position-visibility'> = always | [ anchors-valid || anchors-visible || no-overflow ]
+// https://www.w3.org/TR/css-anchor-position-1/#propdef-position-visibility
+struct PositionVisibility : CSS::PrimitiveKeywordSet<PositionVisibility, CSS::Keyword::Always, CSS::Keyword::AnchorsValid, CSS::Keyword::AnchorsVisible, CSS::Keyword::NoOverflow> {
     using Base::Base;
 };
-static_assert(sizeof(LineBoxContain) == 1);
+static_assert(sizeof(PositionVisibility) == 1);
 
 } // namespace Style
 } // namespace WebCore
 
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::LineBoxContain)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::PositionVisibility)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueConversion.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveKeywordSet.h"
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveKeyword+CSSValueConversion.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+template<CSS::PrimitiveKeywordSetDerived T> struct CSSValueConversion<T> {
+    auto operator()(BuilderState& state, const CSSValue& value) -> T
+    {
+        if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(value)) {
+            auto valueID = primitive->valueID();
+
+            if (primitive->valueID() == T::emptyCase)
+                return T::emptyCase;
+
+            std::optional<T> result;
+            auto processKeyword = [&](const auto keyword, CSSValueID valueID) -> bool {
+                if (keyword.value == valueID) {
+                    result = T { keyword };
+                    return true;
+                }
+                return false;
+            };
+            WTF::apply([&](const auto& ...keyword) { (processKeyword(keyword, valueID) || ...); }, T::Keywords::tuple);
+            if (result)
+                return *result;
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return { };
+        }
+
+        auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(state, value);
+        if (!list)
+            return { };
+
+        T result;
+        auto addKeyword = [&](const auto keyword, CSSValueID valueID) -> bool {
+            if (keyword.value == valueID) {
+                result.add(keyword);
+                return true;
+            }
+            return false;
+        };
+
+        for (Ref primitive : *list) {
+            auto valueID = primitive->valueID();
+
+            bool success = WTF::apply([&](const auto& ...keyword) { return (addKeyword(keyword, valueID) || ...); }, T::Keywords::tuple);
+            if (success)
+                continue;
+
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return { };
+        }
+
+        return result;
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h
@@ -24,16 +24,29 @@
 
 #pragma once
 
-#include "CSSPrimitiveValueMappings.h"
+#include "CSSPrimitiveKeywordSet.h"
+#include "CSSValueList.h"
+#include "StylePrimitiveKeyword+CSSValueCreation.h"
 #include "StyleValueTypes.h"
 
 namespace WebCore {
 namespace Style {
 
-template<typename T> requires std::is_enum_v<T> struct CSSValueConversion<T> {
-    T operator()(BuilderState&, const CSSValue& value)
+template<CSS::PrimitiveKeywordSetDerived T> struct CSSValueCreation<T> {
+    auto operator()(CSSValuePool& pool, const RenderStyle& style, const T& value) -> Ref<CSSValue>
     {
-        return fromCSSValueID<T>(value.valueID());
+        if (!value)
+            return createCSSValue(pool, style, T::emptyCase);
+
+        CSSValueListBuilder list;
+
+        auto appendKeyword = [&](auto keyword) {
+            if (value.contains(keyword))
+                list.append(createCSSValue(pool, style, keyword));
+        };
+        WTF::apply([&](const auto& ...x) { (appendKeyword(x), ...); }, T::Keywords::tuple);
+
+        return CSSValueList::createSpaceSeparated(WTFMove(list));
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Logging.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Logging.h
@@ -24,18 +24,33 @@
 
 #pragma once
 
-#include "CSSPrimitiveValueMappings.h"
+#include "CSSPrimitiveKeywordSet.h"
 #include "StyleValueTypes.h"
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
-template<typename T> requires std::is_enum_v<T> struct CSSValueConversion<T> {
-    T operator()(BuilderState&, const CSSValue& value)
-    {
-        return fromCSSValueID<T>(value.valueID());
-    }
-};
+template<CSS::PrimitiveKeywordSetDerived T> TextStream& operator<<(TextStream& ts, const T& value)
+{
+    if (!value)
+        return ts << '[' << T::emptyCase << ']';
+
+    ts << '[';
+
+    bool listEmpty = true;
+    auto appendKeyword = [&](auto keyword) {
+        if (value.contains(keyword)) {
+            if (!listEmpty)
+                ts << ' ';
+            ts << keyword;
+            listEmpty = false;
+        }
+    };
+    WTF::apply([&](const auto& ...x) { (appendKeyword(x), ...); }, T::Keywords::tuple);
+
+    return ts << ']';
+}
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Serialization.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Serialization.h
@@ -24,16 +24,32 @@
 
 #pragma once
 
-#include "CSSPrimitiveValueMappings.h"
+#include "CSSPrimitiveKeywordSet.h"
+#include "CSSSerializationContext.h"
+#include "StylePrimitiveKeyword+Serialization.h"
 #include "StyleValueTypes.h"
 
 namespace WebCore {
 namespace Style {
 
-template<typename T> requires std::is_enum_v<T> struct CSSValueConversion<T> {
-    T operator()(BuilderState&, const CSSValue& value)
+template<CSS::PrimitiveKeywordSetDerived T> struct Serialize<T> {
+    void operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, const T& value)
     {
-        return fromCSSValueID<T>(value.valueID());
+        if (!value) {
+            serializationForCSS(builder, context, style, T::emptyCase);
+            return;
+        }
+
+        bool listEmpty = true;
+        auto appendKeyword = [&](auto keyword) {
+            if (value.contains(keyword)) {
+                if (!listEmpty)
+                    builder.append(' ');
+                serializationForCSS(builder, context, style, keyword);
+                listEmpty = false;
+            }
+        };
+        WTF::apply([&](const auto& ...x) { (appendKeyword(x), ...); }, T::Keywords::tuple);
     }
 };
 

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2011 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,14 +32,14 @@
 namespace WebCore {
 namespace Style {
 
-// <'-webkit-line-box-contain'> = none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]
-// Non-standard
-struct LineBoxContain : CSS::PrimitiveKeywordSet<LineBoxContain, CSS::Keyword::None, CSS::Keyword::Block, CSS::Keyword::Inline, CSS::Keyword::Font, CSS::Keyword::Glyphs, CSS::Keyword::Replaced, CSS::Keyword::InlineBox, CSS::Keyword::InitialLetter> {
+// <'text-decoration-line'> = none | [ underline || overline || line-through || blink ]
+// https://www.w3.org/TR/css-text-decor-3/#propdef-text-decoration-line
+struct TextDecorationLine : CSS::PrimitiveKeywordSet<TextDecorationLine, CSS::Keyword::None, CSS::Keyword::Underline, CSS::Keyword::Overline, CSS::Keyword::LineThrough, CSS::Keyword::Blink> {
     using Base::Base;
 };
-static_assert(sizeof(LineBoxContain) == 1);
+static_assert(sizeof(TextDecorationLine) == 1);
 
 } // namespace Style
 } // namespace WebCore
 
-DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::LineBoxContain)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::TextDecorationLine)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -9444,7 +9444,7 @@ static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle
                     String value = typingStyle->style()->getPropertyValue(CSSPropertyWebkitTextDecorationsInEffect);
                     [_private->_textTouchBarItemController setTextIsUnderlined:value.contains("underline"_s)];
                 } else
-                    [_private->_textTouchBarItemController setTextIsUnderlined:style->textDecorationLineInEffect().contains(TextDecorationLine::Underline)];
+                    [_private->_textTouchBarItemController setTextIsUnderlined:style->textDecorationLineInEffect().contains(CSS::Keyword::Underline { })];
 
                 Color textColor = style->visitedDependentColor(CSSPropertyColor);
                 if (textColor.isValid())


### PR DESCRIPTION
#### e392d8bdb33c03ca0bb10802d180a2782f10c871
<pre>
[Style] Convert some OptionSet based properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296333">https://bugs.webkit.org/show_bug.cgi?id=296333</a>

Reviewed by NOBODY (OOPS!).

Adds a new aggregate, `CSS::PrimitiveKeywordSet`, that acts just like
an OptionSet, but instead of using an `enum`, it uses a set of CSS::Keyword
constants. This allows for completely generating the conversion and
serialization in the general case.

Adopts new type for `text-decoration-line`, `position-visibility`,
and `-webkit-line-box-contain`.

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXCoreObject.cpp:
* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/scripts/process-css-values.py:
* Source/WebCore/css/values/primitives/CSSPrimitiveKeywordSet.h: Added.
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/rendering/StyledMarkedText.cpp:
* Source/WebCore/rendering/TextBoxPainter.cpp:
* Source/WebCore/rendering/TextDecorationPainter.cpp:
* Source/WebCore/rendering/TextDecorationPainter.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleDifference.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/InlineTextBoxStyle.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/values/anchor-position/StylePositionVisibility.h: Added.
* Source/WebCore/style/values/inline/StyleLineBoxContain.h:
* Source/WebCore/style/values/primitives/StylePrimitiveKeyword+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueConversion.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+CSSValueCreation.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Logging.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveKeywordSet+Serialization.h: Added.
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h: Added.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e392d8bdb33c03ca0bb10802d180a2782f10c871

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113041 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32776 "Hash e392d8bd for PR 48480 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23254 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119245 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63624 "Hash e392d8bd for PR 48480 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115003 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33428 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41339 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/119245 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/63624 "Hash e392d8bd for PR 48480 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/115988 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/33428 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101679 "Found 1 new API test failure: TestWebKitAPI.WKWebView.RequestAllTextRunsWithSubframes (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/119245 "Hash e392d8bd for PR 48480 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/33428 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19811 "Found 60 new test failures: css1/conformance/forward_compatible_parsing.html css1/font_properties/font.html css1/formatting_model/inline_elements.html css1/text_properties/line_height.html css2.1/20110323/absolute-non-replaced-height-002.htm css2.1/20110323/absolute-non-replaced-height-007.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-width-001.htm css2.1/20110323/absolute-non-replaced-width-002.htm css2.1/20110323/absolute-non-replaced-width-003.htm ... (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63003 "Hash e392d8bd for PR 48480 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/33428 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19885 "Found 60 new test failures: compositing/clipping/border-radius-with-composited-descendant.html compositing/transforms/3d-transformed-fixed.html css1/conformance/forward_compatible_parsing.html css1/font_properties/font.html css1/formatting_model/inline_elements.html css1/text_properties/line_height.html css2.1/20110323/absolute-non-replaced-height-002.htm css2.1/20110323/absolute-non-replaced-height-007.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-width-001.htm ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122466 "Hash e392d8bd for PR 48480 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40119 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/41339 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/122466 "Hash e392d8bd for PR 48480 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40503 "Hash e392d8bd for PR 48480 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97900 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/122466 "Hash e392d8bd for PR 48480 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17570 "Found 60 new test failures: css1/conformance/forward_compatible_parsing.html css1/font_properties/font.html css1/formatting_model/inline_elements.html css1/text_properties/line_height.html css2.1/20110323/absolute-non-replaced-height-002.htm css2.1/20110323/absolute-non-replaced-height-007.htm css2.1/20110323/absolute-non-replaced-height-009.htm css2.1/20110323/absolute-non-replaced-width-001.htm css2.1/20110323/absolute-non-replaced-width-002.htm css2.1/20110323/absolute-non-replaced-width-003.htm ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36244 "Hash e392d8bd for PR 48480 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40005 "Hash e392d8bd for PR 48480 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45504 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39646 "Hash e392d8bd for PR 48480 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/42979 "Hash e392d8bd for PR 48480 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41383 "Hash e392d8bd for PR 48480 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->