### PR TITLE
Optimize change of text in trivial container using strict containment

### DIFF
--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-expected.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <body>
+    <div>
+      <span>baar</span>
+      <span>baarbaar baarbaar</span>
+      <span>baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span>baar baar baar baar</span>
+      <span>baar</span>
+      <span>b &#x55e8;</span>
+      <span>baar&#9;baar&#9;baar&#9;baar</span>
+      <span>baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+    <div>
+      <span class="first-line">baar</span>
+      <span class="first-line">baarbaar baarbaar</span>
+      <span class="first-line">baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span class="first-line">baar baar baar baar</span>
+      <span class="first-line">baar</span>
+      <span class="first-line">b &#x55e8;</span>
+      <span class="first-line">baar&#9;baar&#9;baar&#9;baar</span>
+      <span class="first-line">baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl-expected.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl-expected.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        direction: rtl;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <body>
+    <div>
+      <span>baar</span>
+      <span>baarbaar baarbaar</span>
+      <span>baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span>baar baar baar baar</span>
+      <span>baar</span>
+      <span>b &#x55e8;</span>
+      <span>baar&#9;baar&#9;baar&#9;baar</span>
+      <span>baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+    <div>
+      <span class="first-line">baar</span>
+      <span class="first-line">baarbaar baarbaar</span>
+      <span class="first-line">baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span class="first-line">baar baar baar baar</span>
+      <span class="first-line">baar</span>
+      <span class="first-line">b &#x55e8;</span>
+      <span class="first-line">baar&#9;baar&#9;baar&#9;baar</span>
+      <span class="first-line">baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        direction: rtl;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <script>
+    const originalValues = [
+        "foo",
+        "foofoo foofoo",
+        "foofoofoo foofoofoo foofoofoo foofoofoo foofoofoo",
+        "foo",
+        "foo foo foo foo foo",
+        "foo",
+        "foo",
+        "foo",
+    ];
+    const newValues = [
+        "baar",
+        "baarbaar baarbaar",
+        "baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar",
+        "baar baar baar baar",
+        "baar",
+        "b \u55e8",
+        "baar\tbaar\tbaar\tbaar",
+        "baar\nbaar\nbaar\nbaar",
+    ];
+    function setupTest() {
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.className = "first-line";
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+    }
+    function changeTextNodeData() {
+        let divs = document.getElementsByTagName("span");
+        for (let i = 0; i < divs.length; i++) {
+            divs[i].childNodes[0].data = newValues[i % newValues.length];
+        }
+    }
+    function runTest() {
+        setupTest();
+        document.body.offsetLeft; // Force layout.
+        changeTextNodeData();
+    }
+  </script>
+  <body onload="runTest();">
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right-expected.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right-expected.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        text-align: right;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <body>
+    <div>
+      <span>baar</span>
+      <span>baarbaar baarbaar</span>
+      <span>baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span>baar baar baar baar</span>
+      <span>baar</span>
+      <span>b &#x55e8;</span>
+      <span>baar&#9;baar&#9;baar&#9;baar</span>
+      <span>baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+    <div>
+      <span class="first-line">baar</span>
+      <span class="first-line">baarbaar baarbaar</span>
+      <span class="first-line">baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar</span>
+      <span class="first-line">baar baar baar baar</span>
+      <span class="first-line">baar</span>
+      <span class="first-line">b &#x55e8;</span>
+      <span class="first-line">baar&#9;baar&#9;baar&#9;baar</span>
+      <span class="first-line">baar&#10;baar&#10;baar&#10;baar</span>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+        text-align: right;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <script>
+    const originalValues = [
+        "foo",
+        "foofoo foofoo",
+        "foofoofoo foofoofoo foofoofoo foofoofoo foofoofoo",
+        "foo",
+        "foo foo foo foo foo",
+        "foo",
+        "foo",
+        "foo",
+    ];
+    const newValues = [
+        "baar",
+        "baarbaar baarbaar",
+        "baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar",
+        "baar baar baar baar",
+        "baar",
+        "b \u55e8",
+        "baar\tbaar\tbaar\tbaar",
+        "baar\nbaar\nbaar\nbaar",
+    ];
+    function setupTest() {
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.className = "first-line";
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+    }
+    function changeTextNodeData() {
+        let divs = document.getElementsByTagName("span");
+        for (let i = 0; i < divs.length; i++) {
+            divs[i].childNodes[0].data = newValues[i % newValues.length];
+        }
+    }
+    function runTest() {
+        setupTest();
+        document.body.offsetLeft; // Force layout.
+        changeTextNodeData();
+    }
+  </script>
+  <body onload="runTest();">
+  </body>
+</html>

