### PR TITLE
[Layout][Grid] Mitigate incorrect baseline for vertical-lr flex/grid boxes.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5314,7 +5314,6 @@ imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.gri
 
 webkit.org/b/209460 imported/w3c/web-platform-tests/css/css-grid/abspos/descendant-static-position-002.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-baseline-align-cycles-001.html [ ImageOnlyFailure ]
-webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-inline-baseline.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-content-baseline-001.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-content-baseline-002.html [ ImageOnlyFailure ]
 webkit.org/b/212246 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-content-baseline-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-container-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-container-baseline-001-expected.txt
@@ -24,50 +24,10 @@
 PASS .wrapper 1
 PASS .wrapper 2
 PASS .wrapper 3
-FAIL .wrapper 4 assert_equals:
-<div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-  <div class="grid">
-    <div class="i1"></div>
-    <div class="i2" data-offset-x="0"></div>
-    <div class="i3"></div>
-  </div>
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-</div>
-offsetLeft expected 0 but got 150
-FAIL .wrapper 5 assert_equals:
-<div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-  <div class="grid">
-    <div class="i1"></div>
-    <div class="i2" style="writing-mode: horizontal-tb;" data-offset-x="0"></div>
-    <div class="i3"></div>
-  </div>
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-</div>
-offsetLeft expected 0 but got 150
-FAIL .wrapper 6 assert_equals:
-<div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-  <div class="grid">
-    <div class="i1"></div>
-    <div class="i2" data-offset-x="0"></div>
-    <div class="i3"></div>
-  </div>
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-</div>
-offsetLeft expected 0 but got 150
-FAIL .wrapper 7 assert_equals:
-<div class="wrapper" style="writing-mode: vertical-lr; text-orientation: sideways;">
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-  <div class="grid">
-    <div class="i1"></div>
-    <div class="i2" style="writing-mode: horizontal-tb;" data-offset-x="0"></div>
-    <div class="i3"></div>
-  </div>
-  <div style="display: inline-block; width: 20px; height: 10px; background: black" data-offset-x="0"></div>
-</div>
-offsetLeft expected 0 but got 150
+PASS .wrapper 4
+PASS .wrapper 5
+PASS .wrapper 6
+PASS .wrapper 7
 PASS .wrapper 8
 PASS .wrapper 9
 PASS .wrapper 10

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -467,7 +467,7 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
 
     if (is<RenderFlexibleBox>(renderBox) || is<RenderGrid>(renderBox)) {
         if (auto baseline = renderBox.firstLineBaseline())
-            return *baseline;
+            return writingMode.isLineInverted() ? renderBox.logicalHeight() - *baseline : *baseline;
         return { };
     }
 


### PR DESCRIPTION
#### bc8615f6c27ba7b374ae8d88aa0497bff1f986cb
<pre>
[Layout][Grid] Mitigate incorrect baseline for vertical-lr flex/grid boxes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296443">https://bugs.webkit.org/show_bug.cgi?id=296443</a>
&lt;<a href="https://rdar.apple.com/156628380">rdar://156628380</a>&gt;

Reviewed by Alan Baradlay.

Inline layout currently performs an unnecessary coordinate flip in

InlineDisplayContentBuilder::mapInlineRectLogicalToVisual()

for vertical-lr content.

This is not necessary for boxes that provide the correct coordinates
and baselines, which are then broken by this flip.

This change introduces a temporary fix in

LayoutIntegrationGeometryUpdate::baselineForBox()

by performing another flip for line-inverted writing modes. This ensures
that the baselines computed by the LayoutIntegrationGeometryUpdate will
allow the content to be rendered correctly.

 * LayoutTests/TestExpectations:
 * LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-container-baseline-001-expected.txt:
 * Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
 (WebCore::LayoutIntegration::baselineForBox):

Canonical link: <a href="https://commits.webkit.org/298204@main">https://commits.webkit.org/298204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c83322df99d7a2fa3948e9df6718d1107d89f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65155 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c83dd3ff-047a-45bd-9079-3c3c8dd18faa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86970 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41870 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8865b517-b326-429a-975d-bdb06639654c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67363 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64291 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95789 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95574 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/24379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37482 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41333 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46841 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40924 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42674 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->