### PR TITLE
Add Document support to _WKSerializedNode

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1349,6 +1349,7 @@ dom/SecurityContext.cpp
 dom/SecurityOriginPolicy.cpp
 dom/SecurityPolicyViolationEvent.cpp
 dom/SelectorQuery.cpp
+dom/SerializedNode.cpp
 dom/ShadowRoot.cpp
 dom/SimpleRange.cpp
 dom/SimulatedClick.cpp

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -30,6 +30,7 @@ namespace WebCore {
 class HTMLCollection;
 class RadioNodeList;
 class RenderElement;
+struct SerializedNode;
 
 enum class CollectionType : uint8_t;
 
@@ -79,6 +80,7 @@ public:
     void takeAllChildrenFrom(ContainerNode*);
 
     void cloneChildNodes(Document&, CustomElementRegistry*, ContainerNode& clone, size_t currentDepth = 0) const;
+    Vector<SerializedNode> serializeChildNodes(size_t currentDepth = 0) const;
 
     enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
     struct ChildChange {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -396,6 +396,8 @@ enum class CustomElementNameValidationStatus {
     ConflictsWithStandardElementName
 };
 
+enum class ClonedDocumentType : uint8_t { XMLDocument, XHTMLDocument, HTMLDocument, SVGDocument, Document };
+
 using RenderingContext = Variant<
 #if ENABLE(WEBGL)
     RefPtr<WebGLRenderingContext>,
@@ -435,6 +437,7 @@ public:
     inline static Ref<Document> create(const Settings&, const URL&);
     static Ref<Document> createNonRenderedPlaceholder(LocalFrame&, const URL&);
     static Ref<Document> create(Document&);
+    static Ref<Document> createCloned(ClonedDocumentType, const Settings&, const URL&, const URL& baseURL, const URL& baseURLOverride, const Variant<String, URL>& documentURI, DocumentCompatibilityMode, Document& contextDocument, SecurityOriginPolicy*, const String& contentType, TextResourceDecoder*);
 
     virtual ~Document();
 
@@ -903,6 +906,7 @@ public:
     bool inQuirksMode() const { return m_compatibilityMode == DocumentCompatibilityMode::QuirksMode; }
     bool inLimitedQuirksMode() const { return m_compatibilityMode == DocumentCompatibilityMode::LimitedQuirksMode; }
     bool inNoQuirksMode() const { return m_compatibilityMode == DocumentCompatibilityMode::NoQuirksMode; }
+    DocumentCompatibilityMode compatibilityMode() const { return m_compatibilityMode; }
 
     void setReadyState(ReadyState);
     void setParsing(bool);
@@ -2012,8 +2016,6 @@ protected:
 
     void clearXMLVersion() { m_xmlVersion = String(); }
 
-    virtual Ref<Document> cloneDocumentWithoutChildren() const;
-
 private:
     friend class DocumentParserYieldToken;
     friend class DocumentSyncData;
@@ -2069,8 +2071,9 @@ private:
     String nodeName() const final;
     bool childTypeAllowed(NodeType) const final;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const final;
+    ClonedDocumentType clonedDocumentType() const;
+
     SerializedNode serializeNode(CloningOperation) const final;
-    void cloneDataFromDocument(const Document&);
 
     Seconds minimumDOMTimerInterval() const final;
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -46,11 +46,6 @@ namespace WTF {
 class TextStream;
 }
 
-namespace JSC {
-class JSValue;
-class JSGlobalObject;
-}
-
 namespace WebCore {
 
 class ContainerNode;
@@ -203,7 +198,6 @@ public:
     };
     virtual Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const = 0;
     virtual SerializedNode serializeNode(CloningOperation) const = 0;
-    WEBCORE_EXPORT static JSC::JSValue deserializeNode(JSC::JSGlobalObject*, JSDOMGlobalObject*, Document&, SerializedNode&&);
     Ref<Node> cloneNode(bool deep) const;
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> cloneNodeForBindings(bool deep) const;
 

--- a/Source/WebCore/dom/SerializedNode.cpp
+++ b/Source/WebCore/dom/SerializedNode.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SerializedNode.h"
+
+#include "Attr.h"
+#include "CDATASection.h"
+#include "Comment.h"
+#include "DocumentType.h"
+#include "JSNode.h"
+#include "ProcessingInstruction.h"
+#include "SecurityOriginPolicy.h"
+#include "Text.h"
+
+namespace WebCore {
+
+JSC::JSValue SerializedNode::deserialize(SerializedNode&& serializedNode, JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* domGlobalObject, WebCore::Document& document)
+{
+    // FIXME: Support other kinds of nodes and change RefPtr to Ref.
+    RefPtr node = WTF::switchOn(WTFMove(serializedNode.data), [&] (SerializedNode::Text&& text) -> RefPtr<Node> {
+        return WebCore::Text::create(document, WTFMove(text.data));
+    }, [&] (SerializedNode::ProcessingInstruction&& instruction) -> RefPtr<Node> {
+        return WebCore::ProcessingInstruction::create(document, WTFMove(instruction.target), WTFMove(instruction.data));
+    }, [&] (SerializedNode::DocumentType&& type) -> RefPtr<Node> {
+        return WebCore::DocumentType::create(document, type.name, type.publicId, type.systemId);
+    }, [&] (SerializedNode::Comment&& comment) -> RefPtr<Node> {
+        return WebCore::Comment::create(document, WTFMove(comment.data));
+    }, [&] (SerializedNode::CDATASection&& section) -> RefPtr<Node> {
+        return WebCore::CDATASection::create(document, WTFMove(section.data));
+    }, [&] (SerializedNode::Attr&& attr) -> RefPtr<Node> {
+        QualifiedName name(AtomString(WTFMove(attr.prefix)), AtomString(WTFMove(attr.localName)), AtomString(WTFMove(attr.namespaceURI)));
+        return WebCore::Attr::create(document, name, AtomString(WTFMove(attr.value)));
+    }, [&] (SerializedNode::Document&& serializedDocument) -> RefPtr<Node> {
+        return WebCore::Document::createCloned(
+            serializedDocument.type,
+            document.settings(),
+            serializedDocument.url,
+            serializedDocument.baseURL,
+            serializedDocument.baseURLOverride,
+            serializedDocument.documentURI,
+            document.compatibilityMode(),
+            document,
+            RefPtr { document.securityOriginPolicy() }.get(),
+            serializedDocument.contentType,
+            document.protectedDecoder().get()
+        );
+    }, [] (auto&&) -> RefPtr<Node> {
+        return nullptr;
+    });
+    return toJSNewlyCreated(lexicalGlobalObject, domGlobalObject, WTFMove(node));
+}
+
+}

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -25,9 +25,20 @@
 
 #pragma once
 
+#include "SecurityOriginData.h"
 #include <wtf/text/WTFString.h>
 
+namespace JSC {
+class JSGlobalObject;
+class JSValue;
+}
+
 namespace WebCore {
+
+class Document;
+class JSDOMGlobalObject;
+
+enum class ClonedDocumentType : uint8_t;
 
 struct SerializedNode {
     struct Attr {
@@ -36,10 +47,18 @@ struct SerializedNode {
         String namespaceURI;
         String value;
     };
-    struct Document {
-        // FIXME: Implement.
+    struct ContainerNode {
+        Vector<SerializedNode> children;
     };
-    struct DocumentFragment {
+    struct Document : public ContainerNode {
+        ClonedDocumentType type;
+        URL url;
+        URL baseURL;
+        URL baseURLOverride;
+        Variant<String, URL> documentURI;
+        String contentType;
+    };
+    struct DocumentFragment : public ContainerNode {
         // FIXME: Implement.
     };
     struct DocumentType {
@@ -47,13 +66,13 @@ struct SerializedNode {
         String publicId;
         String systemId;
     };
-    struct Element {
+    struct Element : public ContainerNode {
         // FIXME: Implement.
     };
-    struct ShadowRoot {
+    struct ShadowRoot : public DocumentFragment {
         // FIXME: Implement.
     };
-    struct HTMLTemplateElement {
+    struct HTMLTemplateElement : public Element {
         // FIXME: Implement.
     };
     struct CharacterData {
@@ -67,6 +86,8 @@ struct SerializedNode {
     };
 
     Variant<Attr, CDATASection, Comment, Document, DocumentFragment, DocumentType, Element, ProcessingInstruction, ShadowRoot, Text, HTMLTemplateElement> data;
+
+    WEBCORE_EXPORT static JSC::JSValue deserialize(SerializedNode&&, JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject*, WebCore::Document&);
 };
 
 }

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -238,9 +238,4 @@ bool HTMLDocument::isFrameSet() const
     return !!childrenOfType<HTMLFrameSetElement>(*documentElement()).first();
 }
 
-Ref<Document> HTMLDocument::cloneDocumentWithoutChildren() const
-{
-    return create(nullptr, settings(), url());
-}
-
 }

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -59,7 +59,6 @@ protected:
 private:
     bool isFrameSet() const final;
     Ref<DocumentParser> createParser() override;
-    Ref<Document> cloneDocumentWithoutChildren() const final;
 
     TreeScopeOrderedMap m_documentNamedItem;
     TreeScopeOrderedMap m_windowNamedItem;

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -72,9 +72,9 @@ Ref<WebKitNodeInfo> WebKitNamespace::createNodeInfo(Node& node)
     return WebKitNodeInfo::create(node);
 }
 
-Ref<WebKitSerializedNode> WebKitNamespace::serializeNode(Node& node)
+Ref<WebKitSerializedNode> WebKitNamespace::serializeNode(Node& node, SerializedNodeInit&& init)
 {
-    return WebKitSerializedNode::create(node);
+    return WebKitSerializedNode::create(node, init.deep);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -50,7 +50,11 @@ public:
 
     UserMessageHandlersNamespace* messageHandlers();
     Ref<WebKitNodeInfo> createNodeInfo(Node&);
-    Ref<WebKitSerializedNode> serializeNode(Node&);
+
+    struct SerializedNodeInit {
+        bool deep { false };
+    };
+    Ref<WebKitSerializedNode> serializeNode(Node&, SerializedNodeInit&&);
 
 private:
     explicit WebKitNamespace(LocalDOMWindow&, UserContentProvider&);

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -32,5 +32,9 @@
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
     [EnabledForWorld=nodeInfoEnabled] WebKitNodeInfo createNodeInfo(Node node);
-    [EnabledForWorld=nodeInfoEnabled] WebKitSerializedNode serializeNode(Node node);
+    [EnabledForWorld=nodeInfoEnabled] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
+};
+
+dictionary WebKitSerializedNodeInit {
+    boolean deep;
 };

--- a/Source/WebCore/page/WebKitSerializedNode.cpp
+++ b/Source/WebCore/page/WebKitSerializedNode.cpp
@@ -30,8 +30,8 @@
 
 namespace WebCore {
 
-WebKitSerializedNode::WebKitSerializedNode(const Node& node)
-    : m_serializedNode(node.serializeNode(Node::CloningOperation::SelfOnly))
+WebKitSerializedNode::WebKitSerializedNode(const Node& node, bool deep)
+    : m_serializedNode(node.serializeNode(deep ? Node::CloningOperation::Everything : Node::CloningOperation::SelfOnly))
 {
 }
 

--- a/Source/WebCore/page/WebKitSerializedNode.h
+++ b/Source/WebCore/page/WebKitSerializedNode.h
@@ -33,12 +33,12 @@ class Node;
 
 class WebKitSerializedNode : public RefCounted<WebKitSerializedNode> {
 public:
-    static Ref<WebKitSerializedNode> create(const Node& node) { return adoptRef(*new WebKitSerializedNode(node)); }
+    static Ref<WebKitSerializedNode> create(const Node& node, bool deep) { return adoptRef(*new WebKitSerializedNode(node, deep)); }
 
     const SerializedNode& serializedNode() const { return m_serializedNode; }
 
 private:
-    WebKitSerializedNode(const Node&);
+    WebKitSerializedNode(const Node&, bool);
 
     const SerializedNode m_serializedNode;
 };

--- a/Source/WebCore/svg/SVGDocument.cpp
+++ b/Source/WebCore/svg/SVGDocument.cpp
@@ -60,9 +60,4 @@ void SVGDocument::updatePan(const FloatPoint& position) const
     element->setCurrentTranslate(position - m_panningOffset);
 }
 
-Ref<Document> SVGDocument::cloneDocumentWithoutChildren() const
-{
-    return create(nullptr, settings(), url());
-}
-
 }

--- a/Source/WebCore/svg/SVGDocument.h
+++ b/Source/WebCore/svg/SVGDocument.h
@@ -40,8 +40,6 @@ public:
 private:
     SVGDocument(LocalFrame*, const Settings&, const URL&);
 
-    Ref<Document> cloneDocumentWithoutChildren() const override;
-
     FloatSize m_panningOffset;
 };
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -61,9 +61,12 @@ using JSObjectID = ObjectIdentifier<JSObjectIDType>;
 class JavaScriptEvaluationResult {
 public:
     enum class EmptyType : bool { Undefined, Null };
-    using Value = Variant<EmptyType, bool, double, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>, NodeInfo, WebCore::SerializedNode>;
+    struct Value {
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Value);
+        Variant<EmptyType, bool, double, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>, NodeInfo, WebCore::SerializedNode> value;
+    };
 
-    JavaScriptEvaluationResult(JSObjectID, HashMap<JSObjectID, Value>&&);
+    JavaScriptEvaluationResult(JSObjectID, HashMap<JSObjectID, UniqueRef<Value>>&&);
     static std::optional<JavaScriptEvaluationResult> extract(JSGlobalContextRef, JSValueRef);
 
     JavaScriptEvaluationResult(JavaScriptEvaluationResult&&);
@@ -71,7 +74,7 @@ public:
     ~JavaScriptEvaluationResult();
 
     JSObjectID root() const { return m_root; }
-    const HashMap<JSObjectID, Value>& map() const { return m_map; }
+    const HashMap<JSObjectID, UniqueRef<Value>>& map() const { return m_map; }
 
     String toString() const;
 
@@ -136,7 +139,7 @@ private:
     Vector<std::pair<Vector<JSObjectID>, Protected<JSValueRef>>> m_jsArrays;
 
     // IPC representation
-    HashMap<JSObjectID, Value> m_map;
+    HashMap<JSObjectID, UniqueRef<Value>> m_map;
     JSObjectID m_root;
 };
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
@@ -25,9 +25,13 @@ struct WebKit::NodeInfo {
     Markable<WebCore::FrameIdentifier> contentFrameIdentifier;
 };
 
+[Nested] struct WebKit::JavaScriptEvaluationResult::Value {
+    Variant<WebKit::JavaScriptEvaluationResult::EmptyType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>, WebKit::NodeInfo, WebCore::SerializedNode> value;
+}
+
 class WebKit::JavaScriptEvaluationResult {
     WebKit::JSObjectID root()
-    HashMap<WebKit::JSObjectID, Variant<WebKit::JavaScriptEvaluationResult::EmptyType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>, WebKit::NodeInfo, WebCore::SerializedNode>> map()
+    HashMap<WebKit::JSObjectID, UniqueRef<WebKit::JavaScriptEvaluationResult::Value>> map()
 }
 
 [Nested] enum class WebKit::JavaScriptEvaluationResult::EmptyType : bool

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9223,6 +9223,9 @@ header: <WebCore/ScriptTrackingPrivacyCategory.h>
     FormControls,
 };
 
+[Nested] struct WebCore::SerializedNode::ContainerNode {
+    Vector<WebCore::SerializedNode> children;
+};
 [Nested] struct WebCore::SerializedNode::Attr {
     String prefix;
     String localName;
@@ -9232,16 +9235,29 @@ header: <WebCore/ScriptTrackingPrivacyCategory.h>
 [Nested] struct WebCore::SerializedNode::CharacterData {
     String data;
 };
-[Nested] struct WebCore::SerializedNode::Document {
+[Nested] struct WebCore::SerializedNode::Document : WebCore::SerializedNode::ContainerNode {
+    WebCore::ClonedDocumentType type;
+    URL url;
+    URL baseURL;
+    URL baseURLOverride;
+    Variant<String, URL> documentURI;
+    String contentType;
 };
-[Nested] struct WebCore::SerializedNode::DocumentFragment {
+[Nested] enum class WebCore::ClonedDocumentType : uint8_t {
+    XMLDocument,
+    XHTMLDocument,
+    HTMLDocument,
+    SVGDocument,
+    Document
+};
+[Nested] struct WebCore::SerializedNode::DocumentFragment : WebCore::SerializedNode::ContainerNode {
 };
 [Nested] struct WebCore::SerializedNode::DocumentType {
     String name;
     String publicId;
     String systemId;
 };
-[Nested] struct WebCore::SerializedNode::Element {
+[Nested] struct WebCore::SerializedNode::Element : WebCore::SerializedNode::ContainerNode {
 };
 [Nested] struct WebCore::SerializedNode::Comment : WebCore::SerializedNode::CharacterData {
 };
@@ -9252,9 +9268,9 @@ header: <WebCore/ScriptTrackingPrivacyCategory.h>
 [Nested] struct WebCore::SerializedNode::ProcessingInstruction : WebCore::SerializedNode::CharacterData {
     String target;
 };
-[Nested] struct WebCore::SerializedNode::ShadowRoot {
+[Nested] struct WebCore::SerializedNode::ShadowRoot : WebCore::SerializedNode::DocumentFragment {
 };
-[Nested] struct WebCore::SerializedNode::HTMLTemplateElement {
+[Nested] struct WebCore::SerializedNode::HTMLTemplateElement : WebCore::SerializedNode::Element {
 };
 
 struct WebCore::SerializedNode {

--- a/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
+++ b/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
@@ -45,7 +45,7 @@ GRefPtr<JSCValue> JavaScriptEvaluationResult::toJSC()
 JSObjectID JavaScriptEvaluationResult::addObjectToMap(GVariant* variant)
 {
     auto identifier = JSObjectID::generate();
-    m_map.add(identifier, toValue(variant));
+    m_map.add(identifier, makeUniqueRef<Value>(toValue(variant)));
     return identifier;
 }
 
@@ -61,33 +61,33 @@ auto JavaScriptEvaluationResult::toValue(GVariant* variant) -> Value
             if (!key || !value)
                 continue;
             auto keyID = JSObjectID::generate();
-            m_map.add(keyID, String::fromUTF8(key));
+            m_map.add(keyID, makeUniqueRef<Value>(Value { { String::fromUTF8(key) } }));
             auto valueID = JSObjectID::generate();
-            m_map.add(valueID, toValue(value));
+            m_map.add(valueID, makeUniqueRef<Value>(toValue(value)));
             map.add(keyID, valueID);
         }
-        return { WTFMove(map) };
+        return { { WTFMove(map) } };
     }
 
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT32))
-        return static_cast<double>(g_variant_get_uint32(variant));
+        return { static_cast<double>(g_variant_get_uint32(variant)) };
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT32))
-        return static_cast<double>(g_variant_get_int32(variant));
+        return { static_cast<double>(g_variant_get_int32(variant)) };
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT64))
-        return static_cast<double>(g_variant_get_uint64(variant));
+        return { static_cast<double>(g_variant_get_uint64(variant)) };
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT64))
-        return static_cast<double>(g_variant_get_int64(variant));
+        return { static_cast<double>(g_variant_get_int64(variant)) };
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT16))
-        return static_cast<double>(g_variant_get_int16(variant));
+        return { static_cast<double>(g_variant_get_int16(variant)) };
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT16))
-        return static_cast<double>(g_variant_get_uint16(variant));
+        return { static_cast<double>(g_variant_get_uint16(variant)) };
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_DOUBLE))
-        return static_cast<double>(g_variant_get_double(variant));
+        return { static_cast<double>(g_variant_get_double(variant)) };
 
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_STRING))
-        return String::fromUTF8(g_variant_get_string(variant, nullptr));
+        return { String::fromUTF8(g_variant_get_string(variant, nullptr)) };
 