--- a/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container.html
+++ b/LayoutTests/fast/text/change-text-node-data-in-contain-strict-container.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <style>
+    body {
+        font-size: 0px;
+    }
+    span {
+        display: inline-block;
+        background: silver;
+        width: 100px;
+        height: 100px;
+        margin: 20px;
+        font-size: 25px;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+    }
+    .first-line::first-line {
+        font-size: 35px;
+    }
+  </style>
+  <script>
+    const originalValues = [
+        "foo",
+        "foofoo foofoo",
+        "foofoofoo foofoofoo foofoofoo foofoofoo foofoofoo",
+        "foo",
+        "foo foo foo foo foo",
+        "foo",
+        "foo",
+        "foo",
+    ];
+    const newValues = [
+        "baar",
+        "baarbaar baarbaar",
+        "baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar baarbaarbaar",
+        "baar baar baar baar",
+        "baar",
+        "b \u55e8",
+        "baar\tbaar\tbaar\tbaar",
+        "baar\nbaar\nbaar\nbaar",
+    ];
+    function setupTest() {
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+
+        {
+            let div = document.createElement("div");
+            originalValues.forEach((text) => {
+                let span = document.createElement("span");
+                span.className = "first-line";
+                span.appendChild(document.createTextNode(text));
+                div.appendChild(span);
+            });
+            document.body.appendChild(div);
+        }
+    }
+    function changeTextNodeData() {
+        let divs = document.getElementsByTagName("span");
+        for (let i = 0; i < divs.length; i++) {
+            divs[i].childNodes[0].data = newValues[i % newValues.length];
+        }
+    }
+    function runTest() {
+        setupTest();
+        document.body.offsetLeft; // Force layout.
+        changeTextNodeData();
+    }
+  </script>
+  <body onload="runTest();">
+  </body>
+</html>

--- a/PerformanceTests/Containment/change-text-in-large-grid.html
+++ b/PerformanceTests/Containment/change-text-in-large-grid.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+        display: grid;
+        grid: repeat(100, 30px) / repeat(100, 60px);
+    }
+    span {
+        border: solid;
+        width: 60px;
+        height: 30px;
+        box-sizing: border-box;
+        contain: strict;
+        line-height: 1;
+        white-space: pre;
+    }
+  </style>
+  <script src="../resources/runner.js"></script>
+  <script>
+    let textNodes = [];
+    function populateData() {
+        for (let i = 0; i < 100*100; i++) {
+            let span = document.createElement('span');
+            span.classList.add('cell');
+            let textNode = document.createTextNode('' + (100 * Math.random()).toFixed(2));
+            span.appendChild(textNode);
+            document.body.appendChild(span);
+            textNodes.push(textNode);
+        }
+    }
+    function forceLayout() {
+        document.body.offsetHeight;
+    }
+    function startTest() {
+        populateData();
+        forceLayout();
+        PerfTestRunner.measureRunsPerSecond({
+            description: "Measures performance of changing text nodes content.",
+            run: function() {
+                for (let i = 0; i < textNodes.length; i++) {
+                    textNodes[i].data = '' + (100 * Math.random()).toFixed(2);
+                }
+                document.body.offsetHeight;
+                forceLayout();
+            },
+        });
+    }
+  </script>
+</head>
+<body onload="startTest();">
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -145,6 +145,7 @@ struct Box {
     void setHasContent() { m_hasContent = true; }
     void setIsFullyTruncated() { m_isFullyTruncated = true; }
 
+    void setText(Text&&);
     Text& text() LIFETIME_BOUND { ASSERT(isTextOrSoftLineBreak()); return m_text; }
     const Text& text() const LIFETIME_BOUND { ASSERT(isTextOrSoftLineBreak()); return m_text; }
 
@@ -306,6 +307,11 @@ inline void Box::setRect(const FloatRect& rect, const FloatRect& inkOverflow)
 {
     m_unflippedVisualRect = rect;
     m_inkOverflow = inkOverflow;
+}
+
+inline void Box::setText(Text&& text)
+{
+    m_text = WTF::move(text);
 }
 
 inline void Box::removeFromGlyphDisplayListCache()

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -734,6 +734,19 @@ FloatRect LineLayout::applySVGTextFragments(SVGTextFragmentMap&& fragmentMap)
     return fullBoundaries;
 }
 
