### PR TITLE
[Liquid Glass] wsj.com: top fixed element color extension disappears after scrolling back down

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-header-visibility-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-header-visibility-expected.txt
@@ -1,0 +1,6 @@
+PASS colorBeforeHiding is "rgb(255, 0, 0)"
+PASS colorAfterHiding is "rgb(255, 0, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-header-visibility.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-header-visibility.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .top {
+            position: fixed;
+            top: 0;
+            height: 60px;
+            left: 0;
+            right: 0;
+        }
+
+        .content {
+            width: 100%;
+            height: 100%;
+        }
+
+        .top > .content {
+            background: red;
+        }
+
+        .tall {
+            height: 500vh;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+
+        colorBeforeHiding = (await UIHelper.fixedContainerEdgeColors()).top;
+        shouldBeEqualToString("colorBeforeHiding", "rgb(255, 0, 0)");
+
+        scrollBy(0, 500);
+        document.querySelector(".tall").style.visibility = "hidden";
+        await UIHelper.ensurePresentationUpdate();
+
+        colorAfterHiding = (await UIHelper.fixedContainerEdgeColors()).top;
+        shouldBeEqualToString("colorAfterHiding", "rgb(255, 0, 0)");
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <header class="top"><div class="content"></div></header>
+    <div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5395,7 +5395,9 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
             if (!renderer)
                 continue;
 
-            if (renderer->style().usedVisibility() != Visibility::Visible)
+            if (renderer->style().usedVisibility() != Visibility::Visible
+                && (side != BoxSide::Top || !lastElement->hasTagName(HTMLNames::headerTag))
+                && (side != BoxSide::Bottom || !lastElement->hasTagName(HTMLNames::footerTag)))
                 continue;
 
             elements.setAt(side, WTFMove(lastElement));


### PR DESCRIPTION
#### fc8c073ca9650f6b1e4c52e9f75667b6bb539228
<pre>
[Liquid Glass] wsj.com: top fixed element color extension disappears after scrolling back down
<a href="https://bugs.webkit.org/show_bug.cgi?id=296454">https://bugs.webkit.org/show_bug.cgi?id=296454</a>
<a href="https://rdar.apple.com/156610120">rdar://156610120</a>

Reviewed by Abrar Rahman Protyasha.

In the very first iteration of the fixed element color sampling heuristic, fixed color extensions
would disappear once the sampled color along that edge was no longer the same (e.g., if the fixed
element was hidden). This caused fixed color extension views to appear and disappear too frequently
on many websites, especially with sticky headers and footer elements.

To mitigate this, we added a hysteresis to maintain the last sampled color, if the last sampled
element&apos;s renderer still exists in the render tree. However, this resulted in the opposite problem,
where fixed color extensions would often linger around forever after dismissing a popup, or if a
toast temporarily appeared and then disappeared via `visibility: hidden;`.

To mitigate that, we then adjusted the heuristic once again to require the last sampled element to
be visible. However, on wsj.com, after scrolling down, up, and down again, WSJ applies visibility:
hidden to the header, which causes the corresponding color extension to disappear.

To mitigate this, we devise an even narrower carve-out for `header` and `footer` elements fixed near
the top or bottom edges of the viewport (respectively), such that we allow their corresponding color
extensions to stay around.

* LayoutTests/fast/page-color-sampling/color-sampling-header-visibility-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-header-visibility.html: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):

Canonical link: <a href="https://commits.webkit.org/297849@main">https://commits.webkit.org/297849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03823037c5f62ad276f4161c5414896ca57e07f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32847 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23325 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63711 "Built successfully") | ✅ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86091 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/37752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66410 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26029 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19880 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Passed layout tests; 22 flakes; Uploaded test results; 37 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63074 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/19954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122537 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40190 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94938 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/97968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94680 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45575 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39717 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43050 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->