### PR TITLE
[Absolute Positioning][Grid] Expand alignment within static position rectangle to align-self center for simple content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-center-large-border-padding-ref.html"
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 100px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-self-center-ref.html"
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+  align-self: center;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -290,6 +290,7 @@ bool PositionedLayoutConstraints::isEligibleForStaticRangeAlignment(LayoutUnit s
         auto& itemStyle = m_renderer->style();
         auto itemAlignSelf = itemStyle.alignSelf();
         switch (itemStyle.alignSelf().position()) {
+        case ItemPosition::Center:
         case ItemPosition::FlexEnd:
         case ItemPosition::SelfEnd:
         case ItemPosition::End: {


### PR DESCRIPTION
#### b5d8bc6b1c06af27cb2d5175f4bfe3bde81ee77f
<pre>
[Absolute Positioning][Grid] Expand alignment within static position rectangle to align-self center for simple content
<a href="https://bugs.webkit.org/show_bug.cgi?id=296455">https://bugs.webkit.org/show_bug.cgi?id=296455</a>
<a href="https://rdar.apple.com/156643206">rdar://156643206</a>

Reviewed by Alan Baradlay.

Continues to build upon alignment within the static position rectangle
for abspos children of grids. We keep the same constraints as we
curently have (horizontal-tb LTR content) for end alignment and just
expand eligibility for center. We continue to compute the offset to
satisfy the alignment via resolveAlignmentShift.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center-large-border-padding.html: Added.
Grid with a large border and padding on the top aht bottom. Content box
size is fairly large to make it obvious if the item is not being aligned
properly in the center.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-self-center.html: Added.
Simple testcase to make sure alignment works in a basic scenario.

Canonical link: <a href="https://commits.webkit.org/297900@main">https://commits.webkit.org/297900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a10fd7fc12787b710ad040b87d8540de5cc19c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64013 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86229 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101917 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66556 "Found 147 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20042 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122721 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40375 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30122 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95076 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94822 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39970 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17787 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36524 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45759 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->