### PR TITLE
[css-anchor-position-1] Align multicol tests with anchor fragmentation rules described in CSSWG issue

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt
@@ -1,6 +1,6 @@
 Lorem ipsum dolor sit amet.
 Lorem ipsum dolor sit amet.
 
-FAIL getComputedStyle() with fragmented containing block in multicolumn layout assert_equals: expected "-85px" but got "25px"
+PASS getComputedStyle() with fragmented containing block in multicolumn layout
 PASS getComputedStyle() with fragmented containing block in inline layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002.html
@@ -71,9 +71,9 @@ test(() => {
   const target = test1.querySelector('.target');
   const style = getComputedStyle(target);
   assert_equals(style.left, '25px');
-  assert_equals(style.right, '-85px');
-  assert_equals(style.top, '100px');
-  assert_equals(style.bottom, '100px');
+  assert_equals(style.right, '25px');
+  assert_equals(style.top, '175px');
+  assert_equals(style.bottom, '75px');
 }, 'getComputedStyle() with fragmented containing block in multicolumn layout');
 </script>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" data-expected-width="70" data-expected-height="50"></div>
-width expected 70 but got 10
-FAIL .target 2 assert_equals:
-<div class="target" data-expected-width="70" data-expected-height="50"></div>
-width expected 70 but got 10
+PASS .target 1
+PASS .target 2
 PASS .target 3
 PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003.html
@@ -53,10 +53,10 @@
           <div class="anchor" style="height: 60px"></div>
           <div class="anchor abspos" style="top: 120px; height: 100px"></div>
           <div class="target"
-               data-expected-width=70 data-expected-height=50></div>
+               data-expected-width=10 data-expected-height=100></div>
         </div>
         <div class="target"
-             data-expected-width=70 data-expected-height=50></div>
+             data-expected-width=10 data-expected-height=100></div>
       </div>
       <div class="target"
            data-expected-width=70 data-expected-height=50></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004-expected.txt
@@ -1,6 +1,4 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" data-expected-width="40" data-expected-height="50"></div>
-width expected 40 but got 10
+PASS .target 1
 PASS .target 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004.html
@@ -52,7 +52,7 @@
         <div class="anchor abspos" style="top: 120px; height: 100px"></div>
         <div class="anchor" style="height: 60px"></div>
         <div class="target"
-             data-expected-width=40 data-expected-height=50></div>
+             data-expected-width=10 data-expected-height=60></div>
       </div>
       <div class="target"
            data-expected-width=40 data-expected-height=50></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt
@@ -3,13 +3,7 @@
 3
 
 PASS .target 1
-FAIL .target 2 assert_equals:
-<div class="target target1-r" data-offset-x="404" data-expected-height="100"></div>
-offsetLeft expected 404 but got 194
-FAIL .target 3 assert_equals:
-<div class="target target1-t" data-offset-y="0" data-expected-width="310"></div>
-width expected 310 but got 100
-FAIL .target 4 assert_equals:
-<div class="target target1-b" data-offset-y="95" data-expected-width="310"></div>
-width expected 310 but got 100
+PASS .target 2
+PASS .target 3
+PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001.html
@@ -74,9 +74,9 @@
         <div class="anchor1"></div>
 
         <div class="target target1-l" data-offset-x=100 data-expected-height=100></div>
-        <div class="target target1-r" data-offset-x=404 data-expected-height=100></div>
-        <div class="target target1-t" data-offset-y=0 data-expected-width=310></div>
-        <div class="target target1-b" data-offset-y=95 data-expected-width=310></div>
+        <div class="target target1-r" data-offset-x=194 data-expected-height=100></div>
+        <div class="target target1-t" data-offset-y=50 data-expected-width=100></div>
+        <div class="target target1-b" data-offset-y=145 data-expected-width=100></div>
       </div>
     </div>
   </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt
