### PR TITLE
More smart pointer adoption in UIProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -69,9 +69,7 @@ Shared/mac/AuxiliaryProcessMac.mm
 Shared/mac/ScrollingAccelerationCurveMac.mm
 UIProcess/API/C/mac/WKNotificationPrivateMac.mm
 UIProcess/API/C/mac/WKProtectionSpaceNS.mm
-UIProcess/API/Cocoa/APIAttachmentCocoa.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
-UIProcess/API/Cocoa/WKContentRuleListStore.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
@@ -148,7 +146,6 @@ UIProcess/Cocoa/WebPageProxyCocoa.mm
 UIProcess/Cocoa/WebProcessPoolCocoa.mm
 UIProcess/Cocoa/WebProcessProxyCocoa.mm
 UIProcess/Cocoa/_WKWarningView.mm
-UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
 UIProcess/Extensions/WebExtensionController.h
 UIProcess/Gamepad/mac/UIGamepadProviderMac.mm
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
@@ -194,7 +191,6 @@ UIProcess/mac/WKQuickLookPreviewController.mm
 UIProcess/mac/WKRevealItemPresenter.mm
 UIProcess/mac/WKSharingServicePickerDelegate.mm
 UIProcess/mac/WKTextAnimationManagerMac.mm
-UIProcess/mac/WKTextFinderClient.mm
 UIProcess/mac/WebColorPickerMac.mm
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -209,7 +209,8 @@ void Attachment::updateFromSerializedRepresentation(Ref<WebCore::SharedBuffer>&&
     if (!serializedData)
         return;
 
-    RetainPtr fileWrapper = [NSKeyedUnarchiver unarchivedObjectOfClasses:pageClient->serializableFileWrapperClasses() fromData:serializedData.get() error:nullptr];
+    RetainPtr classes = pageClient->serializableFileWrapperClasses();
+    RetainPtr fileWrapper = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes.get() fromData:serializedData.get() error:nullptr];
     if (![fileWrapper isKindOfClass:NSFileWrapper.class])
         return;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -103,7 +103,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
             // We want to use error.message, but here we want to only pass on CompileFailed with userInfo from the std::error_code.
             return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorContentRuleListStoreCompileFailed userInfo:userInfo.get()]);
         }
-        completionHandler(wrapper(*contentRuleList), nil);
+        completionHandler(wrapper(WTFMove(contentRuleList)).get(), nil);
     });
 #endif
 }
@@ -119,7 +119,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
             return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:wkError userInfo:userInfo.get()]);
         }
 
-        completionHandler(wrapper(*contentRuleList), nil);
+        completionHandler(wrapper(WTFMove(contentRuleList)).get(), nil);
     });
 #endif
 }

--- a/Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm
@@ -49,7 +49,8 @@
 
 - (void)findPreferenceChangesAndNotifyForKeys:(NSDictionary<NSString *, id> *)oldValues toValuesForKeys:(NSDictionary<NSString *, id> *)newValues
 {
-    if (!m_observer)
+    RetainPtr strongObserver = m_observer.get();
+    if (!strongObserver)
         return;
 
     for (NSString *key in oldValues) {
@@ -80,10 +81,10 @@
         };
 
         if (preferenceValuesAreEqual((__bridge id)systemValue.get(), newValue.get()) || preferenceValuesAreEqual((__bridge id)globalValue.get(), newValue.get()))
-            [m_observer preferenceDidChange:nil key:key encodedValue:encodedString.get()];
+            [strongObserver.get() preferenceDidChange:nil key:key encodedValue:encodedString.get()];
 
         if (preferenceValuesAreEqual((__bridge id)domainValue.get(), newValue.get()))
-            [m_observer preferenceDidChange:m_suiteName.get() key:key encodedValue:encodedString.get()];
+            [strongObserver.get() preferenceDidChange:m_suiteName.get() key:key encodedValue:encodedString.get()];
     }
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -192,7 +192,8 @@ bool WebExtension::validateResourceData(NSURL *resourceURL, NSData *resourceData
     if (!staticCode)
         return false;
 
-    NSURL *bundleSupportFilesURL = CFBridgingRelease(CFBundleCopySupportFilesDirectoryURL(m_bundle.get()._cfBundle));
+    RetainPtr<__CFBundle> bundle = m_bundle.get()._cfBundle;
+    NSURL *bundleSupportFilesURL = CFBridgingRelease(CFBundleCopySupportFilesDirectoryURL(bundle.get()));
     NSString *bundleSupportFilesURLString = bundleSupportFilesURL.absoluteString;
     NSString *resourceURLString = resourceURL.absoluteString;
     ASSERT([resourceURLString hasPrefix:bundleSupportFilesURLString]);

--- a/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextFinderClient.mm
@@ -299,7 +299,8 @@ private:
             rectsArray = createNSArray(rects);
         else
             rectsArray = @[];
-        return adoptNS([[WKTextFinderMatch alloc] initWithClient:self view:_view index:index++ rects:rectsArray.get()]);
+        RetainPtr strongView = _view;
+        return adoptNS([[WKTextFinderMatch alloc] initWithClient:self view:strongView.get() index:index++ rects:rectsArray.get()]);
     });
 
     _findReplyCallbacks.takeFirst()(matchObjects.get(), didWrapAround);


### PR DESCRIPTION
#### 41d2dffe94b0715c092eda1c9e205e644695ac77
<pre>
More smart pointer adoption in UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=296379">https://bugs.webkit.org/show_bug.cgi?id=296379</a>

Reviewed by Timothy Hatcher.

Fix [alpha.webkit.UnretainedCallArgsChecker] warnings in UIProcess.

* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::updateFromSerializedRepresentation):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore compileContentRuleListForIdentifier:encodedContentRuleList:completionHandler:]):
(-[WKContentRuleListStore lookUpContentRuleListForIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm:
(-[WKUserDefaults findPreferenceChangesAndNotifyForKeys:toValuesForKeys:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::validateResourceData):
* Source/WebKit/UIProcess/mac/WKTextFinderClient.mm:
(-[WKTextFinderClient didFindStringMatchesWithRects:didWrapAround:]):

Canonical link: <a href="https://commits.webkit.org/298908@main">https://commits.webkit.org/298908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1061998790ef3b0d455d8b1b6cc40083842aa137

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123096 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69029 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88861 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43573 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28876 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126233 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97532 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97331 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42659 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40306 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49400 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->