### PR TITLE
[WTF] Use enum class for Safer C++ in WTF

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -97,7 +97,7 @@ public:
         static_assert(hasOneBitSet(structureHeapAddressSize));
         uintptr_t mappedHeapSize = structureHeapAddressSize;
         for (unsigned i = 0; i < 8; ++i) {
-            g_jscConfig.startOfStructureHeap = reinterpret_cast<uintptr_t>(OSAllocator::tryReserveUncommittedAligned(mappedHeapSize, structureHeapAddressSize, OSAllocator::FastMallocPages));
+            g_jscConfig.startOfStructureHeap = reinterpret_cast<uintptr_t>(OSAllocator::tryReserveUncommittedAligned(mappedHeapSize, structureHeapAddressSize, OSAllocator::Usage::FastMallocPages));
             if (g_jscConfig.startOfStructureHeap)
                 break;
             mappedHeapSize /= 2;

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -185,7 +185,7 @@ void ExecutableAllocator::disableJIT()
 
         constexpr size_t size = 1;
         constexpr int protection = PROT_READ | PROT_WRITE | PROT_EXEC;
-        constexpr int fd = OSAllocator::JSJITCodePages;
+        constexpr int fd = OSAllocator::Usage::JSJITCodePages;
         int flags = MAP_PRIVATE | MAP_ANON | (Options::useJITCage() ? MAP_EXECUTABLE_FOR_JIT_WITH_JIT_CAGE : MAP_EXECUTABLE_FOR_JIT);
         void* allocation = mmap(nullptr, size, protection, flags, fd, 0);
         const void* executableMemoryAllocationFailure = reinterpret_cast<void*>(-1);
@@ -395,11 +395,11 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
         // This makes the following JIT code logging broken and some of JIT code is not recorded correctly.
         // To avoid this problem, we use committed reservation if we need perf JITDump logging.
         if (Options::useJITDump())
-            return PageReservation::tryReserveAndCommitWithGuardPages(reservationSize, OSAllocator::JSJITCodePages, EXECUTABLE_POOL_WRITABLE, true, false);
+            return PageReservation::tryReserveAndCommitWithGuardPages(reservationSize, OSAllocator::Usage::JSJITCodePages, EXECUTABLE_POOL_WRITABLE, true, false);
 #endif
         if (Options::useJITCage() && JSC_ALLOW_JIT_CAGE_SPECIFIC_RESERVATION)
-            return PageReservation::tryReserve(reservationSize, OSAllocator::JSJITCodePages, EXECUTABLE_POOL_WRITABLE, true, Options::useJITCage());
-        return PageReservation::tryReserveWithGuardPages(reservationSize, OSAllocator::JSJITCodePages, EXECUTABLE_POOL_WRITABLE, true, false);
+            return PageReservation::tryReserve(reservationSize, OSAllocator::Usage::JSJITCodePages, EXECUTABLE_POOL_WRITABLE, true, Options::useJITCage());
+        return PageReservation::tryReserveWithGuardPages(reservationSize, OSAllocator::Usage::JSJITCodePages, EXECUTABLE_POOL_WRITABLE, true, false);
     };
 
     reservation.pageReservation = tryCreatePageReservation(reservation.size);

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -1552,7 +1552,7 @@ static CheckedInt128 checkedCastDoubleToInt128(double n)
 
     // If the value is too large for the integer type, overflow.
     if (exponent >= 128)
-        return { WTF::ResultOverflowed };
+        return { WTF::ResultOverflowedTag::ResultOverflowed };
 
     // If 0 <= exponent < significandBits, right shift to get the result.
     // Otherwise, shift left.

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
@@ -98,7 +98,7 @@ ProfilerSupport::ProfilerSupport()
         auto* file = fdopen(m_fd, "wb");
         RELEASE_ASSERT(file);
 
-        m_fileStream = makeUnique<FilePrintStream>(file, FilePrintStream::Adopt);
+        m_fileStream = makeUnique<FilePrintStream>(file, FilePrintStream::AdoptionMode::Adopt);
         RELEASE_ASSERT(m_fileStream);
     }
 }

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -286,8 +286,8 @@ public:
     
     WTF_EXPORT_PRIVATE void dump(PrintStream& out) const;
     
-    enum EmptyValueTag { EmptyValue };
-    enum DeletedValueTag { DeletedValue };
+    enum class EmptyValueTag { EmptyValue };
+    enum class DeletedValueTag { DeletedValue };
     
     BitVector(EmptyValueTag)
         : m_bitsOrPointer(0)

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -627,7 +627,7 @@ template <typename U, typename V> static inline bool safeEquals(U lhs, V rhs)
     return ArithmeticOperations<U, V>::equals(lhs, rhs);
 }
 
