### PR TITLE
AX: YouTube embed elements should create AX elements based on their node

### DIFF
--- a/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt
+++ b/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt
@@ -1,0 +1,6 @@
+Blocked access to external URL https://www.youtube.com/embed/UF8uR6Z6KLc
+This test verifies that we don't hang when building the accessibility tree with a YouTube embed.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html
+++ b/LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+<meta charset="UTF-8">
+</head>
+<body>
+
+<embed id="youtube-embed" src="https://www.youtube.com/v/UF8uR6Z6KLc" type="application/x-shockwave-flash" width="425" height="350">
+
+<script>
+var output = "This test verifies that we don't hang when building the accessibility tree with a YouTube embed.";
+
+if (window.accessibilityController) {
+    // Just getting the embed shouldn't cause a hang.
+    var embed = accessibilityController.accessibleElementById("youtube-embed");
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -971,6 +971,9 @@ accessibility/full-size-kana-untransformed.html [ Skip ]
 # Static text are not exposed as accessibility elements on glib appointments.
 accessibility/element-outside-modal-with-zindex.html [ Skip ]
 
+# Skipping because different hierarchy.
+accessibility/youtube-embed-accessibility-hierarchy.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Accessibility-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -983,6 +983,9 @@ accessibility/dynamic-table-row-column-indices.html [ Skip ]
 # Skipping because AccessibilityUIElement::boundsForRangeWithPagePosition() is not supported on WK1.
 accessibility/mac/bounds-for-range-centered.html [ Skip ]
 
+# Skipping because different hierarchy on WK1
+accessibility/youtube-embed-accessibility-hierarchy.html [ Skip ]
+
 # DOM paste access requests are not implemented in WebKit1.
 editing/async-clipboard/clipboard-change-data-while-reading.html [ Skip ]
 editing/async-clipboard/clipboard-do-not-read-text-from-platform-if-text-changes.html [ Skip ]

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -243,8 +243,12 @@ bool HTMLPlugInElement::supportsFocus() const
 
 RenderPtr<RenderElement> HTMLPlugInElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
-    if (m_pluginReplacement && m_pluginReplacement->willCreateRenderer())
-        return m_pluginReplacement->createElementRenderer(*this, WTFMove(style), insertionPosition);
+    if (m_pluginReplacement && m_pluginReplacement->willCreateRenderer()) {
+        RenderPtr<RenderElement> renderer = m_pluginReplacement->createElementRenderer(*this, WTFMove(style), insertionPosition);
+        if (renderer)
+            renderer->markIsYouTubeReplacement();
+        return renderer;
+    }
 
     return createRenderer<RenderEmbeddedObject>(*this, WTFMove(style));
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2120,6 +2120,11 @@ void RenderObject::setHasOutlineAutoAncestor(bool hasOutlineAutoAncestor)
         ensureRareData().hasOutlineAutoAncestor = hasOutlineAutoAncestor;
 }
 
+void RenderObject::markIsYouTubeReplacement()
+{
+    ensureRareData().isYouTubeReplacement = true;
+}
+
 RenderObject::RareDataMap& RenderObject::rareDataMap()
 {
     static NeverDestroyed<RareDataMap> map;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -684,6 +684,9 @@ public:
     void setIsExcludedFromNormalLayout(bool excluded) { m_stateBitfields.setFlag(StateFlag::IsExcludedFromNormalLayout, excluded); }
     bool isExcludedAndPlacedInBorder() const { return isExcludedFromNormalLayout() && isLegend(); }
 
+    bool isYouTubeReplacement() const { return hasRareData() && rareData().isYouTubeReplacement; }
+    void markIsYouTubeReplacement();
+
     bool hasLayer() const { return m_stateBitfields.hasFlag(StateFlag::HasLayer); }
 
     enum class BoxDecorationState : uint8_t {
@@ -1286,6 +1289,7 @@ private:
         bool hasOutlineAutoAncestor { false };
         // Dirty bit was set with MarkingBehavior::MarkOnlyThis
         bool preferredLogicalWidthsNeedUpdateIsMarkOnlyThis { false };
+        bool isYouTubeReplacement { false };
         OptionSet<MarginTrimType> trimmedMargins;
 
         // From RenderElement


### PR DESCRIPTION
#### aa91363e81fca4caddf839b549de043fc456bab0
<pre>
AX: YouTube embed elements should create AX elements based on their node
<a href="https://bugs.webkit.org/show_bug.cgi?id=296488">https://bugs.webkit.org/show_bug.cgi?id=296488</a>
<a href="https://rdar.apple.com/156331833">rdar://156331833</a>

Reviewed by Tyler Wilcock.

Accessibility elements are (in most cases) based off of the renderer. For
YouTube embed elements, due to some special-casing, the Embed parent and
the shadow dom child share the same renderer (see
HTMLPlugInElement::createElementRenderer). This breaks accessibility
assumptions. Instead, add a rare data field on render objects to indicate
if it is a youtube embed replacement, and if so, default to using its
renderer.

* LayoutTests/accessibility/youtube-embed-accessibility-hierarchy-expected.txt: Added.
* LayoutTests/accessibility/youtube-embed-accessibility-hierarchy.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::get const):
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::createElementRenderer):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::markIsYouTubeReplacement):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isYouTubeReplacement const):

Canonical link: <a href="https://commits.webkit.org/297939@main">https://commits.webkit.org/297939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/932d6b15e0c6d6ae183b4831a75f62ecf7652239

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86196 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95042 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24227 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36465 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45714 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39856 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->