### PR TITLE
[GTK][WPE] Rename DMABufRendererBufferFormat as RendererBufferFormat

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -70,7 +70,7 @@ endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
-    Shared/glib/DMABufRendererBufferFormat.serialization.in
+    Shared/glib/RendererBufferFormat.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/RendererBufferTransportMode.serialization.in
     Shared/glib/SelectionData.serialization.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -107,7 +107,7 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
     "SourcesWPE.txt"
 )
 
-list(APPEND WebKit_SERIALIZATION_IN_FILES Shared/glib/DMABufRendererBufferFormat.serialization.in)
+list(APPEND WebKit_SERIALIZATION_IN_FILES Shared/glib/RendererBufferFormat.serialization.in)
 
 if (USE_GBM)
   list(APPEND WebKit_SERIALIZATION_IN_FILES Shared/gbm/DMABufBuffer.serialization.in)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -633,7 +633,7 @@ def conditions_for_header(header):
         '"CoreIPCAuditToken.h"': ["HAVE(AUDIT_TOKEN)"],
         '"DataDetectionResult.h"': ["PLATFORM(COCOA)"],
         '"DynamicViewportSizeUpdate.h"': ["PLATFORM(IOS_FAMILY)"],
-        '"DMABufRendererBufferFormat.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
+        '"RendererBufferFormat.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"GestureTypes.h"': ["PLATFORM(IOS_FAMILY)"],
         '"InputMethodState.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"MediaPlaybackTargetContextSerialized.h"': ["ENABLE(WIRELESS_PLAYBACK_TARGET)"],

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -74,7 +74,7 @@
 #endif
 
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
-#include "DMABufRendererBufferFormat.h"
+#include "RendererBufferFormat.h"
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -337,7 +337,7 @@ struct WebPageCreationParameters {
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #if USE(GBM)
-    Vector<DMABufRendererBufferFormat> preferredBufferFormats { };
+    Vector<RendererBufferFormat> preferredBufferFormats { };
 #endif
 #endif
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -258,7 +258,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #if USE(GBM)
-    Vector<WebKit::DMABufRendererBufferFormat> preferredBufferFormats;
+    Vector<WebKit::RendererBufferFormat> preferredBufferFormats;
 #endif
 #endif
 

--- a/Source/WebKit/Shared/glib/RendererBufferFormat.h
+++ b/Source/WebKit/Shared/glib/RendererBufferFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2023 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,17 +25,27 @@
 
 #pragma once
 
-#include "DMABufRendererBufferFormat.h"
+#include <wtf/Vector.h>
+#include <wtf/text/CString.h>
 
 namespace WebKit {
 
-struct RendererBufferFormat {
-    enum class Type : bool { DMABuf, SharedMemory };
+enum class RendererBufferFormatUsage : uint8_t {
+    Rendering,
+    Mapping,
+    Scanout
+};
 
-    Type type { Type::DMABuf };
-    DMABufRendererBufferFormat::Usage usage { DMABufRendererBufferFormat::Usage::Rendering };
-    uint32_t fourcc { 0 };
-    uint64_t modifier { 0 };
+struct RendererBufferFormat {
+    struct Format {
+        uint32_t fourcc { 0 };
+        Vector<uint64_t, 1> modifiers;
+    };
+
+    using Usage = RendererBufferFormatUsage;
+    Usage usage { Usage::Rendering };
+    CString drmDevice;
+    Vector<Format> formats;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/glib/RendererBufferFormat.serialization.in
+++ b/Source/WebKit/Shared/glib/RendererBufferFormat.serialization.in
@@ -22,19 +22,19 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-struct WebKit::DMABufRendererBufferFormat {
-    WebKit::DMABufRendererBufferFormat::Usage usage;
+struct WebKit::RendererBufferFormat {
+    WebKit::RendererBufferFormat::Usage usage;
     CString drmDevice;
-    Vector<WebKit::DMABufRendererBufferFormat::Format> formats;
+    Vector<WebKit::RendererBufferFormat::Format> formats;
 }
 
-enum class WebKit::DMABufRendererBufferFormatUsage : uint8_t {
+enum class WebKit::RendererBufferFormatUsage : uint8_t {
     Rendering,
     Mapping,
     Scanout
 }
 
-[Nested] struct WebKit::DMABufRendererBufferFormat::Format {
+[Nested] struct WebKit::RendererBufferFormat::Format {
     uint32_t fourcc;
     Vector<uint64_t, 1> modifiers;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -252,45 +252,45 @@ static char* webkitDrmGetFormatName(uint32_t format)
     return str;
 }
 
-static String renderBufferFormat(WebKitURISchemeRequest* request)
+static String renderBufferDescription(WebKitURISchemeRequest* request)
 {
-    StringBuilder bufferFormat;
-    auto format = webkitWebViewGetRendererBufferFormat(webkit_uri_scheme_request_get_web_view(request));
-    if (format.fourcc) {
-        auto* formatName = webkitDrmGetFormatName(format.fourcc);
-        switch (format.type) {
-        case RendererBufferFormat::Type::DMABuf: {
+    StringBuilder bufferDescription;
+    auto description = webkitWebViewGetRendererBufferDescription(webkit_uri_scheme_request_get_web_view(request));
+    if (description.fourcc) {
+        auto* formatName = webkitDrmGetFormatName(description.fourcc);
+        switch (description.type) {
+        case RendererBufferDescription::Type::DMABuf: {
 #if HAVE(DRM_GET_FORMAT_MODIFIER_VENDOR) && HAVE(DRM_GET_FORMAT_MODIFIER_NAME)
-            auto* modifierVendor = drmGetFormatModifierVendor(format.modifier);
-            auto* modifierName = drmGetFormatModifierName(format.modifier);
-            bufferFormat.append("DMA-BUF: "_s, String::fromUTF8(formatName), " ("_s, String::fromUTF8(modifierVendor), "_"_s, String::fromUTF8(modifierName), ")"_s);
+            auto* modifierVendor = drmGetFormatModifierVendor(description.modifier);
+            auto* modifierName = drmGetFormatModifierName(description.modifier);
+            bufferDescription.append("DMA-BUF: "_s, String::fromUTF8(formatName), " ("_s, String::fromUTF8(modifierVendor), "_"_s, String::fromUTF8(modifierName), ")"_s);
             free(modifierVendor);
             free(modifierName);
 #else
-            bufferFormat.append("Unknown"_s);
+            bufferDescription.append("Unknown"_s);
 #endif
             break;
         }
-        case RendererBufferFormat::Type::SharedMemory:
-            bufferFormat.append("Shared Memory: "_s, String::fromUTF8(formatName));
+        case RendererBufferDescription::Type::SharedMemory:
+            bufferDescription.append("Shared Memory: "_s, String::fromUTF8(formatName));
             break;
         }
         free(formatName);
-        switch (format.usage) {
-        case DMABufRendererBufferFormat::Usage::Rendering:
-            bufferFormat.append(" [Rendering]"_s);
+        switch (description.usage) {
+        case RendererBufferFormat::Usage::Rendering:
+            bufferDescription.append(" [Rendering]"_s);
             break;
-        case DMABufRendererBufferFormat::Usage::Scanout:
-            bufferFormat.append(" [Scanout]"_s);
+        case RendererBufferFormat::Usage::Scanout:
+            bufferDescription.append(" [Scanout]"_s);
             break;
-        case DMABufRendererBufferFormat::Usage::Mapping:
-            bufferFormat.append(" [Mapping]"_s);
+        case RendererBufferFormat::Usage::Mapping:
+            bufferDescription.append(" [Mapping]"_s);
             break;
         }
     } else
-        bufferFormat.append("Unknown"_s);
+        bufferDescription.append("Unknown"_s);
 
-    return bufferFormat.toString();
+    return bufferDescription.toString();
 }
 #endif
 #endif
@@ -545,14 +545,14 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
         if (usingDMABufRenderer) {
             addTableRow(hardwareAccelerationObject, "Renderer"_s, dmabufRendererWithSupportedBuffers());
 #if USE(LIBDRM)
-            addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferFormat(request));
+            addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferDescription(request));
 #endif
         }
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
         if (usingWPEPlatformAPI) {
             addTableRow(hardwareAccelerationObject, "Renderer"_s, dmabufRendererWithSupportedBuffers());
 #if USE(LIBDRM)
-            addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferFormat(request));
+            addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferDescription(request));
 #endif
         }
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3172,12 +3172,12 @@ void webkitWebViewPermissionStateQuery(WebKitWebView* webView, WebKitPermissionS
 }
 
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-RendererBufferFormat webkitWebViewGetRendererBufferFormat(WebKitWebView* webView)
+RendererBufferDescription webkitWebViewGetRendererBufferDescription(WebKitWebView* webView)
 {
 #if PLATFORM(GTK)
-    return webkitWebViewBaseGetRendererBufferFormat(WEBKIT_WEB_VIEW_BASE(webView));
+    return webkitWebViewBaseGetRendererBufferDescription(WEBKIT_WEB_VIEW_BASE(webView));
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-    return static_cast<WKWPE::ViewPlatform*>(webView->priv->view.get())->renderBufferFormat();
+    return static_cast<WKWPE::ViewPlatform*>(webView->priv->view.get())->renderBufferDescription();
 #endif
 }
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include "EditingRange.h"
-#include "RendererBufferFormat.h"
+#include "RendererBufferDescription.h"
 #include "UserMessage.h"
 #include "WebContextMenuItemData.h"
 #include "WebEvent.h"
@@ -130,5 +130,5 @@ guint createShowOptionMenuSignal(WebKitWebViewClass*);
 guint createContextMenuSignal(WebKitWebViewClass*);
 
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-WebKit::RendererBufferFormat webkitWebViewGetRendererBufferFormat(WebKitWebView*);
+WebKit::RendererBufferDescription webkitWebViewGetRendererBufferDescription(WebKitWebView*);
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3474,13 +3474,13 @@ void webkitWebViewBaseSetPlugID(WebKitWebViewBase* webViewBase, const String& pl
 }
 #endif
 
-RendererBufferFormat webkitWebViewBaseGetRendererBufferFormat(WebKitWebViewBase* webViewBase)
+RendererBufferDescription webkitWebViewBaseGetRendererBufferDescription(WebKitWebViewBase* webViewBase)
 {
     auto* drawingArea = static_cast<DrawingAreaProxyCoordinatedGraphics*>(webViewBase->priv->pageProxy->drawingArea());
     if (!drawingArea || !drawingArea->isInAcceleratedCompositingMode())
         return { };
 
-    return webViewBase->priv->acceleratedBackingStore->bufferFormat();
+    return webViewBase->priv->acceleratedBackingStore->bufferDescription();
 }
 
 #if USE(CAIRO)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -29,7 +29,7 @@
 
 #include "APIPageConfiguration.h"
 #include "InputMethodState.h"
-#include "RendererBufferFormat.h"
+#include "RendererBufferDescription.h"
 #include "SameDocumentNavigationType.h"
 #include "ViewGestureController.h"
 #include "ViewSnapshotStore.h"
@@ -144,4 +144,4 @@ void webkitWebViewBaseCallAfterNextPresentationUpdate(WebKitWebViewBase*, Comple
 void webkitWebViewBaseSetPlugID(WebKitWebViewBase*, const String&);
 #endif
 
-WebKit::RendererBufferFormat webkitWebViewBaseGetRendererBufferFormat(WebKitWebViewBase*);
+WebKit::RendererBufferDescription webkitWebViewBaseGetRendererBufferDescription(WebKitWebViewBase*);

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -252,9 +252,9 @@ void ViewPlatform::updateAcceleratedSurface(uint64_t surfaceID)
     m_backingStore->updateSurfaceID(surfaceID);
 }
 
-RendererBufferFormat ViewPlatform::renderBufferFormat() const
+RendererBufferDescription ViewPlatform::renderBufferDescription() const
 {
-    return m_backingStore->bufferFormat();
+    return m_backingStore->bufferDescription();
 }
 
 void ViewPlatform::updateDisplayID()

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -28,7 +28,7 @@
 #if ENABLE(WPE_PLATFORM)
 
 #include "GRefPtrWPE.h"
-#include "RendererBufferFormat.h"
+#include "RendererBufferDescription.h"
 #include "WPEWebView.h"
 #include <wpe/wpe-platform.h>
 #include <wtf/HashMap.h>
@@ -63,7 +63,7 @@ public:
 #endif
 
     void updateAcceleratedSurface(uint64_t);
-    WebKit::RendererBufferFormat renderBufferFormat() const;
+    WebKit::RendererBufferDescription renderBufferDescription() const;
 
 private:
     ViewPlatform(WPEDisplay*, const API::PageConfiguration&);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -594,7 +594,7 @@ struct WebSpeechSynthesisVoice;
 struct WebURLSchemeHandlerIdentifierType;
 struct WebsitePoliciesData;
 #if USE(GBM) && (PLATFORM(GTK) || PLATFORM(WPE))
-struct DMABufRendererBufferFormat;
+struct RendererBufferFormat;
 #endif
 
 enum class ColorControlSupportsAlpha : bool;
@@ -3042,7 +3042,7 @@ private:
     void bindAccessibilityTree(const String&);
     OptionSet<WebCore::PlatformEventModifier> currentStateOfModifierKeys();
 #if USE(GBM)
-    Vector<DMABufRendererBufferFormat> preferredBufferFormats() const;
+    Vector<RendererBufferFormat> preferredBufferFormats() const;
 #endif
 #endif
 

--- a/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
+++ b/Source/WebKit/UIProcess/glib/AcceleratedBackingStore.messages.in
@@ -22,7 +22,7 @@
 
 [ExceptionForEnabledBy]
 messages -> AcceleratedBackingStore {
-    DidCreateDMABufBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::DMABufRendererBufferFormat::Usage usage)
+    DidCreateDMABufBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::RendererBufferFormat::Usage usage)
     DidCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle handle)
     DidDestroyBuffer(uint64_t id)
     Frame(uint64_t id, Vector<WebCore::IntRect, 1> damage, UnixFileDescriptor syncFD)

--- a/Source/WebKit/UIProcess/glib/RendererBufferDescription.h
+++ b/Source/WebKit/UIProcess/glib/RendererBufferDescription.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,27 +26,17 @@
 
 #pragma once
 
-#include <wtf/Vector.h>
-#include <wtf/text/CString.h>
+#include "RendererBufferFormat.h"
 
 namespace WebKit {
 
-enum class DMABufRendererBufferFormatUsage : uint8_t {
-    Rendering,
-    Mapping,
-    Scanout
-};
+struct RendererBufferDescription {
+    enum class Type : bool { DMABuf, SharedMemory };
 
-struct DMABufRendererBufferFormat {
-    struct Format {
-        uint32_t fourcc { 0 };
-        Vector<uint64_t, 1> modifiers;
-    };
-
-    using Usage = DMABufRendererBufferFormatUsage;
-    Usage usage { Usage::Rendering };
-    CString drmDevice;
-    Vector<Format> formats;
+    Type type { Type::DMABuf };
+    RendererBufferFormat::Usage usage { RendererBufferFormat::Usage::Rendering };
+    uint32_t fourcc { 0 };
+    uint64_t modifier { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -150,7 +150,7 @@ OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifier
 }
 
 #if USE(GBM)
-Vector<DMABufRendererBufferFormat> WebPageProxy::preferredBufferFormats() const
+Vector<RendererBufferFormat> WebPageProxy::preferredBufferFormats() const
 {
     return AcceleratedBackingStore::preferredBufferFormats();
 }

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -98,7 +98,7 @@ void AcceleratedBackingStore::updateSurfaceID(uint64_t surfaceID)
     }
 }
 
-void AcceleratedBackingStore::didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage usage)
+void AcceleratedBackingStore::didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage usage)
 {
     Vector<int> fileDescriptors;
     fileDescriptors.reserveInitialCapacity(fds.size());
@@ -195,32 +195,32 @@ void AcceleratedBackingStore::bufferReleased(WPEBuffer* buffer)
     }
 }
 
-RendererBufferFormat AcceleratedBackingStore::bufferFormat() const
+RendererBufferDescription AcceleratedBackingStore::bufferDescription() const
 {
-    RendererBufferFormat format;
+    RendererBufferDescription description;
     auto* buffer = m_committedBuffer ? m_committedBuffer.get() : m_pendingBuffer.get();
     if (!buffer)
-        return format;
+        return description;
 
     if (WPE_IS_BUFFER_DMA_BUF(buffer)) {
         auto* dmabuf = WPE_BUFFER_DMA_BUF(buffer);
-        format.type = RendererBufferFormat::Type::DMABuf;
-        format.fourcc = wpe_buffer_dma_buf_get_format(dmabuf);
-        format.modifier = wpe_buffer_dma_buf_get_modifier(dmabuf);
-        format.usage = static_cast<DMABufRendererBufferFormat::Usage>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(buffer), "wk-buffer-format-usage")));
+        description.type = RendererBufferDescription::Type::DMABuf;
+        description.fourcc = wpe_buffer_dma_buf_get_format(dmabuf);
+        description.modifier = wpe_buffer_dma_buf_get_modifier(dmabuf);
+        description.usage = static_cast<RendererBufferFormat::Usage>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(buffer), "wk-buffer-format-usage")));
     } else if (WPE_IS_BUFFER_SHM(buffer)) {
-        format.type = RendererBufferFormat::Type::SharedMemory;
+        description.type = RendererBufferDescription::Type::SharedMemory;
         switch (wpe_buffer_shm_get_format(WPE_BUFFER_SHM(buffer))) {
         case WPE_PIXEL_FORMAT_ARGB8888:
 #if USE(LIBDRM)
-            format.fourcc = DRM_FORMAT_ARGB8888;
+            description.fourcc = DRM_FORMAT_ARGB8888;
 #endif
             break;
         }
-        format.usage = DMABufRendererBufferFormat::Usage::Rendering;
+        description.usage = RendererBufferFormat::Usage::Rendering;
     }
 
