### PR TITLE
REGRESSION(297237@main): 3 imported/w3c/web-platform-tests/digital-credentials tests are constant text failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <html>
     <head>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <title>Digital Credential tests.</title>
 <link rel="help" href="https://wicg.github.io/digital-credentials/" />

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <!DOCTYPE html>
 <title>Digital Credential API: get() consumes user activation.</title>
 <script src="/resources/testdriver.js"></script>


### PR DESCRIPTION
#### 315ae16a7176bc17019ecf833798de5383b4c5f4
<pre>
REGRESSION(297237@main): 3 imported/w3c/web-platform-tests/digital-credentials tests are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=296446">https://bugs.webkit.org/show_bug.cgi?id=296446</a>
<a href="https://rdar.apple.com/156620165">rdar://156620165</a>

Reviewed by Richard Robinson.

In 297237, we started producing JS console logs when a credential
request involved an unsupported protocol, in this case &quot;openid4vp&quot;.
These logs are benign and can be forwarded to stderr instead.

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-get.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/get.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/user-activation.https.html:

Canonical link: <a href="https://commits.webkit.org/297843@main">https://commits.webkit.org/297843@main</a>
</pre>
