### PR TITLE
AX: De-virtualize AccessibilityObject::axObjectCache as it regularly shows up in samples

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1244,8 +1244,6 @@ public:
     // Non-localized string associated with the object's subrole.
     virtual String subrolePlatformString() const = 0;
 
-    virtual AXObjectCache* axObjectCache() const = 0;
-
     bool supportsPressAction() const;
     virtual Element* actionElement() const = 0;
 

--- a/Source/WebCore/accessibility/AXImage.cpp
+++ b/Source/WebCore/accessibility/AXImage.cpp
@@ -37,14 +37,14 @@
 
 namespace WebCore {
 
-AXImage::AXImage(AXID axID, RenderImage& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AXImage::AXImage(AXID axID, RenderImage& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-Ref<AXImage> AXImage::create(AXID axID, RenderImage& renderer)
+Ref<AXImage> AXImage::create(AXID axID, RenderImage& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AXImage(axID, renderer));
+    return adoptRef(*new AXImage(axID, renderer, cache));
 }
 
 AccessibilityRole AXImage::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AXImage.h
+++ b/Source/WebCore/accessibility/AXImage.h
@@ -35,11 +35,11 @@ namespace WebCore {
 
 class AXImage final : public AccessibilityRenderObject {
 public:
-    static Ref<AXImage> create(AXID, RenderImage&);
+    static Ref<AXImage> create(AXID, RenderImage&, AXObjectCache&);
     virtual ~AXImage() = default;
 
 private:
-    explicit AXImage(AXID, RenderImage&);
+    explicit AXImage(AXID, RenderImage&, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final;
     std::optional<AccessibilityChildrenVector> imageOverlayElements() final;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -315,6 +315,8 @@ public:
     explicit AXObjectCache(Page&, Document*);
     ~AXObjectCache();
 
+    String debugDescription() const;
+
     // Returns the root object for a specific frame.
     WEBCORE_EXPORT AXCoreObject* rootObjectForFrame(LocalFrame&);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -983,6 +985,11 @@ private:
     VisibleSelection m_lastSelection;
 #endif
 };
+
+inline AXObjectCache* AccessibilityObject::axObjectCache() const
+{
+    return m_axObjectCache.get();
+}
 
 template<typename U>
 inline Vector<Ref<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs) const

--- a/Source/WebCore/accessibility/AXRemoteFrame.cpp
+++ b/Source/WebCore/accessibility/AXRemoteFrame.cpp
@@ -28,14 +28,14 @@
 
 namespace WebCore {
 
-AXRemoteFrame::AXRemoteFrame(AXID axID)
-    : AccessibilityMockObject(axID)
+AXRemoteFrame::AXRemoteFrame(AXID axID, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
 {
 }
 
-Ref<AXRemoteFrame> AXRemoteFrame::create(AXID axID)
+Ref<AXRemoteFrame> AXRemoteFrame::create(AXID axID, AXObjectCache& cache)
 {
-    return adoptRef(*new AXRemoteFrame(axID));
+    return adoptRef(*new AXRemoteFrame(axID, cache));
 }
 
 LayoutRect AXRemoteFrame::elementRect() const

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -33,7 +33,7 @@ class RemoteFrame;
 
 class AXRemoteFrame final : public AccessibilityMockObject {
 public:
-    static Ref<AXRemoteFrame> create(AXID);
+    static Ref<AXRemoteFrame> create(AXID, AXObjectCache&);
 
 #if PLATFORM(COCOA)
     void initializePlatformElementWithRemoteToken(std::span<const uint8_t>, int);
@@ -46,7 +46,7 @@ public:
 
 private:
     virtual ~AXRemoteFrame() = default;
-    explicit AXRemoteFrame(AXID);
+    explicit AXRemoteFrame(AXID, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::RemoteFrame; }
     bool computeIsIgnored() const final { return false; }

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -199,9 +199,9 @@ static void appendAccessibilityObject(Ref<AXCoreObject> object, AccessibilityObj
 {
     if (!object->isAttachment()) [[likely]]
         results.append(WTFMove(object));
-    else {
+    else if (RefPtr axObject = dynamicDowncast<AccessibilityObject>(object)) {
         // Find the next descendant of this attachment object so search can continue through frames.
-        RefPtr widget = object->widgetForAttachmentView();
+        RefPtr widget = axObject->widgetForAttachmentView();
         RefPtr frameView = dynamicDowncast<LocalFrameView>(widget);
         if (!frameView)
             return;
@@ -209,9 +209,9 @@ static void appendAccessibilityObject(Ref<AXCoreObject> object, AccessibilityObj
         if (!document || !document->hasLivingRenderTree())
             return;
 
-        CheckedPtr cache = object->axObjectCache();
+        CheckedPtr cache = axObject->axObjectCache();
         if (RefPtr axDocument = cache ? cache->getOrCreate(*document) : nullptr)
-            results.append(*axDocument);
+            results.append(axDocument.releaseNonNull());
     }
 }
 

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
@@ -37,26 +37,26 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityARIAGridCell::AccessibilityARIAGridCell(AXID axID, RenderObject& renderer)
-    : AccessibilityTableCell(axID, renderer)
+AccessibilityARIAGridCell::AccessibilityARIAGridCell(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityTableCell(axID, renderer, cache)
 {
 }
 
-AccessibilityARIAGridCell::AccessibilityARIAGridCell(AXID axID, Node& node)
-    : AccessibilityTableCell(axID, node)
+AccessibilityARIAGridCell::AccessibilityARIAGridCell(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityTableCell(axID, node, cache)
 {
 }
 
 AccessibilityARIAGridCell::~AccessibilityARIAGridCell() = default;
 
-Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityARIAGridCell(axID, renderer));
+    return adoptRef(*new AccessibilityARIAGridCell(axID, renderer, cache));
 }
 
-Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(AXID axID, Node& node)
+Ref<AccessibilityARIAGridCell> AccessibilityARIAGridCell::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityARIAGridCell(axID, node));
+    return adoptRef(*new AccessibilityARIAGridCell(axID, node, cache));
 }
 
 AccessibilityTable* AccessibilityARIAGridCell::parentTable() const

--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.h
@@ -34,13 +34,13 @@ namespace WebCore {
     
 class AccessibilityARIAGridCell final : public AccessibilityTableCell {
 public:
-    static Ref<AccessibilityARIAGridCell> create(AXID, RenderObject&);
-    static Ref<AccessibilityARIAGridCell> create(AXID, Node&);
+    static Ref<AccessibilityARIAGridCell> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityARIAGridCell> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityARIAGridCell();
 
 private:
-    explicit AccessibilityARIAGridCell(AXID, RenderObject&);
-    explicit AccessibilityARIAGridCell(AXID, Node&);
+    explicit AccessibilityARIAGridCell(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityARIAGridCell(AXID, Node&, AXObjectCache&);
     bool isAccessibilityARIAGridCellInstance() const final { return true; }
 
     AccessibilityTable* parentTable() const final;

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -34,26 +34,26 @@
 
 namespace WebCore {
     
-AccessibilityARIAGridRow::AccessibilityARIAGridRow(AXID axID, RenderObject& renderer)
-    : AccessibilityTableRow(axID, renderer)
+AccessibilityARIAGridRow::AccessibilityARIAGridRow(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityTableRow(axID, renderer, cache)
 {
 }
 
-AccessibilityARIAGridRow::AccessibilityARIAGridRow(AXID axID, Node& node)
-    : AccessibilityTableRow(axID, node)
+AccessibilityARIAGridRow::AccessibilityARIAGridRow(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityTableRow(axID, node, cache)
 {
 }
 
 AccessibilityARIAGridRow::~AccessibilityARIAGridRow() = default;
 
-Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityARIAGridRow(axID, renderer));
+    return adoptRef(*new AccessibilityARIAGridRow(axID, renderer, cache));
 }
 
-Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(AXID axID, Node& node)
+Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityARIAGridRow(axID, node));
+    return adoptRef(*new AccessibilityARIAGridRow(axID, node, cache));
 }
 
 bool AccessibilityARIAGridRow::isARIATreeGridRow() const

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.h
@@ -36,16 +36,16 @@ class AccessibilityTable;
     
 class AccessibilityARIAGridRow final : public AccessibilityTableRow {
 public:
-    static Ref<AccessibilityARIAGridRow> create(AXID, RenderObject&);
-    static Ref<AccessibilityARIAGridRow> create(AXID, Node&);
+    static Ref<AccessibilityARIAGridRow> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityARIAGridRow> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityARIAGridRow();
 
     AccessibilityChildrenVector disclosedRows() final;
     AccessibilityObject* disclosedByRow() const final;
 
 private:
-    explicit AccessibilityARIAGridRow(AXID, RenderObject&);
-    explicit AccessibilityARIAGridRow(AXID, Node&);
+    explicit AccessibilityARIAGridRow(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityARIAGridRow(AXID, Node&, AXObjectCache&);
     bool isAccessibilityARIAGridRowInstance() const final { return true; }
 
     bool isARIAGridRow() const final { return true; }

--- a/Source/WebCore/accessibility/AccessibilityARIATable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIATable.cpp
@@ -35,26 +35,26 @@ namespace WebCore {
 
 class RenderObject;
 
-AccessibilityARIATable::AccessibilityARIATable(AXID axID, RenderObject& renderer)
-    : AccessibilityTable(axID, renderer)
+AccessibilityARIATable::AccessibilityARIATable(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityTable(axID, renderer, cache)
 {
 }
 
-AccessibilityARIATable::AccessibilityARIATable(AXID axID, Node& node)
-    : AccessibilityTable(axID, node)
+AccessibilityARIATable::AccessibilityARIATable(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityTable(axID, node, cache)
 {
 }
 
 AccessibilityARIATable::~AccessibilityARIATable() = default;
 
-Ref<AccessibilityARIATable> AccessibilityARIATable::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityARIATable> AccessibilityARIATable::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityARIATable(axID, renderer));
+    return adoptRef(*new AccessibilityARIATable(axID, renderer, cache));
 }
 
-Ref<AccessibilityARIATable> AccessibilityARIATable::create(AXID axID, Node& node)
+Ref<AccessibilityARIATable> AccessibilityARIATable::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityARIATable(axID, node));
+    return adoptRef(*new AccessibilityARIATable(axID, node, cache));
 }
 
 bool AccessibilityARIATable::isMultiSelectable() const

--- a/Source/WebCore/accessibility/AccessibilityARIATable.h
+++ b/Source/WebCore/accessibility/AccessibilityARIATable.h
@@ -35,13 +35,13 @@ namespace WebCore {
 
 class AccessibilityARIATable final : public AccessibilityTable {
 public:
-    static Ref<AccessibilityARIATable> create(AXID, RenderObject&);
-    static Ref<AccessibilityARIATable> create(AXID, Node&);
+    static Ref<AccessibilityARIATable> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityARIATable> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityARIATable();
 
 private:
-    explicit AccessibilityARIATable(AXID, RenderObject&);
-    explicit AccessibilityARIATable(AXID, Node&);
+    explicit AccessibilityARIATable(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityARIATable(AXID, Node&, AXObjectCache&);
 
     bool isMultiSelectable() const final;
     bool computeIsTableExposableThroughAccessibility() const final { return true; }

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -38,14 +38,14 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityAttachment::AccessibilityAttachment(AXID axID, RenderAttachment& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityAttachment::AccessibilityAttachment(AXID axID, RenderAttachment& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-Ref<AccessibilityAttachment> AccessibilityAttachment::create(AXID axID, RenderAttachment& renderer)
+Ref<AccessibilityAttachment> AccessibilityAttachment::create(AXID axID, RenderAttachment& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityAttachment(axID, renderer));
+    return adoptRef(*new AccessibilityAttachment(axID, renderer, cache));
 }
 
 bool AccessibilityAttachment::hasProgress(float* progress) const

--- a/Source/WebCore/accessibility/AccessibilityAttachment.h
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.h
@@ -37,12 +37,12 @@ class RenderAttachment;
     
 class AccessibilityAttachment final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityAttachment> create(AXID, RenderAttachment&);
+    static Ref<AccessibilityAttachment> create(AXID, RenderAttachment&, AXObjectCache&);
     HTMLAttachmentElement* attachmentElement() const;
     bool hasProgress(float* progress = nullptr) const;
     
 private:
-    explicit AccessibilityAttachment(AXID, RenderAttachment&);
+    explicit AccessibilityAttachment(AXID, RenderAttachment&, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Button; }
 

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.cpp
@@ -38,16 +38,16 @@ namespace WebCore {
 
 using namespace HTMLNames;
     
-AccessibilityImageMapLink::AccessibilityImageMapLink(AXID axID, HTMLAreaElement& element)
-    : AccessibilityNodeObject(axID, &element)
+AccessibilityImageMapLink::AccessibilityImageMapLink(AXID axID, HTMLAreaElement& element, AXObjectCache& cache)
+    : AccessibilityNodeObject(axID, &element, cache)
 {
 }
 
 AccessibilityImageMapLink::~AccessibilityImageMapLink() = default;
 
-Ref<AccessibilityImageMapLink> AccessibilityImageMapLink::create(AXID axID, HTMLAreaElement& element)
+Ref<AccessibilityImageMapLink> AccessibilityImageMapLink::create(AXID axID, HTMLAreaElement& element, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityImageMapLink(axID, element));
+    return adoptRef(*new AccessibilityImageMapLink(axID, element, cache));
 }
 
 AccessibilityObject* AccessibilityImageMapLink::parentObject() const

--- a/Source/WebCore/accessibility/AccessibilityImageMapLink.h
+++ b/Source/WebCore/accessibility/AccessibilityImageMapLink.h
@@ -37,7 +37,7 @@ namespace WebCore {
     
 class AccessibilityImageMapLink final : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityImageMapLink> create(AXID, HTMLAreaElement&);
+    static Ref<AccessibilityImageMapLink> create(AXID, HTMLAreaElement&, AXObjectCache&);
     virtual ~AccessibilityImageMapLink();
     
     AccessibilityRole determineAccessibilityRole() final;
@@ -54,7 +54,7 @@ public:
     LayoutRect elementRect() const final;
 
 private:
-    explicit AccessibilityImageMapLink(AXID, HTMLAreaElement&);
+    explicit AccessibilityImageMapLink(AXID, HTMLAreaElement&, AXObjectCache&);
 
     Path elementPath() const final;
     RenderElement* imageMapLinkRenderer() const;

--- a/Source/WebCore/accessibility/AccessibilityLabel.cpp
+++ b/Source/WebCore/accessibility/AccessibilityLabel.cpp
@@ -33,16 +33,16 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityLabel::AccessibilityLabel(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityLabel::AccessibilityLabel(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
 AccessibilityLabel::~AccessibilityLabel() = default;
 
-Ref<AccessibilityLabel> AccessibilityLabel::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityLabel> AccessibilityLabel::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityLabel(axID, renderer));
+    return adoptRef(*new AccessibilityLabel(axID, renderer, cache));
 }
 
 String AccessibilityLabel::stringValue() const

--- a/Source/WebCore/accessibility/AccessibilityLabel.h
+++ b/Source/WebCore/accessibility/AccessibilityLabel.h
@@ -34,12 +34,12 @@ namespace WebCore {
 
 class AccessibilityLabel final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityLabel> create(AXID, RenderObject&);
+    static Ref<AccessibilityLabel> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilityLabel();
 
     bool containsOnlyStaticText() const final;
 private:
-    explicit AccessibilityLabel(AXID, RenderObject&);
+    explicit AccessibilityLabel(AXID, RenderObject&, AXObjectCache&);
     bool computeIsIgnored() const final { return isIgnoredByDefault(); }
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Label; }

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -42,26 +42,26 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityList::AccessibilityList(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityList::AccessibilityList(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-AccessibilityList::AccessibilityList(AXID axID, Node& node)
-    : AccessibilityRenderObject(axID, node)
+AccessibilityList::AccessibilityList(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, node, cache)
 {
 }
 
 AccessibilityList::~AccessibilityList() = default;
 
-Ref<AccessibilityList> AccessibilityList::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityList> AccessibilityList::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityList(axID, renderer));
+    return adoptRef(*new AccessibilityList(axID, renderer, cache));
 }
 
-Ref<AccessibilityList> AccessibilityList::create(AXID axID, Node& node)
+Ref<AccessibilityList> AccessibilityList::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityList(axID, node));
+    return adoptRef(*new AccessibilityList(axID, node, cache));
 }
 
 bool AccessibilityList::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityList.h
+++ b/Source/WebCore/accessibility/AccessibilityList.h
@@ -34,13 +34,13 @@ namespace WebCore {
     
 class AccessibilityList final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityList> create(AXID, RenderObject&);
-    static Ref<AccessibilityList> create(AXID, Node&);
+    static Ref<AccessibilityList> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityList> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityList();
 
 private:
-    explicit AccessibilityList(AXID, RenderObject&);
-    explicit AccessibilityList(AXID, Node&);
+    explicit AccessibilityList(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityList(AXID, Node&, AXObjectCache&);
     bool isListInstance() const final { return true; }
 
     bool isUnorderedList() const final;

--- a/Source/WebCore/accessibility/AccessibilityListBox.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBox.cpp
@@ -42,16 +42,16 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityListBox::AccessibilityListBox(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityListBox::AccessibilityListBox(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
 AccessibilityListBox::~AccessibilityListBox() = default;
 
-Ref<AccessibilityListBox> AccessibilityListBox::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityListBox> AccessibilityListBox::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityListBox(axID, renderer));
+    return adoptRef(*new AccessibilityListBox(axID, renderer, cache));
 }
 
 void AccessibilityListBox::addChildren()

--- a/Source/WebCore/accessibility/AccessibilityListBox.h
+++ b/Source/WebCore/accessibility/AccessibilityListBox.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class AccessibilityListBox final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityListBox> create(AXID, RenderObject&);
+    static Ref<AccessibilityListBox> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilityListBox();
 
     WEBCORE_EXPORT void setSelectedChildren(const AccessibilityChildrenVector&) final;
@@ -46,7 +46,7 @@ public:
     void addChildren() final;
 
 private:
-    explicit AccessibilityListBox(AXID, RenderObject&);
+    explicit AccessibilityListBox(AXID, RenderObject&, AXObjectCache&);
 
     bool isAccessibilityListBoxInstance() const final { return true; }
     AccessibilityObject* listBoxOptionAccessibilityObject(HTMLElement*) const;

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -45,16 +45,16 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityListBoxOption::AccessibilityListBoxOption(AXID axID, HTMLElement& element)
-    : AccessibilityNodeObject(axID, &element)
+AccessibilityListBoxOption::AccessibilityListBoxOption(AXID axID, HTMLElement& element, AXObjectCache& cache)
+    : AccessibilityNodeObject(axID, &element, cache)
 {
 }
 
 AccessibilityListBoxOption::~AccessibilityListBoxOption() = default;
 
-Ref<AccessibilityListBoxOption> AccessibilityListBoxOption::create(AXID axID, HTMLElement& element)
+Ref<AccessibilityListBoxOption> AccessibilityListBoxOption::create(AXID axID, HTMLElement& element, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityListBoxOption(axID, element));
+    return adoptRef(*new AccessibilityListBoxOption(axID, element, cache));
 }
 
 bool AccessibilityListBoxOption::isEnabled() const

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.h
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.h
@@ -37,14 +37,14 @@ class HTMLSelectElement;
 
 class AccessibilityListBoxOption final : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityListBoxOption> create(AXID, HTMLElement&);
+    static Ref<AccessibilityListBoxOption> create(AXID, HTMLElement&, AXObjectCache&);
     virtual ~AccessibilityListBoxOption();
 
     bool isSelected() const final;
     void setSelected(bool) final;
 
 private:
-    explicit AccessibilityListBoxOption(AXID, HTMLElement&);
+    explicit AccessibilityListBoxOption(AXID, HTMLElement&, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ListBoxOption; }
     bool isEnabled() const final;

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -37,17 +37,17 @@
 
 namespace WebCore {
 
-AccessibilityMathMLElement::AccessibilityMathMLElement(AXID axID, RenderObject& renderer, bool isAnonymousOperator)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityMathMLElement::AccessibilityMathMLElement(AXID axID, RenderObject& renderer, AXObjectCache& cache, bool isAnonymousOperator)
+    : AccessibilityRenderObject(axID, renderer, cache)
     , m_isAnonymousOperator(isAnonymousOperator)
 {
 }
 
 AccessibilityMathMLElement::~AccessibilityMathMLElement() = default;
 
-Ref<AccessibilityMathMLElement> AccessibilityMathMLElement::create(AXID axID, RenderObject& renderer, bool isAnonymousOperator)
+Ref<AccessibilityMathMLElement> AccessibilityMathMLElement::create(AXID axID, RenderObject& renderer, AXObjectCache& cache, bool isAnonymousOperator)
 {
-    return adoptRef(*new AccessibilityMathMLElement(axID, renderer, isAnonymousOperator));
+    return adoptRef(*new AccessibilityMathMLElement(axID, renderer, cache, isAnonymousOperator));
 }
 
 AccessibilityRole AccessibilityMathMLElement::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.h
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.h
@@ -41,11 +41,11 @@ namespace WebCore {
 class AccessibilityMathMLElement : public AccessibilityRenderObject {
 
 public:
-    static Ref<AccessibilityMathMLElement> create(AXID, RenderObject&, bool isAnonymousOperator);
+    static Ref<AccessibilityMathMLElement> create(AXID, RenderObject&, AXObjectCache&, bool isAnonymousOperator);
     virtual ~AccessibilityMathMLElement();
 
 protected:
-    explicit AccessibilityMathMLElement(AXID, RenderObject&, bool isAnonymousOperator);
+    explicit AccessibilityMathMLElement(AXID, RenderObject&, AXObjectCache&, bool isAnonymousOperator);
 
 private:
     AccessibilityRole determineAccessibilityRole() final;

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
@@ -41,16 +41,16 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityMediaObject::AccessibilityMediaObject(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityMediaObject::AccessibilityMediaObject(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
 AccessibilityMediaObject::~AccessibilityMediaObject() = default;
 
-Ref<AccessibilityMediaObject> AccessibilityMediaObject::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityMediaObject> AccessibilityMediaObject::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityMediaObject(axID, renderer));
+    return adoptRef(*new AccessibilityMediaObject(axID, renderer, cache));
 }
 
 bool AccessibilityMediaObject::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.h
@@ -36,7 +36,7 @@ namespace WebCore {
     
 class AccessibilityMediaObject final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityMediaObject> create(AXID, RenderObject&);
+    static Ref<AccessibilityMediaObject> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilityMediaObject();
     
     void enterFullscreen() const;
@@ -49,7 +49,7 @@ public:
     bool isMuted() const;
 
 private:
-    explicit AccessibilityMediaObject(AXID, RenderObject&);
+    explicit AccessibilityMediaObject(AXID, RenderObject&, AXObjectCache&);
 
     enum class AXSeekDirection : bool { Backward, Forward };
     bool computeIsIgnored() const final;

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 AccessibilityMenuList::AccessibilityMenuList(AXID axID, RenderMenuList& renderer, AXObjectCache& cache)
-    : AccessibilityRenderObject(axID, renderer)
+    : AccessibilityRenderObject(axID, renderer, cache)
     , m_popup(downcast<AccessibilityMenuListPopup>(*cache.create(AccessibilityRole::MenuListPopup)))
 {
 }

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.cpp
@@ -37,15 +37,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityMenuListOption::AccessibilityMenuListOption(AXID axID, HTMLOptionElement& element)
-    : AccessibilityNodeObject(axID, &element)
+AccessibilityMenuListOption::AccessibilityMenuListOption(AXID axID, HTMLOptionElement& element, AXObjectCache& cache)
+    : AccessibilityNodeObject(axID, &element, cache)
     , m_parent(nullptr)
 {
 }
 
-Ref<AccessibilityMenuListOption> AccessibilityMenuListOption::create(AXID axID, HTMLOptionElement& element)
+Ref<AccessibilityMenuListOption> AccessibilityMenuListOption::create(AXID axID, HTMLOptionElement& element, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityMenuListOption(axID, element));
+    return adoptRef(*new AccessibilityMenuListOption(axID, element, cache));
 }
 
 HTMLOptionElement* AccessibilityMenuListOption::optionElement() const

--- a/Source/WebCore/accessibility/AccessibilityMenuListOption.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListOption.h
@@ -34,11 +34,11 @@ class HTMLOptionElement;
 
 class AccessibilityMenuListOption final : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityMenuListOption> create(AXID, HTMLOptionElement&);
+    static Ref<AccessibilityMenuListOption> create(AXID, HTMLOptionElement&, AXObjectCache&);
     void setParent(AccessibilityObject* parent) { m_parent = parent; }
 
 private:
-    explicit AccessibilityMenuListOption(AXID, HTMLOptionElement&);
+    explicit AccessibilityMenuListOption(AXID, HTMLOptionElement&, AXObjectCache&);
 
     bool isMenuListOption() const final { return true; }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -38,8 +38,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityMenuListPopup::AccessibilityMenuListPopup(AXID axID)
-    : AccessibilityMockObject(axID)
+AccessibilityMenuListPopup::AccessibilityMenuListPopup(AXID axID, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
 {
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.h
@@ -36,7 +36,7 @@ class HTMLElement;
 class AccessibilityMenuListPopup final : public AccessibilityMockObject {
     friend class AXObjectCache;
 public:
-    static Ref<AccessibilityMenuListPopup> create(AXID axID) { return adoptRef(*new AccessibilityMenuListPopup(axID)); }
+    static Ref<AccessibilityMenuListPopup> create(AXID axID, AXObjectCache& cache) { return adoptRef(*new AccessibilityMenuListPopup(axID, cache)); }
 
     bool isEnabled() const final;
     bool isOffScreen() const final;
@@ -44,7 +44,7 @@ public:
     void didUpdateActiveOption(int optionIndex);
 
 private:
-    explicit AccessibilityMenuListPopup(AXID);
+    explicit AccessibilityMenuListPopup(AXID, AXObjectCache&);
 
     bool isMenuListPopup() const final { return true; }
 

--- a/Source/WebCore/accessibility/AccessibilityMockObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.cpp
@@ -28,8 +28,8 @@
 
 namespace WebCore {
 
-AccessibilityMockObject::AccessibilityMockObject(AXID axID)
-    : AccessibilityObject(axID)
+AccessibilityMockObject::AccessibilityMockObject(AXID axID, AXObjectCache& cache)
+    : AccessibilityObject(axID, cache)
 {
 }
 

--- a/Source/WebCore/accessibility/AccessibilityMockObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.h
@@ -39,7 +39,7 @@ public:
     bool isEnabled() const override { return true; }
 
 protected:
-    explicit AccessibilityMockObject(AXID);
+    explicit AccessibilityMockObject(AXID, AXObjectCache&);
 
     WeakPtr<AccessibilityObject> m_parent;
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -105,8 +105,8 @@ using namespace HTMLNames;
 static String accessibleNameForNode(Node&, Node* labelledbyNode = nullptr);
 static void appendNameToStringBuilder(StringBuilder&, String&&, bool prependSpace = true);
 
-AccessibilityNodeObject::AccessibilityNodeObject(AXID axID, Node* node)
-    : AccessibilityObject(axID)
+AccessibilityNodeObject::AccessibilityNodeObject(AXID axID, Node* node, AXObjectCache& cache)
+    : AccessibilityObject(axID, cache)
     , m_node(node)
 {
 }
@@ -125,9 +125,9 @@ void AccessibilityNodeObject::init()
     AccessibilityObject::init();
 }
 
-Ref<AccessibilityNodeObject> AccessibilityNodeObject::create(AXID axID, Node& node)
+Ref<AccessibilityNodeObject> AccessibilityNodeObject::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityNodeObject(axID, &node));
+    return adoptRef(*new AccessibilityNodeObject(axID, &node, cache));
 }
 
 void AccessibilityNodeObject::detachRemoteParts(AccessibilityDetachmentType detachmentType)
@@ -207,7 +207,7 @@ AccessibilityObject* AccessibilityNodeObject::parentObject() const
     if (!node)
         return nullptr;
 
-    if (RefPtr ownerParent = ownerParentObject())
+    if (RefPtr ownerParent = ownerParentObject()) [[unlikely]]
         return ownerParent.get();
 
     CheckedPtr cache = axObjectCache();

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -41,7 +41,7 @@ class Node;
 
 class AccessibilityNodeObject : public AccessibilityObject {
 public:
-    static Ref<AccessibilityNodeObject> create(AXID, Node&);
+    static Ref<AccessibilityNodeObject> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityNodeObject();
 
     void init() override;
@@ -139,7 +139,7 @@ public:
 #endif
 
 protected:
-    explicit AccessibilityNodeObject(AXID, Node*);
+    explicit AccessibilityNodeObject(AXID, Node*, AXObjectCache&);
     void detachRemoteParts(AccessibilityDetachmentType) override;
 
     AccessibilityRole m_ariaRole { AccessibilityRole::Unknown };

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -118,8 +118,9 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityObject::AccessibilityObject(AXID axID)
+AccessibilityObject::AccessibilityObject(AXID axID, AXObjectCache& cache)
     : AXCoreObject(axID)
+    , m_axObjectCache(cache)
 {
 }
 
@@ -3135,12 +3136,6 @@ AccessibilityObject* AccessibilityObject::elementAccessibilityHitTest(const IntP
     return const_cast<AccessibilityObject*>(this);
 }
     
-AXObjectCache* AccessibilityObject::axObjectCache() const
-{
-    RefPtr document = this->document();
-    return document ? document->axObjectCache() : nullptr;
-}
-
 CommandType AccessibilityObject::commandType() const
 {
     return CommandType::Invalid;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -56,7 +56,6 @@ OBJC_CLASS NSView;
 
 namespace WebCore {
 
-class AccessibilityObject;
 class IntPoint;
 class IntSize;
 class ScrollableArea;
@@ -428,7 +427,7 @@ public:
 
     String ariaRoleDescription() const final { return getAttributeTrimmed(HTMLNames::aria_roledescriptionAttr); };
 
-    AXObjectCache* axObjectCache() const override;
+    AXObjectCache* axObjectCache() const;
 
     static AccessibilityObject* anchorElementForNode(Node&);
     static AccessibilityObject* headingElementForNode(Node*);
@@ -874,7 +873,7 @@ public:
     }; // class iterator
 
 protected:
-    explicit AccessibilityObject(AXID);
+    explicit AccessibilityObject(AXID, AXObjectCache&);
 
     // FIXME: Make more of these member functions private.
 
@@ -933,6 +932,7 @@ private:
 protected: // FIXME: Make the data members private.
     AccessibilityChildrenVector m_children;
 private:
+    const WeakPtr<AXObjectCache> m_axObjectCache;
 #if PLATFORM(IOS_FAMILY)
     InlineTextPrediction m_lastPresentedTextPrediction;
     InlineTextPrediction m_lastPresentedTextPredictionComplete;

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -35,15 +35,15 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
     ASSERT(is<RenderProgress>(renderer) || is<RenderMeter>(renderer) || is<HTMLProgressElement>(renderer.node()) || is<HTMLMeterElement>(renderer.node()));
 }
 
-Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityProgressIndicator(axID, renderer));
+    return adoptRef(*new AccessibilityProgressIndicator(axID, renderer, cache));
 }
 
 bool AccessibilityProgressIndicator::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
@@ -32,12 +32,12 @@ class RenderProgress;
     
 class AccessibilityProgressIndicator final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityProgressIndicator> create(AXID, RenderObject&);
+    static Ref<AccessibilityProgressIndicator> create(AXID, RenderObject&, AXObjectCache&);
 
     bool isIndeterminate() const final;
 
 private:
-    explicit AccessibilityProgressIndicator(AXID, RenderObject&);
+    explicit AccessibilityProgressIndicator(AXID, RenderObject&, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final;
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -54,7 +54,7 @@ class VisibleSelection;
 
 class AccessibilityRenderObject : public AccessibilityNodeObject {
 public:
-    static Ref<AccessibilityRenderObject> create(AXID, RenderObject&);
+    static Ref<AccessibilityRenderObject> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilityRenderObject();
     
     FloatRect frameRect() const final;
@@ -138,8 +138,8 @@ public:
     String secureFieldValue() const final;
     void labelText(Vector<AccessibilityText>&) const override;
 protected:
-    explicit AccessibilityRenderObject(AXID, RenderObject&);
-    explicit AccessibilityRenderObject(AXID, Node&);
+    explicit AccessibilityRenderObject(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityRenderObject(AXID, Node&, AXObjectCache&);
     void detachRemoteParts(AccessibilityDetachmentType) final;
     ScrollableArea* getScrollableAreaIfScrollable() const final;
     void scrollTo(const IntPoint&) const final;
@@ -172,8 +172,8 @@ private:
 
     bool isSVGImage() const;
     void detachRemoteSVGRoot();
-    enum CreationChoice { Create, Retrieve };
-    AccessibilitySVGRoot* remoteSVGRootElement(CreationChoice createIfNecessary) const;
+    enum class CreateIfNecessary : bool { No, Yes };
+    AccessibilitySVGRoot* remoteSVGRootElement(CreateIfNecessary) const;
     AccessibilityObject* remoteSVGElementHitTest(const IntPoint&) const;
     void offsetBoundingBoxForRemoteSVGElement(LayoutRect&) const;
     bool supportsPath() const final;

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -46,16 +46,14 @@
 
 namespace WebCore {
 
-AccessibilitySVGObject::AccessibilitySVGObject(AXID axID, RenderObject& renderer, AXObjectCache* cache)
-    : AccessibilityRenderObject(axID, renderer)
-    , m_axObjectCache(cache)
+AccessibilitySVGObject::AccessibilitySVGObject(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
-    ASSERT(cache);
 }
 
 AccessibilitySVGObject::~AccessibilitySVGObject() = default;
 
-Ref<AccessibilitySVGObject> AccessibilitySVGObject::create(AXID axID, RenderObject& renderer, AXObjectCache* cache)
+Ref<AccessibilitySVGObject> AccessibilitySVGObject::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
     return adoptRef(*new AccessibilitySVGObject(axID, renderer, cache));
 }

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -33,12 +33,11 @@ namespace WebCore {
 
 class AccessibilitySVGObject : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilitySVGObject> create(AXID, RenderObject&, AXObjectCache*);
+    static Ref<AccessibilitySVGObject> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilitySVGObject();
 
 protected:
-    explicit AccessibilitySVGObject(AXID, RenderObject&, AXObjectCache*);
-    AXObjectCache* axObjectCache() const final { return m_axObjectCache.get(); }
+    explicit AccessibilitySVGObject(AXID, RenderObject&, AXObjectCache&);
     AccessibilityRole determineAriaRoleAttribute() const final;
 
 private:
@@ -55,8 +54,6 @@ private:
     bool hasTitleOrDescriptionChild() const;
     template <typename ChildrenType>
     Element* childElementWithMatchingLanguage(ChildrenType&) const;
-
-    const WeakPtr<AXObjectCache> m_axObjectCache;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.cpp
@@ -39,14 +39,14 @@
 
 namespace WebCore {
 
-AccessibilitySVGRoot::AccessibilitySVGRoot(AXID axID, RenderObject& renderer, AXObjectCache* cache)
+AccessibilitySVGRoot::AccessibilitySVGRoot(AXID axID, RenderObject& renderer, AXObjectCache& cache)
     : AccessibilitySVGObject(axID, renderer, cache)
 {
 }
 
 AccessibilitySVGRoot::~AccessibilitySVGRoot() = default;
 
-Ref<AccessibilitySVGRoot> AccessibilitySVGRoot::create(AXID axID, RenderObject& renderer, AXObjectCache* cache)
+Ref<AccessibilitySVGRoot> AccessibilitySVGRoot::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
     return adoptRef(*new AccessibilitySVGRoot(axID, renderer, cache));
 }

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.h
@@ -35,14 +35,14 @@ namespace WebCore {
 
 class AccessibilitySVGRoot final : public AccessibilitySVGObject {
 public:
-    static Ref<AccessibilitySVGRoot> create(AXID, RenderObject&, AXObjectCache*);
+    static Ref<AccessibilitySVGRoot> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilitySVGRoot();
 
     AccessibilityObject* parentObject() const final;
     void setParent(AccessibilityRenderObject*);
     bool hasAccessibleContent() const;
 private:
-    explicit AccessibilitySVGRoot(AXID, RenderObject&, AXObjectCache*);
+    explicit AccessibilitySVGRoot(AXID, RenderObject&, AXObjectCache&);
 
     bool isAccessibilitySVGRoot() const final { return true; }
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -39,8 +39,8 @@
 
 namespace WebCore {
     
-AccessibilityScrollView::AccessibilityScrollView(AXID axID, ScrollView& view)
-    : AccessibilityObject(axID)
+AccessibilityScrollView::AccessibilityScrollView(AXID axID, ScrollView& view, AXObjectCache& cache)
+    : AccessibilityObject(axID, cache)
     , m_childrenDirty(false)
     , m_scrollView(view)
 {
@@ -90,9 +90,9 @@ void AccessibilityScrollView::detachRemoteParts(AccessibilityDetachmentType deta
     m_frameOwnerElement = nullptr;
 }
 
-Ref<AccessibilityScrollView> AccessibilityScrollView::create(AXID axID, ScrollView& view)
+Ref<AccessibilityScrollView> AccessibilityScrollView::create(AXID axID, ScrollView& view, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityScrollView(axID, view));
+    return adoptRef(*new AccessibilityScrollView(axID, view, cache));
 }
 
 ScrollView* AccessibilityScrollView::currentScrollView() const

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -38,7 +38,7 @@ class ScrollView;
     
 class AccessibilityScrollView final : public AccessibilityObject {
 public:
-    static Ref<AccessibilityScrollView> create(AXID, ScrollView&);
+    static Ref<AccessibilityScrollView> create(AXID, ScrollView&, AXObjectCache&);
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::ScrollArea; }
     ScrollView* scrollView() const final { return currentScrollView(); }
 
@@ -53,7 +53,7 @@ public:
     String extraDebugInfo() const final { return ownerDebugDescription(); }
 
 private:
-    explicit AccessibilityScrollView(AXID, ScrollView&);
+    explicit AccessibilityScrollView(AXID, ScrollView&, AXObjectCache&);
     void detachRemoteParts(AccessibilityDetachmentType) final;
 
     ScrollView* currentScrollView() const;

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.cpp
@@ -36,15 +36,15 @@
 
 namespace WebCore {
 
-AccessibilityScrollbar::AccessibilityScrollbar(AXID axID, Scrollbar& scrollbar)
-    : AccessibilityMockObject(axID)
+AccessibilityScrollbar::AccessibilityScrollbar(AXID axID, Scrollbar& scrollbar, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
     , m_scrollbar(scrollbar)
 {
 }
 
-Ref<AccessibilityScrollbar> AccessibilityScrollbar::create(AXID axID, Scrollbar& scrollbar)
+Ref<AccessibilityScrollbar> AccessibilityScrollbar::create(AXID axID, Scrollbar& scrollbar, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityScrollbar(axID, scrollbar));
+    return adoptRef(*new AccessibilityScrollbar(axID, scrollbar, cache));
 }
     
 LayoutRect AccessibilityScrollbar::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilityScrollbar.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollbar.h
@@ -36,10 +36,10 @@ class Scrollbar;
 
 class AccessibilityScrollbar final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityScrollbar> create(AXID, Scrollbar&);
+    static Ref<AccessibilityScrollbar> create(AXID, Scrollbar&, AXObjectCache&);
 
 private:
-    explicit AccessibilityScrollbar(AXID, Scrollbar&);
+    explicit AccessibilityScrollbar(AXID, Scrollbar&, AXObjectCache&);
 
     bool canSetValueAttribute() const final { return true; }
 

--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -43,14 +43,14 @@ namespace WebCore {
     
 using namespace HTMLNames;
 
-AccessibilitySlider::AccessibilitySlider(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilitySlider::AccessibilitySlider(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-Ref<AccessibilitySlider> AccessibilitySlider::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilitySlider> AccessibilitySlider::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilitySlider(axID, renderer));
+    return adoptRef(*new AccessibilitySlider(axID, renderer, cache));
 }
 
 std::optional<AccessibilityOrientation> AccessibilitySlider::explicitOrientation() const
@@ -154,14 +154,14 @@ HTMLInputElement* AccessibilitySlider::inputElement() const
 }
 
 
-AccessibilitySliderThumb::AccessibilitySliderThumb(AXID axID)
-    : AccessibilityMockObject(axID)
+AccessibilitySliderThumb::AccessibilitySliderThumb(AXID axID, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
 {
 }
 
-Ref<AccessibilitySliderThumb> AccessibilitySliderThumb::create(AXID axID)
+Ref<AccessibilitySliderThumb> AccessibilitySliderThumb::create(AXID axID, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilitySliderThumb(axID));
+    return adoptRef(*new AccessibilitySliderThumb(axID, cache));
 }
     
 LayoutRect AccessibilitySliderThumb::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilitySlider.h
+++ b/Source/WebCore/accessibility/AccessibilitySlider.h
@@ -37,11 +37,11 @@ class HTMLInputElement;
 
 class AccessibilitySlider final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilitySlider> create(AXID, RenderObject&);
+    static Ref<AccessibilitySlider> create(AXID, RenderObject&, AXObjectCache&);
     virtual ~AccessibilitySlider() = default;
 
 private:
-    explicit AccessibilitySlider(AXID, RenderObject&);
+    explicit AccessibilitySlider(AXID, RenderObject&, AXObjectCache&);
 
     HTMLInputElement* inputElement() const;
     AccessibilityObject* elementAccessibilityHitTest(const IntPoint&) const final;
@@ -61,14 +61,14 @@ private:
 
 class AccessibilitySliderThumb final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilitySliderThumb> create(AXID);
+    static Ref<AccessibilitySliderThumb> create(AXID, AXObjectCache&);
     virtual ~AccessibilitySliderThumb() = default;
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SliderThumb; }
     LayoutRect elementRect() const final;
 
 private:
-    explicit AccessibilitySliderThumb(AXID);
+    explicit AccessibilitySliderThumb(AXID, AXObjectCache&);
 
     bool isSliderThumb() const final { return true; }
     bool computeIsIgnored() const final;

--- a/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButton.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 AccessibilitySpinButton::AccessibilitySpinButton(AXID axID, AXObjectCache& cache)
-    : AccessibilityMockObject(axID)
+    : AccessibilityMockObject(axID, cache)
     , m_spinButtonElement(nullptr)
     , m_incrementor(downcast<AccessibilitySpinButtonPart>(*cache.create(AccessibilityRole::SpinButtonPart)))
     , m_decrementor(downcast<AccessibilitySpinButtonPart>(*cache.create(AccessibilityRole::SpinButtonPart)))

--- a/Source/WebCore/accessibility/AccessibilitySpinButtonPart.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySpinButtonPart.cpp
@@ -30,15 +30,15 @@
 
 namespace WebCore {
 
-AccessibilitySpinButtonPart::AccessibilitySpinButtonPart(AXID axID)
-    : AccessibilityMockObject(axID)
+AccessibilitySpinButtonPart::AccessibilitySpinButtonPart(AXID axID, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
     , m_isIncrementor(false)
 {
 }
 
-Ref<AccessibilitySpinButtonPart> AccessibilitySpinButtonPart::create(AXID axID)
+Ref<AccessibilitySpinButtonPart> AccessibilitySpinButtonPart::create(AXID axID, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilitySpinButtonPart(axID));
+    return adoptRef(*new AccessibilitySpinButtonPart(axID, cache));
 }
 
 LayoutRect AccessibilitySpinButtonPart::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilitySpinButtonPart.h
+++ b/Source/WebCore/accessibility/AccessibilitySpinButtonPart.h
@@ -31,14 +31,14 @@ namespace WebCore {
 
 class AccessibilitySpinButtonPart final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilitySpinButtonPart> create(AXID);
+    static Ref<AccessibilitySpinButtonPart> create(AXID, AXObjectCache&);
     virtual ~AccessibilitySpinButtonPart() = default;
 
     bool isIncrementor() const final { return m_isIncrementor; }
     void setIsIncrementor(bool value) { m_isIncrementor = value; }
 
 private:
-    explicit AccessibilitySpinButtonPart(AXID);
+    explicit AccessibilitySpinButtonPart(AXID, AXObjectCache&);
 
     bool press() final;
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::SpinButtonPart; }

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -56,15 +56,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityTable::AccessibilityTable(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityTable::AccessibilityTable(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
     , m_headerContainer(nullptr)
     , m_isExposable(true)
 {
 }
 
-AccessibilityTable::AccessibilityTable(AXID axID, Node& node)
-    : AccessibilityRenderObject(axID, node)
+AccessibilityTable::AccessibilityTable(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, node, cache)
     , m_headerContainer(nullptr)
     , m_isExposable(true)
 {
@@ -81,14 +81,14 @@ void AccessibilityTable::init()
     AccessibilityRenderObject::init();
 }
 
-Ref<AccessibilityTable> AccessibilityTable::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityTable> AccessibilityTable::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTable(axID, renderer));
+    return adoptRef(*new AccessibilityTable(axID, renderer, cache));
 }
 
-Ref<AccessibilityTable> AccessibilityTable::create(AXID axID, Node& node)
+Ref<AccessibilityTable> AccessibilityTable::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTable(axID, node));
+    return adoptRef(*new AccessibilityTable(axID, node, cache));
 }
 
 bool AccessibilityTable::hasNonTableARIARole() const

--- a/Source/WebCore/accessibility/AccessibilityTable.h
+++ b/Source/WebCore/accessibility/AccessibilityTable.h
@@ -38,8 +38,8 @@ class HTMLTableElement;
 
 class AccessibilityTable : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTable> create(AXID, RenderObject&);
-    static Ref<AccessibilityTable> create(AXID, Node&);
+    static Ref<AccessibilityTable> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityTable> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityTable();
 
     void init() final;
@@ -82,8 +82,8 @@ public:
     void setCellSlotsDirty();
 
 protected:
-    explicit AccessibilityTable(AXID, RenderObject&);
-    explicit AccessibilityTable(AXID, Node&);
+    explicit AccessibilityTable(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityTable(AXID, Node&, AXObjectCache&);
 
     AccessibilityChildrenVector m_rows;
     AccessibilityChildrenVector m_columns;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -42,26 +42,26 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityTableCell::AccessibilityTableCell(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityTableCell::AccessibilityTableCell(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-AccessibilityTableCell::AccessibilityTableCell(AXID axID, Node& node)
-    : AccessibilityRenderObject(axID, node)
+AccessibilityTableCell::AccessibilityTableCell(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, node, cache)
 {
 }
 
 AccessibilityTableCell::~AccessibilityTableCell() = default;
 
-Ref<AccessibilityTableCell> AccessibilityTableCell::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityTableCell> AccessibilityTableCell::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTableCell(axID, renderer));
+    return adoptRef(*new AccessibilityTableCell(axID, renderer, cache));
 }
 
-Ref<AccessibilityTableCell> AccessibilityTableCell::create(AXID axID, Node& node)
+Ref<AccessibilityTableCell> AccessibilityTableCell::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTableCell(axID, node));
+    return adoptRef(*new AccessibilityTableCell(axID, node, cache));
 }
 
 bool AccessibilityTableCell::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -37,8 +37,8 @@ class AccessibilityTableRow;
 
 class AccessibilityTableCell : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTableCell> create(AXID, RenderObject&);
-    static Ref<AccessibilityTableCell> create(AXID, Node&);
+    static Ref<AccessibilityTableCell> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityTableCell> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityTableCell();
     bool isTableCell() const final { return true; }
 
@@ -73,8 +73,8 @@ public:
 #endif
 
 protected:
-    explicit AccessibilityTableCell(AXID, RenderObject&);
-    explicit AccessibilityTableCell(AXID, Node&);
+    explicit AccessibilityTableCell(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityTableCell(AXID, Node&, AXObjectCache&);
 
     AccessibilityTableRow* parentRow() const;
     AccessibilityRole determineAccessibilityRole() final;

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -33,16 +33,16 @@
 
 namespace WebCore {
 
-AccessibilityTableColumn::AccessibilityTableColumn(AXID axID)
-    : AccessibilityMockObject(axID)
+AccessibilityTableColumn::AccessibilityTableColumn(AXID axID, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
 {
 }
 
 AccessibilityTableColumn::~AccessibilityTableColumn() = default;
 
-Ref<AccessibilityTableColumn> AccessibilityTableColumn::create(AXID axID)
+Ref<AccessibilityTableColumn> AccessibilityTableColumn::create(AXID axID, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTableColumn(axID));
+    return adoptRef(*new AccessibilityTableColumn(axID, cache));
 }
 
 void AccessibilityTableColumn::setParent(AccessibilityObject* parent)

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.h
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.h
@@ -36,7 +36,7 @@ class RenderTableSection;
 
 class AccessibilityTableColumn final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityTableColumn> create(AXID);
+    static Ref<AccessibilityTableColumn> create(AXID, AXObjectCache&);
     virtual ~AccessibilityTableColumn();
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Column; }
@@ -50,7 +50,7 @@ public:
     LayoutRect elementRect() const final;
 
 private:
-    explicit AccessibilityTableColumn(AXID);
+    explicit AccessibilityTableColumn(AXID, AXObjectCache&);
     
     bool computeIsIgnored() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp
@@ -34,16 +34,16 @@
 
 namespace WebCore {
 
-AccessibilityTableHeaderContainer::AccessibilityTableHeaderContainer(AXID axID)
-    : AccessibilityMockObject(axID)
+AccessibilityTableHeaderContainer::AccessibilityTableHeaderContainer(AXID axID, AXObjectCache& cache)
+    : AccessibilityMockObject(axID, cache)
 {
 }
 
 AccessibilityTableHeaderContainer::~AccessibilityTableHeaderContainer() = default;
 
-Ref<AccessibilityTableHeaderContainer> AccessibilityTableHeaderContainer::create(AXID axID)
+Ref<AccessibilityTableHeaderContainer> AccessibilityTableHeaderContainer::create(AXID axID, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTableHeaderContainer(axID));
+    return adoptRef(*new AccessibilityTableHeaderContainer(axID, cache));
 }
     
 LayoutRect AccessibilityTableHeaderContainer::elementRect() const

--- a/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
+++ b/Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class AccessibilityTableHeaderContainer final : public AccessibilityMockObject {
 public:
-    static Ref<AccessibilityTableHeaderContainer> create(AXID axID);
+    static Ref<AccessibilityTableHeaderContainer> create(AXID, AXObjectCache&);
     virtual ~AccessibilityTableHeaderContainer();
     
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::TableHeaderContainer; }
@@ -46,7 +46,7 @@ public:
     LayoutRect elementRect() const final;
 
 private:
-    explicit AccessibilityTableHeaderContainer(AXID);
+    explicit AccessibilityTableHeaderContainer(AXID, AXObjectCache&);
     
     bool computeIsIgnored() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -39,26 +39,26 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityTableRow::AccessibilityTableRow(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityTableRow::AccessibilityTableRow(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-AccessibilityTableRow::AccessibilityTableRow(AXID axID, Node& node)
-    : AccessibilityRenderObject(axID, node)
+AccessibilityTableRow::AccessibilityTableRow(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, node, cache)
 {
 }
 
 AccessibilityTableRow::~AccessibilityTableRow() = default;
 
-Ref<AccessibilityTableRow> AccessibilityTableRow::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityTableRow> AccessibilityTableRow::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTableRow(axID, renderer));
+    return adoptRef(*new AccessibilityTableRow(axID, renderer, cache));
 }
 
-Ref<AccessibilityTableRow> AccessibilityTableRow::create(AXID axID, Node& node)
+Ref<AccessibilityTableRow> AccessibilityTableRow::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTableRow(axID, node));
+    return adoptRef(*new AccessibilityTableRow(axID, node, cache));
 }
 
 AccessibilityRole AccessibilityTableRow::determineAccessibilityRole()

--- a/Source/WebCore/accessibility/AccessibilityTableRow.h
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.h
@@ -36,8 +36,8 @@ class AccessibilityTable;
 
 class AccessibilityTableRow : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTableRow> create(AXID, RenderObject&);
-    static Ref<AccessibilityTableRow> create(AXID, Node&);
+    static Ref<AccessibilityTableRow> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityTableRow> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityTableRow();
 
     virtual AccessibilityTable* parentTable() const;
@@ -55,8 +55,8 @@ public:
     std::optional<unsigned> axRowIndex() const final;
 
 protected:
-    explicit AccessibilityTableRow(AXID, RenderObject&);
-    explicit AccessibilityTableRow(AXID, Node&);
+    explicit AccessibilityTableRow(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityTableRow(AXID, Node&, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final;
 

--- a/Source/WebCore/accessibility/AccessibilityTree.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTree.cpp
@@ -40,26 +40,26 @@ namespace WebCore {
 
 using namespace HTMLNames;
     
-AccessibilityTree::AccessibilityTree(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityTree::AccessibilityTree(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-AccessibilityTree::AccessibilityTree(AXID axID, Node& node)
-    : AccessibilityRenderObject(axID, node)
+AccessibilityTree::AccessibilityTree(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, node, cache)
 {
 }
 
 AccessibilityTree::~AccessibilityTree() = default;
     
-Ref<AccessibilityTree> AccessibilityTree::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityTree> AccessibilityTree::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTree(axID, renderer));
+    return adoptRef(*new AccessibilityTree(axID, renderer, cache));
 }
 
-Ref<AccessibilityTree> AccessibilityTree::create(AXID axID, Node& node)
+Ref<AccessibilityTree> AccessibilityTree::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTree(axID, node));
+    return adoptRef(*new AccessibilityTree(axID, node, cache));
 }
 
 bool AccessibilityTree::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityTree.h
+++ b/Source/WebCore/accessibility/AccessibilityTree.h
@@ -37,13 +37,13 @@ namespace WebCore {
 // of the "accessibility tree".
 class AccessibilityTree final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTree> create(AXID, RenderObject&);
-    static Ref<AccessibilityTree> create(AXID, Node&);
+    static Ref<AccessibilityTree> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityTree> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityTree();
 
 private:
-    explicit AccessibilityTree(AXID, RenderObject&);
-    explicit AccessibilityTree(AXID, Node&);
+    explicit AccessibilityTree(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityTree(AXID, Node&, AXObjectCache&);
     bool computeIsIgnored() const final;
     AccessibilityRole determineAccessibilityRole() final;
     bool isTreeValid() const;

--- a/Source/WebCore/accessibility/AccessibilityTreeItem.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTreeItem.cpp
@@ -36,26 +36,26 @@ namespace WebCore {
     
 using namespace HTMLNames;
     
-AccessibilityTreeItem::AccessibilityTreeItem(AXID axID, RenderObject& renderer)
-    : AccessibilityRenderObject(axID, renderer)
+AccessibilityTreeItem::AccessibilityTreeItem(AXID axID, RenderObject& renderer, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, renderer, cache)
 {
 }
 
-AccessibilityTreeItem::AccessibilityTreeItem(AXID axID, Node& node)
-    : AccessibilityRenderObject(axID, node)
+AccessibilityTreeItem::AccessibilityTreeItem(AXID axID, Node& node, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, node, cache)
 {
 }
 
 AccessibilityTreeItem::~AccessibilityTreeItem() = default;
     
-Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(AXID axID, RenderObject& renderer)
+Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTreeItem(axID, renderer));
+    return adoptRef(*new AccessibilityTreeItem(axID, renderer, cache));
 }
 
-Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(AXID axID, Node& node)
+Ref<AccessibilityTreeItem> AccessibilityTreeItem::create(AXID axID, Node& node, AXObjectCache& cache)
 {
-    return adoptRef(*new AccessibilityTreeItem(axID, node));
+    return adoptRef(*new AccessibilityTreeItem(axID, node, cache));
 }
 
 bool AccessibilityTreeItem::supportsCheckedState() const

--- a/Source/WebCore/accessibility/AccessibilityTreeItem.h
+++ b/Source/WebCore/accessibility/AccessibilityTreeItem.h
@@ -34,15 +34,15 @@ namespace WebCore {
     
 class AccessibilityTreeItem final : public AccessibilityRenderObject {
 public:
-    static Ref<AccessibilityTreeItem> create(AXID, RenderObject&);
-    static Ref<AccessibilityTreeItem> create(AXID, Node&);
+    static Ref<AccessibilityTreeItem> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityTreeItem> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityTreeItem();
 
     bool supportsCheckedState() const final;
 
 private:
-    explicit AccessibilityTreeItem(AXID, RenderObject&);
-    explicit AccessibilityTreeItem(AXID, Node&);
+    explicit AccessibilityTreeItem(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityTreeItem(AXID, Node&, AXObjectCache&);
     bool shouldIgnoreAttributeRole() const final { return !m_isTreeItemValid; }
     AccessibilityRole determineAccessibilityRole() final;
     bool m_isTreeItemValid;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -1037,7 +1037,7 @@ RelationMap AccessibilityObjectAtspi::relationMap() const
     } else if (m_coreObject->role() == AccessibilityRole::Legend) {
         if (auto* renderFieldset = ancestorsOfType<RenderBlock>(*m_coreObject->renderer()).first()) {
             if (renderFieldset->isFieldset())
-                ariaLabelledByElements.append(*m_coreObject->axObjectCache()->getOrCreate(renderFieldset));
+                ariaLabelledByElements.append(*downcast<AccessibilityObject>(m_coreObject)->axObjectCache()->getOrCreate(renderFieldset));
         }
     } else {
         auto* liveObject = dynamicDowncast<AccessibilityObject>(m_coreObject.get());

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -192,7 +192,7 @@ RetainPtr<NSArray> AXTextMarkerRange::platformData() const
     if (!*this)
         return nil;
 
-    RefPtr object = m_start.object();
+    RefPtr object = downcast<AccessibilityObject>(m_start.object());
     ASSERT(object); // Since *this is not null.
     auto* cache = object->axObjectCache();
     if (!cache)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -152,7 +152,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 // This is needed for external clients to be able to create a text marker without having a pointer to the cache.
 - (id)initWithData:(NSData *)data accessibilityObject:(AccessibilityObjectWrapper *)wrapper
 {
-    WebCore::AXCoreObject* axObject = wrapper.axBackingObject;
+    RefPtr<AccessibilityObject> axObject = wrapper.axBackingObject;
     if (!axObject)
         return nil;
     

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -539,7 +539,7 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
 #endif
-    AXObjectCache* axObjectCache() const final;
+    AXObjectCache* axObjectCache() const;
     Element* actionElement() const final;
     Path elementPath() const final { return pathAttributeValue(AXProperty::Path); };
     bool supportsPath() const final { return boolAttributeValue(AXProperty::SupportsPath); }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1607,7 +1607,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
             if (!backingObject)
                 return nil;
 
@@ -1623,7 +1623,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
             if (!backingObject)
                 return nil;
 
@@ -2470,7 +2470,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)_accessibilityPrintTrees
 {
     Accessibility::performFunctionOnMainThread([protectedSelf = retainPtr(self)] {
-        RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+        RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         if (!backingObject)
             return;
 
@@ -2645,7 +2645,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (AXTextMarkerRef)_textMarkerForIndex:(NSInteger)textIndex
 {
     return Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRef>([&textIndex, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRef> {
-        RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+        RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         if (!backingObject)
             return nil;
 
@@ -2671,7 +2671,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 #if ENABLE(TREE_DEBUGGING)
 - (void)showNodeForTextMarker:(AXTextMarkerRef)textMarker
 {
-    auto visiblePosition = visiblePositionForTextMarker(self.axBackingObject->axObjectCache(), textMarker);
+    CheckedPtr cache = downcast<AccessibilityObject>(self.axBackingObject)->axObjectCache();
+    auto visiblePosition = visiblePositionForTextMarker(cache.get(), textMarker);
     RefPtr node = visiblePosition.deepEquivalent().deprecatedNode();
     if (!node)
         return;
@@ -2681,7 +2682,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)showNodeTreeForTextMarker:(AXTextMarkerRef)textMarker
 {
-    auto visiblePosition = visiblePositionForTextMarker(self.axBackingObject->axObjectCache(), textMarker);
+    CheckedPtr cache = downcast<AccessibilityObject>(self.axBackingObject)->axObjectCache();
+    auto visiblePosition = visiblePositionForTextMarker(cache.get(), textMarker);
     RefPtr node = visiblePosition.deepEquivalent().deprecatedNode();
     if (!node)
         return;
@@ -2728,7 +2730,7 @@ enum class TextUnit {
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     return Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRangeRef>([textMarker = retainPtr(textMarker), &textUnit, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRangeRef> {
-        RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+        RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         if (!backingObject)
             return nil;
 
@@ -2833,7 +2835,7 @@ enum class TextUnit {
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     return Accessibility::retrieveAutoreleasedValueFromMainThread<AXTextMarkerRef>([textMarkerRef = retainPtr(textMarkerRef), &textUnit, protectedSelf = retainPtr(self)] () -> RetainPtr<AXTextMarkerRef> {
-        RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+        RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
         if (!backingObject)
             return nil;
 
@@ -2983,7 +2985,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attribute isEqualToString:NSAccessibilitySearchTextWithCriteriaParameterizedAttribute]) {
         auto criteria = accessibilitySearchTextCriteriaForParameterizedAttribute(dictionary);
         return Accessibility::retrieveAutoreleasedValueFromMainThread<NSArray *>([&criteria, protectedSelf = retainPtr(self)] () -> RetainPtr<NSArray> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
             if (!backingObject)
                 return nil;
             auto ranges = backingObject->findTextRanges(criteria);
@@ -2997,7 +2999,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attribute isEqualToString:NSAccessibilityTextOperationParameterizedAttribute]) {
         auto operationResult = Accessibility::retrieveValueFromMainThread<Vector<String>>([dictionary, protectedSelf = retainPtr(self)] () -> Vector<String> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
             if (!backingObject)
                 return Vector<String>();
 
@@ -3066,11 +3068,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attribute isEqualToString:NSAccessibilityEndTextMarkerForBoundsAttribute]) {
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([&rect, protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
-            if (!backingObject)
-                return nil;
-
-            WeakPtr cache = backingObject->axObjectCache();
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
+            WeakPtr cache = backingObject ? backingObject->axObjectCache() : nullptr;
             if (!cache)
                 return nil;
 
@@ -3083,11 +3082,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attribute isEqualToString:NSAccessibilityStartTextMarkerForBoundsAttribute]) {
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([&rect, protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
-            if (!backingObject)
-                return nil;
-
-            WeakPtr cache = backingObject->axObjectCache();
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
+            WeakPtr cache = backingObject ? backingObject->axObjectCache() : nullptr;
             if (!cache)
                 return nil;
 
@@ -3214,7 +3210,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([&number, protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
             if (!backingObject)
                 return nil;
 
@@ -3290,7 +3286,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
         return Accessibility::retrieveValueFromMainThread<RetainPtr<NSString>>([&range, protectedSelf = retainPtr(self)] () -> RetainPtr<NSString> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
             if (!backingObject)
                 return @"";
             auto* cache = backingObject->axObjectCache();
@@ -3345,14 +3341,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
 #endif
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([textMarker = retainPtr(textMarker), protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
-            if (!backingObject)
-                return nil;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
+            WeakPtr cache = backingObject ? backingObject->axObjectCache() : nullptr;
 
-            auto* cache = backingObject->axObjectCache();
-            if (!cache)
-                return nil;
-            return nextTextMarker(cache, AXTextMarker { textMarker.get() }).bridgingAutorelease();
+            return nextTextMarker(cache.get(), AXTextMarker { textMarker.get() }).bridgingAutorelease();
         });
     }
 
@@ -3364,14 +3356,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
 #endif
         return Accessibility::retrieveAutoreleasedValueFromMainThread<id>([textMarker = retainPtr(textMarker), protectedSelf = retainPtr(self)] () -> RetainPtr<id> {
-            RefPtr<AXCoreObject> backingObject = protectedSelf.get().axBackingObject;
-            if (!backingObject)
-                return nil;
+            RefPtr backingObject = downcast<AccessibilityObject>(protectedSelf.get().axBackingObject);
+            WeakPtr cache = backingObject ? backingObject->axObjectCache() : nullptr;
 
-            auto* cache = backingObject->axObjectCache();
-            if (!cache)
-                return nil;
-            return previousTextMarker(cache, AXTextMarker { textMarker.get() }).bridgingAutorelease();
+            return previousTextMarker(cache.get(), AXTextMarker { textMarker.get() }).bridgingAutorelease();
         });
     }
 


### PR DESCRIPTION
#### d7d8a131bf98da957b2114e18a57d9b1ffb2366d
<pre>
AX: De-virtualize AccessibilityObject::axObjectCache as it regularly shows up in samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=296464">https://bugs.webkit.org/show_bug.cgi?id=296464</a>
<a href="https://rdar.apple.com/156663957">rdar://156663957</a>

Reviewed by Joshua Hoffman.

This commit makes an AccessibilityObject::m_axObjectCache member variable and remove the virtual implementation.
AccessibilityObject::axObject() regularly shows up as taking thousands of samples (i.e. seconds) to compute,
solved by making this a simple member variable read. This may increase the compilers ability to inline things in lots
more places too, as this method is called everywhere.

This commit also adds an [[unlikely]] annotation to the `parentObject` implementation of AccessibilityRenderObject and
AccessibilityNodeObject, as this method shows up heavily in samples too (partly because axObjectCache() was so weirdly
expensive, but this [[unlikely]] addition will still help).

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXImage.cpp:
(WebCore::AXImage::AXImage):
(WebCore::AXImage::create):
* Source/WebCore/accessibility/AXImage.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
(WebCore::AXObjectCache::createFromNode):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::create):
* Source/WebCore/accessibility/AXRemoteFrame.cpp:
(WebCore::AXRemoteFrame::AXRemoteFrame):
(WebCore::AXRemoteFrame::create):
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendAccessibilityObject):
* Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp:
(WebCore::AccessibilityARIAGridCell::AccessibilityARIAGridCell):
(WebCore::AccessibilityARIAGridCell::create):
* Source/WebCore/accessibility/AccessibilityARIAGridCell.h:
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::AccessibilityARIAGridRow):
(WebCore::AccessibilityARIAGridRow::create):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.h:
* Source/WebCore/accessibility/AccessibilityARIATable.cpp:
(WebCore::AccessibilityARIATable::AccessibilityARIATable):
(WebCore::AccessibilityARIATable::create):
* Source/WebCore/accessibility/AccessibilityARIATable.h:
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::AccessibilityAttachment):
(WebCore::AccessibilityAttachment::create):
* Source/WebCore/accessibility/AccessibilityAttachment.h:
* Source/WebCore/accessibility/AccessibilityImageMapLink.cpp:
(WebCore::AccessibilityImageMapLink::AccessibilityImageMapLink):
(WebCore::AccessibilityImageMapLink::create):
* Source/WebCore/accessibility/AccessibilityImageMapLink.h:
* Source/WebCore/accessibility/AccessibilityLabel.cpp:
(WebCore::AccessibilityLabel::AccessibilityLabel):
(WebCore::AccessibilityLabel::create):
* Source/WebCore/accessibility/AccessibilityLabel.h:
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::AccessibilityList):
(WebCore::AccessibilityList::create):
* Source/WebCore/accessibility/AccessibilityList.h:
* Source/WebCore/accessibility/AccessibilityListBox.cpp:
(WebCore::AccessibilityListBox::AccessibilityListBox):
(WebCore::AccessibilityListBox::create):
* Source/WebCore/accessibility/AccessibilityListBox.h:
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::AccessibilityListBoxOption):
(WebCore::AccessibilityListBoxOption::create):
* Source/WebCore/accessibility/AccessibilityListBoxOption.h:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::AccessibilityMathMLElement):
(WebCore::AccessibilityMathMLElement::create):
* Source/WebCore/accessibility/AccessibilityMathMLElement.h:
* Source/WebCore/accessibility/AccessibilityMediaObject.cpp:
(WebCore::AccessibilityMediaObject::AccessibilityMediaObject):
(WebCore::AccessibilityMediaObject::create):
* Source/WebCore/accessibility/AccessibilityMediaObject.h:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::AccessibilityMenuList):
* Source/WebCore/accessibility/AccessibilityMenuListOption.cpp:
(WebCore::AccessibilityMenuListOption::AccessibilityMenuListOption):
(WebCore::AccessibilityMenuListOption::create):
* Source/WebCore/accessibility/AccessibilityMenuListOption.h:
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::AccessibilityMenuListPopup):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.h:
* Source/WebCore/accessibility/AccessibilityMockObject.cpp:
(WebCore::AccessibilityMockObject::AccessibilityMockObject):
* Source/WebCore/accessibility/AccessibilityMockObject.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::AccessibilityNodeObject):
(WebCore::AccessibilityNodeObject::create):
(WebCore::AccessibilityNodeObject::parentObject const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::AccessibilityObject):
(WebCore::AccessibilityObject::axObjectCache const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::axObjectCache const):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::AccessibilityProgressIndicator):
(WebCore::AccessibilityProgressIndicator::create):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::AccessibilityRenderObject):
(WebCore::AccessibilityRenderObject::create):
(WebCore::AccessibilityRenderObject::parentObject const):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::AccessibilitySVGObject):
(WebCore::AccessibilitySVGObject::create):
* Source/WebCore/accessibility/AccessibilitySVGObject.h:
(): Deleted.
* Source/WebCore/accessibility/AccessibilitySVGRoot.cpp:
(WebCore::AccessibilitySVGRoot::AccessibilitySVGRoot):
(WebCore::AccessibilitySVGRoot::create):
* Source/WebCore/accessibility/AccessibilitySVGRoot.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::AccessibilityScrollView):
(WebCore::AccessibilityScrollView::create):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibilityScrollbar.cpp:
(WebCore::AccessibilityScrollbar::AccessibilityScrollbar):
(WebCore::AccessibilityScrollbar::create):
* Source/WebCore/accessibility/AccessibilityScrollbar.h:
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::AccessibilitySlider):
(WebCore::AccessibilitySlider::create):
(WebCore::AccessibilitySliderThumb::AccessibilitySliderThumb):
(WebCore::AccessibilitySliderThumb::create):
* Source/WebCore/accessibility/AccessibilitySlider.h:
* Source/WebCore/accessibility/AccessibilitySpinButton.cpp:
(WebCore::AccessibilitySpinButton::AccessibilitySpinButton):
* Source/WebCore/accessibility/AccessibilitySpinButtonPart.cpp:
(WebCore::AccessibilitySpinButtonPart::AccessibilitySpinButtonPart):
(WebCore::AccessibilitySpinButtonPart::create):
* Source/WebCore/accessibility/AccessibilitySpinButtonPart.h:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
(WebCore::AccessibilityTable::AccessibilityTable):
(WebCore::AccessibilityTable::create):
* Source/WebCore/accessibility/AccessibilityTable.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::AccessibilityTableCell):
(WebCore::AccessibilityTableCell::create):
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::AccessibilityTableColumn):
(WebCore::AccessibilityTableColumn::create):
* Source/WebCore/accessibility/AccessibilityTableColumn.h:
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.cpp:
(WebCore::AccessibilityTableHeaderContainer::AccessibilityTableHeaderContainer):
(WebCore::AccessibilityTableHeaderContainer::create):
* Source/WebCore/accessibility/AccessibilityTableHeaderContainer.h:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::AccessibilityTableRow):
(WebCore::AccessibilityTableRow::create):
* Source/WebCore/accessibility/AccessibilityTableRow.h:
* Source/WebCore/accessibility/AccessibilityTree.cpp:
(WebCore::AccessibilityTree::AccessibilityTree):
(WebCore::AccessibilityTree::create):
* Source/WebCore/accessibility/AccessibilityTree.h:
* Source/WebCore/accessibility/AccessibilityTreeItem.cpp:
(WebCore::AccessibilityTreeItem::AccessibilityTreeItem):
(WebCore::AccessibilityTreeItem::create):
* Source/WebCore/accessibility/AccessibilityTreeItem.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(-[WebAccessibilityObjectWrapper _accessibilityPrintTrees]):
(-[WebAccessibilityObjectWrapper _textMarkerForIndex:]):
(-[WebAccessibilityObjectWrapper showNodeForTextMarker:]):
(-[WebAccessibilityObjectWrapper showNodeTreeForTextMarker:]):
(-[WebAccessibilityObjectWrapper textMarkerRangeAtTextMarker:forUnit:]):
(-[WebAccessibilityObjectWrapper textMarkerForTextMarker:atUnit:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/297879@main">https://commits.webkit.org/297879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2757c43860af2afc06bb9400903d5a36df8711a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86165 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66485 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19968 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63167 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122630 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94758 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24181 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17718 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36419 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45668 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->