### PR TITLE
REGRESSION (297264@main): Visible <model> does not load after source change

### DIFF
--- a/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
@@ -3,4 +3,5 @@ PASS <model> main load/unload transitions
 PASS <model> jump back to deferred when quickly scrolled through
 PASS <model> invalid state if usdz does not exist
 PASS <model> invalid state for incorrect usdz file
+PASS <model> reload visible model after source change
 

--- a/LayoutTests/model-element/model-element-lazy-loading-unloading.html
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading.html
@@ -90,5 +90,19 @@ promise_test(async t => {
     );
 }, `<model> invalid state for incorrect usdz file`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = "model-element";
+    assert_equals(internals.modelElementState(model), "Deferred");
+    assert_false(internals.isModelElementIntersectingViewport(model));
+
+    scrollElementIntoView(model);
+    await model.ready;
+
+    source.src = "resources/cube.usdz";
+    await model.ready;
+}, `<model> reload visible model after source change`);
+
+
 </script>
 </body>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1107,7 +1107,7 @@ bool HTMLModelElement::shouldDeferLoading() const
     if (!document().frame() || !document().frame()->script().canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return false;
 
-    return isModelDeferred() && !document().page()->shouldDisableModelLoadDelaysForTesting();
+    return !isVisible() && isModelDeferred() && !document().page()->shouldDisableModelLoadDelaysForTesting();
 }
 
 void HTMLModelElement::modelResourceFinished()


### PR DESCRIPTION
#### bda9ee24cf747fe43bfb08eaf7d676ca3cab2e56
<pre>
REGRESSION (297264@main): Visible &lt;model&gt; does not load after source change
<a href="https://bugs.webkit.org/show_bug.cgi?id=296505">https://bugs.webkit.org/show_bug.cgi?id=296505</a>
<a href="https://rdar.apple.com/156717545">rdar://156717545</a>

Reviewed by Tim Horton.

shouldDeferLoading() did not take into account model&apos;s visibility. Since
the method is triggered during both element creation and source change,
the visibility check is required.

* LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt:
* LayoutTests/model-element/model-element-lazy-loading-unloading.html:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::shouldDeferLoading const):

Canonical link: <a href="https://commits.webkit.org/297884@main">https://commits.webkit.org/297884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25dd181e22258517441c6b634d5c6ddcee29c35d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/32979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63900 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86185 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26858 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63201 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122664 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95036 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94778 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24187 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39928 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40203 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->