### PR TITLE
[JSC] Add inlined fast path for MakeAtomStringWithCache

### DIFF
--- a/JSTests/microbenchmarks/make-atom-string-cache.js
+++ b/JSTests/microbenchmarks/make-atom-string-cache.js
@@ -1,0 +1,19 @@
+function test(object, string) {
+    return object["Visit" + string];
+}
+noInline(test);
+
+var object = {};
+for (let i = 0; i < 1e6; ++i) {
+    test(object, "T0");
+    test(object, "T1");
+    test(object, "T1");
+    test(object, "T2");
+    test(object, "T3");
+    test(object, "T4");
+    test(object, "T5");
+    test(object, "T6");
+    test(object, "T7");
+    test(object, "T8");
+    test(object, "T9");
+}

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -56,6 +56,10 @@ namespace JSC { namespace FTL {
     macro(CallFrame_callerFrame, CallFrame::callerFrameOffset()) \
     macro(ClassInfo_parentClass, ClassInfo::offsetOfParentClass()) \
     macro(ClonedArguments_callee, ClonedArguments::offsetOfCallee()) \
+    macro(ConcatKeyAtomStringCache_quickCache0_key, ConcatKeyAtomStringCache::offsetOfQuickCache0() + ConcatKeyAtomStringCache::CacheEntry::offsetOfKey()) \
+    macro(ConcatKeyAtomStringCache_quickCache0_value, ConcatKeyAtomStringCache::offsetOfQuickCache0() + ConcatKeyAtomStringCache::CacheEntry::offsetOfValue()) \
+    macro(ConcatKeyAtomStringCache_quickCache1_key, ConcatKeyAtomStringCache::offsetOfQuickCache1() + ConcatKeyAtomStringCache::CacheEntry::offsetOfKey()) \
+    macro(ConcatKeyAtomStringCache_quickCache1_value, ConcatKeyAtomStringCache::offsetOfQuickCache1() + ConcatKeyAtomStringCache::CacheEntry::offsetOfValue()) \
     macro(DateInstance_internalNumber, DateInstance::offsetOfInternalNumber()) \
     macro(DateInstance_data, DateInstance::offsetOfData()) \
     macro(DateInstanceData_gregorianDateTimeCachedForMS, DateInstanceData::offsetOfGregorianDateTimeCachedForMS()) \

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10996,32 +10996,100 @@ IGNORE_CLANG_WARNINGS_END
             break;
         case 2: {
             const ConcatKeyAtomStringCache* cache = nullptr;
-            if (auto string = m_node->child1()->tryGetString(m_graph); !string.isNull())
+            LValue variable = nullptr;
+            if (auto string = m_node->child1()->tryGetString(m_graph); !string.isNull()) {
                 cache = m_graph.tryAddConcatKeyAtomStringCache(string, emptyString(), ConcatKeyAtomStringCache::Mode::Variable1);
-            else if (auto string = m_node->child2()->tryGetString(m_graph); !string.isNull())
+                variable = strings[1];
+            } else if (auto string = m_node->child2()->tryGetString(m_graph); !string.isNull()) {
                 cache = m_graph.tryAddConcatKeyAtomStringCache(string, emptyString(), ConcatKeyAtomStringCache::Mode::Variable0);
+                variable = strings[0];
+            }
 
-            if (cache)
-                setJSValue(vmCall(pointerType(), operationMakeAtomString2WithCache, weakPointer(globalObject), strings[0], strings[1], m_out.constIntPtr(cache)));
-            else
+            if (cache) {
+                LBasicBlock cacheHit0Case = m_out.newBlock();
+                LBasicBlock cacheCheck1Case = m_out.newBlock();
+                LBasicBlock cacheHit1Case = m_out.newBlock();
+                LBasicBlock genericCase = m_out.newBlock();
+                LBasicBlock continuation = m_out.newBlock();
+
+                LValue cachePtr = m_out.constIntPtr(cache);
+                m_out.branch(
+                    m_out.equal(variable, m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache0_key)),
+                    unsure(cacheHit0Case), unsure(cacheCheck1Case));
+
+                LBasicBlock lastNext = m_out.appendTo(cacheHit0Case, cacheCheck1Case);
+                ValueFromBlock fastResult0 = m_out.anchor(m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache0_value));
+                m_out.jump(continuation);
+
+                m_out.appendTo(cacheCheck1Case, cacheHit1Case);
+                m_out.branch(
+                    m_out.equal(variable, m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache1_key)),
+                    unsure(cacheHit1Case), unsure(genericCase));
+
+                m_out.appendTo(cacheHit1Case, genericCase);
+                ValueFromBlock fastResult1 = m_out.anchor(m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache1_value));
+                m_out.jump(continuation);
+
+                m_out.appendTo(genericCase, continuation);
+                ValueFromBlock genericResult = m_out.anchor(vmCall(pointerType(), operationMakeAtomString2WithCache, weakPointer(globalObject), strings[0], strings[1], cachePtr));
+                m_out.jump(continuation);
+
+                m_out.appendTo(continuation, lastNext);
+                setJSValue(m_out.phi(pointerType(), fastResult0, fastResult1, genericResult));
+            } else
                 setJSValue(vmCall(pointerType(), operationMakeAtomString2, weakPointer(globalObject), strings[0], strings[1]));
             break;
         }
         case 3: {
             const ConcatKeyAtomStringCache* cache = nullptr;
+            LValue variable = nullptr;
             if (auto s0 = m_node->child1()->tryGetString(m_graph); !s0.isNull()) {
-                if (auto s1 = m_node->child2()->tryGetString(m_graph); !s1.isNull())
+                if (auto s1 = m_node->child2()->tryGetString(m_graph); !s1.isNull()) {
                     cache = m_graph.tryAddConcatKeyAtomStringCache(s0, s1, ConcatKeyAtomStringCache::Mode::Variable2);
-                else if (auto s2 = m_node->child3()->tryGetString(m_graph); !s2.isNull())
+                    variable = strings[2];
+                } else if (auto s2 = m_node->child3()->tryGetString(m_graph); !s2.isNull()) {
                     cache = m_graph.tryAddConcatKeyAtomStringCache(s0, s2, ConcatKeyAtomStringCache::Mode::Variable1);
+                    variable = strings[1];
+                }
             } else if (auto s1 = m_node->child2()->tryGetString(m_graph); !s1.isNull()) {
-                if (auto s2 = m_node->child3()->tryGetString(m_graph); !s2.isNull())
+                if (auto s2 = m_node->child3()->tryGetString(m_graph); !s2.isNull()) {
                     cache = m_graph.tryAddConcatKeyAtomStringCache(s1, s2, ConcatKeyAtomStringCache::Mode::Variable0);
+                    variable = strings[0];
+                }
             }
 
-            if (cache)
-                setJSValue(vmCall(pointerType(), operationMakeAtomString3WithCache, weakPointer(globalObject), strings[0], strings[1], strings[2], m_out.constIntPtr(cache)));
-            else
+            if (cache) {
+                LBasicBlock cacheHit0Case = m_out.newBlock();
+                LBasicBlock cacheCheck1Case = m_out.newBlock();
+                LBasicBlock cacheHit1Case = m_out.newBlock();
+                LBasicBlock genericCase = m_out.newBlock();
+                LBasicBlock continuation = m_out.newBlock();
+
+                LValue cachePtr = m_out.constIntPtr(cache);
+                m_out.branch(
+                    m_out.equal(variable, m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache0_key)),
+                    unsure(cacheHit0Case), unsure(cacheCheck1Case));
+
+                LBasicBlock lastNext = m_out.appendTo(cacheHit0Case, cacheCheck1Case);
+                ValueFromBlock fastResult0 = m_out.anchor(m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache0_value));
+                m_out.jump(continuation);
+
+                m_out.appendTo(cacheCheck1Case, cacheHit1Case);
+                m_out.branch(
+                    m_out.equal(variable, m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache1_key)),
+                    unsure(cacheHit1Case), unsure(genericCase));
+
+                m_out.appendTo(cacheHit1Case, genericCase);
+                ValueFromBlock fastResult1 = m_out.anchor(m_out.loadPtr(cachePtr, m_heaps.ConcatKeyAtomStringCache_quickCache1_value));
+                m_out.jump(continuation);
+
+                m_out.appendTo(genericCase, continuation);
+                ValueFromBlock genericResult = m_out.anchor(vmCall(pointerType(), operationMakeAtomString3WithCache, weakPointer(globalObject), strings[0], strings[1], strings[2], cachePtr));
+                m_out.jump(continuation);
+
+                m_out.appendTo(continuation, lastNext);
+                setJSValue(m_out.phi(pointerType(), fastResult0, fastResult1, genericResult));
+            } else
                 setJSValue(vmCall(pointerType(), operationMakeAtomString3, weakPointer(globalObject), strings[0], strings[1], strings[2]));
             break;
         }

