### PR TITLE
Fixed Auto-dimming effect in portal window of APMP playback from WebView's Div Element Fullscreen

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -150,6 +150,9 @@ public:
     virtual bool supportsLinearMediaPlayer() const { return false; }
 #endif
 
+    virtual bool prefersAutoDimming() const { return false; }
+    virtual void setPrefersAutoDimming(bool) { }
+
 #if !RELEASE_LOG_DISABLED
     virtual uint64_t logIdentifier() const { return 0; }
     virtual const Logger* loggerPtr() const { return nullptr; }

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -136,6 +136,8 @@ void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<vo
         if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(m_spatialTrackingLabel);
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Large);
+
+            playableViewController().prefersAutoDimming = playbackSessionModel->prefersAutoDimming();
         }
         completionHandler(success, error);
     }).get()];
@@ -148,6 +150,8 @@ void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, Function<vo
         if (auto* playbackSessionModel = this->playbackSessionModel()) {
             playbackSessionModel->setSpatialTrackingLabel(nullString());
             playbackSessionModel->setSoundStageSize(WebCore::AudioSessionSoundStageSize::Automatic);
+
+            playbackSessionModel->setPrefersAutoDimming(playableViewController().prefersAutoDimming);
         }
         completionHandler(success, error);
     }).get()];
@@ -319,6 +323,9 @@ void VideoPresentationInterfaceLMK::ensurePlayableViewController()
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_playerViewController = [linearMediaPlayer() makeViewController];
     [m_playerViewController viewController].view.alpha = 0;
+
+    if (auto* playbackSessionModel = playbackSessionInterface().playbackSessionModel())
+        [m_playerViewController setPrefersAutoDimming:playbackSessionModel->prefersAutoDimming()];
 }
 
 void VideoPresentationInterfaceLMK::swapFullscreenModesWith(VideoPresentationInterfaceIOS& otherInterfaceIOS)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -189,6 +189,9 @@ private:
     WebCore::AudioSessionSoundStageSize soundStageSize() const final { return m_soundStageSize; }
     void setSoundStageSize(WebCore::AudioSessionSoundStageSize) final;
 
+    bool prefersAutoDimming() const final { return m_prefersAutoDimming; }
+    void setPrefersAutoDimming(bool) final;
+
     void swapVideoReceiverEndpointsWith(PlaybackSessionModelContext&);
 
 #if !RELEASE_LOG_DISABLED
@@ -238,6 +241,7 @@ private:
     std::optional<WebCore::SpatialVideoMetadata> m_spatialVideoMetadata;
     std::optional<WebCore::VideoProjectionMetadata> m_videoProjectionMetadata;
 
+    bool m_prefersAutoDimming { false };
 #if !RELEASE_LOG_DISABLED
     uint64_t m_logIdentifier { 0 };
 #endif
@@ -356,6 +360,9 @@ private:
     void addNowPlayingMetadataObserver(PlaybackSessionContextIdentifier, const WebCore::NowPlayingMetadataObserver&);
     void removeNowPlayingMetadataObserver(PlaybackSessionContextIdentifier, const WebCore::NowPlayingMetadataObserver&);
     void setSoundStageSize(PlaybackSessionContextIdentifier, WebCore::AudioSessionSoundStageSize);
+
+    bool prefersAutoDimming() const;
+    void setPrefersAutoDimming(bool);
 
     void updateVideoControlsManager(PlaybackSessionContextIdentifier);
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1433,7 +1433,9 @@ void VideoPresentationManagerProxy::didExitFullscreen(PlaybackSessionContextIden
         page->didExitStandby(contextId);
     else
 #endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
     page->didExitFullscreen(contextId);
+#endif
 
     callCloseCompletionHandlers();
 }
@@ -1455,7 +1457,9 @@ void VideoPresentationManagerProxy::didEnterFullscreen(PlaybackSessionContextIde
         page->didEnterStandby(contextId);
     else
 #endif
+#if ENABLE(VIDEO_PRESENTATION_MODE)
     page->didEnterFullscreen(contextId);
+#endif
 }
 
 void VideoPresentationManagerProxy::failedToEnterFullscreen(PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -87,6 +87,7 @@ OBJC_CLASS UIView;
 OBJC_CLASS UIViewController;
 OBJC_CLASS WKBaseScrollView;
 OBJC_CLASS WKBEScrollViewScrollUpdate;
+OBJC_CLASS WKFullScreenWindowController;
 OBJC_CLASS _WKRemoteObjectRegistry;
 
 #if USE(APPKIT)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -87,6 +87,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    WebFullScreenManagerProxyClient* client() { return m_client.get(); }
+
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const;
 
     bool isFullScreen();

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -348,8 +348,8 @@ private:
     bool hasResizableWindows() const final;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    void didEnterFullscreen() final { };
-    void didExitFullscreen() final { };
+    void didEnterFullscreen() final;
+    void didExitFullscreen() final;
     void didCleanupFullscreen() final;
 #endif
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -815,7 +815,6 @@ WebFullScreenManagerProxyClient& PageClientImpl::fullScreenManagerProxyClient()
         return *m_fullscreenClientForTesting;
     return *this;
 }
