### PR TITLE
Very low framerate on youtube.com when system is under load

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -42,7 +42,6 @@
 OBJC_CLASS AVSampleBufferDisplayLayer;
 OBJC_CLASS AVSampleBufferVideoRenderer;
 OBJC_PROTOCOL(WebSampleBufferVideoRendering);
-typedef struct opaqueCMBufferQueue *CMBufferQueueRef;
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 typedef struct OpaqueCMTimebase* CMTimebaseRef;
 typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
@@ -104,6 +103,8 @@ public:
 
     void setResourceOwner(const ProcessIdentity&);
 
+    static WorkQueue& queueSingleton();
+
 private:
     VideoMediaSampleRenderer(WebSampleBufferVideoRendering *);
 
@@ -158,7 +159,7 @@ private:
     bool useDecompressionSessionForProtectedContent() const;
     bool useStereoDecoding() const;
 
-    const RefPtr<WTF::WorkQueue> m_workQueue;
+    const bool m_rendererIsThreadSafe { false };
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
 #if HAVE(AVSAMPLEBUFFERVIDEORENDERER)
     RetainPtr<AVSampleBufferVideoRenderer> m_renderer;


### PR DESCRIPTION
#### 448ac3794648a33e8ce7c4a936dff24ad443515c
<pre>
Very low framerate on youtube.com when system is under load
<a href="https://bugs.webkit.org/show_bug.cgi?id=296474">https://bugs.webkit.org/show_bug.cgi?id=296474</a>
<a href="https://rdar.apple.com/156331158">rdar://156331158</a>

Reviewed by Jer Noble.

We enqueued samples to be decoded and rendered using a standard priority thread
to be decoded by the WebCoreDecompressionSession.
When the AVSampleBufferDisplayLayer was doing this work, it used a queue
with elevated priority to decode video. This allowed videos to play smoothly
even when the system was under very heavy load.

We make the VideoMediaSampleRenderer use a common queue now with UserInteractive
priority.
We also allow for a way to optionally provide a workqueue to the WebCoreDecompressionSession
to enqueue frame to the VTDecompressionSession. We now share the VideoMediaSampleRenderer&apos;s
queue with the WebCoreDecompressionSession so that both tasks run at the same priority.

No change to JS observable behaviour, covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/297881@main">https://commits.webkit.org/297881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff04ab2f71773058acefc07e6d2a2144203e3a6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19986 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63202 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122665 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95037 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94779 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17734 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45703 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->