### PR TITLE
Parse text-decoration-line: spelling-error

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt
@@ -15,6 +15,6 @@ PASS Property text-decoration-line value 'underline overline blink'
 PASS Property text-decoration-line value 'underline line-through blink'
 PASS Property text-decoration-line value 'overline line-through blink'
 PASS Property text-decoration-line value 'underline overline line-through blink'
-FAIL Property text-decoration-line value 'spelling-error' assert_true: 'spelling-error' is a supported value for text-decoration-line. expected true got false
+PASS Property text-decoration-line value 'spelling-error'
 FAIL Property text-decoration-line value 'grammar-error' assert_true: 'grammar-error' is a supported value for text-decoration-line. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-valid-expected.txt
@@ -64,6 +64,6 @@ PASS e.style['text-decoration-line'] = "blink overline underline line-through" s
 PASS e.style['text-decoration-line'] = "blink overline line-through underline" should set the property value
 PASS e.style['text-decoration-line'] = "blink line-through underline overline" should set the property value
 PASS e.style['text-decoration-line'] = "blink line-through overline underline" should set the property value
-FAIL e.style['text-decoration-line'] = "spelling-error" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['text-decoration-line'] = "spelling-error" should set the property value
 FAIL e.style['text-decoration-line'] = "grammar-error" should set the property value assert_not_equals: property should be set got disallowed value ""
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
@@ -9,7 +9,7 @@ PASS Can set 'text-decoration-line' to the 'underline' keyword: underline
 PASS Can set 'text-decoration-line' to the 'overline' keyword: overline
 PASS Can set 'text-decoration-line' to the 'line-through' keyword: line-through
 PASS Can set 'text-decoration-line' to the 'blink' keyword: blink
-FAIL Can set 'text-decoration-line' to the 'spelling-error' keyword: spelling-error Invalid values
+PASS Can set 'text-decoration-line' to the 'spelling-error' keyword: spelling-error
 FAIL Can set 'text-decoration-line' to the 'grammar-error' keyword: grammar-error Invalid values
 PASS Setting 'text-decoration-line' to a length: 0px throws TypeError
 PASS Setting 'text-decoration-line' to a length: -3.14em throws TypeError

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1420,6 +1420,20 @@ CSSTextBoxTrimEnabled:
     WebCore:
       default: true
 
+CSSTextDecorationLineErrorValues:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS text-decoration-line: spelling-error/grammar-error"
+  humanReadableDescription: "Enable support for spelling-error and grammar-error values on text-decoration-line"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextGroupAlignEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1223,7 +1223,7 @@ template<> constexpr TextJustify fromCSSValueID(CSSValueID valueID)
 }
 
 #define TYPE TextDecorationLine
-#define FOR_EACH(CASE) CASE(Underline) CASE(Overline) CASE(LineThrough) CASE(Blink)
+#define FOR_EACH(CASE) CASE(Underline) CASE(Overline) CASE(LineThrough) CASE(Blink) CASE(SpellingError)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10761,6 +10761,10 @@
                 {
                     "value": "blink",
                     "comment": "The value is parsed and computed but ignored for rendering."
+                },
+                {
+                    "value": "spelling-error",
+                    "settings-flag": "cssTextDecorationLineErrorValues"
                 }
             ],
             "codegen-properties": {
@@ -10768,7 +10772,7 @@
                 "aliases": [
                     "-webkit-text-decoration-line"
                 ],
-                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt)",
+                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues)",
                 "parser-exported": true
             },
             "specification": {
@@ -10911,7 +10915,7 @@
                 "skip-style-builder": true,
                 "style-extractor-converter": "TextDecorationLine",
                 "render-style-name-for-methods": "TextDecorationLineInEffect",
-                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt)",
+                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues)",
                 "comment": "FIXME: Should this be an alias of text-decoration-line?"
             },
             "status": "non-standard"

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1714,6 +1714,9 @@ standalone enable-if=ENABLE_APPLICATION_MANIFEST
 minimal-ui enable-if=ENABLE_APPLICATION_MANIFEST
 browser enable-if=ENABLE_APPLICATION_MANIFEST
 