--- a/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.cpp
+++ b/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.cpp
@@ -36,9 +36,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ConcatKeyAtomStringCache);
 template<typename Visitor>
 void ConcatKeyAtomStringCache::visitAggregateImpl(Visitor& visitor)
 {
-    Locker locker { m_lock };
-    for (auto& entry : m_cache)
-        visitor.appendUnbarriered(entry.value);
+    {
+        Locker locker { m_lock };
+        for (auto& entry : m_cache)
+            visitor.appendUnbarriered(entry.value);
+    }
+    for (auto& entry : m_quickCache) {
+        visitor.append(entry.m_key);
+        visitor.append(entry.m_value);
+    }
 }
 
 DEFINE_VISIT_AGGREGATE(ConcatKeyAtomStringCache);

--- a/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.h
@@ -55,10 +55,40 @@ public:
     template<typename Func>
     JSString* getOrInsert(VM&, JSString*, JSString*, JSString*, const Func&);
 
+    struct CacheEntry {
+        static constexpr ptrdiff_t offsetOfKey()
+        {
+            return OBJECT_OFFSETOF(CacheEntry, m_key);
+        }
+
+        static constexpr ptrdiff_t offsetOfValue()
+        {
+            return OBJECT_OFFSETOF(CacheEntry, m_value);
+        }
+
+        WriteBarrier<JSString> m_key { };
+        WriteBarrier<JSString> m_value { };
+    };
+
+    static constexpr ptrdiff_t offsetOfQuickCache0()
+    {
+        return OBJECT_OFFSETOF(ConcatKeyAtomStringCache, m_quickCache);
+    }
+
+    static constexpr ptrdiff_t offsetOfQuickCache1()
+    {
+        return OBJECT_OFFSETOF(ConcatKeyAtomStringCache, m_quickCache) + sizeof(CacheEntry);
+    }
+
+
+
     DECLARE_VISIT_AGGREGATE;