@@ -1,18 +1,10 @@
 The green box should be a union of blue boxes, and the purple box should be at the right-bottom of the green box.
 
 
-FAIL .target 1 assert_equals:
-<div class="target target1" data-offset-x="18" data-offset-y="65" data-expected-width="160" data-expected-height="100"></div>
-width expected 160 but got 50
-FAIL .target 2 assert_equals:
-<div class="target target1-rb" data-offset-x="168" data-offset-y="155"></div>
-offsetLeft expected 168 but got 58
-FAIL .target 3 assert_equals:
-<div class="target fixed target1" data-offset-x="26" data-offset-y="70" data-expected-width="160" data-expected-height="100"></div>
-width expected 160 but got 50
-FAIL .target 4 assert_equals:
-<div class="target fixed target1-rb" data-offset-x="176" data-offset-y="160"></div>
-offsetLeft expected 176 but got 66
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
 PASS .target 5
 PASS .target 6
 PASS .target 7

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002.html
@@ -71,15 +71,15 @@
 
         <!-- The containing block of querying elements is block-fragmented. -->
         <div class="target target1"
-             data-offset-x=18 data-offset-y=65
-             data-expected-width=160 data-expected-height=100></div>
+             data-offset-x=18 data-offset-y=135
+             data-expected-width=50 data-expected-height=90></div>
         <div class="target target1-rb"
-             data-offset-x=168 data-offset-y=155></div>
+             data-offset-x=58 data-offset-y=215></div>
         <div class="target fixed target1"
-             data-offset-x=26 data-offset-y=70
-             data-expected-width=160 data-expected-height=100></div>
+             data-offset-x=26 data-offset-y=140
+             data-expected-width=50 data-expected-height=90></div>
         <div class="target fixed target1-rb"
-             data-offset-x=176 data-offset-y=160></div>
+             data-offset-x=66 data-offset-y=220></div>
       </div>
 
       <!-- The containing block of querying elements is a multi-column.  -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003-expected.txt
@@ -1,15 +1,9 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
+PASS .target 1
 PASS .target 2
 PASS .target 3
-FAIL .target 4 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
-FAIL .target 5 assert_equals:
-<div class="target" data-expected-height="50"></div>
-height expected 50 but got 30
+PASS .target 4
+PASS .target 5
 PASS .target 6
 PASS .target 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003.html
@@ -40,7 +40,7 @@
       <div class="relpos">
         <div class="spacer" style="height: 30px"></div>
         <div class="anchor1"></div>
-        <div class="target" data-expected-height=50></div>
+        <div class="target" data-expected-height=30></div>
       </div>
       <div class="target" data-expected-height=50></div>
     </div>
@@ -56,9 +56,9 @@
         <div class="relpos">
           <div class="spacer" style="height: 10px"></div>
           <div class="anchor1"></div>
-          <div class="target" data-expected-height=50></div>
+          <div class="target" data-expected-height=30></div>
         </div>
-        <div class="target" data-expected-height=50></div>
+        <div class="target" data-expected-height=30></div>
       </div>
       <div class="target" data-expected-height=50></div>
     </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt
@@ -1,16 +1,8 @@
 The green box should be a union of two blue boxes in the right, and the purple box should be at the right-bottom of the green box.
 
 