-    return format;
+    return description;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.h
@@ -28,7 +28,7 @@
 #if ENABLE(WPE_PLATFORM)
 #include "FenceMonitor.h"
 #include "MessageReceiver.h"
-#include "RendererBufferFormat.h"
+#include "RendererBufferDescription.h"
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <wtf/HashMap.h>
@@ -67,7 +67,7 @@ public:
 
     void updateSurfaceID(uint64_t);
 
-    RendererBufferFormat bufferFormat() const;
+    RendererBufferDescription bufferDescription() const;
 
 private:
     AcceleratedBackingStore(WebPageProxy&, WPEView*);
@@ -75,7 +75,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
+    void didCreateDMABufBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage);
     void didCreateSHMBuffer(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
     void frame(uint64_t bufferID, Rects&&, WTF::UnixFileDescriptor&&);

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -45,7 +45,7 @@
 #endif
 
 #if USE(GBM)
-#include "DMABufRendererBufferFormat.h"
+#include "RendererBufferFormat.h"
 #endif
 
 #if USE(GBM) && ENABLE(WPE_PLATFORM)
@@ -124,7 +124,7 @@ void WebPageProxy::setInputMethodState(std::optional<InputMethodState>&& state)
 }
 
 #if USE(GBM)
-Vector<DMABufRendererBufferFormat> WebPageProxy::preferredBufferFormats() const
+Vector<RendererBufferFormat> WebPageProxy::preferredBufferFormats() const
 {
 #if ENABLE(WPE_PLATFORM)
     auto* view = wpeView();
@@ -135,28 +135,28 @@ Vector<DMABufRendererBufferFormat> WebPageProxy::preferredBufferFormats() const
     if (!formats)
         return { };
 
-    Vector<DMABufRendererBufferFormat> dmabufFormats;
+    Vector<RendererBufferFormat> bufferFormats;
     const char* mainDevice = wpe_buffer_dma_buf_formats_get_device(formats);
     auto groupCount = wpe_buffer_dma_buf_formats_get_n_groups(formats);
     for (unsigned i = 0; i < groupCount; ++i) {
-        DMABufRendererBufferFormat dmabufFormat;
+        RendererBufferFormat bufferFormat;
         switch (wpe_buffer_dma_buf_formats_get_group_usage(formats, i)) {
         case WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING:
-            dmabufFormat.usage = DMABufRendererBufferFormat::Usage::Rendering;
+            bufferFormat.usage = RendererBufferFormat::Usage::Rendering;
             break;
         case WPE_BUFFER_DMA_BUF_FORMAT_USAGE_MAPPING:
-            dmabufFormat.usage = DMABufRendererBufferFormat::Usage::Mapping;
+            bufferFormat.usage = RendererBufferFormat::Usage::Mapping;
             break;
         case WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT:
-            dmabufFormat.usage = DMABufRendererBufferFormat::Usage::Scanout;
+            bufferFormat.usage = RendererBufferFormat::Usage::Scanout;
             break;
         }
         const char* targetDevice = wpe_buffer_dma_buf_formats_get_group_device(formats, i);
-        dmabufFormat.drmDevice = targetDevice ? targetDevice : mainDevice;
+        bufferFormat.drmDevice = targetDevice ? targetDevice : mainDevice;
         auto formatsCount = wpe_buffer_dma_buf_formats_get_group_n_formats(formats, i);
-        dmabufFormat.formats.reserveInitialCapacity(formatsCount);
+        bufferFormat.formats.reserveInitialCapacity(formatsCount);
         for (unsigned j = 0; j < formatsCount; ++j) {
-            DMABufRendererBufferFormat::Format format;
+            RendererBufferFormat::Format format;
             format.fourcc = wpe_buffer_dma_buf_formats_get_format_fourcc(formats, i, j);
             auto* modifiers = wpe_buffer_dma_buf_formats_get_format_modifiers(formats, i, j);
             format.modifiers.reserveInitialCapacity(modifiers->len);
@@ -166,12 +166,12 @@ Vector<DMABufRendererBufferFormat> WebPageProxy::preferredBufferFormats() const
                 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 format.modifiers.append(*modifier);
             }
-            dmabufFormat.formats.append(WTFMove(format));
+            bufferFormat.formats.append(WTFMove(format));
         }
-        dmabufFormats.append(WTFMove(dmabufFormat));
+        bufferFormats.append(WTFMove(bufferFormat));
     }
 
