### PR TITLE
[SiteIsolation] RemoteDOMWindow::setLocation should have same security checks as LocalDOMWindow::setLocation

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -51,6 +51,7 @@
 #include "WebKitPoint.h"
 #include "WindowProxy.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -85,6 +86,126 @@ Location& DOMWindow::location()
     if (!m_location)
         m_location = Location::create(*this);
     return *m_location;
+}
+
+bool DOMWindow::isCurrentlyDisplayedInFrame() const
+{
+    RefPtr frame = this->frame();
+    return frame && frame->window() == this;
+}
+
+bool DOMWindow::isInsecureScriptAccess(LocalDOMWindow& activeWindow, const String& urlString)
+{
+    if (!WTF::protocolIsJavaScript(urlString))
+        return false;
+
+    // If this LocalDOMWindow isn't currently active in the Frame, then there's no
+    // way we should allow the access.
+    // FIXME: Remove this check if we're able to disconnect LocalDOMWindow from
+    // Frame on navigation: https://bugs.webkit.org/show_bug.cgi?id=62054
+    if (isCurrentlyDisplayedInFrame()) {
+        // FIXME: Is there some way to eliminate the need for a separate "activeWindow == this" check?
+        if (&activeWindow == this)
+            return false;
+
+        if (this->document().hasException())
+            return true;
+        RefPtr document = this->document().returnValue();
+        if (!document)
+            return true;
+        // FIXME: The name canAccess seems to be a roundabout way to ask "can execute script".
+        // Can we name the SecurityOrigin function better to make this more clear?
+        if (activeWindow.document()->protectedSecurityOrigin()->isSameOriginDomain(document->protectedSecurityOrigin()))
+            return false;
+    }
+
+    printErrorMessage(crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));
+    return true;
+}
+
+
+String DOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin includeTargetOrigin)
+{
+    const URL& activeWindowURL = activeWindow.document()->url();
+    if (activeWindowURL.isNull())
+        return String();
+
+    RefPtr document = documentIfLocal();
+    if (!document)
+        return String("No target document"_s);
+    Ref activeOrigin = activeWindow.document()->securityOrigin();
+    Ref targetOrigin = document->securityOrigin();
+    ASSERT(!activeOrigin->isSameOriginDomain(targetOrigin));
+
+    // FIXME: This message, and other console messages, have extra newlines. Should remove them.
+    String message;
+    if (includeTargetOrigin == IncludeTargetOrigin::Yes)
+        message = makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a frame with origin \""_s, targetOrigin->toString(), "\". "_s);
+    else
+        message = makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a cross-origin frame. "_s);
+
+    // Sandbox errors: Use the origin of the frames' location, rather than their actual origin (since we know that at least one will be "null").
+    URL activeURL = activeWindow.document()->url();
+    URL targetURL = document->url();
+    if (document->isSandboxed(SandboxFlag::Origin) || activeWindow.document()->isSandboxed(SandboxFlag::Origin)) {
+        if (includeTargetOrigin == IncludeTargetOrigin::Yes)
+            message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a frame at \""_s, SecurityOrigin::create(targetURL).get().toString(), "\". "_s);
+        else
+            message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a cross-origin frame. "_s);
+
+        if (document->isSandboxed(SandboxFlag::Origin) && activeWindow.document()->isSandboxed(SandboxFlag::Origin))
+            return makeString("Sandbox access violation: "_s, message, " Both frames are sandboxed and lack the \"allow-same-origin\" flag."_s);
+        if (document->isSandboxed(SandboxFlag::Origin))
+            return makeString("Sandbox access violation: "_s, message, " The frame being accessed is sandboxed and lacks the \"allow-same-origin\" flag."_s);
+        return makeString("Sandbox access violation: "_s, message, " The frame requesting access is sandboxed and lacks the \"allow-same-origin\" flag."_s);
+    }
+
+    if (includeTargetOrigin == IncludeTargetOrigin::Yes) {
+        // Protocol errors: Use the URL's protocol rather than the origin's protocol so that we get a useful message for non-heirarchal URLs like 'data:'.
+        if (targetOrigin->protocol() != activeOrigin->protocol())
+            return makeString(message, " The frame requesting access has a protocol of \""_s, activeURL.protocol(), "\", the frame being accessed has a protocol of \""_s, targetURL.protocol(), "\". Protocols must match.\n"_s);
+
+        // 'document.domain' errors.
+        if (targetOrigin->domainWasSetInDOM() && activeOrigin->domainWasSetInDOM())
+            return makeString(message, "The frame requesting access set \"document.domain\" to \""_s, activeOrigin->domain(), "\", the frame being accessed set it to \""_s, targetOrigin->domain(), "\". Both must set \"document.domain\" to the same value to allow access."_s);
+        if (activeOrigin->domainWasSetInDOM())
+            return makeString(message, "The frame requesting access set \"document.domain\" to \""_s, activeOrigin->domain(), "\", but the frame being accessed did not. Both must set \"document.domain\" to the same value to allow access."_s);
+        if (targetOrigin->domainWasSetInDOM())
+            return makeString(message, "The frame being accessed set \"document.domain\" to \""_s, targetOrigin->domain(), "\", but the frame requesting access did not. Both must set \"document.domain\" to the same value to allow access."_s);
+    }
+
+    // Default.
+    return makeString(message, "Protocols, domains, and ports must match."_s);
+}
+
+void DOMWindow::printErrorMessage(const String& message) const
+{
+    if (message.isEmpty())
+        return;
+
+    if (CheckedPtr pageConsole = console())
+        pageConsole->addMessage(MessageSource::JS, MessageLevel::Error, message);
+}
+
+bool DOMWindow::setLocationSecurityChecks(LocalDOMWindow& activeWindow, const URL& completedURL, CanNavigateState navigationState)
+{
+    ASSERT(navigationState != CanNavigateState::Unchecked);
+
+    RefPtr activeDocument = activeWindow.document();
+    if (!activeDocument)
+        return false;
+
+    RefPtr frame = this->frame();
+    if (!frame)
+        return false;
+    if (navigationState != CanNavigateState::Able) [[unlikely]]
+        navigationState = activeDocument->canNavigate(frame.get(), completedURL);
+    if (navigationState == CanNavigateState::Unable)
+        return false;
+    if (isInsecureScriptAccess(activeWindow, completedURL.string()))
+        return false;
+
+    return true;
 }
 
 bool DOMWindow::closed() const

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -94,6 +94,7 @@ struct WindowPostMessageOptions;
 
 enum class SetLocationLocking : bool { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
 enum class NavigationHistoryBehavior : uint8_t;
+enum class IncludeTargetOrigin : bool { No, Yes };
 
 using IntDegrees = int32_t;
 
@@ -223,6 +224,14 @@ public:
     ExceptionOr<PushManager&> pushManager();
 #endif
 
+    String crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin);
+    void printErrorMessage(const String& message) const;
+    // FIXME: When this LocalDOMWindow is no longer the active LocalDOMWindow (i.e.,
+    // when its document is no longer the document that is displayed in its
+    // frame), we would like to zero out m_frame to avoid being confused
+    // by the document that is currently active in m_frame.
+    bool isCurrentlyDisplayedInFrame() const;
+
 protected:
     explicit DOMWindow(GlobalWindowIdentifier&&, DOMWindowType);
 
