### PR TITLE
[Site-Isolation] RemoteDOMWindow::setLocation should have identical security checks as LocalDOMWindow::setLocation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/remotedomwindow-setlocation-passes-security-checks-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/remotedomwindow-setlocation-passes-security-checks-expected.txt
@@ -1,0 +1,5 @@
+ALERT: PASS: Iframe window is confirmed to be a cross-origin proxy.
+CONSOLE MESSAGE: Blocked a frame with origin "http://127.0.0.1:8000" from accessing a frame with origin "http://localhost:8000". Protocols, domains, and ports must match.
+This test verifies that navigating a cross-origin RemoteDOMWindow to a javascript: URL is blocked and produces the correct cross-origin error message.
+
+

--- a/LayoutTests/http/tests/site-isolation/remotedomwindow-setlocation-passes-security-checks.html
+++ b/LayoutTests/http/tests/site-isolation/remotedomwindow-setlocation-passes-security-checks.html
@@ -1,0 +1,40 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test verifies that navigating a cross-origin RemoteDOMWindow to a javascript: URL is blocked and produces the correct cross-origin error message.</p>
+<iframe id="child"></iframe>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    const childFrame = document.getElementById('child');
+
+    childFrame.onload = function() {
+        const childWindow = childFrame.contentWindow;
+        // Make sure we're doing a cross-origin navigation to test RemoteDOMWindow
+        try {
+            const doc = childWindow.document;
+            alert("FAIL: Iframe window is not a cross-origin proxy. This test requires a cross-origin iframe.");
+            if (window.testRunner) testRunner.notifyDone();
+        } catch (e) {
+            if (e.name === 'SecurityError') {
+                alert("PASS: Iframe window is confirmed to be a cross-origin proxy.");
+            }
+        }
+
+        try {
+            childWindow.location = "javascript:alert('should not execute')";
+        } catch (e) {
+            alert(`FAIL: Should fail silently, not throw exception: ${e.name}`);
+        }
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    };
+    childFrame.src = "http://localhost:8000/site-isolation/resources/simple.html";
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -92,6 +92,7 @@ struct StructuredSerializeOptions;
 struct WindowFeatures;
 struct WindowPostMessageOptions;
 
+enum class IncludeTargetOrigin : bool { No, Yes };
 enum class SetLocationLocking : bool { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
 enum class NavigationHistoryBehavior : uint8_t;
 
@@ -126,6 +127,7 @@ public:
 
     WindowProxy* opener() const;
     Document* documentIfLocal();
+    RefPtr<Document> protectedDocumentIfLocal();
 
     WindowProxy* top() const;
     WindowProxy* parent() const;
@@ -223,7 +225,17 @@ public:
     ExceptionOr<PushManager&> pushManager();
 #endif
 
+    // FIXME: When this LocalDOMWindow is no longer the active LocalDOMWindow (i.e.,
+    // when its document is no longer the document that is displayed in its
+    // frame), we would like to zero out m_frame to avoid being confused
+    // by the document that is currently active in m_frame.
+    bool isCurrentlyDisplayedInFrame() const;
+    void printErrorMessage(const String&) const;
+    String crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin);
+
 protected:
+    bool isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const String& urlString);
+    bool passesSetLocationSecurityChecks(const LocalDOMWindow& activeWindow, const URL& completedURL, CanNavigateState& navigationState);
     explicit DOMWindow(GlobalWindowIdentifier&&, DOMWindowType);
 
     ExceptionOr<RefPtr<SecurityOrigin>> createTargetOriginForPostMessage(const String&, Document&);

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -69,8 +69,6 @@ using ReducedResolutionSeconds = Seconds;
 
 template<typename> class ExceptionOr;
 
-enum class IncludeTargetOrigin : bool { No, Yes };
-
 class LocalDOMWindowObserver : public CanMakeWeakPtr<LocalDOMWindowObserver> {
 public:
     virtual ~LocalDOMWindowObserver() { }
@@ -226,10 +224,6 @@ public:
     RefPtr<WebKitPoint> webkitConvertPointFromPageToNode(Node*, const WebKitPoint*) const;
     RefPtr<WebKitPoint> webkitConvertPointFromNodeToPage(Node*, const WebKitPoint*) const;
 
-    void printErrorMessage(const String&) const;
-
-    String crossDomainAccessErrorMessage(const LocalDOMWindow& activeWindow, IncludeTargetOrigin);
-
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&&);
     WEBCORE_EXPORT void postMessageFromRemoteFrame(JSC::JSGlobalObject&, RefPtr<WindowProxy>&& source, const String& sourceOrigin, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);
 
