### PR TITLE
text-decoration-line: blink (deprecated) should be serialized to the computed value but ignored for rendering

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line-expected.txt
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line-expected.txt
@@ -27,13 +27,13 @@ Value 'line-through':
 PASS e.style.textDecorationLine is "line-through"
 PASS computedStyle.textDecorationLine is "line-through"
 
-Value 'blink' (valid but ignored):
+Value 'blink' (valid and computed but ignored for rendering):
 PASS e.style.textDecorationLine is "blink"
-PASS computedStyle.textDecorationLine is "none"
+PASS computedStyle.textDecorationLine is "blink"
 
 Value 'underline overline line-through blink':
 PASS e.style.textDecorationLine is "underline overline line-through blink"
-PASS computedStyle.textDecorationLine is "underline overline line-through"
+PASS computedStyle.textDecorationLine is "underline overline line-through blink"
 
 Value '':
 PASS e.style.textDecorationLine is ""

--- a/LayoutTests/fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line.html
+++ b/LayoutTests/fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line.html
@@ -41,11 +41,11 @@ test("overline", "overline", "overline");
 debug("Value 'line-through':");
 test("line-through", "line-through", "line-through");
 
-debug("Value 'blink' (valid but ignored):");
-test("blink", "blink", "none");
+debug("Value 'blink' (valid and computed but ignored for rendering):");
+test("blink", "blink", "blink");
 
 debug("Value 'underline overline line-through blink':");
-test("underline overline line-through blink", "underline overline line-through blink", "underline overline line-through");
+test("underline overline line-through blink", "underline overline line-through blink", "underline overline line-through blink");
 
 debug("Value '':");
 test("", "", "none");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt
@@ -3,18 +3,18 @@ PASS Property text-decoration-line value 'none'
 PASS Property text-decoration-line value 'underline'
 PASS Property text-decoration-line value 'overline'
 PASS Property text-decoration-line value 'line-through'
-FAIL Property text-decoration-line value 'blink' assert_equals: expected "blink" but got "none"
+PASS Property text-decoration-line value 'blink'
 PASS Property text-decoration-line value 'underline overline'
 PASS Property text-decoration-line value 'underline line-through'
-FAIL Property text-decoration-line value 'underline blink' assert_equals: expected "underline blink" but got "underline"
+PASS Property text-decoration-line value 'underline blink'
 PASS Property text-decoration-line value 'overline line-through'
-FAIL Property text-decoration-line value 'overline blink' assert_equals: expected "overline blink" but got "overline"
-FAIL Property text-decoration-line value 'line-through blink' assert_equals: expected "line-through blink" but got "line-through"
+PASS Property text-decoration-line value 'overline blink'
+PASS Property text-decoration-line value 'line-through blink'
 PASS Property text-decoration-line value 'underline overline line-through'
-FAIL Property text-decoration-line value 'underline overline blink' assert_equals: expected "underline overline blink" but got "underline overline"
-FAIL Property text-decoration-line value 'underline line-through blink' assert_equals: expected "underline line-through blink" but got "underline line-through"
-FAIL Property text-decoration-line value 'overline line-through blink' assert_equals: expected "overline line-through blink" but got "overline line-through"
-FAIL Property text-decoration-line value 'underline overline line-through blink' assert_equals: expected "underline overline line-through blink" but got "underline overline line-through"
+PASS Property text-decoration-line value 'underline overline blink'
+PASS Property text-decoration-line value 'underline line-through blink'
+PASS Property text-decoration-line value 'overline line-through blink'
+PASS Property text-decoration-line value 'underline overline line-through blink'
 FAIL Property text-decoration-line value 'spelling-error' assert_true: 'spelling-error' is a supported value for text-decoration-line. expected true got false
 FAIL Property text-decoration-line value 'grammar-error' assert_true: 'grammar-error' is a supported value for text-decoration-line. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
