### PR TITLE
Some WebVTT ref files place font styling on the inline element, affecting line height

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -604,9 +604,6 @@ imported/w3c/web-platform-tests/x-frame-options/multiple.html [ DumpJSConsoleLog
 imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window.html [ DumpJSConsoleLogInStdErr ]
 
-# We need to fix our WebVTT implementation to pass most of the WebVTT rendering WPT (https://bugs.webkit.org/show_bug.cgi?id=277975).
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
-
 webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.lang.dynamic.html [ ImageOnlyFailure ]
 webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.lang.html [ ImageOnlyFailure ]
 webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.lang.inherit.disconnected.canvas.html [ ImageOnlyFailure ]
@@ -622,24 +619,34 @@ webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.direction.inherit.html [ ImageOnlyFailure ]
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.worker.direction.inherit.html [ ImageOnlyFailure ]
 
+# We need to fix our WebVTT implementation to pass most of the WebVTT rendering WPT (https://bugs.webkit.org/show_bug.cgi?id=277975).
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
+
 # These are the WebVTT rendering WPT we are already passing.
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html [ Pass ] 
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_remove_cue_while_paused.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority_layer.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_imports_blocked.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_invalid_format.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_media_queries.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_media_queries_resized.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_selectors.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_urls.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html [ Pass ]
 
 # These WebVTT rendering WPT are flaky.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/non-standard-pseudo-elements.html [ ImageOnlyFailure Pass Failure ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/audio_has_no_subtitles.html [ ImageOnlyFailure Pass Failure ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_white-space_pre-line_wrapped.html [ Crash ImageOnlyFailure ]
-
-# These WebVTT rendering WPT occasionally time out.
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks.html [ Skip ]
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks.html [ Skip ]
 
 # Flaky crashing test.
 media/modern-media-controls/tracks-support/no-tracks.html [ Crash Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
-    color: green;
+    background: rgba(0,0,0,0.8); 
 }
 </style>
 <div class="video">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-expected.html
@@ -27,10 +27,12 @@ body { margin:0 }
     margin-top: 4.5px;
     text-align: center
 }