+// text-decoration-line
+spelling-error
+
 // text-decoration-thickness, text-underline-offset
 from-font
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -92,6 +92,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
     , cssShapeFunctionEnabled { document.settings().cssShapeFunctionEnabled() }
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
+    , cssTextDecorationLineErrorValues { document.settings().cssTextDecorationLineErrorValues() }
     , cssBackgroundClipBorderAreaEnabled  { document.settings().cssBackgroundClipBorderAreaEnabled() }
     , cssWordBreakAutoPhraseEnabled { document.settings().cssWordBreakAutoPhraseEnabled() }
     , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }
@@ -153,7 +154,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssURLIntegrityModifierEnabled            << 26
         | context.cssAxisRelativePositionKeywordsEnabled    << 27
         | context.cssDynamicRangeLimitMixEnabled            << 28
-        | context.cssConstrainedDynamicRangeLimitEnabled    << 29;
+        | context.cssConstrainedDynamicRangeLimitEnabled    << 29
+        | context.cssTextDecorationLineErrorValues          << 30;
     add(hasher, context.baseURL, context.charset, context.propertySettings, context.mode, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -65,6 +65,7 @@ struct CSSParserContext {
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssShapeFunctionEnabled : 1 { false };
     bool cssTextUnderlinePositionLeftRightEnabled : 1 { false };
+    bool cssTextDecorationLineErrorValues : 1 { false };
     bool cssBackgroundClipBorderAreaEnabled : 1 { false };
     bool cssWordBreakAutoPhraseEnabled : 1 { false };
     bool popoverAttributeEnabled : 1 { false };

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -401,7 +401,7 @@ using WebkitBorderSpacing = Length<CSS::Nonnegative>;
 }
 
 constexpr auto PublicPseudoIDBits = 17;
-constexpr auto TextDecorationLineBits = 4;
+constexpr auto TextDecorationLineBits = 5;
 constexpr auto TextTransformBits = 5;
 constexpr auto PseudoElementTypeBits = 5;
 
@@ -2401,7 +2401,6 @@ private:
         PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
         PREFERRED_TYPE(bool) unsigned usesContainerUnits : 1;
         PREFERRED_TYPE(bool) unsigned useTreeCountingFunctions : 1;
-        PREFERRED_TYPE(OptionSet<TextDecorationLine>) unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
         PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
         PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;
 
@@ -2412,6 +2411,7 @@ private:
         PREFERRED_TYPE(bool) unsigned isLink : 1;
         PREFERRED_TYPE(PseudoId) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
+        PREFERRED_TYPE(OptionSet<TextDecorationLine>) unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element.
 
         // If you add more style bits here, you will also need to update RenderStyle::NonInheritedFlags::copyNonInheritedFrom().
     };

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1194,6 +1194,7 @@ TextStream& operator<<(TextStream& ts, TextDecorationLine line)
     case TextDecorationLine::Overline: ts << "overline"_s; break;
     case TextDecorationLine::LineThrough: ts << "line-through"_s; break;
     case TextDecorationLine::Blink: ts << "blink"_s; break;
+    case TextDecorationLine::SpellingError: ts << "spelling-error"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -658,8 +658,9 @@ enum class TextDecorationLine : uint8_t {
     Overline      = 1 << 1,
     LineThrough   = 1 << 2,
     Blink         = 1 << 3,
+    SpellingError = 1 << 4
 };
