### PR TITLE
[Absolute Positioning][Grid] align-self self-end and flex-end are equivalent to end for simple content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-end-large-border-padding-ref.html"
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-end-ref.html"
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: flex-end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-end-large-border-padding-ref.html"
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: end;
+}
+</style>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-end-ref.html"
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and end self alignment.">
+<style>
+.grid {
+  display: grid;
+  border: 1 solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: self-end;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -286,41 +286,46 @@ bool PositionedLayoutConstraints::isEligibleForStaticRangeAlignment(LayoutUnit s
         return false;
 
     if (parent->isRenderGrid()) {
-        if (m_container.get() == parent)
-            return false;
-
-        auto& containingBlockStyle = m_container->style();
-        if (!containingBlockStyle.writingMode().isHorizontal())
-            return false;
-
-        if (!containingBlockStyle.isLeftToRightDirection())
-            return false;
-
-        auto& parentStyle = parent->style();
-        if (!parentStyle.writingMode().isHorizontal())
-            return false;
-
-        if (!parentStyle.isLeftToRightDirection())
-            return false;
 
         auto& itemStyle = m_renderer->style();
-        if (!itemStyle.writingMode().isHorizontal())
-            return false;
-
-        if (!itemStyle.isLeftToRightDirection())
-            return false;
-
         auto itemAlignSelf = itemStyle.alignSelf();
-        if (itemAlignSelf.position() != ItemPosition::End)
-            return false;
+        switch (itemStyle.alignSelf().position()) {
+        case ItemPosition::FlexEnd:
+        case ItemPosition::SelfEnd:
+        case ItemPosition::End: {
+            if (m_container.get() == parent)
+                return false;
 
-        if (itemAlignSelf.positionType() != ItemPositionType::NonLegacy)
-            return false;
+            auto& containingBlockStyle = m_container->style();
+            if (!containingBlockStyle.writingMode().isHorizontal())
+                return false;
 
-        if (itemAlignSelf.overflow() != OverflowAlignment::Default)
-            return false;
+            if (!containingBlockStyle.isLeftToRightDirection())
+                return false;
 
-        return spaceInStaticRange >= itemSize;
+            auto& parentStyle = parent->style();
+            if (!parentStyle.writingMode().isHorizontal())
+                return false;
+
+            if (!parentStyle.isLeftToRightDirection())
+                return false;
+
+            if (!itemStyle.writingMode().isHorizontal())
+                return false;
+
+            if (!itemStyle.isLeftToRightDirection())
+                return false;
+
+            if (itemAlignSelf.positionType() != ItemPositionType::NonLegacy)
+                return false;
+
+            if (itemAlignSelf.overflow() != OverflowAlignment::Default)
+                return false;
+            return spaceInStaticRange >= itemSize;
+        }
+        default:
+            return false;
+        }
     }
 
     // We can hit this in certain pieces of content (e.g. see mathml/crashtests/fixed-pos-children.html),


### PR DESCRIPTION
#### 95ac4a4f3b2b6a677050b5e5ce9c8138a99e3847
<pre>
[Absolute Positioning][Grid] align-self self-end and flex-end are equivalent to end for simple content
<a href="https://bugs.webkit.org/show_bug.cgi?id=296439">https://bugs.webkit.org/show_bug.cgi?id=296439</a>
<a href="https://rdar.apple.com/156623092">rdar://156623092</a>

Reviewed by Alan Baradlay.

In 297803@main, we added some support for alignment of boxes within its
static position rectangle when the parent is a grid, it is not the
containing block, and it has align-self: end. However, both flex-end and
self-end are equivalent to align-self: end in these contexts. For
flex-end, this value simply behaves as end. For self-end, since the
writing modes of the box and alignment container should be the same, the
box should get aligned in the same way.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-flex-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-self-end.html: Added.
These tests are equivalent to the tests in the patch mentioned above but
are adjusted to use these new values to make sure everything works.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::isEligibleForStaticRangeAlignment const):
Expands eligibility to allow ItemPosition values of FlexEnd and SelfEnd
but also a small refactoring so that we switch on the item position and
then add additional constraints instead of looking at item position as
one of the last pieces of criteria. As eligibility expands in future
patches, the current values may diverge to have different constraints
(e.g. when we incorporate writing mode changes, end and self-end may
require different constraints).

Canonical link: <a href="https://commits.webkit.org/297875@main">https://commits.webkit.org/297875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ca35d58d47c75679d249334e84cf162d54e2e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36714 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66365 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/25985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63027 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122490 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24179 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36268 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45528 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->