+bool LineLayout::preventsSkippingLayout() const
+{
+    // Line layout does not have enough information to tell if layout can be skipped but
+    // it has enough information to tell that it definitely cannot be skipped.
+
+    if (!m_inlineContent)
+        return true;
+
+    return m_inlineContent->displayContent().lines.size() != 1
+        || m_inlineContent->displayContent().boxes.size() != 2
+        || m_inlineContent->displayContent().boxes[0].isText() == m_inlineContent->displayContent().boxes[1].isText();
+}
+
 void LineLayout::preparePlacedFloats()
 {
     auto& placedFloats = m_blockFormattingState.placedFloats();
@@ -1481,6 +1494,23 @@ bool LineLayout::updateTextContent(const RenderText& textRenderer, std::optional
 
     int delta = inlineTextBox->content().length() - oldLength;
     return delta >= 0 ? invalidation.textInserted(inlineTextBox, offset) : invalidation.textWillBeRemoved(inlineTextBox, offset);
+}
+
+bool LineLayout::propagateInplaceTextContentChange(const RenderText& textRenderer)
+{
+    if (!m_inlineContent)
+        return false;
+
+    const CheckedPtr inlineTextBox = textRenderer.layoutBox();
+    auto box = std::find_if(m_inlineContent->displayContent().boxes.begin(), m_inlineContent->displayContent().boxes.end(), [&inlineTextBox](const auto& box) {
+        return &box.layoutBox() == inlineTextBox;
+    });
+    if (box == m_inlineContent->displayContent().boxes.end())
+        return false;
+    box->setText(InlineDisplay::Box::Text { 0, textRenderer.text().length(), textRenderer.text() });
+    box->removeFromGlyphDisplayListCache();
+
+    return true;
 }
 
 void LineLayout::releaseCaches(RenderView& view)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -87,6 +87,7 @@ public:
     bool insertedIntoTree(const RenderElement& parent, RenderObject& child);
     bool removedFromTree(const RenderElement& parent, RenderObject& child);
     bool updateTextContent(const RenderText&, std::optional<size_t> offset, size_t oldLength);
+    bool propagateInplaceTextContentChange(const RenderText&);
     bool rootStyleWillChange(const RenderBlockFlow&, const Style::ComputedStyle& newStyle);
     bool styleWillChange(const RenderElement&, const Style::ComputedStyle& newStyle, Style::Difference);
     bool boxContentWillChange(const RenderBox&);
@@ -149,6 +150,8 @@ public:
     FloatRect applySVGTextFragments(SVGTextFragmentMap&&);
 
     bool NODELETE hasBlocks() const;
+
+    bool preventsSkippingLayout() const;
 
 private:
     void preparePlacedFloats();

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1897,7 +1897,40 @@ static void invalidateLineLayoutPathOnContentChangeIfNeeded(RenderText& renderer
         container->invalidateLineLayout(RenderBlockFlow::InvalidationReason::ContentChange);
 }
 
-void RenderText::setTextInternal(const String& text, bool force)
+static void updateLineLayoutPathOnInplaceContentChangeIfNeeded(RenderText& renderer, std::optional<size_t> offset, size_t oldLength)
+{
+    auto* container = LayoutIntegration::LineLayout::blockContainer(renderer);
+    if (!container)
+        return;
+
+    auto* inlineLayout = container->inlineLayout();
+    if (!inlineLayout)
+        return;
+
+    if (!inlineLayout->updateTextContent(renderer, offset, oldLength) || !inlineLayout->propagateInplaceTextContentChange(renderer))
+        container->invalidateLineLayout(RenderBlockFlow::InvalidationReason::ContentChange);
+}
+
+bool RenderText::canSkipLayout(const String& newText) const
+{
+    // Under certain circumstances it's possible to skip layout despite text node change.
+    // In such case it's just enough to propagate text change internally and trigger repaint.
+
+    if (auto* container = dynamicDowncast<RenderBlockFlow>(parent())) {
+        return container->style().usedContain().containsAll({ Style::ContainValue::Size, Style::ContainValue::Layout, Style::ContainValue::Style, Style::ContainValue::Paint })
+            && container->style().whiteSpaceCollapse() == WhiteSpaceCollapse::Preserve
+            && container->style().textWrapMode() == TextWrapMode::NoWrap
+            && container->style().writingMode().isBidiLTR()
+            && (container->style().textAlign() == Style::TextAlign::Start || container->style().textAlign() == Style::TextAlign::Left)
+            && container->inlineLayout()
+            && !container->inlineLayout()->preventsSkippingLayout()
+            && !newText.contains('\n');
+    }
+
+    return false;
+}
+
+void RenderText::setTextInternal(const String& text, bool force, bool skipLayout)
 {
     ASSERT(!text.isNull());
 
@@ -1910,7 +1943,14 @@ void RenderText::setTextInternal(const String& text, bool force)
         m_originalTextDiffersFromRendered = false;
     }
 
-    updateRenderedText(text);
+    setRenderedText(text);
+
+    if (skipLayout)
+        parent()->repaint();
+    else
+        invalidateContentLogicalWidths();
+
+    m_knownToHaveNoOverflowAndNoFallbackFonts = false;
 
     if (AXObjectCache* cache = document().existingAXObjectCache())
         cache->deferTextChangedIfNeeded(textNode());
@@ -1938,9 +1978,14 @@ void RenderText::updateRenderedText()
 void RenderText::setText(const String& newContent, bool force)
 {
     auto isDifferent = newContent != text();
-    setTextInternal(newContent, force);
-    if (isDifferent || force)
-        invalidateLineLayoutPathOnContentChangeIfNeeded(*this, { }, { });
+    const auto skipLayout = canSkipLayout(newContent);
+    setTextInternal(newContent, force, skipLayout);
+    if (isDifferent || force) {
+        if (skipLayout)
+            updateLineLayoutPathOnInplaceContentChangeIfNeeded(*this, { }, { });
+        else
+            invalidateLineLayoutPathOnContentChangeIfNeeded(*this, { }, { });
+    }
 }
 
 void RenderText::setTextWithOffset(const String& newText, unsigned offset)
@@ -1949,8 +1994,12 @@ void RenderText::setTextWithOffset(const String& newText, unsigned offset)
         return;
 
     size_t oldLength = text().length();
-    setTextInternal(newText, false);
-    invalidateLineLayoutPathOnContentChangeIfNeeded(*this, offset, oldLength);
+    const auto skipLayout = canSkipLayout(newText);
+    setTextInternal(newText, false, skipLayout);
+    if (skipLayout)
+        updateLineLayoutPathOnInplaceContentChangeIfNeeded(*this, offset, oldLength);
+    else
+        invalidateLineLayoutPathOnContentChangeIfNeeded(*this, offset, oldLength);
 }
 
 String RenderText::textWithoutConvertingBackslashToYenSymbol() const

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -198,7 +198,7 @@ protected:
     virtual void setRenderedText(const String&);
     virtual char32_t previousCharacter() const;
 