-    return EmptyType::Null;
+    return { EmptyType::Null };
 }
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(GVariant* variant)


### PR DESCRIPTION
#### 00d5122b17f1d0baec9835d7854ce49b7714d0a3
<pre>
Add Document support to _WKSerializedNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=296506">https://bugs.webkit.org/show_bug.cgi?id=296506</a>
<a href="https://rdar.apple.com/156746228">rdar://156746228</a>

Reviewed by Ryosuke Niwa.

This PR is mostly moving things around to be shared between node cloning and serialization.
I begin to add the shape of cloning ContainerNodes, but it&apos;s not really implemented much yet.
I add IDL support for serializeNode(node, {deep:true}).
I changed cloneDocumentWithoutChildren from a virtual function to Document::clonedDocumentType
and Document::createCloned which know about all supported subclasses of Document.
When deserializing a Document, some properties are taken from the serialized values and some
are taken from the context Document into which you are deserializing a Node.
JavaScriptEvaluationResult::Value has become too big to fit into a HashMap value without
hitting the static assertion in HashMap::inlineLookup, so I switch to a UniqueRef&lt;Value&gt;.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::cloneChildNodes const):
(WebCore::ContainerNode::serializeChildNodes const):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::clonedDocumentType const):
(WebCore::Document::cloneNodeInternal const):
(WebCore::Document::serializeNode const):
(WebCore::Document::createCloned):
(WebCore::Document::cloneDocumentWithoutChildren const): Deleted.
(WebCore::Document::cloneDataFromDocument): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::compatibilityMode const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::deserializeNode): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/SerializedNode.cpp: Added.
(WebCore::SerializedNode::deserialize):
* Source/WebCore/dom/SerializedNode.h:
* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::cloneDocumentWithoutChildren const): Deleted.
* Source/WebCore/html/HTMLDocument.h:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::serializeNode):
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WebKitSerializedNode.cpp:
(WebCore::WebKitSerializedNode::WebKitSerializedNode):
* Source/WebCore/page/WebKitSerializedNode.h:
(WebCore::WebKitSerializedNode::create):
* Source/WebCore/svg/SVGDocument.cpp:
(WebCore::SVGDocument::cloneDocumentWithoutChildren const): Deleted.
* Source/WebCore/svg/SVGDocument.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::toAPI):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::toValue):
(WebKit::JavaScriptEvaluationResult::toJS):
(WebKit::JavaScriptEvaluationResult::toString const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
(WebKit::JavaScriptEvaluationResult::map const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toID):
(WebKit::JavaScriptEvaluationResult::toValue):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
* Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp:
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::toValue):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NodeInfo.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):

Canonical link: <a href="https://commits.webkit.org/297895@main">https://commits.webkit.org/297895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29eb985eea95608aea2eb2d44780cdc790b26408

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113291 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86225 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101911 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66552 "Found 141 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20037 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63253 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96281 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/20113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122716 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30117 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94817 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39965 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36515 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18205 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40255 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45754 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->