+
+    size_t size() const { return m_cache.size(); }
 
 private:
     CodeBlock* m_owner { nullptr };
+    std::array<CacheEntry, 2> m_quickCache { };
     UncheckedKeyHashMap<Ref<AtomStringImpl>, JSString*> m_cache;
     Mode m_mode { Mode::Megamorphic };
     Lock m_lock;


### PR DESCRIPTION
#### b816a51d8abd8cf45376a809523550e2a344a2ad
<pre>
[JSC] Add inlined fast path for MakeAtomStringWithCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=296496">https://bugs.webkit.org/show_bug.cgi?id=296496</a>
<a href="https://rdar.apple.com/problem/156738773">rdar://problem/156738773</a>

Reviewed by Dan Hecht.

This patch adds inlined fast path for MakeAtomStringWithCache.
We have two quickCache entries and check and use them when we hit the
condition, avoiding C++ function calls.

* JSTests/microbenchmarks/make-atom-string-cache.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileMakeAtomString):
* Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.cpp:
(JSC::ConcatKeyAtomStringCache::visitAggregateImpl):
* Source/JavaScriptCore/runtime/ConcatKeyAtomStringCache.h:
(JSC::ConcatKeyAtomStringCache::CacheEntry::offsetOfKey):
(JSC::ConcatKeyAtomStringCache::CacheEntry::offsetOfValue):
(JSC::ConcatKeyAtomStringCache::offsetOfQuickCache0):
(JSC::ConcatKeyAtomStringCache::offsetOfQuickCache1):
(JSC::ConcatKeyAtomStringCache::size const):
* Source/JavaScriptCore/runtime/ConcatKeyAtomStringCacheInlines.h:
(JSC::ConcatKeyAtomStringCache::getOrInsert):

Canonical link: <a href="https://commits.webkit.org/297877@main">https://commits.webkit.org/297877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c0f2f1ebe8b18c02f86184662fe86c605cf67b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63859 "Built successfully") | ✅ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86166 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101835 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66486 "Found 141 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19961 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63166 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105721 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96216 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122629 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111820 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95015 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94757 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39904 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17711 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36418 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18199 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40168 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45667 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136050 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39809 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36509 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->