-    return dmabufFormats;
+    return bufferFormats;
 #else
     return { };
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -473,7 +473,7 @@ struct ContentWorldData;
 struct ContentWorldIdentifierType;
 struct CoreIPCAuditToken;
 #if (PLATFORM(GTK) || PLATFORM(WPE)) && USE(GBM)
-struct DMABufRendererBufferFormat;
+struct RendererBufferFormat;
 #endif
 struct DataDetectionResult;
 struct DeferredDidReceiveMouseEvent;
@@ -1954,7 +1954,7 @@ public:
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #if USE(GBM)
-    const Vector<DMABufRendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
+    const Vector<RendererBufferFormat>& preferredBufferFormats() const { return m_preferredBufferFormats; }
 #endif
 #endif
 
@@ -2510,7 +2510,7 @@ private:
 #endif
 
 #if PLATFORM(WPE) && USE(GBM) && ENABLE(WPE_PLATFORM)
-    void preferredBufferFormatsDidChange(Vector<DMABufRendererBufferFormat>&&);
+    void preferredBufferFormatsDidChange(Vector<RendererBufferFormat>&&);
 #endif
 
     void platformDidScalePage();
@@ -3043,7 +3043,7 @@ private:
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 #if USE(GBM)
-    Vector<DMABufRendererBufferFormat> m_preferredBufferFormats;
+    Vector<RendererBufferFormat> m_preferredBufferFormats;
 #endif
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -711,7 +711,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if PLATFORM(WPE) && USE(GBM) && ENABLE(WPE_PLATFORM)
-    PreferredBufferFormatsDidChange(Vector<WebKit::DMABufRendererBufferFormat> preferredBufferFormats)
+    PreferredBufferFormatsDidChange(Vector<WebKit::RendererBufferFormat> preferredBufferFormats)
 #endif
 
     StartTextManipulations(Vector<WebCore::TextManipulationControllerExclusionRule> exclusionRules, bool includeSubframes) -> ()

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -29,8 +29,8 @@
 
 #include "AcceleratedSurface.h"
 
