### PR TITLE
Prevent failed @namespace insertions from affecting namespace map

### DIFF
--- a/LayoutTests/fast/css/insertrule-namespace-after-layer-expected.txt
+++ b/LayoutTests/fast/css/insertrule-namespace-after-layer-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: HierarchyRequestError: The operation would yield an incorrect node tree.
+CONSOLE MESSAGE: InvalidStateError: The object is in an invalid state.
 Test passes if doesn't crash

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/at-namespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/at-namespace-expected.txt
@@ -1,6 +1,4 @@
 Should be green
 
-FAIL CSS Test: @namespace in CSSOM is not severely broken assert_throws_dom: function "function() {
-    s.sheet.insertRule('@namespace myhtml url("http://www.w3.org/1999/xhtml")', 0);
-  }" threw object "HierarchyRequestError: The operation would yield an incorrect node tree." that is not a DOMException InvalidStateError: property "code" is equal to 3, expected 11
+PASS CSS Test: @namespace in CSSOM is not severely broken
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -1,6 +1,6 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -367,9 +367,14 @@ ExceptionOr<unsigned> CSSStyleSheet::insertRule(const String& ruleString, unsign
 
     RuleMutationScope mutationScope(this, RuleInsertion, dynamicDowncast<StyleRuleKeyframes>(*rule));
 
+    bool isNamespace = rule->isNamespaceRule();
     bool success = m_contents.get().wrapperInsertRule(rule.releaseNonNull(), index);
-    if (!success)
+    if (!success) {
+        if (isNamespace)
+            return Exception { ExceptionCode::InvalidStateError };
         return Exception { ExceptionCode::HierarchyRequestError };
+    }
+
     if (!m_childRuleCSSOMWrappers.isEmpty())
         m_childRuleCSSOMWrappers.insert(index, RefPtr<CSSRule>());
 


### PR DESCRIPTION
#### 60e9bab7502a480ea1c4e11f9069f9dae47b388a
<pre>
Prevent failed @namespace insertions from affecting namespace map
<a href="https://bugs.webkit.org/show_bug.cgi?id=296462">https://bugs.webkit.org/show_bug.cgi?id=296462</a>
<a href="https://rdar.apple.com/156651404">rdar://156651404</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

It fixes an issue where @namespace rules that failed insertion [1] (e.g., due
to InvalidStateError or hierarchy violations) could still affect the internal
namespace map. This led to incorrect parsing behavior for subsequent rules
and test failure.

[1] <a href="https://drafts.csswg.org/cssom/#insert-a-css-rule">https://drafts.csswg.org/cssom/#insert-a-css-rule</a>

* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::insertRule):
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/at-namespace-expected.txt: Progression
* LayoutTests/fast/css/insertrule-namespace-after-layer-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/297893@main">https://commits.webkit.org/297893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9a905f6fffbd2083a90b7a34396c28e23256cca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119495 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20034 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63249 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94814 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17779 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36505 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45750 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39892 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->