### PR TITLE
Add more tests to LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html

### DIFF
--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html
@@ -2,11 +2,12 @@
 <script>
   window.addEventListener("load", () => {
     window.testRunner?.dumpAsText();
+    let rawData, audioData, copyDestination;
 
     // Bug 288440: assertion/crash in audioElementSpan() because copyDestination
     // is not castable to a buffer of 16bits elements.
-    let rawData = new Uint8ClampedArray(4);
-    let audioData = new AudioData({
+    rawData = new Uint8ClampedArray(4);
+    audioData = new AudioData({
       format: "s16-planar",
       sampleRate: 1,
       numberOfFrames: 1,
@@ -14,7 +15,37 @@
       timestamp: 0,
       data: rawData
     });
-    let copyDestination = new Uint8ClampedArray(3);
+    copyDestination = new Uint8ClampedArray(3);
+    audioData.copyTo(copyDestination, {planeIndex: 0});
+
+    // Bug 289885: release assertion in GstMappedAudioBuffer::samples() because
+    // GST_AUDIO_INFO_IS_VALID returns false.
+    try {
+      rawData = new Uint8ClampedArray(4);
+      audioData = new AudioData({
+        format: "s16-planar",
+        sampleRate: 0.1,
+        numberOfFrames: 1,
+        numberOfChannels: 2,
+        timestamp: 0,
+        data: rawData
+      });
+      copyDestination = new Uint8ClampedArray(2);
+      audioData.copyTo(copyDestination, {planeIndex: 0});
+    } catch {}
+
+    // Bug 289885: crash in PlatformRawAudioData::copyTo() because the copied
+    // buffer is smaller than the result of "Compute Copy Element Count".
+    rawData = new Uint8ClampedArray(12);
+    audioData = new AudioData({
+      format: "s16-planar",
+      sampleRate: 1,
+      numberOfFrames: 1,
+      numberOfChannels: 2,
+      timestamp: 0,
+      data: rawData
+    });
+    copyDestination = new Uint8ClampedArray(6);
     audioData.copyTo(copyDestination, {planeIndex: 0});
 
     document.body.innerHTML = "PASS if no crash.";


### PR DESCRIPTION
#### d0124d1da411b39bf1cdbc017d71f4c26aa384b4
<pre>
Add more tests to LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=296480">https://bugs.webkit.org/show_bug.cgi?id=296480</a>

Reviewed by Philippe Normand.

Add tests for bug 289885.

* LayoutTests/fast/webcodecs/audio-data-copy-to-crash.html: Add two subtests.

Canonical link: <a href="https://commits.webkit.org/298082@main">https://commits.webkit.org/298082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d596918c7be0bcbb2143a4ee47db1c662e0d13d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64480 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86311 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41513 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63362 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94917 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24311 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40044 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17857 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36635 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40357 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40010 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->