-
 // WebFullScreenManagerProxyClient
 
 void PageClientImpl::closeFullScreenManager()
@@ -895,6 +894,20 @@ void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntR
 }
 
 #endif // ENABLE(FULLSCREEN_API)
+
+void PageClientImpl::didEnterFullscreen()
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE) && ENABLE(FULLSCREEN_API)
+    [[webView() fullScreenWindowController] didEnterVideoFullscreen];
+#endif
+}
+
+void PageClientImpl::didExitFullscreen()
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE) && ENABLE(FULLSCREEN_API)
+    [[webView() fullScreenWindowController] didExitVideoFullscreen];
+#endif
+}
 
 void PageClientImpl::didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, std::span<const uint8_t> dataReference)
 {

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -60,6 +60,8 @@
 - (void)videoControlsManagerDidChange;
 - (void)videosInElementFullscreenChanged;
 - (void)didCleanupFullscreen;
+- (void)didEnterVideoFullscreen;
+- (void)didExitVideoFullscreen;
 
 #if PLATFORM(VISION)
 - (void)toggleSceneDimming;

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -96,18 +96,8 @@
         base.environmentPickerButtonViewController
     }
 
-    @nonobjc final var playable: (any Playable)? {
-        get {
-            #if USE_APPLE_INTERNAL_SDK
-            base.playable
-            #else
-            nil
-            #endif
-        }
-        set { base.playable = newValue }
-    }
-
-    @nonobjc final var prefersAutoDimming: Bool {
+    @objc
+    var prefersAutoDimming: Bool {
         get {
             #if USE_APPLE_INTERNAL_SDK
             base.prefersAutoDimming
@@ -115,7 +105,24 @@
             false
             #endif
         }
-        set { base.prefersAutoDimming = newValue }
+        set {
+            base.prefersAutoDimming = newValue
+        }
+    }
+
+    @nonobjc
+    final var playable: (any Playable)? {
+        get {
+            #if USE_APPLE_INTERNAL_SDK
+            base.playable
+            #else
+            nil
+            #endif
+        }
+        set {
+            base.playable = newValue
+        }
+
     }
 }
 

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h
@@ -106,6 +106,8 @@ NS_SWIFT_UI_ACTOR
 
 @property (nonatomic) BOOL automaticallyDockOnFullScreenPresentation;
 
+@property (nonatomic) BOOL prefersAutoDimming;
+
 @end
 
 NS_HEADER_AUDIT_END(nullability, sendability)


### PR DESCRIPTION
#### 52379892b081a3a346c979641831dedddcf224c7
<pre>
Fixed Auto-dimming effect in portal window of APMP playback from WebView&apos;s Div Element Fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=296495">https://bugs.webkit.org/show_bug.cgi?id=296495</a>
<a href="https://rdar.apple.com/154223902">rdar://154223902</a>

Reviewed by Andy Estes and Jean-Yves Avenard.

This patch creates a single place to store a user preference: whether videos should automatically
dim the background when played in fullscreen. PlaybackSessionModel carries a boolean
m_prefersAutoDimming, with accessors that notify its clients when the value changes.
PlaybackSessionModelContext forwards the change to VideoPresentationManagerProxy, allowing every
concurrent playback context to observe the current setting. PlaybackSessionManagerProxy persists
the value to user defaults and relays it to the Web-process fullscreen manager so the system knows
which darkness level to apply. VideoPresentationInterfaceLMK applies the flag to the underlying
AVPlayerViewController, caches the previous stage darkness on entry and restores it on exit.
WKFullScreenWindowControllerIOS consults the proxy when entering fullscreen, reflects user changes
made regarding autoDimming back into the proxy.

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModel::prefersAutoDimming const):
(WebCore::PlaybackSessionModel::setPrefersAutoDimming):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::presentFullscreen):
(WebKit::VideoPresentationInterfaceLMK::dismissFullscreen):
(WebKit::VideoPresentationInterfaceLMK::ensurePlayableViewController):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::PlaybackSessionModelContext):
(WebKit::PlaybackSessionModelContext::setPrefersAutoDimming):
(WebKit::PlaybackSessionManagerProxy::prefersAutoDimming const):
(WebKit::PlaybackSessionManagerProxy::setPrefersAutoDimming):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::didExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::client):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::fullScreenManagerProxyClient):
(WebKit::PageClientImpl::didEnterFullscreen):
(WebKit::PageClientImpl::didExitFullscreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController initWithWebView:]):
(-[WKFullScreenWindowController didEnterVideoFullscreen]):
(-[WKFullScreenWindowController didExitVideoFullscreen]):
(-[WKFullScreenWindowController prefersSceneDimming]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
(-[WKFullScreenWindowController toggleSceneDimming]):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift:
(WKSPlayableViewControllerHost.prefersAutoDimming):
(WKSPlayableViewControllerHost.playable):
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaTypes.h:

Canonical link: <a href="https://commits.webkit.org/298720@main">https://commits.webkit.org/298720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccba76bdea583325fa4fa8124479d1ae4de0b6c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66982 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68857 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22546 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125625 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97124 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20114 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39267 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48792 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143645 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42667 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/143645 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46007 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->