-    virtual void setTextInternal(const String&, bool force);
+    virtual void setTextInternal(const String&, bool force, bool skipLayout = false);
 
 private:
     void updateRenderedText();
@@ -234,6 +234,8 @@ private:
     float maxWordFragmentWidth(const Style::ComputedStyle&, const FontCascade&, StringView word, unsigned minimumPrefixLength, unsigned minimumSuffixLength, bool currentCharacterIsSpace, unsigned characterIndex, float xPos, float entireWordWidth, WordTrailingSpace&, SingleThreadWeakHashSet<const Font>& fallbackFonts, GlyphOverflow&);
     float widthFromCacheConsideringPossibleTrailingSpace(const Style::ComputedStyle&, const FontCascade&, unsigned startIndex, unsigned wordLen, float xPos, bool currentCharacterIsSpace, WordTrailingSpace&, SingleThreadWeakHashSet<const Font>& fallbackFonts, GlyphOverflow&) const;
     void initiateFontLoadingByAccessingGlyphDataAndComputeCanUseSimplifiedTextMeasuring(const String&);
+
+    bool canSkipLayout(const String&) const;
 
 #if ENABLE(TEXT_AUTOSIZING)
     // FIXME: This should probably be part of the text sizing structures in Document instead. That would save some memory.

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -79,7 +79,7 @@ bool RenderTextFragment::canBeSelectionLeaf() const
     return anonymousInlineWrapper && anonymousInlineWrapper->firstLetterRemainingText();
 }
 
