### PR TITLE
AX: VoiceOver does not announce keypress on contenteditable="plaintext-only" elements

### DIFF
--- a/LayoutTests/accessibility/contenteditable-values-expected.txt
+++ b/LayoutTests/accessibility/contenteditable-values-expected.txt
@@ -1,0 +1,15 @@
+This test ensures we parse contenteditable correctly.
+
+PASS: element.role === 'AXRole: AXTextArea'
+PASS: element.role === 'AXRole: AXGroup'
+PASS: element.role === 'AXRole: AXTextArea'
+PASS: element.role === 'AXRole: AXGroup'
+PASS: element.role === 'AXRole: AXTextArea'
+PASS: element.role === 'AXRole: AXGroup'
+PASS: element.role === 'AXRole: AXTextArea'
+PASS: element.role === 'AXRole: AXGroup'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/contenteditable-values.html
+++ b/LayoutTests/accessibility/contenteditable-values.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container">
+    <div id="c-true" contenteditable="true">True</div>
+    <div id="c-false" contenteditable="false">False</div>
+    <div id="c-plaintext-only" contenteditable="plaintext-only">Plaintext-Only</div>
+    <div id="c-none">None</div>
+    <div id="c-empty" contenteditable="">Empty</div>
+    <div id="c-other" contenteditable="other">Other</div>
+    <div id="c-truecaps" contenteditable="TRUE">TRUE</div>
+    <div id="c-truespace" contenteditable=" true ">&nbsp;true&nbsp;</div>
+</div>
+
+<script>
+var output = "This test ensures we parse contenteditable correctly.\n\n";
+
+if (window.accessibilityController) {
+    [
+        ['c-true', true],
+        ['c-false', false],
+        ['c-plaintext-only', true],
+        ['c-none', false],
+        ['c-empty', true],
+        ['c-other', false],
+        ['c-truecaps', true],
+        ['c-truespace', false],
+    ].forEach(([elementId, expected]) => {
+        element = accessibilityController.accessibleElementById(elementId);
+        expectedRole = expected ? "'AXRole: AXTextArea'" : "'AXRole: AXGroup'";
+        output += expect("element.role", expectedRole);
+    });
+    document.getElementById('container').hidden = true;
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -875,6 +875,9 @@ accessibility/datetime [ Skip ]
 # Requires AccessibilityUIElement::dismiss to return whether or not it was handled.
 accessibility/dismiss-action-returns-whether-keyevent-handled.html [ Skip ]
 
+# Different roles
+accessibility/contenteditable-values.html [ Skip ]
+
 # Added in r263823. Both tests are timing out.
 webkit.org/b/213874 accessibility/keyevents-for-increment-actions-with-node-removal.html [ Skip ]
 webkit.org/b/213874 accessibility/keyevents-posted-for-increment-actions.html [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2103,9 +2103,15 @@ bool AccessibilityObject::contentEditableAttributeIsEnabled(Element& element)
     const AtomString& contentEditableValue = element.attributeWithoutSynchronization(contenteditableAttr);
     if (contentEditableValue.isNull())
         return false;
-    
-    // Both "true" (case-insensitive) and the empty string count as true.
-    return contentEditableValue.isEmpty() || equalLettersIgnoringASCIICase(contentEditableValue, "true"_s);
+
+    if (auto* htmlElement = dynamicDowncast<HTMLElement>(&element)) {
+        if (htmlElement->isTextControlInnerTextElement())
+            return false;
+    }
+
+    // All of "true", "plaintext-only", (both case-insensitive) and the empty string count as true for accessibility.
+    // This needs to be consistent with contentEditableType(const AtomString&) from HTMLElement.cpp.
+    return contentEditableValue.isEmpty() || equalLettersIgnoringASCIICase(contentEditableValue, "true"_s) || equalLettersIgnoringASCIICase(contentEditableValue, "plaintext-only"_s);
 }
 
 int AccessibilityObject::lineForPosition(const VisiblePosition& visiblePos) const


### PR DESCRIPTION
#### 54da61a17312717e3dd499180955a3a45a4781d3
<pre>
AX: VoiceOver does not announce keypress on contenteditable=&quot;plaintext-only&quot; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=295326">https://bugs.webkit.org/show_bug.cgi?id=295326</a>
<a href="https://rdar.apple.com/154846108">rdar://154846108</a>

Reviewed by Andres Gonzalez and Tyler Wilcock.

Accessibility needs to check for contenteditable=&quot;plaintext-only&quot;

* LayoutTests/accessibility/contenteditable-values-expected.txt: Added.
* LayoutTests/accessibility/contenteditable-values.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::contentEditableAttributeIsEnabled):

Canonical link: <a href="https://commits.webkit.org/298001@main">https://commits.webkit.org/298001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0696f3e80610ca1898378ccbb38c58a2eef00c17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86528 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20374 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63721 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95365 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37040 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40755 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/46268 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Found 70437 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->