@@ -231,6 +240,8 @@ protected:
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::DOMWindow; }
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
+    bool isInsecureScriptAccess(LocalDOMWindow& activeWindow, const String& urlString);
+    bool setLocationSecurityChecks(LocalDOMWindow& activeWindow, const URL& completedURL, CanNavigateState navigationState);
 
 private:
     GlobalWindowIdentifier m_identifier;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -610,12 +610,6 @@ void LocalDOMWindow::resumeFromBackForwardCache()
     m_suspendedForDocumentSuspension = false;
 }
 
-bool LocalDOMWindow::isCurrentlyDisplayedInFrame() const
-{
-    RefPtr frame = localFrame();
-    return frame && frame->document()->window() == this;
-}
-
 CustomElementRegistry& LocalDOMWindow::ensureCustomElementRegistry()
 {
     if (!m_customElementRegistry) {
@@ -2459,125 +2453,30 @@ void LocalDOMWindow::finishedLoading()
 
 void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior historyHandling, SetLocationLocking locking, CanNavigateState navigationState)
 {
-    ASSERT(navigationState != CanNavigateState::Unchecked);
-    if (!isCurrentlyDisplayedInFrame())
-        return;
-
-    RefPtr activeDocument = activeWindow.document();
-    if (!activeDocument)
-        return;
-
-    RefPtr frame = this->frame();
-    if (navigationState != CanNavigateState::Able) [[unlikely]]
-        navigationState = activeDocument->canNavigate(frame.get(), completedURL);
-    if (navigationState == CanNavigateState::Unable)
-        return;
-
-    if (isInsecureScriptAccess(activeWindow, completedURL.string()))
-        return;
-
     // Check the CSP of the embedder to determine if we allow execution of javascript: URLs via child frame navigation.
     if (completedURL.protocolIsJavaScript() && frameElement() && !frameElement()->protectedDocument()->checkedContentSecurityPolicy()->allowJavaScriptURLs(aboutBlankURL().string(), { }, completedURL.string(), protectedFrameElement().get()))
         return;
 
-    RefPtr localParent = dynamicDowncast<LocalFrame>(frame->tree().parent());
+    if (!setLocationSecurityChecks(activeWindow, completedURL, navigationState))
+        return;
+
+    RefPtr activeDocument = activeWindow.document();
+    RefPtr localParent = dynamicDowncast<LocalFrame>(this->frame()->tree().parent());
     // If the loader for activeWindow's frame (browsing context) has no outgoing referrer, set its outgoing referrer
     // to the URL of its parent frame's Document.
-    if (RefPtr activeFrame = activeWindow.localFrame(); activeFrame && activeFrame->loader().outgoingReferrer().isEmpty() && localParent)
-        activeFrame->loader().setOutgoingReferrer(protectedDocument()->completeURL(localParent->document()->url().strippedForUseAsReferrer().string));
-
+    if (RefPtr document = localParent->document()) {
+        if (RefPtr activeFrame = activeWindow.localFrame(); activeFrame && activeFrame->loader().outgoingReferrer().isEmpty() && localParent)
+            activeFrame->loader().setOutgoingReferrer(protectedDocument()->completeURL(document->url().strippedForUseAsReferrer().string));
+    }
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
     LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
+    RefPtr frame = this->frame();
     frame->protectedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->protectedSecurityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
         lockHistory, lockBackForwardList,
         historyHandling);
-}
-
-void LocalDOMWindow::printErrorMessage(const String& message) const
-{
-    if (message.isEmpty())
-        return;
-
-    if (CheckedPtr pageConsole = console())
-        pageConsole->addMessage(MessageSource::JS, MessageLevel::Error, message);
-}
-
-String LocalDOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin includeTargetOrigin)
-{
-    const URL& activeWindowURL = activeWindow.document()->url();
-    if (activeWindowURL.isNull())
-        return String();
-
-    Ref activeOrigin = activeWindow.document()->securityOrigin();
-    Ref targetOrigin = document()->securityOrigin();
-    ASSERT(!activeOrigin->isSameOriginDomain(targetOrigin));
-
-    // FIXME: This message, and other console messages, have extra newlines. Should remove them.
-    String message;
-    if (includeTargetOrigin == IncludeTargetOrigin::Yes)
-        message = makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a frame with origin \""_s, targetOrigin->toString(), "\". "_s);
-    else
-        message = makeString("Blocked a frame with origin \""_s, activeOrigin->toString(), "\" from accessing a cross-origin frame. "_s);
-
-    // Sandbox errors: Use the origin of the frames' location, rather than their actual origin (since we know that at least one will be "null").
-    URL activeURL = activeWindow.document()->url();
-    URL targetURL = document()->url();
-    if (document()->isSandboxed(SandboxFlag::Origin) || activeWindow.document()->isSandboxed(SandboxFlag::Origin)) {
-        if (includeTargetOrigin == IncludeTargetOrigin::Yes)
-            message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a frame at \""_s, SecurityOrigin::create(targetURL).get().toString(), "\". "_s);
-        else
-            message = makeString("Blocked a frame at \""_s, SecurityOrigin::create(activeURL).get().toString(), "\" from accessing a cross-origin frame. "_s);
-
-        if (document()->isSandboxed(SandboxFlag::Origin) && activeWindow.document()->isSandboxed(SandboxFlag::Origin))
-            return makeString("Sandbox access violation: "_s, message, " Both frames are sandboxed and lack the \"allow-same-origin\" flag."_s);
-        if (document()->isSandboxed(SandboxFlag::Origin))
-            return makeString("Sandbox access violation: "_s, message, " The frame being accessed is sandboxed and lacks the \"allow-same-origin\" flag."_s);
-        return makeString("Sandbox access violation: "_s, message, " The frame requesting access is sandboxed and lacks the \"allow-same-origin\" flag."_s);
-    }
-
-    if (includeTargetOrigin == IncludeTargetOrigin::Yes) {
-        // Protocol errors: Use the URL's protocol rather than the origin's protocol so that we get a useful message for non-heirarchal URLs like 'data:'.
-        if (targetOrigin->protocol() != activeOrigin->protocol())
-            return makeString(message, " The frame requesting access has a protocol of \""_s, activeURL.protocol(), "\", the frame being accessed has a protocol of \""_s, targetURL.protocol(), "\". Protocols must match.\n"_s);
-
-        // 'document.domain' errors.
-        if (targetOrigin->domainWasSetInDOM() && activeOrigin->domainWasSetInDOM())
-            return makeString(message, "The frame requesting access set \"document.domain\" to \""_s, activeOrigin->domain(), "\", the frame being accessed set it to \""_s, targetOrigin->domain(), "\". Both must set \"document.domain\" to the same value to allow access."_s);
-        if (activeOrigin->domainWasSetInDOM())
-            return makeString(message, "The frame requesting access set \"document.domain\" to \""_s, activeOrigin->domain(), "\", but the frame being accessed did not. Both must set \"document.domain\" to the same value to allow access."_s);
-        if (targetOrigin->domainWasSetInDOM())
-            return makeString(message, "The frame being accessed set \"document.domain\" to \""_s, targetOrigin->domain(), "\", but the frame requesting access did not. Both must set \"document.domain\" to the same value to allow access."_s);
-    }
-
-    // Default.
-    return makeString(message, "Protocols, domains, and ports must match."_s);
-}
-
-bool LocalDOMWindow::isInsecureScriptAccess(LocalDOMWindow& activeWindow, const String& urlString)
-{
-    if (!WTF::protocolIsJavaScript(urlString))
-        return false;
-
-    // If this LocalDOMWindow isn't currently active in the Frame, then there's no
-    // way we should allow the access.
-    // FIXME: Remove this check if we're able to disconnect LocalDOMWindow from
-    // Frame on navigation: https://bugs.webkit.org/show_bug.cgi?id=62054
-    if (isCurrentlyDisplayedInFrame()) {
-        // FIXME: Is there some way to eliminate the need for a separate "activeWindow == this" check?
-        if (&activeWindow == this)
-            return false;
-
-        // FIXME: The name canAccess seems to be a roundabout way to ask "can execute script".
-        // Can we name the SecurityOrigin function better to make this more clear?
-        if (activeWindow.document()->protectedSecurityOrigin()->isSameOriginDomain(document()->protectedSecurityOrigin()))
-            return false;
-    }
-
-    printErrorMessage(crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));
-    return true;
 }
 
 ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString, const AtomString& frameName, const WindowFeatures& initialWindowFeatures, LocalDOMWindow& activeWindow, LocalFrame& firstFrame, LocalFrame& openerFrame, NOESCAPE const Function<void(LocalDOMWindow&)>& prepareDialogFunction)

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -66,8 +66,6 @@ using ReducedResolutionSeconds = Seconds;
 
 template<typename> class ExceptionOr;
 
