### PR TITLE
Fire scrollend events for non-composited scrollers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Smooth scroll to hash fragment (on pageload) alongside smooth scrollIntoView runs to completion. Test timed out
-NOTRUN Smooth scroll to hash fragment (on click) alongside smooth scrollIntoView runs to completion.
+PASS Smooth scroll to hash fragment (on pageload) alongside smooth scrollIntoView runs to completion.
+PASS Smooth scroll to hash fragment (on click) alongside smooth scrollIntoView runs to completion.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-mandatory-snap-point-after-load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-mandatory-snap-point-after-load-expected.txt
@@ -13,5 +13,5 @@ Page B
 Page C
 
 
-FAIL scrollend event fired after load for mandatory snap point promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+PASS scrollend event fired after load for mandatory snap point
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
@@ -3,4 +3,5 @@
 Harness Error (TIMEOUT), message = null
 
 TIMEOUT scrolled input field should receive scrollend. Test timed out
+NOTRUN scrolled input field should receive scrollend for animated scroll.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
@@ -3,6 +3,7 @@
   <head>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="scroll_support.js"></script>
   </head>
   <body>
     <style>
@@ -14,8 +15,9 @@
     <input type="text" id="inputscroller"
     value="qwertyuiopasddfghjklzxcvbnmqwertyuiopasddfghjklzxcvbnmqwer">
     <script>
-      promise_test(async() => {
+      promise_test(async(t) => {
         const inputscroller = document.getElementById("inputscroller");
+        await waitForScrollReset(t, inputscroller);
         assert_equals(inputscroller.scrollLeft, 0,
           "text input field is not initially scrolled.");
 
@@ -27,6 +29,21 @@
         assert_equals(inputscroller.scrollLeft, 10,
           "text input field is scrolled by the correct amount");
       }, "scrolled input field should receive scrollend.");
+
+      promise_test(async(t) => {
+        const inputscroller = document.getElementById("inputscroller");
+        await waitForScrollReset(t, inputscroller);
+        assert_equals(inputscroller.scrollLeft, 0,
+          "text input field is not initially scrolled.");
+
+        const scrollend_promise = new Promise((resolve) => {
+          inputscroller.addEventListener("scrollend", resolve);
+        });
+        inputscroller.scrollBy({left:10, behavior: 'smooth'});
+        await scrollend_promise;
+        assert_equals(inputscroller.scrollLeft, 10,
+          "text input field is scrolled by the correct amount");
+      }, "scrolled input field should receive scrollend for animated scroll.");
     </script>
   </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-expected.txt
+++ b/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Smooth scroll to hash fragment (on pageload) alongside smooth scrollIntoView runs to completion.
-PASS Smooth scroll to hash fragment (on click) alongside smooth scrollIntoView runs to completion.
-

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -114,6 +114,7 @@ bool ScrollAnimator::scrollToPositionWithoutAnimation(const FloatPoint& position
     m_scrollController.stopAnimatedScroll();
 
     setCurrentPosition(adjustedPosition, NotifyScrollableArea::Yes);
+    scrollableArea().scrollDidEnd();
     return true;
 }
 
@@ -301,6 +302,7 @@ void ScrollAnimator::didStopAnimatedScroll()
 {
     m_scrollableArea.setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
     m_scrollableArea.animatedScrollDidEnd();
+    m_scrollableArea.scrollDidEnd();
 }
 
 #if HAVE(RUBBER_BANDING)


### PR DESCRIPTION
#### dcb5c3e364117b05d3ae4dca7815214deba4f8c5
<pre>
Fire scrollend events for non-composited scrollers
<a href="https://bugs.webkit.org/show_bug.cgi?id=296511">https://bugs.webkit.org/show_bug.cgi?id=296511</a>
<a href="https://rdar.apple.com/156752175">rdar://156752175</a>

Reviewed by Simon Fraser.

Fire scrollend events for non-composited scrollers.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-mandatory-snap-point-after-load-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html:
* LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-expected.txt: Removed.
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::scrollToPositionWithoutAnimation):
(WebCore::ScrollAnimator::didStopAnimatedScroll):

Canonical link: <a href="https://commits.webkit.org/297992@main">https://commits.webkit.org/297992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3398fdec7d44f699c36237c184f169dd2e647f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86470 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41544 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95311 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95077 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24263 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18024 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36969 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->