@@ -352,12 +346,6 @@ public:
     Navigation& navigation();
     Ref<Navigation> protectedNavigation();
 
-    // FIXME: When this LocalDOMWindow is no longer the active LocalDOMWindow (i.e.,
-    // when its document is no longer the document that is displayed in its
-    // frame), we would like to zero out m_frame to avoid being confused
-    // by the document that is currently active in m_frame.
-    bool isCurrentlyDisplayedInFrame() const;
-
     void willDetachDocumentFromFrame();
     void willDestroyCachedFrame();
 
@@ -401,7 +389,6 @@ private:
     bool allowedToChangeWindowGeometry() const;
 
     static ExceptionOr<RefPtr<Frame>> createWindow(const String& urlString, const AtomString& frameName, const WindowFeatures&, LocalDOMWindow& activeWindow, LocalFrame& firstFrame, LocalFrame& openerFrame, NOESCAPE const Function<void(LocalDOMWindow&)>& prepareDialogFunction = nullptr);
-    bool isInsecureScriptAccess(LocalDOMWindow& activeWindow, const String& urlString);
 
 #if ENABLE(DEVICE_ORIENTATION)
     bool isAllowedToUseDeviceMotionOrOrientation(String& message) const;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -35,6 +35,7 @@
 #include "RemoteDOMWindow.h"
 #include "RemoteFrameClient.h"
 #include "RemoteFrameView.h"
+#include "SecurityOrigin.h"
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {
@@ -174,6 +175,14 @@ void RemoteFrame::updateScrollingMode()
 RefPtr<SecurityOrigin> RemoteFrame::frameDocumentSecurityOrigin() const
 {
     return frameTreeSyncData().frameDocumentSecurityOrigin;
+}
+
+const SecurityOrigin& RemoteFrame::frameDocumentSecurityOriginOrOpaque() const
+{
+    RefPtr securityOrigin = frameDocumentSecurityOrigin();
+    if (securityOrigin)
+        return *securityOrigin;
+    return SecurityOrigin::opaqueOrigin();
 }
 
 AutoplayPolicy RemoteFrame::autoplayPolicy() const

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -81,6 +81,7 @@ public:
     AutoplayPolicy autoplayPolicy() const final;
 
     void updateScrollingMode() final;
+    const SecurityOrigin& frameDocumentSecurityOriginOrOpaque() const;
 
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Markable<LayerHostingContextIdentifier>, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);


### PR DESCRIPTION
#### b3ce2e746ba582e3fde8554c1c97bd01914d2b76
<pre>
[Site-Isolation] RemoteDOMWindow::setLocation should have identical security checks as LocalDOMWindow::setLocation
<a href="https://rdar.apple.com/116500603">rdar://116500603</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296457">https://bugs.webkit.org/show_bug.cgi?id=296457</a>

Reviewed by Alex Christensen.

Move a number of functions which check security of setLocation from LocalDOMWindow to DOMWindow parent class and invoke them in a new setLocationSecurityChecks function which is called in both LocalDOMWindow::setLocation() and RemoteDOMWindow::setLocation().

* LayoutTests/http/tests/site-isolation/remotedomwindow-setlocation-passes-security-checks-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/remotedomwindow-setlocation-passes-security-checks.html: Added.
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::protectedDocumentIfLocal):
(WebCore::DOMWindow::isCurrentlyDisplayedInFrame const):
(WebCore::DOMWindow::printErrorMessage const):
(WebCore::DOMWindow::crossDomainAccessErrorMessage):
(WebCore::DOMWindow::isInsecureScriptAccess):
(WebCore::DOMWindow::passesSetLocationSecurityChecks):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::find const):
(WebCore::didAddStorageEventListener):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::isCurrentlyDisplayedInFrame const): Deleted.
(WebCore::LocalDOMWindow::printErrorMessage const): Deleted.
(WebCore::LocalDOMWindow::crossDomainAccessErrorMessage): Deleted.
(WebCore::LocalDOMWindow::isInsecureScriptAccess): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setLocation):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::frameDocumentSecurityOriginOrOpaque const):
* Source/WebCore/page/RemoteFrame.h:

Canonical link: <a href="https://commits.webkit.org/298598@main">https://commits.webkit.org/298598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f5e5f9e8e8b52cade971362a9717682a19be4cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87044 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41952 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67435 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20979 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95862 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95646 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18649 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37583 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18538 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46929 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->