-enum class IncludeTargetOrigin : bool { No, Yes };
-
 class LocalDOMWindowObserver : public CanMakeWeakPtr<LocalDOMWindowObserver> {
 public:
     virtual ~LocalDOMWindowObserver() { }
@@ -223,10 +221,6 @@ public:
     RefPtr<WebKitPoint> webkitConvertPointFromPageToNode(Node*, const WebKitPoint*) const;
     RefPtr<WebKitPoint> webkitConvertPointFromNodeToPage(Node*, const WebKitPoint*) const;
 
-    void printErrorMessage(const String&) const;
-
-    String crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin);
-
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&&);
     WEBCORE_EXPORT void postMessageFromRemoteFrame(JSC::JSGlobalObject&, RefPtr<WindowProxy>&& source, const String& sourceOrigin, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);
 
@@ -344,12 +338,6 @@ public:
     Navigation& navigation();
     Ref<Navigation> protectedNavigation();
 
-    // FIXME: When this LocalDOMWindow is no longer the active LocalDOMWindow (i.e.,
-    // when its document is no longer the document that is displayed in its
-    // frame), we would like to zero out m_frame to avoid being confused
-    // by the document that is currently active in m_frame.
-    bool isCurrentlyDisplayedInFrame() const;
-
     void willDetachDocumentFromFrame();
     void willDestroyCachedFrame();
 