-constexpr auto maxTextDecorationLineValue = TextDecorationLine::Blink;
+constexpr auto maxTextDecorationLineValue = TextDecorationLine::SpellingError;
 
 enum class TextDecorationStyle : uint8_t {
     Solid,

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -335,6 +335,13 @@ inline T BuilderConverter::convertLineWidth(BuilderState& builderState, const CS
 
 inline OptionSet<TextDecorationLine> BuilderConverter::convertTextDecorationLine(BuilderState&, const CSSValue& value)
 {
+    // none or spelling-error
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (primitiveValue->valueID() == CSSValueNone)
+            return { };
+        if (primitiveValue->valueID() == CSSValueSpellingError)
+            return TextDecorationLine::SpellingError;
+    }
     auto result = RenderStyle::initialTextDecorationLine();
     if (auto* list = dynamicDowncast<CSSValueList>(value)) {
         for (auto& currentValue : *list)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -916,7 +916,11 @@ inline Ref<CSSValue> ExtractorConverter::convertTextTransform(ExtractorState&, O
 
 inline Ref<CSSValue> ExtractorConverter::convertTextDecorationLine(ExtractorState&, OptionSet<TextDecorationLine> textDecorationLine)
 {
-    // Blink value is ignored.
+    if (textDecorationLine.isEmpty())
+        return CSSPrimitiveValue::create(CSSValueNone);
+    if (textDecorationLine & TextDecorationLine::SpellingError)
+        return CSSPrimitiveValue::create(CSSValueSpellingError);
+
     CSSValueListBuilder list;
     if (textDecorationLine & TextDecorationLine::Underline)
         list.append(CSSPrimitiveValue::create(CSSValueUnderline));

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -1103,7 +1103,14 @@ inline void ExtractorSerializer::serializeTextTransform(ExtractorState& state, S
 
 inline void ExtractorSerializer::serializeTextDecorationLine(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextDecorationLine> textDecorationLine)
 {
-    // Blink value is ignored for rendering but not for the computed value.
+    if (textDecorationLine.isEmpty()) {
+        serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
+        return;
+    }
+    if (textDecorationLine & TextDecorationLine::SpellingError) {
+        serializationForCSS(builder, context, state.style, CSS::Keyword::SpellingError { });
+        return;
+    }
     bool listEmpty = true;
     auto appendOption = [&](TextDecorationLine test, CSSValueID value) {
         if (textDecorationLine & test) {
@@ -1116,6 +1123,7 @@ inline void ExtractorSerializer::serializeTextDecorationLine(ExtractorState& sta
     appendOption(TextDecorationLine::Underline, CSSValueUnderline);
     appendOption(TextDecorationLine::Overline, CSSValueOverline);
     appendOption(TextDecorationLine::LineThrough, CSSValueLineThrough);
+    // Blink value is ignored for rendering but not for the computed value.
     appendOption(TextDecorationLine::Blink, CSSValueBlink);
 
     if (listEmpty)


### PR DESCRIPTION
#### 977ddc0db3511ae1f0f0e629e76d0694fdc97900
<pre>
Parse text-decoration-line: spelling-error
<a href="https://bugs.webkit.org/show_bug.cgi?id=296510">https://bugs.webkit.org/show_bug.cgi?id=296510</a>
<a href="https://rdar.apple.com/156751610">rdar://156751610</a>

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertTextDecorationLine):
* Source/WebCore/style/StyleExtractorConverter.h:
(WebCore::Style::ExtractorConverter::convertTextDecorationLine):
* Source/WebCore/style/StyleExtractorSerializer.h:
(WebCore::Style::ExtractorSerializer::serializeTextDecorationLine):

Canonical link: <a href="https://commits.webkit.org/298670@main">https://commits.webkit.org/298670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba18fe6e92aafeee90cc0de52c5358c7096bc63f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66759 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9bcc353-100d-465c-a951-18785fd14bf7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44448 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bd17dba-dcad-409c-8fe6-c3c5fca7c2b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68697 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22376 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65937 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/108309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125405 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114727 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32358 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96786 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24638 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19962 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48572 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143424 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42447 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36971 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45782 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->