-FAIL .target 1 assert_equals:
-<div class="target target1" data-offset-x="18" data-offset-y="65" data-expected-width="130" data-expected-height="100"></div>
-width expected 130 but got 20
-FAIL .target 2 assert_equals:
-<div class="target target1-rb" data-offset-x="138" data-offset-y="155"></div>
-offsetLeft expected 138 but got 28
-FAIL .target 3 assert_equals:
-<div class="target target1" data-offset-x="34" data-offset-y="225" data-expected-width="130" data-expected-height="100"></div>
-width expected 130 but got 20
-FAIL .target 4 assert_equals:
-<div class="target target1-rb" data-offset-x="154" data-offset-y="315"></div>
-offsetLeft expected 154 but got 44
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004.html
@@ -25,7 +25,7 @@
 }
 .spacer {
   height: 10px;
-  background: pink;
+  background: silver;
 }
 .anchor1 {
   anchor-name: --a1;
@@ -69,16 +69,16 @@
         <div class="anchor1" style="width: 20px"></div>
 
         <div class="target target1"
-             data-offset-x=18 data-offset-y=65
-             data-expected-width=130 data-expected-height=100></div>
+             data-offset-x=18 data-offset-y=125
+             data-expected-width=20 data-expected-height=90></div>
         <div class="target target1-rb"
-              data-offset-x=138 data-offset-y=155></div>
+              data-offset-x=28 data-offset-y=205></div>
       </div>
 
       <div class="target target1"
-            data-offset-x=34 data-offset-y=225
-            data-expected-width=130 data-expected-height=100></div>
+            data-offset-x=34 data-offset-y=285
+            data-expected-width=20 data-expected-height=90></div>
       <div class="target target1-rb"
-            data-offset-x=154 data-offset-y=315></div>
+            data-offset-x=44 data-offset-y=365></div>
     </div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-fixed-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-fixed-001-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" data-offset-x="10" data-offset-y="20" data-expected-width="130" data-expected-height="50"></div>
-width expected 130 but got 20
-FAIL .target 2 assert_equals:
-<div class="target" data-offset-x="20" data-offset-y="0" data-expected-width="130" data-expected-height="50"></div>
-width expected 130 but got 20
+PASS .target 1
+PASS .target 2
 FAIL .target 3 assert_equals:
 <div class="target" data-offset-x="20" data-offset-y="10" data-expected-width="130" data-expected-height="50"></div>
 width expected 130 but got 20

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-fixed-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-fixed-001.html
@@ -24,7 +24,7 @@
 }
 .spacer {
   height: 10px;
-  background: pink;
+  background: silver;
 }
 .anchor {
   anchor-name: --a1;
@@ -35,6 +35,7 @@
 }
 .fixedpos {
   position: fixed;
+  background: blue;
   margin-left: 0;
   left: 20px;
   top: 20px;
@@ -63,12 +64,12 @@
           <div class="anchor"></div>
           <div class="anchor fixedpos"></div>
           <div class="target"
-               data-offset-x="10" data-offset-y="20"
-               data-expected-width=130 data-expected-height=50></div>
+               data-offset-x="20" data-offset-y="20"
+               data-expected-width=20 data-expected-height=30></div>
         </div>
         <div class="target"
-             data-offset-x="20" data-offset-y="0"
-             data-expected-width=130 data-expected-height=50></div>
+             data-offset-x="20" data-offset-y="40"
+             data-expected-width=20 data-expected-height=30></div>
       </div>
       <div class="target"
            data-offset-x="20" data-offset-y="10"


### PR DESCRIPTION
#### b2b53091f8d7e9b18f6dee8cf557543d7ea6fc07
<pre>
[css-anchor-position-1] Align multicol tests with anchor fragmentation rules described in CSSWG issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=296445">https://bugs.webkit.org/show_bug.cgi?id=296445</a>
<a href="https://rdar.apple.com/156629122">rdar://156629122</a>

Reviewed by Tim Nguyen.

Fixes multicol tests to consider the anchor rect within its fragmented context,
rather than as the bounding box from outside it, per
    <a href="https://github.com/w3c/csswg-drafts/issues/12287">https://github.com/w3c/csswg-drafts/issues/12287</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-getComputedStyle-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-multicol-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-grid-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-fixed-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-multicol-fixed-001.html:

Canonical link: <a href="https://commits.webkit.org/297980@main">https://commits.webkit.org/297980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d61b01fc4b48b4321e6fc69a95708858100199d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63673 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/36724 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19846 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63041 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122504 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24256 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39799 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36282 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40043 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->