-#include "DMABufRendererBufferFormat.h"
 #include "MessageReceiver.h"
+#include "RendererBufferFormat.h"
 #include <WebCore/Damage.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
@@ -158,7 +158,7 @@ private:
         }
         BufferFormat& operator=(BufferFormat&& other)
         {
-            usage = std::exchange(other.usage, DMABufRendererBufferFormat::Usage::Rendering);
+            usage = std::exchange(other.usage, RendererBufferFormat::Usage::Rendering);
             drmDevice = WTFMove(other.drmDevice);
             fourcc = std::exchange(other.fourcc, 0);
             modifiers = WTFMove(other.modifiers);
@@ -171,7 +171,7 @@ private:
             return usage == other.usage && drmDevice == other.drmDevice && fourcc == other.fourcc && modifiers == other.modifiers;
         }
 
-        DMABufRendererBufferFormat::Usage usage { DMABufRendererBufferFormat::Usage::Rendering };
+        RendererBufferFormat::Usage usage { RendererBufferFormat::Usage::Rendering };
         CString drmDevice;
         uint32_t fourcc { 0 };
         Vector<uint64_t, 1> modifiers;
@@ -181,7 +181,7 @@ private:
     class RenderTargetEGLImage final : public RenderTarget {
     public:
         static std::unique_ptr<RenderTarget> create(uint64_t, const WebCore::IntSize&, const BufferFormat&);
-        RenderTargetEGLImage(uint64_t, const WebCore::IntSize&, EGLImage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
+        RenderTargetEGLImage(uint64_t, const WebCore::IntSize&, EGLImage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, RendererBufferFormat::Usage);
         ~RenderTargetEGLImage();
 
     private:
@@ -247,7 +247,7 @@ private:
         unsigned size() const { return m_freeTargets.size() + m_lockedTargets.size(); }
 
 #if USE(GBM)
-        void setupBufferFormat(const Vector<DMABufRendererBufferFormat>&, bool);
+        void setupBufferFormat(const Vector<RendererBufferFormat>&, bool);
 #endif
 
     private:
@@ -261,9 +261,9 @@ private:
         Vector<std::unique_ptr<RenderTarget>, s_maximumBuffers> m_freeTargets;
         Vector<std::unique_ptr<RenderTarget>, s_maximumBuffers> m_lockedTargets;
 #if USE(GBM)
-        Lock m_dmabufFormatLock;
-        BufferFormat m_dmabufFormat WTF_GUARDED_BY_LOCK(m_dmabufFormatLock);
-        bool m_dmabufFormatChanged WTF_GUARDED_BY_LOCK(m_dmabufFormatLock) { false };
+        Lock m_bufferFormatLock;
+        BufferFormat m_bufferFormat WTF_GUARDED_BY_LOCK(m_bufferFormatLock);
+        bool m_bufferFormatChanged WTF_GUARDED_BY_LOCK(m_bufferFormatLock) { false };
 #endif
     };
 

--- a/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
@@ -44,7 +44,7 @@ bool WebPage::platformCanHandleRequest(const ResourceRequest&)
 }
 
 #if USE(GBM) && ENABLE(WPE_PLATFORM)