@@ -8,7 +8,7 @@ PASS Can set 'text-decoration-line' to the 'none' keyword: none
 PASS Can set 'text-decoration-line' to the 'underline' keyword: underline
 PASS Can set 'text-decoration-line' to the 'overline' keyword: overline
 PASS Can set 'text-decoration-line' to the 'line-through' keyword: line-through
-FAIL Can set 'text-decoration-line' to the 'blink' keyword: blink assert_equals: expected "blink" but got "none"
+PASS Can set 'text-decoration-line' to the 'blink' keyword: blink
 FAIL Can set 'text-decoration-line' to the 'spelling-error' keyword: spelling-error Invalid values
 FAIL Can set 'text-decoration-line' to the 'grammar-error' keyword: grammar-error Invalid values
 PASS Setting 'text-decoration-line' to a length: 0px throws TypeError

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10810,7 +10810,7 @@
                 "line-through",
                 {
                     "value": "blink",
-                    "comment": "The value is parsed but ignored for rendering and computed style."
+                    "comment": "The value is parsed and computed but ignored for rendering."
                 }
             ],
             "codegen-properties": {

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -1012,6 +1012,8 @@ inline Ref<CSSValue> ExtractorConverter::convertTextDecorationLine(ExtractorStat
         list.append(CSSPrimitiveValue::create(CSSValueOverline));
     if (textDecorationLine & TextDecorationLine::LineThrough)
         list.append(CSSPrimitiveValue::create(CSSValueLineThrough));
+    if (textDecorationLine & TextDecorationLine::Blink)
+        list.append(CSSPrimitiveValue::create(CSSValueBlink));
     if (list.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
     return CSSValueList::createSpaceSeparated(WTFMove(list));

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -1220,7 +1220,7 @@ inline void ExtractorSerializer::serializeTextTransform(ExtractorState& state, S
 
 inline void ExtractorSerializer::serializeTextDecorationLine(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextDecorationLine> textDecorationLine)
 {
-    // Blink value is ignored.
+    // Blink value is ignored for rendering but not for the computed value.
     bool listEmpty = true;
     auto appendOption = [&](TextDecorationLine test, CSSValueID value) {
         if (textDecorationLine & test) {
@@ -1233,6 +1233,7 @@ inline void ExtractorSerializer::serializeTextDecorationLine(ExtractorState& sta
     appendOption(TextDecorationLine::Underline, CSSValueUnderline);
     appendOption(TextDecorationLine::Overline, CSSValueOverline);
     appendOption(TextDecorationLine::LineThrough, CSSValueLineThrough);
+    appendOption(TextDecorationLine::Blink, CSSValueBlink);
 
     if (listEmpty)
         serializationForCSS(builder, context, state.style, CSS::Keyword::None { });


### PR DESCRIPTION
#### 3de08846bdae62677fe023a6e802e0caf44d0e77
<pre>
text-decoration-line: blink (deprecated) should be serialized to the computed value but ignored for rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=296452">https://bugs.webkit.org/show_bug.cgi?id=296452</a>
<a href="https://rdar.apple.com/156620221">rdar://156620221</a>

Reviewed by Sammy Gill.

text-decoration-line: blink is deprecated and parsed for compatibility.
The value is already ignored for rendering, as it should, but it should
still be serialized to the computed value.

* LayoutTests/fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line-expected.txt:
* LayoutTests/fast/css3-text/css3-text-decoration/getComputedStyle/getComputedStyle-text-decoration-line.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractorConverter.h:
(WebCore::Style::ExtractorConverter::convertTextDecorationLine):
* Source/WebCore/style/StyleExtractorSerializer.h:
(WebCore::Style::ExtractorSerializer::serializeTextDecorationLine):

Canonical link: <a href="https://commits.webkit.org/297847@main">https://commits.webkit.org/297847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b9ca31f0cc15cac39cc3ee3a5e86a1fa635edfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32846 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23324 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/38276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19879 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63073 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122536 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29975 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94937 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; 48 flakes 74 failures; Uploaded test results; 18 flakes 50 failures; Compiled WebKit; 4 flakes 46 failures; Passed layout tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45574 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->