@@ -393,7 +381,6 @@ private:
     bool allowedToChangeWindowGeometry() const;
 
     static ExceptionOr<RefPtr<Frame>> createWindow(const String& urlString, const AtomString& frameName, const WindowFeatures&, LocalDOMWindow& activeWindow, LocalFrame& firstFrame, LocalFrame& openerFrame, NOESCAPE const Function<void(LocalDOMWindow&)>& prepareDialogFunction = nullptr);
-    bool isInsecureScriptAccess(LocalDOMWindow& activeWindow, const String& urlString);
 
 #if ENABLE(DEVICE_ORIENTATION)
     bool isAllowedToUseDeviceMotionOrOrientation(String& message) const;

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -39,6 +39,7 @@
 #include "SecurityOrigin.h"
 #include "SerializedScriptValue.h"
 #include "UserGestureIndicator.h"
+#include "page/DOMWindow.h"
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -135,26 +136,16 @@ ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGloba
 
 void RemoteDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior historyHandling, SetLocationLocking locking, CanNavigateState navigationState)
 {
-    ASSERT(navigationState != CanNavigateState::Unchecked);
-    // FIXME: Add some or all of the security checks in LocalDOMWindow::setLocation. <rdar://116500603>
-    // FIXME: Refactor this duplicate code to share with LocalDOMWindow::setLocation. <rdar://116500603>
-
-    RefPtr activeDocument = activeWindow.document();
-    if (!activeDocument)
-        return;
-
-    RefPtr frame = this->frame();
-    if (navigationState != CanNavigateState::Able) [[unlikely]]
-        navigationState = activeDocument->canNavigate(frame.get(), completedURL);
-    if (navigationState == CanNavigateState::Unable)
+    if (!setLocationSecurityChecks(activeWindow, completedURL, navigationState))
         return;
 
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
     LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
-    frame->protectedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
+    RefPtr frame = this->frame();
+    frame->protectedNavigationScheduler()->scheduleLocationChange(*activeWindow.document(), activeWindow.document()->securityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
-        completedURL, activeDocument->frame()->loader().outgoingReferrer(),
+        completedURL, activeWindow.document()->frame()->loader().outgoingReferrer(),
         lockHistory, lockBackForwardList,
         historyHandling);
 }