-enum ResultOverflowedTag { ResultOverflowed };
+enum class ResultOverflowedTag { ResultOverflowed };
     
 template <typename T, class OverflowHandler> class Checked : public OverflowHandler {
 public:
@@ -853,40 +853,40 @@ private:
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator+(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
     if (!safeAdd<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     return result;
 }
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator-(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
     if (!safeSub<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     return result;
 }
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator*(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
     if (!safeMultiply<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     return result;
 }
 
 template <typename U, typename V, typename OverflowHandler> static inline Checked<typename Result<U, V>::ResultType, OverflowHandler> operator/(Checked<U, OverflowHandler> lhs, Checked<V, OverflowHandler> rhs)
 {
     if (lhs.hasOverflowed() || rhs.hasOverflowed()) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     typename Result<U, V>::ResultType result = 0;
     if (!safeDivide<OverflowHandler>(lhs.value(), rhs.value(), result)) [[unlikely]]
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     return result;
 }
 

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -56,7 +56,7 @@ public:
         PtrTraits::unwrap(m_ptr)->incrementCheckedPtrCount();
     }
 
-    enum AdoptTag { Adopt };
+    enum class AdoptTag { Adopt };
     CheckedRef(T& object, AdoptTag)
         : m_ptr(&object)
     {

--- a/Source/WTF/wtf/CodePtr.h
+++ b/Source/WTF/wtf/CodePtr.h
@@ -55,7 +55,7 @@ struct CodePtrBase {
 public:
     // We need to declare this in this non-template base. Otherwise, every use of
     // AlreadyTaggedValueTag will require a specialized template qualification.
-    enum AlreadyTaggedValueTag { AlreadyTaggedValue };
+    enum class AlreadyTaggedValueTag { AlreadyTaggedValue };
 
     friend bool operator==(CodePtrBase, CodePtrBase) = default;
 
@@ -124,12 +124,12 @@ public:
 
     template<typename Out, typename... In, FunctionAttributes otherAttr>
     CodePtr(const FunctionPtr<tag, Out(In...), otherAttr>& other)
-        : CodePtr(AlreadyTaggedValue, other.taggedPtr())
+        : CodePtr(AlreadyTaggedValueTag::AlreadyTaggedValue, other.taggedPtr())
     { }
 
     template<PtrTag otherTag, typename Out, typename... In, FunctionAttributes otherAttr>
     CodePtr(const FunctionPtr<otherTag, Out(In...), otherAttr>& other)
-        : CodePtr(AlreadyTaggedValue, other.template retaggedPtr<tag>())
+        : CodePtr(AlreadyTaggedValueTag::AlreadyTaggedValue, other.template retaggedPtr<tag>())
     { }
 #endif
 
@@ -138,7 +138,7 @@ public:
         ASSERT(ptr);
         ASSERT_VALID_CODE_POINTER(ptr);
         assertIsTaggedWith<tag>(ptr);
-        return CodePtr(AlreadyTaggedValue, ptr);
+        return CodePtr(AlreadyTaggedValueTag::AlreadyTaggedValue, ptr);
     }
 
     static CodePtr fromUntaggedPtr(void* ptr)
@@ -146,7 +146,7 @@ public:
         ASSERT(ptr);
         ASSERT_VALID_CODE_POINTER(ptr);
         assertIsNotTagged(ptr);
-        return CodePtr(AlreadyTaggedValue, tagCodePtr<tag>(ptr));
+        return CodePtr(AlreadyTaggedValueTag::AlreadyTaggedValue, tagCodePtr<tag>(ptr));
     }
 
     template<PtrTag newTag>
@@ -154,7 +154,7 @@ public:
     {
         if (!m_value)
             return CodePtr<newTag, attr>();
-        return CodePtr<newTag, attr>(AlreadyTaggedValue, retaggedPtr<newTag>());
+        return CodePtr<newTag, attr>(AlreadyTaggedValueTag::AlreadyTaggedValue, retaggedPtr<newTag>());
     }
 
     constexpr UntypedFunc untypedFunc() const { return decodeFunc(m_value); }

--- a/Source/WTF/wtf/DataLog.cpp
+++ b/Source/WTF/wtf/DataLog.cpp
@@ -167,7 +167,7 @@ void setDataFile(const char* path)
     if (!file) {
         // Use placement new; this makes it easier to use dataLog() to debug
         // fastMalloc.
-        file = new (s_fileData) FilePrintStream(stderr, FilePrintStream::Borrow);
+        file = new (s_fileData) FilePrintStream(stderr, FilePrintStream::AdoptionMode::Borrow);
     }
 
     setvbuf(file->file(), nullptr, _IONBF, 0); // Prefer unbuffered output, so that we get a full log upon crash or deadlock.

--- a/Source/WTF/wtf/FilePrintStream.cpp
+++ b/Source/WTF/wtf/FilePrintStream.cpp
@@ -36,7 +36,7 @@ FilePrintStream::FilePrintStream(FILE* file, AdoptionMode adoptionMode)
 
 FilePrintStream::~FilePrintStream()
 {
-    if (m_adoptionMode == Borrow)
+    if (m_adoptionMode == AdoptionMode::Borrow)
         return;
     fclose(m_file);
 }

--- a/Source/WTF/wtf/FilePrintStream.h
+++ b/Source/WTF/wtf/FilePrintStream.h
@@ -32,12 +32,12 @@ namespace WTF {
 
 class FilePrintStream final : public PrintStream {
 public:
-    enum AdoptionMode {
+    enum class AdoptionMode {
         Adopt,
         Borrow
     };
     
-    FilePrintStream(FILE*, AdoptionMode = Adopt);
+    FilePrintStream(FILE*, AdoptionMode = AdoptionMode::Adopt);
     WTF_EXPORT_PRIVATE ~FilePrintStream() final;
     
     WTF_EXPORT_PRIVATE static std::unique_ptr<FilePrintStream> open(const char* filename, const char* mode);

--- a/Source/WTF/wtf/Function.h
+++ b/Source/WTF/wtf/Function.h
@@ -110,7 +110,7 @@ public:
     }
 
 private:
-    enum AdoptTag { Adopt };
+    enum class AdoptTag { Adopt };
     Function(Impl* impl, AdoptTag)
         : m_callableWrapper(impl)
     {
@@ -123,7 +123,7 @@ private:
 
 template<typename Out, typename... In> Function<Out(In...)> adopt(Detail::CallableWrapperBase<Out, In...>* impl)
 {
-    return Function<Out(In...)>(impl, Function<Out(In...)>::Adopt);
+    return Function<Out(In...)>(impl, Function<Out(In...)>::AdoptTag::Adopt);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/FunctionPtr.h
+++ b/Source/WTF/wtf/FunctionPtr.h
@@ -71,7 +71,7 @@ class FunctionPtrBase {
 public:
     // We need to declare this in this non-template base. Otherwise, every use of
     // AlreadyTaggedValueTag will require a specialized template qualification.
-    enum AlreadyTaggedValueTag { AlreadyTaggedValue };
+    enum class AlreadyTaggedValueTag { AlreadyTaggedValue };
 
     friend bool operator==(FunctionPtrBase, FunctionPtrBase) = default;
 };
@@ -120,7 +120,7 @@ public:
     FunctionPtr<otherTag, Out(In...), attr> retagged() const
     {
         static_assert(tag != otherTag);
-        return FunctionPtr<otherTag, Out(In...), attr>(AlreadyTaggedValue, retaggedPtr<otherTag>());
+        return FunctionPtr<otherTag, Out(In...), attr>(AlreadyTaggedValueTag::AlreadyTaggedValue, retaggedPtr<otherTag>());
     }
 
     constexpr void* taggedPtr() const { return reinterpret_cast<void*>(m_ptr); }

--- a/Source/WTF/wtf/Gigacage.h
+++ b/Source/WTF/wtf/Gigacage.h
@@ -40,7 +40,7 @@ constexpr bool hasCapacityToUseLargeGigacage = OS_CONSTANT(EFFECTIVE_ADDRESS_WID
 
 const size_t primitiveGigacageMask = 0;
 
-enum Kind {
+enum class Kind {
     Primitive,
     NumberOfKinds
 };

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -26,7 +26,7 @@
 
 namespace WTF {
 
-enum HexConversionMode { Lowercase, Uppercase };
+enum class HexConversionMode { Lowercase, Uppercase };
 
 namespace Internal {
 
@@ -34,7 +34,7 @@ inline const std::array<LChar, 16>& hexDigitsForMode(HexConversionMode mode)
 {
     static constexpr std::array<LChar, 16> lowercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
     static constexpr std::array<LChar, 16> uppercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-    return mode == Lowercase ? lowercaseHexDigits : uppercaseHexDigits;
+    return mode == HexConversionMode::Lowercase ? lowercaseHexDigits : uppercaseHexDigits;
 }
 
 WTF_EXPORT_PRIVATE std::span<LChar> appendHex(std::span<LChar> buffer, std::uintmax_t number, unsigned minimumDigits, HexConversionMode);
@@ -56,7 +56,7 @@ struct HexNumberBuffer {
     std::span<const LChar> span() const LIFETIME_BOUND { return std::span { buffer }.last(length); }
 };
 
-template<typename NumberType> HexNumberBuffer hex(NumberType number, unsigned minimumDigits = 0, HexConversionMode mode = Uppercase)
+template<typename NumberType> HexNumberBuffer hex(NumberType number, unsigned minimumDigits = 0, HexConversionMode mode = HexConversionMode::Uppercase)
 {
     // Each byte can generate up to two digits.
     HexNumberBuffer buffer;
@@ -97,4 +97,4 @@ WTF_EXPORT_PRIVATE void printInternal(PrintStream&, HexNumberBuffer);
 using WTF::hex;
 using WTF::toHexCString;
 using WTF::toHexString;
-using WTF::Lowercase;
+using WTF::HexConversionMode::Lowercase;

--- a/Source/WTF/wtf/Lock.cpp
+++ b/Source/WTF/wtf/Lock.cpp
@@ -57,7 +57,7 @@ void Lock::unlockSlow()
     // explicitly allow the following allocation(s). In some rare cases, the unlockSlow() algorithm may cause allocations.
     DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
 
-    DefaultLockAlgorithm::unlockSlow(m_byte, DefaultLockAlgorithm::Unfair);
+    DefaultLockAlgorithm::unlockSlow(m_byte, DefaultLockAlgorithm::Fairness::Unfair);
 }
 
 void Lock::unlockFairlySlow()
@@ -66,7 +66,7 @@ void Lock::unlockFairlySlow()
     // explicitly allow the following allocation(s). In some rare cases, the unlockSlow() algorithm may cause allocations.
     DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
 
-    DefaultLockAlgorithm::unlockSlow(m_byte, DefaultLockAlgorithm::Fair);
+    DefaultLockAlgorithm::unlockSlow(m_byte, DefaultLockAlgorithm::Fairness::Fair);
 }
 
 void Lock::safepointSlow()

--- a/Source/WTF/wtf/LockAlgorithm.h
+++ b/Source/WTF/wtf/LockAlgorithm.h
@@ -104,13 +104,13 @@ public:
     static void unlock(Atomic<LockType>& lock)
     {
         if (!unlockFast(lock)) [[unlikely]]
-            unlockSlow(lock, Unfair);
+            unlockSlow(lock, Fairness::Unfair);
     }
     
     static void unlockFairly(Atomic<LockType>& lock)
     {
         if (!unlockFast(lock)) [[unlikely]]
-            unlockSlow(lock, Fair);
+            unlockSlow(lock, Fairness::Fair);
     }
     
     static bool safepointFast(const Atomic<LockType>& lock)
@@ -132,11 +132,11 @@ public:
     
     NEVER_INLINE static void lockSlow(Atomic<LockType>& lock);
     
-    enum Fairness {
+    enum class Fairness {
         Unfair,
         Fair
     };
-    NEVER_INLINE static void unlockSlow(Atomic<LockType>& lock, Fairness fairness = Unfair);
+    NEVER_INLINE static void unlockSlow(Atomic<LockType>& lock, Fairness fairness = Fairness::Unfair);
     
     NEVER_INLINE static void safepointSlow(Atomic<LockType>& lockWord)
     {
@@ -145,7 +145,7 @@ public:
     }
     
 private:
-    enum Token {
+    enum class Token {
         BargingOpportunity,
         DirectHandoff
     };

--- a/Source/WTF/wtf/LockAlgorithmInlines.h
+++ b/Source/WTF/wtf/LockAlgorithmInlines.h
@@ -84,12 +84,12 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<Lo
             ParkingLot::compareAndPark(&lock, currentValue);
         if (parkResult.wasUnparked) {
             switch (static_cast<Token>(parkResult.token)) {
-            case DirectHandoff:
+            case Token::DirectHandoff:
                 // The lock was never released. It was handed to us directly by the thread that did
                 // unlock(). This means we're done!
                 RELEASE_ASSERT(isLocked(lock));
                 return;
-            case BargingOpportunity:
+            case Token::BargingOpportunity:
                 // This is the common case. The thread that called unlock() has released the lock,
                 // and we have been woken up so that we may get an opportunity to grab the lock. But
                 // other threads may barge, so the best that we can do is loop around and try again.
@@ -134,7 +134,7 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::unlockSlow(Atomic<
                 // so we should still see both bits set right now.
                 ASSERT((lock.load() & mask) == (isHeldBit | hasParkedBit));
                 
-                if (result.didUnparkThread && (fairness == Fair || result.timeToBeFair)) {
+                if (result.didUnparkThread && (fairness == Fairness::Fair || result.timeToBeFair)) {
                     // We don't unlock anything. Instead, we hand the lock to the thread that was
                     // waiting.
                     lock.transaction(
@@ -145,7 +145,7 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::unlockSlow(Atomic<
                             value = newValue;
                             return true;
                         });
-                    return DirectHandoff;
+                    return static_cast<intptr_t>(Token::DirectHandoff);
                 }
                 
                 lock.transaction(
@@ -156,7 +156,7 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::unlockSlow(Atomic<
                             value |= hasParkedBit;
                         return true;
                     });
-                return BargingOpportunity;
+                return static_cast<intptr_t>(Token::BargingOpportunity);
             });
         return;
     }

--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -44,7 +44,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 namespace WTF {
 
-enum NoLockingNecessaryTag { NoLockingNecessary };
+enum class NoLockingNecessaryTag { NoLockingNecessary };
 
 class AbstractLocker {
     WTF_MAKE_NONCOPYABLE(AbstractLocker);
@@ -87,7 +87,7 @@ public:
     
     static Locker tryLock(T& lockable)
     {
-        Locker result(NoLockingNecessary);
+        Locker result(NoLockingNecessaryTag::NoLockingNecessary);
         if (lockable.tryLock()) {
             result.m_lockable = &lockable;
             return result;
@@ -232,6 +232,6 @@ using WTF::AbstractLocker;
 using WTF::AdoptLock;
 using WTF::Locker;
 using WTF::NoLockingNecessaryTag;
-using WTF::NoLockingNecessary;
+using WTF::NoLockingNecessaryTag::NoLockingNecessary;
 using WTF::DropLockForScope;
 using WTF::ExternalLocker;

--- a/Source/WTF/wtf/LocklessBag.h
+++ b/Source/WTF/wtf/LocklessBag.h
@@ -50,7 +50,7 @@ public:
     {
     }
 
-    enum PushResult { Empty, NonEmpty };
+    enum class PushResult { Empty, NonEmpty };
     PushResult add(T&& element)
     {
         Node* newNode = new Node();
@@ -64,7 +64,7 @@ public:
             return true;
         });
 
-        return oldHead == nullptr ? Empty : NonEmpty;
+        return oldHead == nullptr ? PushResult::Empty : PushResult::NonEmpty;
     }
 
     // CONSUMER FUNCTIONS: Everything below here is only safe to call from the consumer thread.

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -798,7 +798,7 @@ template<typename T, typename C>
 inline constexpr Checked<T, C> roundUpToMultipleOfNonPowerOfTwo(Checked<T, C> divisor, Checked<T, C> x)
 {
     if (x.hasOverflowed() || divisor.hasOverflowed())
-        return ResultOverflowed;
+        return ResultOverflowedTag::ResultOverflowed;
     T remainder = x % divisor;
     if (!remainder)
         return x;

--- a/Source/WTF/wtf/MessageQueue.h
+++ b/Source/WTF/wtf/MessageQueue.h
@@ -39,7 +39,7 @@
 
 namespace WTF {
 
-    enum MessageQueueWaitResult {
+    enum class MessageQueueWaitResult {
         MessageQueueTerminated,       // Queue was destroyed while waiting for message.
         MessageQueueTimeout,          // Timeout was specified and it expired.
         MessageQueueMessageReceived   // A message was successfully received and returned.
@@ -130,7 +130,7 @@ namespace WTF {
     {
         MessageQueueWaitResult exitReason; 
         std::unique_ptr<DataType> result = waitForMessageFilteredWithTimeout(exitReason, [](const DataType&) { return true; }, Seconds::infinity());
-        ASSERT(exitReason == MessageQueueTerminated || exitReason == MessageQueueMessageReceived);
+        ASSERT(exitReason == MessageQueueWaitResult::MessageQueueTerminated || exitReason == MessageQueueWaitResult::MessageQueueMessageReceived);
         return result;
     }
 
@@ -157,19 +157,19 @@ namespace WTF {
         ASSERT(!timedOut || absoluteTimeout != MonotonicTime::infinity());
 
         if (m_killed) {
-            result = MessageQueueTerminated;
+            result = MessageQueueWaitResult::MessageQueueTerminated;
             return nullptr;
         }
 
         if (timedOut) {
-            result = MessageQueueTimeout;
+            result = MessageQueueWaitResult::MessageQueueTimeout;
             return nullptr;
         }
 
         ASSERT(found != m_queue.end());
         std::unique_ptr<DataType> message = WTFMove(*found);
         m_queue.remove(found);
-        result = MessageQueueMessageReceived;
+        result = MessageQueueWaitResult::MessageQueueMessageReceived;
         return message;
     }
 
@@ -250,6 +250,6 @@ namespace WTF {
 using WTF::MessageQueue;
 // MessageQueueWaitResult enum and all its values.
 using WTF::MessageQueueWaitResult;
-using WTF::MessageQueueTerminated;
-using WTF::MessageQueueTimeout;
-using WTF::MessageQueueMessageReceived;
+using WTF::MessageQueueWaitResult::MessageQueueTerminated;
+using WTF::MessageQueueWaitResult::MessageQueueTimeout;
+using WTF::MessageQueueWaitResult::MessageQueueMessageReceived;

--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -33,7 +33,7 @@ namespace WTF {
 class OSAllocator {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OSAllocator);
 public:
-    enum Usage {
+    enum class Usage {
         UnknownUsage = -1,
         FastMallocPages = VM_TAG_FOR_TCMALLOC_MEMORY,
         JSJITCodePages = VM_TAG_FOR_EXECUTABLEALLOCATOR_MEMORY,
@@ -43,14 +43,14 @@ public:
     // The memory returned by this cannot be released as on Windows there's no guaranteed API to
     // get an aligned address and the size + alignment then rounding trick cannot release the unused parts
     // due to how the Windows syscalls work.
-    WTF_EXPORT_PRIVATE static void* tryReserveUncommittedAligned(size_t size, size_t alignment, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* tryReserveUncommittedAligned(size_t size, size_t alignment, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
 
     // These methods are symmetric; reserveUncommitted allocates VM in an uncommitted state,
     // releaseDecommitted should be called on a region of VM allocated by a single reservation,
     // the memory must all currently be in a decommitted state. reserveUncommitted returns to
     // you memory that is zeroed.
-    WTF_EXPORT_PRIVATE static void* reserveUncommitted(size_t, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
-    WTF_EXPORT_PRIVATE static void* tryReserveUncommitted(size_t, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* reserveUncommitted(size_t, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* tryReserveUncommitted(size_t, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
     WTF_EXPORT_PRIVATE static void releaseDecommitted(void*, size_t);
 
     // These methods are symmetric; they commit or decommit a region of VM (uncommitted VM should
@@ -62,20 +62,20 @@ public:
     // These methods are symmetric; reserveAndCommit allocates VM in an committed state,
     // decommitAndRelease should be called on a region of VM allocated by a single reservation,
     // the memory must all currently be in a committed state.
-    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
-    WTF_EXPORT_PRIVATE static void* tryReserveAndCommit(size_t, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
+    WTF_EXPORT_PRIVATE static void* tryReserveAndCommit(size_t, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false, bool includesGuardPages = false);
     static void decommitAndRelease(void* base, size_t size);
 
     // These methods are akin to reserveAndCommit/decommitAndRelease, above - however rather than
     // committing/decommitting the entire region additional parameters allow a subregion to be
     // specified.
-    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t reserveSize, size_t commitSize, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false);
+    WTF_EXPORT_PRIVATE static void* reserveAndCommit(size_t reserveSize, size_t commitSize, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false);
 
     // Reallocate an existing, committed allocation.
     // The prior allocation must be fully comitted, and the new size will also be fully committed.
     // This interface is provided since it may be possible to optimize this operation on some platforms.
     template<typename T>
-    static T* reallocateCommitted(T*, size_t oldSize, size_t newSize, Usage = UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false);
+    static T* reallocateCommitted(T*, size_t oldSize, size_t newSize, Usage = Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false);
 
     // Hint to the OS that an address range is not expected to be accessed anytime soon.
     WTF_EXPORT_PRIVATE static void hintMemoryNotNeededSoon(void*, size_t);

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -139,7 +139,7 @@ public:
     static ObjectIdentifierGeneric generate()
     {
         RELEASE_ASSERT(!m_generationProtected);
-        return ObjectIdentifierGeneric { ThreadSafety::generateIdentifierInternal(), AssumeValidIdValue };
+        return ObjectIdentifierGeneric { ThreadSafety::generateIdentifierInternal(), AssumeValidId::AssumeValidIdValue };
     }
 
     static void enableGenerationProtection()
@@ -163,14 +163,14 @@ private:
     friend struct MarkableTraits<ObjectIdentifierGeneric>;
     template<typename U, typename V> friend struct ObjectIdentifierGenericHash;
 
-    enum AssumeValidId { AssumeValidIdValue };
+    enum class AssumeValidId { AssumeValidIdValue };
     explicit constexpr ObjectIdentifierGeneric(RawValue identifier, AssumeValidId)
         : ObjectIdentifierGenericBase<RawValue>(identifier)
     {
         ASSERT(!!identifier);
     }
 
-    enum InvalidId { InvalidIdValue };
+    enum class InvalidId { InvalidIdValue };
     ObjectIdentifierGeneric(InvalidId)
     {
     }
@@ -181,7 +181,7 @@ private:
 template<typename T, typename ThreadSafety, typename RawValue>
 struct MarkableTraits<ObjectIdentifierGeneric<T, ThreadSafety, RawValue>> {
     static bool isEmptyValue(ObjectIdentifierGeneric<T, ThreadSafety, RawValue> identifier) { return !identifier.toRawValue(); }
-    static constexpr ObjectIdentifierGeneric<T, ThreadSafety, RawValue> emptyValue() { return ObjectIdentifierGeneric<T, ThreadSafety, RawValue>::InvalidIdValue; }
+    static constexpr ObjectIdentifierGeneric<T, ThreadSafety, RawValue> emptyValue() { return ObjectIdentifierGeneric<T, ThreadSafety, RawValue>::InvalidId::InvalidIdValue; }
 };
 
 template<typename T, typename RawValue> using ObjectIdentifier = ObjectIdentifierGeneric<T, ObjectIdentifierMainThreadAccessTraits<RawValue>, RawValue>;
@@ -220,7 +220,7 @@ template<typename T, typename U, typename V> struct HashTraits<ObjectIdentifierG
     using PeekType = std::optional<ValueType>;
     using TakeType = std::optional<ValueType>;
 
-    static ValueType emptyValue() { return ValueType { ValueType::InvalidIdValue }; }
+    static ValueType emptyValue() { return ValueType { ValueType::InvalidId::InvalidIdValue }; }
     static bool isEmptyValue(ValueType value) { return value.isHashTableEmptyValue(); }
 
     static PeekType peek(ValueType identifier)

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -77,7 +77,7 @@ public:
 
     static constexpr OptionSet fromRaw(StorageType rawValue)
     {
-        return OptionSet(static_cast<E>(rawValue), FromRawValue);
+        return OptionSet(static_cast<E>(rawValue), InitializationTag::FromRawValue);
     }
 
     constexpr OptionSet() = default;
@@ -189,7 +189,7 @@ public:
     static OptionSet all() { return fromRaw(-1); }
 
 private:
-    enum InitializationTag { FromRawValue };
+    enum class InitializationTag { FromRawValue };
     constexpr OptionSet(E e, InitializationTag)
         : m_storage(static_cast<StorageType>(e))
     {

--- a/Source/WTF/wtf/PageAllocation.h
+++ b/Source/WTF/wtf/PageAllocation.h
@@ -81,7 +81,7 @@ public:
     operator bool() const { return PageBlock::operator bool(); }
 #endif
 
-    static PageAllocation allocate(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false)
+    static PageAllocation allocate(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false)
     {
         ASSERT(isPageAligned(size));
         return PageAllocation(OSAllocator::reserveAndCommit(size, usage, writable, executable), size);

--- a/Source/WTF/wtf/PageReservation.h
+++ b/Source/WTF/wtf/PageReservation.h
@@ -89,37 +89,37 @@ public:
         return m_committed;
     }
 
-    static PageReservation reserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
+    static PageReservation reserve(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         return PageReservation(OSAllocator::reserveUncommitted(size, usage, writable, executable, jitCageEnabled, false), size, writable, executable, jitCageEnabled, false);
     }
 
-    static PageReservation tryReserve(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
+    static PageReservation tryReserve(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         return PageReservation(OSAllocator::tryReserveUncommitted(size, usage, writable, executable, jitCageEnabled, false), size, writable, executable, jitCageEnabled, false);
     }
 
-    static PageReservation reserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
+    static PageReservation reserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         return PageReservation(OSAllocator::reserveUncommitted(size + pageSize() * 2, usage, writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
     }
 
-    static PageReservation tryReserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
+    static PageReservation tryReserveWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         return PageReservation(OSAllocator::tryReserveUncommitted(size + pageSize() * 2, usage, writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
     }
 
-    static PageReservation reserveAndCommitWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
+    static PageReservation reserveAndCommitWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         return PageReservation(OSAllocator::reserveAndCommit(size + pageSize() * 2, usage, writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);
     }
 
-    static PageReservation tryReserveAndCommitWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
+    static PageReservation tryReserveAndCommitWithGuardPages(size_t size, OSAllocator::Usage usage = OSAllocator::Usage::UnknownUsage, bool writable = true, bool executable = false, bool jitCageEnabled = false)
     {
         ASSERT(isPageAligned(size));
         return PageReservation(OSAllocator::tryReserveAndCommit(size + pageSize() * 2, usage, writable, executable, jitCageEnabled, true), size, writable, executable, jitCageEnabled, true);

--- a/Source/WTF/wtf/PtrTag.h
+++ b/Source/WTF/wtf/PtrTag.h
@@ -51,7 +51,7 @@ enum class PACKeyType {
     FOR_EACH_BASE_WTF_PTRTAG(v) \
     FOR_EACH_ADDITIONAL_WTF_PTRTAG(v) \
 
-enum PtrTag : uintptr_t {
+enum class PtrTag : uintptr_t {
     NoPtrTag = 0, // Note: We use the 0 tag for temporarily holding the return PC during JSC's arity fixup.
     CFunctionPtrTag,
 };
@@ -63,9 +63,9 @@ template<PtrTag tag, typename PtrType>
 ALWAYS_INLINE static PtrType tagNativeCodePtrImpl(PtrType ptr)
 {
 #if CPU(ARM64E)
-    if constexpr (tag == NoPtrTag)
+    if constexpr (tag == PtrTag::NoPtrTag)
         return ptr;
-    if constexpr (tag == CFunctionPtrTag)
+    if constexpr (tag == PtrTag::CFunctionPtrTag)
         return ptrauth_sign_unauthenticated(ptr, ptrauth_key_function_pointer, 0);
     return ptrauth_sign_unauthenticated(ptr, ptrauth_key_process_dependent_code, tag);
 #else
@@ -77,9 +77,9 @@ template<PtrTag tag, typename PtrType>
 ALWAYS_INLINE static PtrType untagNativeCodePtrImpl(PtrType ptr)
 {
 #if CPU(ARM64E)
-    if constexpr (tag == NoPtrTag)
+    if constexpr (tag == PtrTag::NoPtrTag)
         return ptr;
-    if constexpr (tag == CFunctionPtrTag)
+    if constexpr (tag == PtrTag::CFunctionPtrTag)
         return __builtin_ptrauth_auth(ptr, ptrauth_key_function_pointer, 0);
     return __builtin_ptrauth_auth(ptr, ptrauth_key_process_dependent_code, tag);
 #else
@@ -135,10 +135,10 @@ constexpr uintptr_t makePtrTagHash(const char (&str)[N])
 
 #define WTF_DECLARE_PTRTAG(tag) \
     constexpr PtrTag tag = static_cast<PtrTag>(WTF_PTRTAG_HASH(#tag)); \
-    static_assert(tag != NoPtrTag && tag != CFunctionPtrTag);
+    static_assert(tag != PtrTag::NoPtrTag && tag != PtrTag::CFunctionPtrTag);
 
-static_assert(static_cast<uintptr_t>(NoPtrTag) == static_cast<uintptr_t>(0));
-static_assert(static_cast<uintptr_t>(CFunctionPtrTag) == static_cast<uintptr_t>(1));
+static_assert(static_cast<uintptr_t>(PtrTag::NoPtrTag) == static_cast<uintptr_t>(0));
+static_assert(static_cast<uintptr_t>(PtrTag::CFunctionPtrTag) == static_cast<uintptr_t>(1));
 
 FOR_EACH_ADDITIONAL_WTF_PTRTAG(WTF_DECLARE_PTRTAG)
 
@@ -234,7 +234,7 @@ inline PtrType tagCodePtrImpl(PtrType ptr)
 {
     if (!ptr)
         return nullptr;
-    WTF_PTRTAG_ASSERT(tagAction, ptr, NoPtrTag, removeCodePtrTag(ptr) == ptr);
+    WTF_PTRTAG_ASSERT(tagAction, ptr, PtrTag::NoPtrTag, removeCodePtrTag(ptr) == ptr);
     return PtrTagTraits<tag>::tagCodePtr(ptr);
 }
 
@@ -269,18 +269,18 @@ inline PtrType untagCodePtr(PtrType ptr) { return untagCodePtrImpl<PtrTagAction:
 template<PtrTagAction tagAction, PtrTag oldTag, PtrTag newTag, typename PtrType>
 inline PtrType retagCodePtrImplHelper(PtrType ptr)
 {
-    if constexpr (oldTag == newTag || (oldTag == NoPtrTag && newTag == NoPtrTag))
+    if constexpr (oldTag == newTag || (oldTag == PtrTag::NoPtrTag && newTag == PtrTag::NoPtrTag))
         return ptr;
-    if constexpr (newTag == NoPtrTag)
+    if constexpr (newTag == PtrTag::NoPtrTag)
         return untagCodePtrImpl<tagAction, oldTag>(ptr);
-    if constexpr (oldTag == NoPtrTag)
+    if constexpr (oldTag == PtrTag::NoPtrTag)
         return tagCodePtrImpl<tagAction, newTag>(ptr);
 #if CPU(ARM64E)
     if constexpr (PtrTagTraits<oldTag>::isSpecialized || PtrTagTraits<newTag>::isSpecialized)
         return tagCodePtrImpl<tagAction, newTag>(untagCodePtrImpl<tagAction, oldTag>(ptr));
-    if constexpr (oldTag == CFunctionPtrTag)
+    if constexpr (oldTag == PtrTag::CFunctionPtrTag)
         return ptrauth_auth_and_resign(ptr, ptrauth_key_function_pointer, 0, ptrauth_key_process_dependent_code, newTag);
-    if constexpr (newTag == CFunctionPtrTag)
+    if constexpr (newTag == PtrTag::CFunctionPtrTag)
         return ptrauth_auth_and_resign(ptr, ptrauth_key_process_dependent_code, oldTag, ptrauth_key_function_pointer, 0);
     return ptrauth_auth_and_resign(ptr, ptrauth_key_process_dependent_code, oldTag, ptrauth_key_process_dependent_code, newTag);
 #else
@@ -312,7 +312,7 @@ template<typename PtrType>
 void assertIsCFunctionPtr(PtrType value)
 {
     void* ptr = std::bit_cast<void*>(value);
-    WTF_PTRTAG_ASSERT(PtrTagAction::DebugAssert, ptr, CFunctionPtrTag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, CFunctionPtrTag>(removeCodePtrTag(ptr))));
+    WTF_PTRTAG_ASSERT(PtrTagAction::DebugAssert, ptr, PtrTag::CFunctionPtrTag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, PtrTag::CFunctionPtrTag>(removeCodePtrTag(ptr))));
 }
 
 template<typename PtrType>
@@ -326,7 +326,7 @@ template<typename PtrType>
 void assertIsNotTagged(PtrType value)
 {
     void* ptr = std::bit_cast<void*>(value);
-    WTF_PTRTAG_ASSERT(PtrTagAction::DebugAssert, ptr, NoPtrTag, ptr == removeCodePtrTag(ptr));
+    WTF_PTRTAG_ASSERT(PtrTagAction::DebugAssert, ptr, PtrTag::NoPtrTag, ptr == removeCodePtrTag(ptr));
 }
 
 template<PtrTag tag, typename PtrType>
@@ -344,7 +344,7 @@ template<PtrTag tag, typename PtrType>
 bool isTaggedWith(PtrType value)
 {
     void* ptr = std::bit_cast<void*>(value);
-    if (tag == NoPtrTag)
+    if (tag == PtrTag::NoPtrTag)
         return ptr == removeCodePtrTag(ptr);
     return PtrTagTraits<tag>::isTagged(ptr);
 }
@@ -368,8 +368,8 @@ inline PtrType tagCFunctionPtrImpl(PtrType ptr)
 {
     if (!ptr)
         return nullptr;
-    WTF_PTRTAG_ASSERT(tagAction, ptr, CFunctionPtrTag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, CFunctionPtrTag>(removeCodePtrTag(ptr))));
-    return retagCodePtrImpl<tagAction, CFunctionPtrTag, tag>(ptr);
+    WTF_PTRTAG_ASSERT(tagAction, ptr, PtrTag::CFunctionPtrTag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, PtrTag::CFunctionPtrTag>(removeCodePtrTag(ptr))));
+    return retagCodePtrImpl<tagAction, PtrTag::CFunctionPtrTag, tag>(ptr);
 }
 
 template<typename T, PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
@@ -399,7 +399,7 @@ inline PtrType untagCFunctionPtrImpl(PtrType ptr)
     if (!ptr)
         return nullptr;
     WTF_PTRTAG_ASSERT(tagAction, ptr, tag, ptr == (tagCodePtrImpl<PtrTagAction::NoAssert, tag>(removeCodePtrTag(ptr))));
-    return retagCodePtrImpl<tagAction, tag, CFunctionPtrTag>(ptr);
+    return retagCodePtrImpl<tagAction, tag, PtrTag::CFunctionPtrTag>(ptr);
 }
 
 template<typename T, PtrTag tag, typename PtrType, typename = std::enable_if_t<std::is_pointer<PtrType>::value>>
@@ -590,8 +590,8 @@ inline IntType untagInt(IntType ptrInt, PtrTag tag)
 
 } // namespace WTF
 
-using WTF::CFunctionPtrTag;
-using WTF::NoPtrTag;
+using WTF::PtrTag::CFunctionPtrTag;
+using WTF::PtrTag::NoPtrTag;
 using WTF::PACKeyType;
 using WTF::PlatformRegistersLRPtrTag;
 using WTF::PlatformRegistersPCPtrTag;

--- a/Source/WTF/wtf/RedBlackTree.h
+++ b/Source/WTF/wtf/RedBlackTree.h
@@ -48,7 +48,7 @@ class RedBlackTree final {
 private:
     static constexpr unsigned s_maximumTreeDepth = 128;
 
-    enum Color {
+    enum class Color {
         Red = 1,
         Black
     };
@@ -141,13 +141,13 @@ public:
         Color color() const
         {
             if (m_parentAndRed & 1)
-                return Red;
-            return Black;
+                return Color::Red;
+            return Color::Black;
         }
         
         void setColor(Color value)
         {
-            if (value == Red)
+            if (value == Color::Red)
                 m_parentAndRed |= 1;
             else
                 m_parentAndRed &= ~static_cast<uintptr_t>(1);
@@ -167,18 +167,18 @@ public:
     {
         x->reset();
         treeInsert(x);
-        x->setColor(Red);
+        x->setColor(Color::Red);
 
         unsigned depth = 0;
-        while (x != m_root && x->parent()->color() == Red) {
+        while (x != m_root && x->parent()->color() == Color::Red) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (x->parent() == x->parent()->parent()->left()) {
                 NodeType* y = x->parent()->parent()->right();
-                if (y && y->color() == Red) {
+                if (y && y->color() == Color::Red) {
                     // Case 1
-                    x->parent()->setColor(Black);
-                    y->setColor(Black);
-                    x->parent()->parent()->setColor(Red);
+                    x->parent()->setColor(Color::Black);
+                    y->setColor(Color::Black);
+                    x->parent()->parent()->setColor(Color::Red);
                     x = x->parent()->parent();
                 } else {
                     if (x == x->parent()->right()) {
@@ -187,18 +187,18 @@ public:
                         leftRotate(x);
                     }
                     // Case 3
-                    x->parent()->setColor(Black);
-                    x->parent()->parent()->setColor(Red);
+                    x->parent()->setColor(Color::Black);
+                    x->parent()->parent()->setColor(Color::Red);
                     rightRotate(x->parent()->parent());
                 }
             } else {
                 // Same as "then" clause with "right" and "left" exchanged.
                 NodeType* y = x->parent()->parent()->left();
-                if (y && y->color() == Red) {
+                if (y && y->color() == Color::Red) {
                     // Case 1
-                    x->parent()->setColor(Black);
-                    y->setColor(Black);
-                    x->parent()->parent()->setColor(Red);
+                    x->parent()->setColor(Color::Black);
+                    y->setColor(Color::Black);
+                    x->parent()->parent()->setColor(Color::Red);
                     x = x->parent()->parent();
                 } else {
                     if (x == x->parent()->left()) {
@@ -207,14 +207,14 @@ public:
                         rightRotate(x);
                     }
                     // Case 3
-                    x->parent()->setColor(Black);
-                    x->parent()->parent()->setColor(Red);
+                    x->parent()->setColor(Color::Black);
+                    x->parent()->parent()->setColor(Color::Red);
                     leftRotate(x->parent()->parent());
                 }
             }
         }
 
-        m_root->setColor(Black);
+        m_root->setColor(Color::Black);
     }
 
     NodeType* remove(NodeType* z)
@@ -254,7 +254,7 @@ public:
         }
             
         if (y != z) {
-            if (y->color() == Black)
+            if (y->color() == Color::Black)
                 removeFixup(x, xParent);
             
             y->setParent(z->parent());
@@ -275,7 +275,7 @@ public:
                 ASSERT(m_root == z);
                 m_root = y;
             }
-        } else if (y->color() == Black)
+        } else if (y->color() == Color::Black)
             removeFixup(x, xParent);
 
         return z;
@@ -439,7 +439,7 @@ private:
         ASSERT(!z->left());
         ASSERT(!z->right());
         ASSERT(!z->parent());
-        ASSERT(z->color() == Red);
+        ASSERT(z->color() == Color::Red);
         
         NodeType* y = nullptr;
         NodeType* x = m_root;
@@ -533,7 +533,7 @@ private:
     void removeFixup(NodeType* x, NodeType* xParent)
     {
         unsigned depth = 0;
-        while (x != m_root && (!x || x->color() == Black)) {
+        while (x != m_root && (!x || x->color() == Color::Black)) {
             RELEASE_ASSERT(++depth <= s_maximumTreeDepth);
             if (x == xParent->left()) {
                 // Note: the text points out that w can not be null.
@@ -542,32 +542,32 @@ private:
                 // red-black tree.
                 NodeType* w = xParent->right();
                 ASSERT(w); // x's sibling should not be null.
-                if (w->color() == Red) {
+                if (w->color() == Color::Red) {
                     // Case 1
-                    w->setColor(Black);
-                    xParent->setColor(Red);
+                    w->setColor(Color::Black);
+                    xParent->setColor(Color::Red);
                     leftRotate(xParent);
                     w = xParent->right();
                 }
-                if ((!w->left() || w->left()->color() == Black)
-                    && (!w->right() || w->right()->color() == Black)) {
+                if ((!w->left() || w->left()->color() == Color::Black)
+                    && (!w->right() || w->right()->color() == Color::Black)) {
                     // Case 2
-                    w->setColor(Red);
+                    w->setColor(Color::Red);
                     x = xParent;
                     xParent = x->parent();
                 } else {
-                    if (!w->right() || w->right()->color() == Black) {
+                    if (!w->right() || w->right()->color() == Color::Black) {
                         // Case 3
-                        w->left()->setColor(Black);
-                        w->setColor(Red);
+                        w->left()->setColor(Color::Black);
+                        w->setColor(Color::Red);
                         rightRotate(w);
                         w = xParent->right();
                     }
                     // Case 4
                     w->setColor(xParent->color());
-                    xParent->setColor(Black);
+                    xParent->setColor(Color::Black);
                     if (w->right())
-                        w->right()->setColor(Black);
+                        w->right()->setColor(Color::Black);
                     leftRotate(xParent);
                     x = m_root;
                     xParent = x->parent();
@@ -582,32 +582,32 @@ private:
                 // red-black tree.
                 NodeType* w = xParent->left();
                 ASSERT(w); // x's sibling should not be null.
-                if (w->color() == Red) {
+                if (w->color() == Color::Red) {
                     // Case 1
-                    w->setColor(Black);
-                    xParent->setColor(Red);
+                    w->setColor(Color::Black);
+                    xParent->setColor(Color::Red);
                     rightRotate(xParent);
                     w = xParent->left();
                 }
-                if ((!w->right() || w->right()->color() == Black)
-                    && (!w->left() || w->left()->color() == Black)) {
+                if ((!w->right() || w->right()->color() == Color::Black)
+                    && (!w->left() || w->left()->color() == Color::Black)) {
                     // Case 2
-                    w->setColor(Red);
+                    w->setColor(Color::Red);
                     x = xParent;
                     xParent = x->parent();
                 } else {
-                    if (!w->left() || w->left()->color() == Black) {
+                    if (!w->left() || w->left()->color() == Color::Black) {
                         // Case 3
-                        w->right()->setColor(Black);
-                        w->setColor(Red);
+                        w->right()->setColor(Color::Black);
+                        w->setColor(Color::Red);
                         leftRotate(w);
                         w = xParent->left();
                     }
                     // Case 4
                     w->setColor(xParent->color());
-                    xParent->setColor(Black);
+                    xParent->setColor(Color::Black);
                     if (w->left())
-                        w->left()->setColor(Black);
+                        w->left()->setColor(Color::Black);
                     rightRotate(xParent);
                     x = m_root;
                     xParent = x->parent();
@@ -615,7 +615,7 @@ private:
             }
         }
         if (x)
-            x->setColor(Black);
+            x->setColor(Color::Black);
     }
 
     NodeType* m_root;

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -162,7 +162,7 @@ private:
     template<typename X, typename Y, typename Z, typename U, typename V, typename W>
     friend bool operator==(const Ref<X, Y, Z>&, const Ref<U, V, W>&);
 
-    enum AdoptTag { Adopt };
+    enum class AdoptTag { Adopt };
     Ref(T& object, AdoptTag)
         : m_ptr(&object)
     {
@@ -292,7 +292,7 @@ template<typename T, typename _PtrTraits, typename RefDerefTraits>
 inline Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T& reference)
 {
     adopted(&reference);
-    return Ref<T, _PtrTraits, RefDerefTraits>(reference, Ref<T, _PtrTraits, RefDerefTraits>::Adopt);
+    return Ref<T, _PtrTraits, RefDerefTraits>(reference, Ref<T, _PtrTraits, RefDerefTraits>::AdoptTag::Adopt);
 }
 
 template<typename ExpectedType, typename ArgType, typename PtrTraits, typename RefDerefTraits>

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -101,7 +101,7 @@ private:
     template<typename T1, typename U, typename V, typename X>
     friend bool operator==(const RefPtr<T1, U, V>&, X*);
 
-    enum AdoptTag { Adopt };
+    enum class AdoptTag { Adopt };
     RefPtr(T* ptr, AdoptTag) : m_ptr(ptr) { }
 
     typename PtrTraits::StorageType m_ptr;
@@ -210,7 +210,7 @@ template<typename T, typename U, typename V>
 inline RefPtr<T, U, V> adoptRef(T* p)
 {
     adopted(p);
-    return RefPtr<T, U, V>(p, RefPtr<T, U, V>::Adopt);
+    return RefPtr<T, U, V>(p, RefPtr<T, U, V>::AdoptTag::Adopt);
 }
 
 template<typename T, typename U = RawPtrTraits<T>, typename V = DefaultRefDerefTraits<T>, typename X, typename Y, typename Z>

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -149,7 +149,7 @@ public:
     template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
 private:
-    enum AdoptTag { Adopt };
+    enum class AdoptTag { Adopt };
     constexpr RetainPtr(PtrType ptr, AdoptTag) : m_ptr(ptr) { }
 
 #if __has_feature(objc_arc)
@@ -300,13 +300,13 @@ template<typename T, typename U> constexpr bool operator==(const RetainPtr<T>& a
 template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT ptr)
 {
     static_assert(!IsNSType<T>, "Don't use adoptCF with Objective-C pointer types, use adoptNS.");
-    return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
+    return { ptr, RetainPtr<RetainPtrType<T>>::AdoptTag::Adopt };
 }
 
 template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT ptr)
 {
     static_assert(IsNSType<T>, "Don't use adoptNS with Core Foundation pointer types, use adoptCF.");
-    return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
+    return { ptr, RetainPtr<RetainPtrType<T>>::AdoptTag::Adopt };
 }
 
 template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)

--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -43,7 +43,7 @@
 
 namespace WTF {
 
-enum SentinelTag { Sentinel };
+enum class SentinelTag { Sentinel };
 
 template<typename T, typename PassedPtrTraits = RawPtrTraits<T>>
 class BasicRawSentinelNode {
@@ -117,7 +117,7 @@ public:
     using const_iterator = BaseIterator<const RawNode, const T>;
 
     SentinelLinkedList()
-        : m_sentinel(Sentinel)
+        : m_sentinel(SentinelTag::Sentinel)
     {
         m_sentinel.setPrev(&m_sentinel);
         m_sentinel.setNext(&m_sentinel);

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -143,7 +143,7 @@ inline bool isPointerTypeAlignmentOkay(Type*)
 
 namespace WTF {
 
-enum CheckMoveParameterTag { CheckMoveParameter };
+enum class CheckMoveParameterTag { CheckMoveParameter };
 
 static constexpr size_t KB = 1024;
 static constexpr size_t MB = 1024 * 1024;
@@ -220,7 +220,7 @@ constexpr IntType toTwosComplement(IntType integer)
     return static_cast<IntType>((~static_cast<UnsignedIntType>(integer)) + static_cast<UnsignedIntType>(1));
 }
 
-enum BinarySearchMode {
+enum class BinarySearchMode {
     KeyMustBePresentInArray,
     KeyMightNotBePresentInArray,
     ReturnAdjacentElementIfKeyIsNotPresent
@@ -246,18 +246,18 @@ inline ArrayElementType* binarySearchImpl(ArrayType& array, size_t size, KeyType
             offset += (pos + 1);
         }
 
-        ASSERT(mode != KeyMustBePresentInArray || size);
+        ASSERT(mode != BinarySearchMode::KeyMustBePresentInArray || size);
     }
     
-    if (mode == KeyMightNotBePresentInArray && !size)
+    if (mode == BinarySearchMode::KeyMightNotBePresentInArray && !size)
         return 0;
     
     ArrayElementType* result = &array[offset];
 
-    if (mode == KeyMightNotBePresentInArray && key != extractKey(result))
+    if (mode == BinarySearchMode::KeyMightNotBePresentInArray && key != extractKey(result))
         return 0;
 
-    if (mode == KeyMustBePresentInArray) {
+    if (mode == BinarySearchMode::KeyMustBePresentInArray) {
         ASSERT(size == 1);
         ASSERT(key == extractKey(result));
     }
@@ -269,38 +269,38 @@ inline ArrayElementType* binarySearchImpl(ArrayType& array, size_t size, KeyType
 template<typename ArrayElementType, typename KeyType, typename ArrayType, typename ExtractKey>
 inline ArrayElementType* binarySearch(ArrayType& array, size_t size, KeyType key, ExtractKey extractKey = ExtractKey())
 {
-    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, KeyMustBePresentInArray>(array, size, key, extractKey);
+    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, BinarySearchMode::KeyMustBePresentInArray>(array, size, key, extractKey);
 }
 
 // Return zero if the element is not found.
 template<typename ArrayElementType, typename KeyType, typename ArrayType, typename ExtractKey>
 inline ArrayElementType* tryBinarySearch(ArrayType& array, size_t size, KeyType key, ExtractKey extractKey = ExtractKey())
 {
-    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, KeyMightNotBePresentInArray>(array, size, key, extractKey);
+    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, BinarySearchMode::KeyMightNotBePresentInArray>(array, size, key, extractKey);
 }
 
 // Return the element that is either to the left, or the right, of where the element would have been found.
 template<typename ArrayElementType, typename KeyType, typename ArrayType, typename ExtractKey>
 inline ArrayElementType* approximateBinarySearch(ArrayType& array, size_t size, KeyType key, ExtractKey extractKey = ExtractKey())
 {
-    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, ReturnAdjacentElementIfKeyIsNotPresent>(array, size, key, extractKey);
+    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, BinarySearchMode::ReturnAdjacentElementIfKeyIsNotPresent>(array, size, key, extractKey);
 }
 
 // Variants of the above that use const.
 template<typename ArrayElementType, typename KeyType, typename ArrayType, typename ExtractKey>
 inline ArrayElementType* binarySearch(const ArrayType& array, size_t size, KeyType key, ExtractKey extractKey = ExtractKey())
 {
-    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, KeyMustBePresentInArray>(const_cast<ArrayType&>(array), size, key, extractKey);
+    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, BinarySearchMode::KeyMustBePresentInArray>(const_cast<ArrayType&>(array), size, key, extractKey);
 }
 template<typename ArrayElementType, typename KeyType, typename ArrayType, typename ExtractKey>
 inline ArrayElementType* tryBinarySearch(const ArrayType& array, size_t size, KeyType key, ExtractKey extractKey = ExtractKey())
 {
-    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, KeyMightNotBePresentInArray>(const_cast<ArrayType&>(array), size, key, extractKey);
+    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, BinarySearchMode::KeyMightNotBePresentInArray>(const_cast<ArrayType&>(array), size, key, extractKey);
 }
 template<typename ArrayElementType, typename KeyType, typename ArrayType, typename ExtractKey>
 inline ArrayElementType* approximateBinarySearch(const ArrayType& array, size_t size, KeyType key, ExtractKey extractKey = ExtractKey())
 {
-    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, ReturnAdjacentElementIfKeyIsNotPresent>(const_cast<ArrayType&>(array), size, key, extractKey);
+    return binarySearchImpl<ArrayElementType, KeyType, ArrayType, ExtractKey, BinarySearchMode::ReturnAdjacentElementIfKeyIsNotPresent>(const_cast<ArrayType&>(array), size, key, extractKey);
 }
 
 template<typename VectorType, typename ElementType>
@@ -1493,7 +1493,7 @@ ALWAYS_INLINE std::weak_ordering weakOrderingCast(std::partial_ordering ordering
 
 } // namespace WTF
 
-#define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
+#define WTFMove(value) std::move<WTF::CheckMoveParameterTag::CheckMoveParameter>(value)
 
 namespace WTF {
 namespace detail {

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -326,7 +326,7 @@ protected:
 
     static const char* normalizeThreadName(const char* threadName);
 
-    enum JoinableState : uint8_t {
+    enum class JoinableState : uint8_t {
         // The default thread state. The thread can be joined on.
         Joinable,
 
@@ -341,9 +341,9 @@ protected:
     };
 
     JoinableState joinableState() const { return m_joinableState; }
-    void didBecomeDetached() { m_joinableState = Detached; }
+    void didBecomeDetached() { m_joinableState = JoinableState::Detached; }
     void didExit();
-    void didJoin() { m_joinableState = Joined; }
+    void didJoin() { m_joinableState = JoinableState::Joined; }
     bool hasExited() const { return m_didExit; }
 
     // These functions are only called from ThreadGroup.
@@ -372,7 +372,7 @@ protected:
 
     static Lock s_allThreadsLock;
 
-    JoinableState m_joinableState { Joinable };
+    JoinableState m_joinableState { JoinableState::Joinable };
     bool m_isShuttingDown : 1 { false };
     bool m_didExit : 1 { false };
     bool m_isDestroyedOnce : 1 { false };

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1214,41 +1214,41 @@ static bool isIPv4Address(StringView string)
 
 bool URL::isIPv6Address(StringView string)
 {
-    enum SkipState { None, WillSkip, Skipping, Skipped, Final };
-    auto skipState = None;
+    enum class SkipState { None, WillSkip, Skipping, Skipped, Final };
+    auto skipState = SkipState::None;
     auto count = 0;
 
     for (const auto hextet : string.splitAllowingEmptyEntries(':')) {
-        if (count >= 8 || skipState == Final)
+        if (count >= 8 || skipState == SkipState::Final)
             return false;
 
         const auto length = hextet.length();
         if (!length) {
             // :: may be used anywhere to skip 1 to 8 hextets, but only once.
-            if (skipState == Skipped)
+            if (skipState == SkipState::Skipped)
                 return false;
 
-            if (skipState == None)
-                skipState = !count ? WillSkip : Skipping;
-            else if (skipState == WillSkip)
-                skipState = Skipping;
+            if (skipState == SkipState::None)
+                skipState = !count ? SkipState::WillSkip : SkipState::Skipping;
+            else if (skipState == SkipState::WillSkip)
+                skipState = SkipState::Skipping;
             else
-                skipState = Final;
+                skipState = SkipState::Final;
             continue;
         }
 
-        if (skipState == WillSkip)
+        if (skipState == SkipState::WillSkip)
             return false;
 
-        if (skipState == Skipping)
-            skipState = Skipped;
+        if (skipState == SkipState::Skipping)
+            skipState = SkipState::Skipped;
 
         if (length > 4) {
             // An IPv4 address may be used in place of the final two hextets.
-            if ((skipState == None && count != 6) || (skipState == Skipped && count >= 6) || !isIPv4Address(hextet))
+            if ((skipState == SkipState::None && count != 6) || (skipState == SkipState::Skipped && count >= 6) || !isIPv4Address(hextet))
                 return false;
 
-            skipState = Final;
+            skipState = SkipState::Final;
             continue;
         }
 
@@ -1261,7 +1261,7 @@ bool URL::isIPv6Address(StringView string)
         count++;
     }
 
-    return (count == 8 && skipState == None) || skipState == Skipped || skipState == Final;
+    return (count == 8 && skipState == SkipState::None) || skipState == SkipState::Skipped || skipState == SkipState::Final;
 }
 
 #if !PLATFORM(COCOA) && !USE(SOUP)

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -141,18 +141,18 @@ void Config::initialize()
         if (equalLettersIgnoringASCIICase(useAllocationProfiling, "true"_s)
             || equalLettersIgnoringASCIICase(useAllocationProfiling, "yes"_s)
             || equal(useAllocationProfiling, "1"_s))
-            reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = 1;
+            reservedConfigBytes[static_cast<int>(WebConfig::ReservedConfigByteOffset::ReservedByteForAllocationProfiling)] = 1;
         else if (equalLettersIgnoringASCIICase(useAllocationProfiling, "false"_s)
             || equalLettersIgnoringASCIICase(useAllocationProfiling, "no"_s)
             || equal(useAllocationProfiling, "0"_s))
-            reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = 0;
+            reservedConfigBytes[static_cast<int>(WebConfig::ReservedConfigByteOffset::ReservedByteForAllocationProfiling)] = 0;
 
         const char* useAllocationProfilingModeRaw = getenv("JSC_allocationProfilingMode");
-        if (useAllocationProfilingModeRaw && reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] == 1) {
+        if (useAllocationProfilingModeRaw && reservedConfigBytes[static_cast<int>(WebConfig::ReservedConfigByteOffset::ReservedByteForAllocationProfiling)] == 1) {
             unsigned value { 0 };
             if (sscanf(useAllocationProfilingModeRaw, "%u", &value) == 1) {
                 RELEASE_ASSERT(value <= 0xFF);
-                reservedConfigBytes[WebConfig::ReservedByteForAllocationProfilingMode] = static_cast<uint8_t>(value & 0xFF);
+                reservedConfigBytes[static_cast<int>(WebConfig::ReservedConfigByteOffset::ReservedByteForAllocationProfilingMode)] = static_cast<uint8_t>(value & 0xFF);
             }
         }
     }

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -55,13 +55,13 @@ extern "C" WTF_EXPORT_PRIVATE Slot g_config[];
 constexpr size_t reservedSlotsForExecutableAllocator = 2;
 constexpr size_t additionalReservedSlots = 2;
 
-enum ReservedConfigByteOffset {
+enum class ReservedConfigByteOffset {
     ReservedByteForAllocationProfiling,
     ReservedByteForAllocationProfilingMode,
     NumberOfReservedConfigBytes
 };
 
-static_assert(NumberOfReservedConfigBytes <= sizeof(Slot) * additionalReservedSlots);
+static_assert(static_cast<int>(ReservedConfigByteOffset::NumberOfReservedConfigBytes) <= sizeof(Slot) * additionalReservedSlots);
 
 } // namespace WebConfig
 

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -178,7 +178,7 @@ WorkQueue& WorkQueue::mainSingleton()
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         WTF::initialize();
-        mainWorkQueue.get() = adoptRef(*new WorkQueue(CreateMain));
+        mainWorkQueue.get() = adoptRef(*new WorkQueue(MainTag::CreateMain));
     });
     return *mainWorkQueue.get();
 }

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -108,7 +108,7 @@ public:
 protected:
     WorkQueue(ASCIILiteral name, QOS);
 private:
-    enum MainTag : bool {
+    enum class MainTag : bool {
         CreateMain
     };
     explicit WorkQueue(MainTag);

--- a/Source/WTF/wtf/dtoa/bignum-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/bignum-dtoa.cc
@@ -96,7 +96,7 @@ void BignumDtoa(double v, BignumDtoaMode mode, int requested_digits,
   uint64_t significand;
   int exponent;
   bool lower_boundary_is_closer;
-  if (mode == BIGNUM_DTOA_SHORTEST_SINGLE) {
+  if (mode == BignumDtoaMode::BIGNUM_DTOA_SHORTEST_SINGLE) {
     float f = static_cast<float>(v);
     ASSERT(f == v);
     significand = Single(f).Significand();
@@ -108,7 +108,7 @@ void BignumDtoa(double v, BignumDtoaMode mode, int requested_digits,
     lower_boundary_is_closer = Double(v).LowerBoundaryIsCloser();
   }
   bool need_boundary_deltas =
-      (mode == BIGNUM_DTOA_SHORTEST || mode == BIGNUM_DTOA_SHORTEST_SINGLE);
+      (mode == BignumDtoaMode::BIGNUM_DTOA_SHORTEST || mode == BignumDtoaMode::BIGNUM_DTOA_SHORTEST_SINGLE);
 
   bool is_even = (significand & 1) == 0;
   int normalized_exponent = NormalizedExponent(significand, exponent);
@@ -119,7 +119,7 @@ void BignumDtoa(double v, BignumDtoaMode mode, int requested_digits,
   // The requested digits correspond to the digits after the point. If the
   // number is much too small, then there is no need in trying to get any
   // digits.
-  if (mode == BIGNUM_DTOA_FIXED && -estimated_power - 1 > requested_digits) {
+  if (mode == BignumDtoaMode::BIGNUM_DTOA_FIXED && -estimated_power - 1 > requested_digits) {
     buffer[0] = '\0';
     length = 0;
     // Set decimal-point to -requested_digits. This is what Gay does.
@@ -147,14 +147,14 @@ void BignumDtoa(double v, BignumDtoaMode mode, int requested_digits,
   // We now have v = (numerator / denominator) * 10^(decimal_point-1), and
   //  1 <= (numerator + delta_plus) / denominator < 10
   switch (mode) {
-    case BIGNUM_DTOA_SHORTEST:
-    case BIGNUM_DTOA_SHORTEST_SINGLE:
+    case BignumDtoaMode::BIGNUM_DTOA_SHORTEST:
+    case BignumDtoaMode::BIGNUM_DTOA_SHORTEST_SINGLE:
       GenerateShortestDigits(numerator, denominator, delta_minus, delta_plus, is_even, buffer, length);
       break;
-    case BIGNUM_DTOA_FIXED:
+    case BignumDtoaMode::BIGNUM_DTOA_FIXED:
       BignumToFixed(requested_digits, decimal_point, numerator, denominator, buffer, length);
       break;
-    case BIGNUM_DTOA_PRECISION:
+    case BignumDtoaMode::BIGNUM_DTOA_PRECISION:
       GenerateCountedDigits(requested_digits, decimal_point, numerator, denominator, buffer, length);
       break;
     default:

--- a/Source/WTF/wtf/dtoa/bignum-dtoa.h
+++ b/Source/WTF/wtf/dtoa/bignum-dtoa.h
@@ -33,7 +33,7 @@
 namespace WTF {
 namespace double_conversion {
 
-enum BignumDtoaMode {
+enum class BignumDtoaMode {
   // Return the shortest correct representation.
   // For example the output of 0.299999999999999988897 is (the less accurate but
   // correct) 0.3.

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -367,11 +367,11 @@ bool DoubleToStringConverter::ToPrecision(double value,
 static BignumDtoaMode DtoaToBignumDtoaMode(
     DoubleToStringConverter::DtoaMode dtoa_mode) {
   switch (dtoa_mode) {
-    case DoubleToStringConverter::SHORTEST:  return BIGNUM_DTOA_SHORTEST;
+    case DoubleToStringConverter::SHORTEST:  return BignumDtoaMode::BIGNUM_DTOA_SHORTEST;
     case DoubleToStringConverter::SHORTEST_SINGLE:
-        return BIGNUM_DTOA_SHORTEST_SINGLE;
-    case DoubleToStringConverter::FIXED:     return BIGNUM_DTOA_FIXED;
-    case DoubleToStringConverter::PRECISION: return BIGNUM_DTOA_PRECISION;
+        return BignumDtoaMode::BIGNUM_DTOA_SHORTEST_SINGLE;
+    case DoubleToStringConverter::FIXED:     return BignumDtoaMode::BIGNUM_DTOA_FIXED;
+    case DoubleToStringConverter::PRECISION: return BignumDtoaMode::BIGNUM_DTOA_PRECISION;
     default:
       UNREACHABLE();
   }
@@ -413,16 +413,16 @@ void DoubleToStringConverter::DoubleToAscii(double v,
   bool fast_worked;
   switch (mode) {
     case SHORTEST:
-      fast_worked = FastDtoa(v, FAST_DTOA_SHORTEST, 0, bufferReference, length, point);
+      fast_worked = FastDtoa(v, FastDtoaMode::FAST_DTOA_SHORTEST, 0, bufferReference, length, point);
       break;
     case SHORTEST_SINGLE:
-      fast_worked = FastDtoa(v, FAST_DTOA_SHORTEST_SINGLE, 0, bufferReference, length, point);
+      fast_worked = FastDtoa(v, FastDtoaMode::FAST_DTOA_SHORTEST_SINGLE, 0, bufferReference, length, point);
       break;
     case FIXED:
       fast_worked = FastFixedDtoa(v, requested_digits, bufferReference, length, point);
       break;
     case PRECISION:
-      fast_worked = FastDtoa(v, FAST_DTOA_PRECISION, requested_digits, bufferReference, length, point);
+      fast_worked = FastDtoa(v, FastDtoaMode::FAST_DTOA_PRECISION, requested_digits, bufferReference, length, point);
       break;
     default:
       fast_worked = false;

--- a/Source/WTF/wtf/dtoa/fast-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/fast-dtoa.cc
@@ -527,10 +527,10 @@ static bool Grisu3(double v,
   // boundary_minus and boundary_plus will round to v when convert to a double.
   // Grisu3 will never output representations that lie exactly on a boundary.
   DiyFp boundary_minus, boundary_plus;
-  if (mode == FAST_DTOA_SHORTEST) {
+  if (mode == FastDtoaMode::FAST_DTOA_SHORTEST) {
     Double(v).NormalizedBoundaries(&boundary_minus, &boundary_plus);
   } else {
-    ASSERT(mode == FAST_DTOA_SHORTEST_SINGLE);
+    ASSERT(mode == FastDtoaMode::FAST_DTOA_SHORTEST_SINGLE);
     float single_v = static_cast<float>(v);
     Single(single_v).NormalizedBoundaries(&boundary_minus, &boundary_plus);
   }
@@ -642,11 +642,11 @@ bool FastDtoa(double v,
   bool result = false;
   int decimal_exponent = 0;
   switch (mode) {
-    case FAST_DTOA_SHORTEST:
-    case FAST_DTOA_SHORTEST_SINGLE:
+    case FastDtoaMode::FAST_DTOA_SHORTEST:
+    case FastDtoaMode::FAST_DTOA_SHORTEST_SINGLE:
       result = Grisu3(v, mode, buffer, length, decimal_exponent);
       break;
-    case FAST_DTOA_PRECISION:
+    case FastDtoaMode::FAST_DTOA_PRECISION:
       result = Grisu3Counted(v, requested_digits, buffer, length, decimal_exponent);
       break;
     default:

--- a/Source/WTF/wtf/dtoa/fast-dtoa.h
+++ b/Source/WTF/wtf/dtoa/fast-dtoa.h
@@ -33,7 +33,7 @@
 namespace WTF {
 namespace double_conversion {
 
-enum FastDtoaMode {
+enum class FastDtoaMode {
   // Computes the shortest representation of the given input. The returned
   // result will be the most accurate number of this length. Longer
   // representations might be more accurate.

--- a/Source/WTF/wtf/fast_float/ascii_number.h
+++ b/Source/WTF/wtf/fast_float/ascii_number.h
@@ -311,7 +311,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     return answer;
   }
   int64_t exp_number = 0;            // explicit exponential part
-  if ((fmt & chars_format::scientific) && (p != pend) && ((UC('e') == *p) || (UC('E') == *p))) {
+  if ((static_cast<int>(fmt) & static_cast<int>(chars_format::scientific)) && (p != pend) && ((UC('e') == *p) || (UC('E') == *p))) {
     UC const * location_of_e = p;
     ++p;
     bool neg_exp = false;
@@ -322,7 +322,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
       ++p;
     }
     if ((p == pend) || !is_integer(*p)) {
-      if(!(fmt & chars_format::fixed)) {
+      if(!(static_cast<int>(fmt) & static_cast<int>(chars_format::fixed))) {
         // We are in error.
         return answer;
       }
@@ -341,7 +341,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     }
   } else {
     // If it scientific and not fixed, we have to bail out.
-    if((fmt & chars_format::scientific) && !(fmt & chars_format::fixed)) { return answer; }
+    if((static_cast<int>(fmt) & static_cast<int>(chars_format::scientific)) && !(static_cast<int>(fmt) & static_cast<int>(chars_format::fixed))) { return answer; }
   }
   answer.lastmatch = p;
   answer.valid = true;

--- a/Source/WTF/wtf/fast_float/float_common.h
+++ b/Source/WTF/wtf/fast_float/float_common.h
@@ -14,11 +14,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace fast_float {
 
-enum chars_format {
+enum class chars_format {
   scientific = 1 << 0,
   fixed = 1 << 2,
   hex = 1 << 3,
-  general = fixed | scientific
+  general = static_cast<int>(chars_format::fixed) | static_cast<int>(chars_format::scientific)
 };
 
 template <typename UC>

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -77,7 +77,7 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, bool writable,
 #endif
 
 #if OS(DARWIN)
-    int fd = usage;
+    int fd = static_cast<int>(usage);
 #else
     UNUSED_PARAM(usage);
     int fd = -1;

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -412,7 +412,7 @@ int Thread::waitForCompletion()
         LOG_ERROR("Thread %p was unable to be joined.\n", this);
 
     Locker locker { m_mutex };
-    ASSERT(joinableState() == Joinable);
+    ASSERT(joinableState() == JoinableState::Joinable);
 
     // If the thread has already exited, then do nothing. If the thread hasn't exited yet, then just signal that we've already joined on it.
     // In both cases, Thread::destructTLS() will take care of destroying Thread.

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -32,7 +32,7 @@
 
 namespace WTF {
 
-enum PositiveOrNegativeNumber { PositiveNumber, NegativeNumber };
+enum class PositiveOrNegativeNumber { PositiveNumber, NegativeNumber };
 
 template<typename> struct IntegerToStringConversionTrait;
 
@@ -46,7 +46,7 @@ static typename IntegerToStringConversionTrait<T>::ReturnType numberToStringImpl
         number /= 10;
     } while (number);
 
-    if (NumberType == NegativeNumber)
+    if (NumberType == PositiveOrNegativeNumber::NegativeNumber)
         buffer[--index] = '-';
 
     return IntegerToStringConversionTrait<T>::flush(std::span { buffer }.subspan(index), additionalArgument);
@@ -56,14 +56,14 @@ template<typename T, typename SignedIntegerType>
 inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringSigned(SignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullptr)
 {
     if (number < 0)
-        return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, NegativeNumber>(-unsignedCast(number), additionalArgument);
-    return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, PositiveNumber>(number, additionalArgument);
+        return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, PositiveOrNegativeNumber::NegativeNumber>(-unsignedCast(number), additionalArgument);
+    return numberToStringImpl<T, typename std::make_unsigned_t<SignedIntegerType>, PositiveOrNegativeNumber::PositiveNumber>(number, additionalArgument);
 }
 
 template<typename T, typename UnsignedIntegerType>
 inline typename IntegerToStringConversionTrait<T>::ReturnType numberToStringUnsigned(UnsignedIntegerType number, typename IntegerToStringConversionTrait<T>::AdditionalArgumentType* additionalArgument = nullptr)
 {
-    return numberToStringImpl<T, UnsignedIntegerType, PositiveNumber>(number, additionalArgument);
+    return numberToStringImpl<T, UnsignedIntegerType, PositiveOrNegativeNumber::PositiveNumber>(number, additionalArgument);
 }
 
 template<typename CharacterType, typename UnsignedIntegerType, PositiveOrNegativeNumber NumberType>
@@ -77,7 +77,7 @@ static void writeIntegerToBufferImpl(UnsignedIntegerType number, std::span<Chara
         number /= 10;
     } while (number);
 
-    if (NumberType == NegativeNumber)
+    if (NumberType == PositiveOrNegativeNumber::NegativeNumber)
         buffer[--index] = '-';
     
     for (size_t i = 0; i < buffer.size() - index; ++i)
@@ -89,13 +89,13 @@ inline void writeIntegerToBuffer(IntegerType integer, std::span<CharacterType> d
 {
     static_assert(std::is_integral_v<IntegerType>);
     if constexpr (std::is_same_v<IntegerType, bool>)
-        return writeIntegerToBufferImpl<CharacterType, uint8_t, PositiveNumber>(integer ? 1 : 0, destination);
+        return writeIntegerToBufferImpl<CharacterType, uint8_t, PositiveOrNegativeNumber::PositiveNumber>(integer ? 1 : 0, destination);
     else if constexpr (std::is_signed_v<IntegerType>) {
         if (integer < 0)
-            return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, NegativeNumber>(WTF::negate(integer), destination);
-        return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, PositiveNumber>(unsignedCast(integer), destination);
+            return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, PositiveOrNegativeNumber::NegativeNumber>(WTF::negate(integer), destination);
+        return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, PositiveOrNegativeNumber::PositiveNumber>(unsignedCast(integer), destination);
     } else
-        return writeIntegerToBufferImpl<CharacterType, IntegerType, PositiveNumber>(integer, destination);
+        return writeIntegerToBufferImpl<CharacterType, IntegerType, PositiveOrNegativeNumber::PositiveNumber>(integer, destination);
 }
 
 template<typename UnsignedIntegerType, PositiveOrNegativeNumber NumberType>
@@ -108,7 +108,7 @@ constexpr unsigned lengthOfIntegerAsStringImpl(UnsignedIntegerType number)
         number /= 10;
     } while (number);
 
-    if (NumberType == NegativeNumber)
+    if (NumberType == PositiveOrNegativeNumber::NegativeNumber)
         ++length;
 
     return length;
@@ -124,10 +124,10 @@ constexpr unsigned lengthOfIntegerAsString(IntegerType integer)
     }
     else if constexpr (std::is_signed_v<IntegerType>) {
         if (integer < 0)
-            return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, NegativeNumber>(WTF::negate(integer));
-        return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, PositiveNumber>(unsignedCast(integer));
+            return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, PositiveOrNegativeNumber::NegativeNumber>(WTF::negate(integer));
+        return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, PositiveOrNegativeNumber::PositiveNumber>(unsignedCast(integer));
     } else
-        return lengthOfIntegerAsStringImpl<IntegerType, PositiveNumber>(integer);
+        return lengthOfIntegerAsStringImpl<IntegerType, PositiveOrNegativeNumber::PositiveNumber>(integer);
 }
 
 template<size_t N>

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -153,7 +153,7 @@ protected:
     StringImplShape(unsigned refCount, std::span<const LChar>, unsigned hashAndFlags);
     StringImplShape(unsigned refCount, std::span<const char16_t>, unsigned hashAndFlags);
 
-    enum ConstructWithConstExprTag { ConstructWithConstExpr };
+    enum class ConstructWithConstExprTag { ConstructWithConstExpr };
     template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
     template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
 
@@ -1246,13 +1246,13 @@ inline void StringImpl::assertHashIsCorrect() const
 
 template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char (&characters)[characterCount], StringKind stringKind)
     : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-        s_hashFlag8BitBuffer | s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
+        s_hashFlag8BitBuffer | s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExprTag::ConstructWithConstExpr)
 {
 }
 
 template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char16_t (&characters)[characterCount], StringKind stringKind)
     : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-        s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
+        s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExprTag::ConstructWithConstExpr)
 {
 }
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -860,7 +860,7 @@ public:
     bool operator==(const Iterator&) const;
 
 private:
-    enum PositionTag { AtEnd };
+    enum class PositionTag { AtEnd };
     Iterator(const SplitResult&);
     Iterator(const SplitResult&, PositionTag);
 
@@ -1105,7 +1105,7 @@ inline auto StringView::SplitResult::begin() const -> Iterator
 
 inline auto StringView::SplitResult::end() const -> Iterator
 {
-    return Iterator { *this, Iterator::AtEnd };
+    return Iterator { *this, Iterator::PositionTag::AtEnd };
 }
 
 inline StringView::SplitResult::Iterator::Iterator(const SplitResult& result)

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -115,7 +115,7 @@ inline SymbolImpl::SymbolImpl(Flags flags)
 
 template<unsigned characterCount>
 inline constexpr SymbolImpl::StaticSymbolImpl::StaticSymbolImpl(const char (&characters)[characterCount], Flags flags)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters, s_hashFlag8BitBuffer | s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
+    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters, s_hashFlag8BitBuffer | s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExprTag::ConstructWithConstExpr)
     , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount)
     , m_flags(flags)
 {
@@ -123,7 +123,7 @@ inline constexpr SymbolImpl::StaticSymbolImpl::StaticSymbolImpl(const char (&cha
 
 template<unsigned characterCount>
 inline constexpr SymbolImpl::StaticSymbolImpl::StaticSymbolImpl(const char16_t (&characters)[characterCount], Flags flags)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters, s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
+    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters, s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExprTag::ConstructWithConstExpr)
     , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount)
     , m_flags(flags)
 {

--- a/Source/WTF/wtf/unix/UnixFileDescriptor.h
+++ b/Source/WTF/wtf/unix/UnixFileDescriptor.h
@@ -80,7 +80,7 @@ public:
 
     UnixFileDescriptor duplicate() const
     {
-        return UnixFileDescriptor { m_value, Duplicate };
+        return UnixFileDescriptor { m_value, DuplicationTag::Duplicate };
     }
 
     int release() WARN_UNUSED_RETURN { return std::exchange(m_value, -1); }

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -179,7 +179,7 @@ int Thread::waitForCompletion()
         LOG_ERROR("Thread %p was found to be deadlocked trying to quit", this);
 
     Locker locker { m_mutex };
-    ASSERT(joinableState() == Joinable);
+    ASSERT(joinableState() == JoinableState::Joinable);
 
     // The thread has already exited, do nothing.
     // The thread hasn't exited yet, so don't clean anything up. Just signal that we've already joined on it so that it will clean up after itself.


### PR DESCRIPTION
#### c8eaffedffdfb28891bd1b4e4599b647b8f680e3
<pre>
[WTF] Use enum class for Safer C++ in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=296483">https://bugs.webkit.org/show_bug.cgi?id=296483</a>

Reviewed by NOBODY (OOPS!).

This is a refactoring-only patch with no behavior changes.
This patch replaces `enum` with `enum class` for Safer C++ in WTF [1].
Some enums intentionally left unchanged due to the large scope.

[1]: <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#use-enum-classes-instead-of-old-style-enumerations">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#use-enum-classes-instead-of-old-style-enumerations</a>

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::StructureMemoryManager):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableAllocator::disableJIT):
(JSC::initializeJITPageReservation):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::checkedCastDoubleToInt128):
* Source/JavaScriptCore/runtime/ProfilerSupport.cpp:
(JSC::ProfilerSupport::ProfilerSupport):
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::operator+):
(WTF::operator-):
(WTF::operator*):
(WTF::operator/):
* Source/WTF/wtf/CheckedRef.h:
* Source/WTF/wtf/CodePtr.h:
(WTF::CodePtr::CodePtr):
(WTF::CodePtr::fromTaggedPtr):
(WTF::CodePtr::fromUntaggedPtr):
(WTF::CodePtr::retagged const):
* Source/WTF/wtf/DataLog.cpp:
(WTF::setDataFile):
* Source/WTF/wtf/FilePrintStream.cpp:
(WTF::FilePrintStream::~FilePrintStream):
* Source/WTF/wtf/FilePrintStream.h:
* Source/WTF/wtf/Function.h:
(WTF::Function&lt;Out):
* Source/WTF/wtf/FunctionPtr.h:
* Source/WTF/wtf/Gigacage.h:
(): Deleted.
* Source/WTF/wtf/HexNumber.h:
(WTF::Internal::hexDigitsForMode):
(WTF::hex):
* Source/WTF/wtf/Lock.cpp:
(WTF::Lock::unlockSlow):
(WTF::Lock::unlockFairlySlow):
* Source/WTF/wtf/LockAlgorithm.h:
(WTF::LockAlgorithm::unlock):
(WTF::LockAlgorithm::unlockFairly):
(): Deleted.
* Source/WTF/wtf/LockAlgorithmInlines.h:
(WTF::Hooks&gt;::lockSlow):
(WTF::Hooks&gt;::unlockSlow):
* Source/WTF/wtf/Locker.h:
* Source/WTF/wtf/LocklessBag.h:
* Source/WTF/wtf/MathExtras.h:
(WTF::roundUpToMultipleOfNonPowerOfTwo):
* Source/WTF/wtf/MessageQueue.h:
(WTF::MessageQueue&lt;DataType&gt;::waitForMessage):
(WTF::MessageQueue&lt;DataType&gt;::waitForMessageFilteredWithTimeout):
* Source/WTF/wtf/OSAllocator.h:
(): Deleted.
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifierGeneric::generate):
* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::fromRaw):
* Source/WTF/wtf/PageAllocation.h:
(WTF::PageAllocation::allocate):
* Source/WTF/wtf/PageReservation.h:
(WTF::PageReservation::reserve):
(WTF::PageReservation::tryReserve):
(WTF::PageReservation::reserveWithGuardPages):
(WTF::PageReservation::tryReserveWithGuardPages):
(WTF::PageReservation::reserveAndCommitWithGuardPages):
(WTF::PageReservation::tryReserveAndCommitWithGuardPages):
* Source/WTF/wtf/PtrTag.h:
(WTF::tagNativeCodePtrImpl):
(WTF::untagNativeCodePtrImpl):
(WTF::tagCodePtrImpl):
(WTF::retagCodePtrImplHelper):
(WTF::assertIsCFunctionPtr):
(WTF::assertIsNotTagged):
(WTF::isTaggedWith):
(WTF::tagCFunctionPtrImpl):
(WTF::untagCFunctionPtrImpl):
(): Deleted.
* Source/WTF/wtf/RedBlackTree.h:
* Source/WTF/wtf/Ref.h:
(WTF::adoptRef):
* Source/WTF/wtf/RefPtr.h:
(WTF::adoptRef):
* Source/WTF/wtf/RetainPtr.h:
(WTF::adoptCF):
(WTF::adoptNS):
* Source/WTF/wtf/SentinelLinkedList.h:
(WTF::SentinelLinkedList::SentinelLinkedList):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::binarySearchImpl):
(WTF::binarySearch):
(WTF::tryBinarySearch):
(WTF::approximateBinarySearch):
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::isIPv6Address):
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::initialize):
* Source/WTF/wtf/WTFConfig.h:
(): Deleted.
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::WorkQueue::mainSingleton):
* Source/WTF/wtf/WorkQueue.h:
* Source/WTF/wtf/dtoa/bignum-dtoa.cc:
* Source/WTF/wtf/dtoa/bignum-dtoa.h:
(): Deleted.
* Source/WTF/wtf/dtoa/double-conversion.cc:
* Source/WTF/wtf/dtoa/fast-dtoa.cc:
* Source/WTF/wtf/dtoa/fast-dtoa.h:
(): Deleted.
* Source/WTF/wtf/fast_float/ascii_number.h:
* Source/WTF/wtf/fast_float/float_common.h:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::waitForCompletion):
* Source/WTF/wtf/text/IntegerToStringConversion.h:
(WTF::numberToStringImpl):
(WTF::numberToStringSigned):
(WTF::numberToStringUnsigned):
(WTF::writeIntegerToBufferImpl):
(WTF::writeIntegerToBuffer):
(WTF::lengthOfIntegerAsStringImpl):
(WTF::lengthOfIntegerAsString):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::StaticStringImpl::StaticStringImpl):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::SplitResult::end const):
* Source/WTF/wtf/text/SymbolImpl.h:
(WTF::SymbolImpl::StaticSymbolImpl::StaticSymbolImpl):
* Source/WTF/wtf/unix/UnixFileDescriptor.h:
(WTF::UnixFileDescriptor::duplicate const):
* Source/WTF/wtf/win/ThreadingWin.cpp:
(WTF::Thread::waitForCompletion):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8eaffedffdfb28891bd1b4e4599b647b8f680e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113184 "13 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32919 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23397 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119392 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63830 "Hash c8eaffed for PR 48523 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33571 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41482 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/119392 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/63830 "Hash c8eaffed for PR 48523 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116131 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/33571 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/23397 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/119392 "Hash c8eaffed for PR 48523 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/33571 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/23397 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63146 "Hash c8eaffed for PR 48523 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105701 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/33571 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/23397 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122609 "Hash c8eaffed for PR 48523 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111800 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40262 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/41482 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/122609 "Hash c8eaffed for PR 48523 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40647 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/23397 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/122609 "Hash c8eaffed for PR 48523 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/23397 "Hash c8eaffed for PR 48523 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36398 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40148 "Hash c8eaffed for PR 48523 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45647 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136030 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39789 "Hash c8eaffed for PR 48523 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36503 "Found 1 new JSC stress test failure: stress/builtin-function-is-construct-type-none.js.dfg-eager (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43122 "Hash c8eaffed for PR 48523 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41526 "Hash c8eaffed for PR 48523 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->