### PR TITLE
Add a runtime preference for the Pointer Lock API

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5811,6 +5811,23 @@ PitchCorrectionAlgorithm:
     WebCore:
       default: MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround
 
+PointerLockEnabled:
+  type: bool
+  status: internal
+  category: dom
+  condition: ENABLE(POINTER_LOCK)
+  humanReadableName: "Pointer Lock API"
+  humanReadableDescription: "Enable the Pointer Lock API"
+  defaultValue:
+    WebKitLegacy:
+      "PLATFORM(IOS_FAMILY)": false
+      default: true
+    WebKit:
+      "PLATFORM(IOS_FAMILY)": false
+      default: true
+    WebCore:
+      default: false
+
 PointerLockOptionsEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/dom/Document+PointerLock.idl
+++ b/Source/WebCore/dom/Document+PointerLock.idl
@@ -25,7 +25,8 @@
 
 // https://w3c.github.io/pointerlock/#extensions-to-the-document-interface
 [
-    Conditional=POINTER_LOCK
+    Conditional=POINTER_LOCK,
+    EnabledBySetting=PointerLockEnabled
 ] partial interface Document {
     attribute EventHandler onpointerlockchange;
     attribute EventHandler onpointerlockerror;

--- a/Source/WebCore/dom/DocumentOrShadowRoot+PointerLock.idl
+++ b/Source/WebCore/dom/DocumentOrShadowRoot+PointerLock.idl
@@ -25,7 +25,8 @@
 
 // https://w3c.github.io/pointerlock/#extensions-to-the-documentorshadowroot-mixin
 [
-    Conditional=POINTER_LOCK
+    Conditional=POINTER_LOCK,
+    EnabledBySetting=PointerLockEnabled
 ] partial interface mixin DocumentOrShadowRoot {
     readonly attribute Element? pointerLockElement;
 };

--- a/Source/WebCore/dom/Element+PointerLock.idl
+++ b/Source/WebCore/dom/Element+PointerLock.idl
@@ -24,7 +24,8 @@
  */
 
 [
-    Conditional=POINTER_LOCK
+    Conditional=POINTER_LOCK,
+    EnabledBySetting=PointerLockEnabled
 ] partial interface Element {
     // Returns Promise<undefined> if PointerLockOptionsEnabled Runtime Flag is set, otherwise returns undefined.
     [CallWith=CurrentGlobalObject] any requestPointerLock(optional PointerLockOptions options = {});

--- a/Source/WebCore/dom/PointerLockOptions.idl
+++ b/Source/WebCore/dom/PointerLockOptions.idl
@@ -22,9 +22,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://github.com/w3c/pointerlock/pull/49/
+// https://w3c.github.io/pointerlock/#pointerlockoptions-dictionary
 [
-    Conditional=POINTER_LOCK
+    Conditional=POINTER_LOCK,
+    EnabledBySetting=PointerLockEnabled&PointerLockOptionsEnabled
 ] dictionary PointerLockOptions {
     boolean unadjustedMovement = false;
 };


### PR DESCRIPTION
#### 890eac1f837f3056b6bfbc7e498c1ea0cb0d0cb3
<pre>
Add a runtime preference for the Pointer Lock API
<a href="https://bugs.webkit.org/show_bug.cgi?id=296499">https://bugs.webkit.org/show_bug.cgi?id=296499</a>
<a href="https://rdar.apple.com/156740883">rdar://156740883</a>

Reviewed by Aditya Keerthi.

It is convenient to have a toggle for the Pointer Lock API as we develop
it for currently unsupported configurations.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document+PointerLock.idl:
* Source/WebCore/dom/DocumentOrShadowRoot+PointerLock.idl:
* Source/WebCore/dom/Element+PointerLock.idl:
* Source/WebCore/dom/PointerLockOptions.idl:

Canonical link: <a href="https://commits.webkit.org/297889@main">https://commits.webkit.org/297889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d78bb2398394d723486a9b43a745e196ca6c6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63909 "Built successfully") | ✅ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86192 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66514 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63208 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105763 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122671 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111862 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94783 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36460 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45709 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39851 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36518 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->