-.cue > span {
+.cue {
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue" id="cue1"><span>This is a test subtitle</span></span><span class="cue" id="cue2"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html
@@ -27,10 +27,12 @@ body { margin:0 }
     margin-top: 4.5px;
     text-align: center
 }
-.cue > span {
+.cue {
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue" id="cue1"><span>This is a test subtitle</span></span><span class="cue" id="cue2"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .cueTextGoingUp {
     position: relative;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .cueTextGoingUp {
     position: relative;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks-expected.html
@@ -19,11 +19,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html
@@ -19,11 +19,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks-expected.html
@@ -19,11 +19,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html
@@ -19,11 +19,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cueText {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video">

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: right;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: right;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: right
+    text-align: right;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: right
+    text-align: right;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-expected.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html
@@ -17,11 +17,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle that most likely will span over several rows since it is a pretty long cue with a lot of text.</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-expected.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="cue"><span>.<br><bdo dir=ltr>&#x05D0;ab)</bdo></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-ref.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="cue"><span>.<br><bdo dir=ltr>&#x05D0;ab)</bdo></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-expected.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="cue"><span><bdo dir=ltr>&#x06E9;)</bdo></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-ref.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="cue"><span><bdo dir=ltr>&#x06E9;)</bdo></span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>Here are the escaped <br>entities: &amp; &lt; &gt; &lrm; &rlm; &nbsp;</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>Here are the escaped <br>entities: &amp; &lt; &gt; &lrm; &rlm; &nbsp;</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-expected.html
@@ -14,13 +14,13 @@
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
     font-size: 50px;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>Foo</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-ref.html
@@ -14,13 +14,13 @@
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
     font-size: 50px;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>Foo</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     right: 51.2px;
     width: 64px;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>There is nothing to see here people, move on</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     right: 51.2px;
     width: 64px;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>There is nothing to see here people, move on</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     right: 51.2px;
     width: 64px;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This test tests</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     right: 51.2px;
     width: 64px;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This test tests</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>f o o</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>f o o</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>f o o</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_text_while_paused-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>f o o</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-expected.html
@@ -12,13 +12,13 @@ video {
     bottom: 50px;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
     font-size: 50px;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 
 .media-container {

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
 <title>Reference for WebVTT rendering, cue reposition after enabling controls</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
@@ -13,13 +12,13 @@ video {
     bottom: 50px;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     color: green;
     font-size: 50px;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 
 .media-container {
@@ -49,5 +48,3 @@ video {
         });
     }
 </script>
-</html>
-

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-expected.html
@@ -92,10 +92,10 @@
 }
 .cue {
     width: 9px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-ref.html
@@ -92,10 +92,10 @@
 }
 .cue {
     width: 9px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-expected.html
@@ -92,10 +92,10 @@
 }
 .cue {
     width: 9px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-ref.html
@@ -92,10 +92,10 @@
 }
 .cue {
     width: 9px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-expected.html
@@ -14,12 +14,12 @@
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-ref.html
@@ -14,12 +14,12 @@
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-expected.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    color: green;
+    font-family: sans-serif;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>'</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-ref.html
@@ -15,12 +15,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    color: green;
+    font-family: sans-serif;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>'</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_90-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/size_99-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class=video><span class=cue><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-expected.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that will line break</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that will line break</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-expected.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that will line break</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 80px;
     right: 0;
     width: 160px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that will line break</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent-expected.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 0;
     right: 0;
     margin-top: -4.5px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 0;
     right: 0;
     margin-top: -4.5px;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-expected.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up-expected.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_integer_and_percent_mixed_overlap_move_up-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap-expected.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 90px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up-expected.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_percent_and_integer_mixed_overlap_move_up-ref.html
@@ -23,12 +23,12 @@ body { margin:0 }
     top: 81px;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span id="cue1" class="cue"><span>This is a test subtitle</span></span><span id="cue2" class="cue"><span>This is another test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-expected.html
@@ -17,11 +17,11 @@
     right: 0;
     text-align: center;
     padding-bottom: 40px;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-ref.html
@@ -17,11 +17,11 @@
     right: 0;
     text-align: center;
     padding-bottom: 40px;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_with_controls-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_with_controls-expected.html
@@ -17,11 +17,11 @@
     right: 0;
     text-align: center;
     padding-bottom: 9px;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_with_controls-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_with_controls-ref.html
@@ -17,11 +17,11 @@
     right: 0;
     text-align: center;
     padding-bottom: 9px;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <script src="/common/reftest-wait.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position-ref-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position-ref-1.html
@@ -10,26 +10,17 @@
     position: relative;
     font-size: 50px;
 }
-video {
-    position: absolute;
-    width:320px;
-    height:240px;
-}
 .cue {
     position: absolute;
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    color: green;
+    font-family: Ahem, sans-serif;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
-<video>
-    <source src="/media/white.webm" type="video/webm">
-    <source src="/media/white.mp4" type="video/mp4">
-</video>
 <div class="video"><span class="cue"><span>Foo</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-expected.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 15%;
     right: 0;
     width: 70%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This test subtitle wraps and should be visible<br>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 15%;
     right: 0;
     width: 70%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This test subtitle wraps and should be visible<br>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/basic-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: -50%;
     right: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/regionanchor_x_50_percent-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: -50%;
     right: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/scroll_up-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/scroll_up-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a second test subtitle<br/>This is a third test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/scroll_up-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/scroll_up-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a second test subtitle<br/>This is a third test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     top: 0;
     left: 0;
     right: 0;
-    text-align: left
+    text-align: left;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent-expected.html
@@ -17,12 +17,12 @@ body { margin:0 }
     bottom: 0;
     left: 50%;
     right: -50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_x_50_percent-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     bottom: 0;
     left: 50%;
     right: -50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 50%;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/viewportanchor_y_50_percent-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 50%;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/width_50_percent-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/repaint-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/repaint-expected.html
@@ -14,11 +14,11 @@
     left: 0;
     right: 0;
     text-align: center
+    font-family: sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <p>You should see the word 'PASS' below.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/repaint-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/repaint-ref.html
@@ -14,11 +14,11 @@
     left: 0;
     right: 0;
     text-align: center
+    font-family: sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <p>You should see the word 'PASS' below.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-expected.html
@@ -29,11 +29,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="region-cue"><span>This is a test subtitle</span></span><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-ref.html
@@ -29,11 +29,11 @@ body { margin:0 }
     left: 0;
     right: 0;
     text-align: center;
+    font-family: Ahem, sans-serif;
+    color: white;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: white;
 }
 </style>
 <div class="video"><span class="region-cue"><span>This is a test subtitle</span></span><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: #60ff60;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: #60ff60;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: hsla(100,100%,50%,0.5);
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: hsla(100,100%,50%,0.5);
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: rgba(128,255,128,0.5);
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: rgba(128,255,128,0.5);
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-expected.html
@@ -16,14 +16,14 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-ref.html
@@ -16,14 +16,14 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-expected.html
@@ -16,14 +16,14 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-ref.html
@@ -16,14 +16,14 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-expected.html
@@ -21,11 +21,11 @@ body { margin:0 }
     direction: ltr;
     writing-mode: vertical-lr;
     -webkit-writing-mode: vertical-lr;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: #0f0 url('../../media/background.gif') repeat-x top left;
-    color: green;
 }
 .combine {
     -webkit-text-combine: horizontal;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-ref.html
@@ -21,11 +21,11 @@ body { margin:0 }
     direction: ltr;
     writing-mode: vertical-lr;
     -webkit-writing-mode: vertical-lr;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: #0f0 url('../../media/background.gif') repeat-x top left;
-    color: green;
 }
 .combine {
     -webkit-text-combine: horizontal;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: #0f0 url('../../media/background.gif') repeat-x top left;
     font-size: 9px;
     color: green;
+}
+.cue > span {
+    background: #0f0 url('../../media/background.gif') repeat-x top left;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .green {
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .green {
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: #60ff60;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: #60ff60;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: #60ff60;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: #60ff60;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: hsla(100,100%,50%,0.5);
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: hsla(100,100%,50%,0.5);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: hsla(100,100%,50%,0.5);
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: hsla(100,100%,50%,0.5);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: rgba(128,255,128,0.5);
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: rgba(128,255,128,0.5);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: rgba(128,255,128,0.5);
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: rgba(128,255,128,0.5);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: #00ff00;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
-    background: rgba(0,0,0,0.8);
     font-size: 9px;
     color: #00ff00;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-expected.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
+    outline: solid #00f 2px;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
-    outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
-    color: green;
+    background: rgba(0,0,0,0.8); 
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html
@@ -16,13 +16,13 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
-}
-.cue > span {
+    text-align: center;
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
-    background: rgba(0,0,0,0.8);
     color: green;
+}
+.cue > span {
+    background: rgba(0,0,0,0.8);
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/root_namespace-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-expected.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .green {
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-ref.html
@@ -16,12 +16,12 @@ body { margin:0 }
     bottom: 0;
     left: 0;
     right: 0;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 .green {
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-expected.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 25%;
     right: 0;
     width: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that should wrap</span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-ref.html
@@ -17,12 +17,12 @@ body { margin:0 }
     left: 25%;
     right: 0;
     width: 50%;
-    text-align: center
+    text-align: center;
+    font-family: Ahem, sans-serif;
+    color: green;
 }
 .cue > span {
-    font-family: Ahem, sans-serif;
     background: rgba(0,0,0,0.8);
-    color: green;
 }
 </style>
 <div class="video"><span class="cue"><span>This is a test subtitle that should wrap</span></span></div>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -163,6 +163,9 @@ fast/images/text-recognition [ Pass ]
 fast/images/text-recognition/ios [ Pass ]
 fast/images/text-recognition/mac [ Skip ]
 
+# rdar://157036215
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards.html [ ImageOnlyFailure ]
+
 # Accessibility text recognition support tests.
 accessibility/ios-simulator/image-overlay-elements.html [ Pass ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -32,6 +32,10 @@ http/tests/security/xss-DENIED-xsl-external-entity-no-logging.xml [ Pass ]
 
 imported/w3c/web-platform-tests/css/css-pseudo/selection-over-highlight-001.html [ Pass ]
 
+# rdar://156945624
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue.html [ ImageOnlyFailure ]
+
 # rdar://problem/61793884 : Enabling this test for WK1 only.
 fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Pass ]
 


### PR DESCRIPTION
#### 1d420db4a0cdaa2aa290795fbcb789713f0d1263
<pre>
Some WebVTT ref files place font styling on the inline element, affecting line height
<a href="https://bugs.webkit.org/show_bug.cgi?id=296502">https://bugs.webkit.org/show_bug.cgi?id=296502</a>
<a href="https://rdar.apple.com/136808799">rdar://136808799</a>

Reviewed by NOBODY (OOPS!).

To better imitate WebVTT behavior, the ref files should apply all styling meant for the ::cue pseudo-element
on the block level element (&lt;span class:&quot;cue&quot;&gt;) rather than the inline element. The one exception
is any properties corresponding to the &quot;background&quot; shorthand, which should be applied on the inline element.
This is instructed in the WebVTT spec: <a href="https://www.w3.org/TR/webvtt1/#the-cue-pseudo-element.">https://www.w3.org/TR/webvtt1/#the-cue-pseudo-element.</a>

In many of these tests, the Ahem font was applied to the inline element instead of the block. This caused the
block&apos;s font, the default font, to dictate the line height of the inline block, causing the line height
to differ from the real WebVTT.

This change addresses the WPT GitHub issue: <a href="https://github.com/web-platform-tests/wpt/issues/53984">https://github.com/web-platform-tests/wpt/issues/53984</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_down-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_partially_move_up-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_tracks-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/3_tracks-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_wrapped-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end_wrapped-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start_wrapped-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/enable_controls_reposition-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/9_cues_overlapping_completely_all_cues_have_same_timestamp-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/single_quote-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_-2_wrapped_cue_grow_upwards-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_1_wrapped_cue_grow_downwards-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_height400_with_controls-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_with_controls-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/media_with_controls-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/navigate_cue_position-ref-1.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/one_line_cue_plus_wrapped_cue-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/regions/single_line_top_left-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/repaint-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/repaint-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue-region/font_properties-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_properties-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/background_shorthand_css_relative_url-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hex-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_hsla-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/color_rgba-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_properties-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/outline_shorthand-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue/vertical_text-combine-upright-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/class_object/class_namespace-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/id_color-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/voice_object/voice_namespace-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50-ref.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d420db4a0cdaa2aa290795fbcb789713f0d1263

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120036 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64662 "Failed to checkout and rebase branch from PR 48543") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86553 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/64662 "Failed to checkout and rebase branch from PR 48543") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66926 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26471 "Exiting early after 10 failures. 98 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95159 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40301 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18091 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37060 "Failed to checkout and rebase branch from PR 48543") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40788 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43729 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42188 "Failed to checkout and rebase branch from PR 48543") | | | 
<!--EWS-Status-Bubble-End-->