-void RenderTextFragment::setTextInternal(const String& newText, bool force)
+void RenderTextFragment::setTextInternal(const String& newText, bool force, bool)
 {
     RenderText::setTextInternal(newText, force);
 

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -58,7 +58,7 @@ public:
     void setAltText(const String& altText) { m_altText = altText; }
     
 private:
-    void setTextInternal(const String&, bool force) override;
+    void setTextInternal(const String&, bool force, bool) override;
     void setTextWithOffset(const String&, unsigned offset) override;
     Node* nodeForHitTest() const override;
     char32_t previousCharacter() const override;

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -98,7 +98,7 @@ String RenderSVGInlineText::originalText() const
     return textNode().data();
 }
 
-void RenderSVGInlineText::setTextInternal(const String& newText, bool force)
+void RenderSVGInlineText::setTextInternal(const String& newText, bool force, bool)
 {
     RenderText::setTextInternal(newText, force);
     m_legacyLineBoxes.dirtyForTextChange(*this);

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -76,7 +76,7 @@ private:
     PositionWithAffinity positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
     IntRect linesBoundingBox() const override;
 
-    void setTextInternal(const String&, bool force) final;
+    void setTextInternal(const String&, bool force, bool) final;
 
     float m_scalingFactor;
     FontCascade m_scaledFont;


### PR DESCRIPTION
#### 5795d84f413da15d124eaaff7ef1ac5b92cdea5c
<pre>
Optimize change of text in trivial container using strict containment
<a href="https://bugs.webkit.org/show_bug.cgi?id=296475">https://bugs.webkit.org/show_bug.cgi?id=296475</a>

Reviewed by NOBODY (OOPS!).

This change implements the conditional optimization that - under
certain circumstances - allows WebKit to skip the layout while
updating the text of the text node.

Being more specific, when the text of text node is updated, and the
text node&apos;s container is trivial i.e.:
- uses strict containment
- does not allow for line breaking
- contains a single line of text with a single text box
- has LTR text direction
- has text aligned to the left
the layout can be skipped as no box measurements need to be updated
and no line box layout changes are required (other than changing text).
It effectively means that text change can be as trivial as updating
it in the internal data structures and repainting.

* LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-expected.html: Added.
* LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl-expected.html: Added.
* LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-direction-rtl.html: Added.
* LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right-expected.html: Added.
* LayoutTests/fast/text/change-text-node-data-in-contain-strict-container-with-text-align-right.html: Added.
* LayoutTests/fast/text/change-text-node-data-in-contain-strict-container.html: Added.
Add layout tests for ok-cases and corner-cases.

* PerformanceTests/Containment/change-text-in-large-grid.html: Added.
Add performance test that demonstrates the optimization gives ~5x boost.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::setText):
Add method to replace existing Text.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::preventsSkippingLayout const):
Add method that determines if skipping layout is definitely not possible.
(WebCore::LayoutIntegration::LineLayout::propagateInplaceTextContentChange):
Add method for propagating text update in-place.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
Ditto.

* Source/WebCore/rendering/RenderText.cpp:
(WebCore::updateLineLayoutPathOnInplaceContentChangeIfNeeded):
Add function that either updates line layout in-place or invalidates
it completely if it&apos;s necessary.
(WebCore::RenderText::canSkipLayout const):
Add method that encapsulates the logic for determining whether the
optimization can be applied or not.
(WebCore::RenderText::setTextInternal):
Apply the optimization if possible.
(WebCore::RenderText::setText):
Ditto.
(WebCore::RenderText::setTextWithOffset):
Ditto.
* Source/WebCore/rendering/RenderText.h:
Ditto.
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::setTextInternal):
Align method to new API.
* Source/WebCore/rendering/RenderTextFragment.h:
Ditto.
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::setTextInternal):
Ditto.
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5795d84f413da15d124eaaff7ef1ac5b92cdea5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/55156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197801 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/152179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/189472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/61158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146487 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101245 "3 flakes 34 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/50213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/127004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46780 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46579 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8912 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199851 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/61036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/166511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/156175 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61756 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/43083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155827 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/50139 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133869 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131478 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/60133 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->