### PR DESCRIPTION
#### c37a1f282d55250cc14cbf4b24bf234370108893
<pre>
[SiteIsolation] RemoteDOMWindow::setLocation should have same security checks as LocalDOMWindow::setLocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=296457">https://bugs.webkit.org/show_bug.cgi?id=296457</a>
<a href="https://rdar.apple.com/116500603">rdar://116500603</a>

Reviewed by NOBODY (OOPS!).

Move a number of functions which check security of setLocation from LocalDOMWindow to DOMWindow parent class and invoke them in a new setLocationSecurityChecks function which is called in both LocalDOMWindow::setLocation() and RemoteDOMWindow::setLocation().

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::isCurrentlyDisplayedInFrame const):
(WebCore::DOMWindow::isInsecureScriptAccess):
(WebCore::DOMWindow::crossDomainAccessErrorMessage):
(WebCore::DOMWindow::printErrorMessage const):
(WebCore::DOMWindow::setLocationSecurityChecks):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::find const):
(WebCore::didAddStorageEventListener):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::isCurrentlyDisplayedInFrame const): Deleted.
(WebCore::LocalDOMWindow::printErrorMessage const): Deleted.
(WebCore::LocalDOMWindow::crossDomainAccessErrorMessage): Deleted.
(WebCore::LocalDOMWindow::isInsecureScriptAccess): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setLocation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffd96c8f5c387b0047a55ce92e3a1b9ca3559c39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119313 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/63705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41404 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/63705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116053 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26751 "Build is in progress. Recent messages:") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101742 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 80 api tests failed or timed out; Running re-run-api-tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/66403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/26026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19872 "Found 60 new test failures: accessibility/mac/internal-link-when-document-has-fragment.html animations/no-cancelation-when-entering-page-cache.html compositing/accelerated-layers-after-back.html compositing/fixed-position-scroll-offset-history-restore.html compositing/iframes/page-cache-layer-tree.html compositing/page-cache-back-crash.html editing/input/reveal-selection-having-stored-scroll-position.html editing/mac/input/unconfirmed-text-navigation-with-page-cache.html editing/pasteboard/copy-paste-crash-onbeforeunload-event.html editing/pasteboard/entries-api/DirectoryEntry-getFile-back-forward-cache.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63068 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/96136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/19945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122531 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40184 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/29970 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 18905 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 19172 tests run. 60 failures; Compiled WebKit (warnings); Running run-layout-tests-without-change") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/94933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97960 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/94675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39824 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/17625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40070 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45569 "Found 6 new failures in page/RemoteDOMWindow.cpp, page/DOMWindow.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39711 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/43044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->