### PR TITLE
Fix grid-abspos-staticpos-align-self-end-large-border-padding reference

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-expected.html
@@ -3,11 +3,11 @@
 <style>
 .grid {
   display: grid;
-  border: 1 solid black;
+  border: 1px solid black;
   width: 100px;
   height: 100px;
 }
-.abspos {
+.item {
   width: 50px;
   height: 50px;
   background-color: green;
@@ -16,7 +16,7 @@
 </style>
 <body>
 <div class="grid">
-  <div class="abspos"></div>
+  <div class="item"></div>
 </div>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-expected.html
@@ -10,8 +10,7 @@
   width: 100px;
   height: 100px;
 }
-.abspos {
-  position: absolute;
+.item {
   width: 50px;
   height: 50px;
   background-color: green;
@@ -20,7 +19,7 @@
 </style>
 <body>
 <div class="grid">
-  <div class="abspos"></div>
+  <div class="item"></div>
 </div>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-large-border-padding-ref.html
@@ -10,8 +10,7 @@
   width: 100px;
   height: 100px;
 }
-.abspos {
-  position: absolute;
+.item {
   width: 50px;
   height: 50px;
   background-color: green;
@@ -20,7 +19,7 @@
 </style>
 <body>
 <div class="grid">
-  <div class="abspos"></div>
+  <div class="item"></div>
 </div>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end-ref.html
@@ -3,11 +3,11 @@
 <style>
 .grid {
   display: grid;
-  border: 1 solid black;
+  border: 1px solid black;
   width: 100px;
   height: 100px;
 }
-.abspos {
+.item {
   width: 50px;
   height: 50px;
   background-color: green;
@@ -16,7 +16,7 @@
 </style>
 <body>
 <div class="grid">
-  <div class="abspos"></div>
+  <div class="item"></div>
 </div>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-end.html
@@ -8,7 +8,7 @@
 <style>
 .grid {
   display: grid;
-  border: 1 solid black;
+  border: 1px solid black;
   width: 100px;
   height: 100px;
 }


### PR DESCRIPTION
#### 3b939e1afb31a512b8877d56f94cf73fab20f190
<pre>
Fix grid-abspos-staticpos-align-self-end-large-border-padding reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=296441">https://bugs.webkit.org/show_bug.cgi?id=296441</a>
<a href="https://rdar.apple.com/156634932">rdar://156634932</a>

Reviewed by Vitor Roriz.

The item in this test reference should not be abspos since that is what
we are testing. It should just be a normal grid item so remove
position: absolute from it. grid-abspos-staticpos-align-self-end also
had a typo (missing px) in the border value so fix that.

Also rename the class from abspos to item so that is not misleading
anymore.

Canonical link: <a href="https://commits.webkit.org/297850@main">https://commits.webkit.org/297850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42f9586248260f7da0fa5ac6641cb00bf28ecb0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63724 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86075 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/38278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66389 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63054 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96122 "Found 5 new API test failures: TestWebKitAPI.SiteIsolation.StopsMediaCaptureInRemoteFrame, TestWebKitAPI.WebKit.CookieCachePruning, TestWebKitAPI.WKWebViewSuspendAllMediaPlayback.FullscreenWhileSuspended, TestWebKitAPI.QuickLook.AllowResponseAfterLoadingPreview, TestWebKitAPI.WKWebExtensionAPIRuntime.PortDisconnectFromContentScriptWithMultipleListeners (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122517 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40170 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94921 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94662 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24163 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40056 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->