-void WebPage::preferredBufferFormatsDidChange(Vector<DMABufRendererBufferFormat>&& preferredBufferFormats)
+void WebPage::preferredBufferFormatsDidChange(Vector<RendererBufferFormat>&& preferredBufferFormats)
 {
     m_preferredBufferFormats = WTFMove(preferredBufferFormats);
     if (m_drawingArea)


### PR DESCRIPTION
#### 73a5a049222e8f3705ce2d5c1c9ff89709a4116b
<pre>
[GTK][WPE] Rename DMABufRendererBufferFormat as RendererBufferFormat
<a href="https://bugs.webkit.org/show_bug.cgi?id=296481">https://bugs.webkit.org/show_bug.cgi?id=296481</a>

Reviewed by Carlos Garcia Campos.

The concept of a buffer format can apply to other types of buffers other
than DMA-BUF ones, therefore remove the DMABufRendererBufferFormat,
leaving it as plainly RendererBufferFormat.

A class named RendererBufferFormat already existed, but its name was
confusing because it is used to describe the properties of buffers being
used for rendering in order to display the information in webkit://gpu.
Therefore, its name gets changed to RendererBufferDescription, which
is clearer given its intended usage.

Canonical link: <a href="https://commits.webkit.org/297929@main">https://commits.webkit.org/297929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f6294ee1a7d9c4314820d34e169eb412d41cb83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119683 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64267 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/64267 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102035 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66685 "Found 145 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/112878 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26284 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30274 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94968 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40087 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17895 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40398 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/45899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->