### PR TITLE
[WebGPU] Fix the WebGPU Swift build

### DIFF
--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <iterator>
+#include <memory>
 #include <wtf/MallocCommon.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <memory>
 #include <wtf/EmbeddedFixedVector.h>
 #include <wtf/MallocCommon.h>
 

--- a/Source/WTF/wtf/HashIterators.h
+++ b/Source/WTF/wtf/HashIterators.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <iterator>
+#include <wtf/HashTable.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -28,6 +28,7 @@
 #include <wtf/HashTraits.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/KeyValuePair.h>
+#include <wtf/OptionSetHash.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -36,6 +36,7 @@
 #include <wtf/HashTraits.h>
 #include <wtf/Lock.h>
 #include <wtf/MathExtras.h>
+#include <wtf/Packed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/ValueCheck.h>
 #include <wtf/WeakRandomNumber.h>

--- a/Source/WTF/wtf/SystemMalloc.h
+++ b/Source/WTF/wtf/SystemMalloc.h
@@ -35,7 +35,7 @@ namespace WTF {
 struct SystemMalloc {
     static void* malloc(size_t size)
     {
-        auto* result = ::malloc(size);
+        void* result = ::malloc(size);
         if (!result)
             CRASH();
         return result;
@@ -48,7 +48,7 @@ struct SystemMalloc {
 
     static void* zeroedMalloc(size_t size)
     {
-        auto* result = ::malloc(size);
+        void* result = ::malloc(size);
         if (!result)
             CRASH();
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -59,7 +59,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     static void* tryZeroedMalloc(size_t size)
     {
-        auto* result = ::malloc(size);
+        void* result = ::malloc(size);
         if (!result)
             return nullptr;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -70,7 +70,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     static void* realloc(void* p, size_t size)
     {
-        auto* result = ::realloc(p, size);
+        void* result = ::realloc(p, size);
         if (!result)
             CRASH();
         return result;

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <memory>
 #include <wtf/EmbeddedFixedVector.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include <cmath>
 #include <type_traits>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/FixedVector.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/StringHash.h>

--- a/Source/WebGPU/WebGPU/Adapter.h
+++ b/Source/WebGPU/WebGPU/Adapter.h
@@ -27,11 +27,16 @@
 
 #import "HardwareCapabilities.h"
 #import <Metal/Metal.h>
+#import <bmalloc/CompactAllocationMode.h>
+#import <wtf/Assertions.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
+#import <wtf/HashSet.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
+#import <wtf/RefPtr.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUAdapterImpl {

--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -29,6 +29,7 @@
 #import "ShaderStage.h"
 #import <wtf/EnumeratedArray.h>
 #import <wtf/FastMalloc.h>
+#import <wtf/HashTraits.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
 #import <wtf/TZoneMalloc.h>

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -26,9 +26,14 @@
 #pragma once
 
 #import <Metal/Metal.h>
+#import <limits>
+#import <type_traits>
+#import <utility>
+#import <wtf/HashFunctions.h>
 #import <wtf/HashMap.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RefPtr.h>
+#import <wtf/Variant.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -31,6 +31,7 @@
 #import "WebGPUExt.h"
 #import <Metal/Metal.h>
 #import <utility>
+#import <wtf/Compiler.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -37,6 +37,7 @@
 #import <wtf/RetainReleaseSwift.h>
 #import <wtf/SwiftCXXThunk.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/TaggedPtr.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -141,7 +141,7 @@ extension WebGPU.CommandEncoder {
 
         commandBuffer?.label = unsafe WebGPU_Internal.convertWTFStringToNSString(WebGPU.fromAPI(descriptor.label))
 
-    #if os(macOS) || targetEnvironment(macCatalyst)
+        #if arch(x86_64) && (os(macOS) || targetEnvironment(macCatalyst))
         if m_managedBuffers.count != 0 || m_managedTextures.count != 0 {
             let blitCommandEncoder = commandBuffer?.makeBlitCommandEncoder()
             for case let buffer as MTLBuffer in m_managedBuffers {
@@ -152,7 +152,7 @@ extension WebGPU.CommandEncoder {
             }
             blitCommandEncoder?.endEncoding()
         }
-    #endif
+        #endif
 
         let result = createCommandBuffer(commandBuffer, m_device.ptr(), m_sharedEvent, m_sharedEventSignalValue)
         m_sharedEvent = nil

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -40,6 +40,10 @@
 #import <wtf/CompletionHandler.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/Function.h>
+#import <wtf/HashIterators.h>
+#import <wtf/HashMap.h>
+#import <wtf/HashTable.h>
+#import <wtf/KeyValuePair.h>
 #import <wtf/Ref.h>
 #import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -35,6 +35,7 @@
 #import <wtf/Ref.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/ThreadSafetyAnalysis.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -40,10 +40,13 @@
 #include "Texture.h"
 #include "TextureView.h"
 #include "WebGPU.h"
+#include <algorithm>
 #include <cstdint>
+#include <os/log.h>
 #include <span>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HashSet.h>
+#include <wtf/MathExtras.h>
 #include <wtf/Ref.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -30,7 +30,15 @@
 #ifndef WEBGPU_H_
 #define WEBGPU_H_
 
+#include <array>
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/SwiftBridging.h>
+
+#if __has_include(<swift/bridging>)
+#include <swift/bridging>
+#endif
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
#### 5f6e3af86a230c67cb54b066f28e649ca3ce8789
<pre>
[WebGPU] Fix the WebGPU Swift build
<a href="https://bugs.webkit.org/show_bug.cgi?id=296479">https://bugs.webkit.org/show_bug.cgi?id=296479</a>
<a href="https://rdar.apple.com/156696312">rdar://156696312</a>

Reviewed by Mike Wyrzykowski.

After modulemaps got added, Swift now treats WebGPU and WTF as clang modules,
and that has caused some build errors, mostly requiring adding imports for
files that were previously available only transitively.

* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FixedVector.h:
* Source/WTF/wtf/HashIterators.h:
* Source/WTF/wtf/HashMap.h:
* Source/WTF/wtf/HashTable.h:
* Source/WTF/wtf/SystemMalloc.h:
(WTF::SystemMalloc::malloc):
(WTF::SystemMalloc::zeroedMalloc):
(WTF::SystemMalloc::tryZeroedMalloc):
(WTF::SystemMalloc::realloc):
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
* Source/WebGPU/WGSL/ConstantValue.h:
* Source/WebGPU/WebGPU/Adapter.h:
* Source/WebGPU/WebGPU/BindGroup.h:
* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.finish(_:)):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
* Source/WebGPU/WebGPU/WebGPU.h:

Canonical link: <a href="https://commits.webkit.org/298189@main">https://commits.webkit.org/298189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/859f15cac6c11fb0d5e9322cfc8269d3d8fcc46e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119371 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64240 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86142 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41342 "Unexpected infrastructure issue, retrying build") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19929 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63125 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105680 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122588 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111779 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/94988 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94730 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24375 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36373 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45626 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136009 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39768 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36497 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->