### PR TITLE
Decouple computeIntrinsicSizeAndPreferredAspectRatio into two separate functions.

### DIFF
--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -873,10 +873,10 @@ void RenderImage::layout()
         layoutShadowContent(oldSize);
 }
 
-std::pair<FloatSize, FloatSize> RenderImage::computeIntrinsicSizeAndPreferredAspectRatio() const
+FloatSize RenderImage::computeIntrinsicSize() const
 {
     ASSERT(!shouldApplySizeContainment());
-    auto [intrinsicSize, preferredAspectRatio] = RenderReplaced::computeIntrinsicSizeAndPreferredAspectRatio();
+    auto intrinsicSize = RenderReplaced::computeIntrinsicSize();
 
     // Our intrinsicSize is empty if we're rendering generated images with relative width/height. Figure out the right intrinsic size to use.
     if (intrinsicSize.isEmpty() && (imageResource().imageHasRelativeWidth() || imageResource().imageHasRelativeHeight())) {
@@ -887,14 +887,21 @@ std::pair<FloatSize, FloatSize> RenderImage::computeIntrinsicSizeAndPreferredAsp
         }
     }
 
+    return intrinsicSize;
+}
+
+FloatSize RenderImage::preferredAspectRatio() const
+{
+    ASSERT(!shouldApplySizeContainment());
+
     // Don't compute an intrinsic ratio to preserve historical WebKit behavior if we're painting alt text and/or a broken image.
     if (shouldDisplayBrokenImageIcon()) {
         if (style().aspectRatio().isAutoAndRatio() && !isShowingAltText())
-            return { intrinsicSize, FloatSize::narrowPrecision(style().aspectRatioLogicalWidth().value, style().aspectRatioLogicalHeight().value) };
-        return { intrinsicSize, { 1.0, 1.0 } };
+            return FloatSize::narrowPrecision(style().aspectRatioLogicalWidth().value, style().aspectRatioLogicalHeight().value);
+        return { 1.0, 1.0 };
     }
 
-    return { intrinsicSize, preferredAspectRatio };
+    return RenderReplaced::preferredAspectRatio();
 }
 
 bool RenderImage::shouldInvalidatePreferredWidths() const

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -91,7 +91,8 @@ protected:
 
     bool shouldInvalidatePreferredWidths() const final;
     RenderBox* embeddedContentBox() const final;
-    std::pair<FloatSize, FloatSize> computeIntrinsicSizeAndPreferredAspectRatio() const final;
+    FloatSize computeIntrinsicSize() const final;
+    FloatSize preferredAspectRatio() const final;
     bool foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, unsigned maxDepthToTest) const override;
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -47,7 +47,6 @@ public:
 
     double computeIntrinsicAspectRatio() const;
 
-    virtual std::pair<FloatSize, FloatSize> computeIntrinsicSizeAndPreferredAspectRatio() const;
 
     virtual bool paintsContent() const { return true; }
 
@@ -65,6 +64,9 @@ protected:
     bool isSelected() const;
 
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
+
+    virtual FloatSize computeIntrinsicSize() const;
+    virtual FloatSize preferredAspectRatio() const;
 
     void setIntrinsicSize(const LayoutSize& intrinsicSize) { m_intrinsicSize = intrinsicSize; }
     virtual void intrinsicSizeChanged();

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -45,7 +45,8 @@ public:
     bool isEmbeddedThroughSVGImage() const;
     bool isEmbeddedThroughFrameContainingSVGDocument() const;
 
-    std::pair<FloatSize, FloatSize> computeIntrinsicSizeAndPreferredAspectRatio() const final;
+    FloatSize computeIntrinsicSize() const final;
+    FloatSize preferredAspectRatio() const final;
     bool hasIntrinsicAspectRatio() const final;
 
     bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
@@ -94,8 +95,6 @@ private:
     void updateFromStyle() final;
     bool needsHasSVGTransformFlags() const final;
     void updateLayerTransform() final;
-
-    FloatSize calculateIntrinsicSize() const;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -46,7 +46,8 @@ public:
     bool isEmbeddedThroughSVGImage() const;
     bool isEmbeddedThroughFrameContainingSVGDocument() const;
 
-    std::pair<FloatSize, FloatSize> computeIntrinsicSizeAndPreferredAspectRatio() const override;
+    FloatSize computeIntrinsicSize() const final;
+    FloatSize preferredAspectRatio() const final;
     bool hasIntrinsicAspectRatio() const final;
 
     bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
@@ -110,8 +111,6 @@ private:
     bool shouldApplyViewportClip() const;
     void updateCachedBoundaries();
     void buildLocalToBorderBoxTransform();
-
-    FloatSize calculateIntrinsicSize() const;
 
     IntSize m_containerSize;
     FloatRect m_repaintBoundingBox;


### PR DESCRIPTION
#### 155d07de56e25c9b835595973c4b8c5a31cebb04
<pre>
Decouple computeIntrinsicSizeAndPreferredAspectRatio into two separate functions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296523">https://bugs.webkit.org/show_bug.cgi?id=296523</a>
<a href="https://rdar.apple.com/problem/156800789">rdar://problem/156800789</a>

Reviewed by Brent Fulgham.

computeIntrinsicSizeAndPreferredAspectRatio currently does two different
things: compute the intrinsic size of the renderer as well as the
preferred aspect ratio. If we instead decouple this into two different
functions, this will improve the readability and maintainability of the
code. For example, any changes that are made to the logic related to
determining the preferred aspect ratio will not need to be concerned
about the other logic related to the renderer&apos;s intrinsic size. In some
cases, you may need the intrinsic size to determine the preferred aspect
ratio, but that will be just a matter of calling the new helper function
whose responsibility will be to give that value to the caller.

* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::computeIntrinsicSize const):
(WebCore::RenderSVGRoot::calculateIntrinsicSize const): Deleted.
calculateIntrinsicSize was only being used in two different places:
1.) Inside the constructor of RenderSVGRoot
2.) Directly from the newly added computeIntrinsicSize.
Since these are the only two locations, and is being used in a fairly
straightforward manner in both cases, we probably do not need to keep
both of them around especially since they are both similarly named. It
might end up becoming confusing to determine which one you should call
and when. So I went ahead and moved the logic inside of
calculateIntrinsicSize into the new function and replaced the call
inside the constructor. This required modifying the previous ASSERT we
were using to only trigger when we are inside of render tree layout so
that we can keep using it inside the constructor.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::computeIntrinsicSize const):
(WebCore::LegacyRenderSVGRoot::calculateIntrinsicSize const): Deleted.
Same as RenderSVGRoot.cpp.

Canonical link: <a href="https://commits.webkit.org/298315@main">https://commits.webkit.org/298315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b9ff84d91b168e43c27e101dbffd9add2881dd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120802 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/01aa4878-49b4-44fd-85ad-a8a6964a0169) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87142 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42043 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f32bad56-8d6c-4def-86f4-d88495d3431b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67530 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21077 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64479 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124004 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95952 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42025 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99138 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37747 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47038 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41112 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44419 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42862 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->