### PR TITLE
[JSC] Allow "length" and "name" megamorphic cache

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4579,6 +4579,20 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
 
                 if (accessCase->usesPolyProto())
                     ++numberOfUndesiredMegamorphicAccessVariants;
+
+                Structure* currStructure = accessCase->structure();
+                if (auto* object = accessCase->tryGetAlternateBase())
+                    currStructure = object->structure();
+
+                if (identifier.uid() == vm().propertyNames->length) {
+                    if (currStructure->typeInfo().type() == JSFunctionType || currStructure->typeInfo().type() == ArrayType)
+                        return nullptr;
+                }
+
+                if (identifier.uid() == vm().propertyNames->name) {
+                    if (currStructure->typeInfo().type() == JSFunctionType)
+                        return nullptr;
+                }
             }
 
             // Currently, we do not apply megamorphic cache for "length" property since Array#length and String#length are too common.
@@ -4692,6 +4706,20 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
 
                 if (accessCase->usesPolyProto())
                     ++numberOfUndesiredMegamorphicAccessVariants;
+
+                Structure* currStructure = accessCase->structure();
+                if (auto* object = accessCase->tryGetAlternateBase())
+                    currStructure = object->structure();
+
+                if (identifier.uid() == vm().propertyNames->length) {
+                    if (currStructure->typeInfo().type() == JSFunctionType || currStructure->typeInfo().type() == ArrayType)
+                        return nullptr;
+                }
+
+                if (identifier.uid() == vm().propertyNames->name) {
+                    if (currStructure->typeInfo().type() == JSFunctionType)
+                        return nullptr;
+                }
             }
 
             // Currently, we do not apply megamorphic cache for "length" property since Array#length and String#length are too common.

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -285,7 +285,7 @@ private:
 
 ALWAYS_INLINE bool canUseMegamorphicGetByIdExcludingIndex(VM& vm, UniquedStringImpl* uid)
 {
-    return uid != vm.propertyNames->length && uid != vm.propertyNames->name && uid != vm.propertyNames->prototype && uid != vm.propertyNames->underscoreProto;
+    return uid != vm.propertyNames->prototype && uid != vm.propertyNames->underscoreProto;
 }
 
 inline bool canUseMegamorphicGetById(VM& vm, UniquedStringImpl* uid)

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -424,12 +424,14 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
     bool shouldGiveUp = false;
     bool cacheable = true;
     while (true) {
-        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) [[unlikely]] {
-            if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
-                repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
-            if (object->getNonIndexPropertySlot(globalObject, uid, slot))
-                return slot.getValue(globalObject, uid);
-            return jsUndefined();
+        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags())) {
+            if ((object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) || (uid == vm.propertyNames->length || uid == vm.propertyNames->name)) [[unlikely]] {
+                if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
+                    repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
+                if (object->getNonIndexPropertySlot(globalObject, uid, slot))
+                    return slot.getValue(globalObject, uid);
+                return jsUndefined();
+            }
         }
 
         Structure* structure = object->structure();
@@ -743,12 +745,14 @@ static ALWAYS_INLINE JSValue inByIdMegamorphic(JSGlobalObject* globalObject, VM&
     bool shouldGiveUp = false;
     bool cacheable = true;
     while (true) {
-        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) [[unlikely]] {
-            if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm)) {
-                dataLogLnIf(verbose, " ", __LINE__);
-                repatchInBySlowPathCall(callFrame->codeBlock(), *stubInfo, InByKind::ById);
+        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags())) {
+            if ((object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) || (uid == vm.propertyNames->length || uid == vm.propertyNames->name)) [[unlikely]] {
+                if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm)) {
+                    dataLogLnIf(verbose, " ", __LINE__);
+                    repatchInBySlowPathCall(callFrame->codeBlock(), *stubInfo, InByKind::ById);
+                }
+                RELEASE_AND_RETURN(scope, jsBoolean(object->getNonIndexPropertySlot(globalObject, uid, slot)));
             }
-            RELEASE_AND_RETURN(scope, jsBoolean(object->getNonIndexPropertySlot(globalObject, uid, slot)));
         }
 
         Structure* structure = object->structure();
@@ -933,12 +937,13 @@ static ALWAYS_INLINE JSValue inByValMegamorphic(JSGlobalObject* globalObject, VM
     bool shouldGiveUp = false;
     bool cacheable = true;
     while (true) {
-        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) [[unlikely]] {
-            dataLogLnIf(verbose, " ", __LINE__);
-            if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm)) {
-                repatchInBySlowPathCall(callFrame->codeBlock(), *stubInfo, InByKind::ByVal);
+        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags())) {
+            if ((object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) || (uid == vm.propertyNames->length || uid == vm.propertyNames->name)) [[unlikely]] {
+                dataLogLnIf(verbose, " ", __LINE__);
+                if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
+                    repatchInBySlowPathCall(callFrame->codeBlock(), *stubInfo, InByKind::ByVal);
+                RELEASE_AND_RETURN(scope, jsBoolean(object->getNonIndexPropertySlot(globalObject, uid, slot)));
             }
-            RELEASE_AND_RETURN(scope, jsBoolean(object->getNonIndexPropertySlot(globalObject, uid, slot)));
         }
 
         Structure* structure = object->structure();
@@ -3644,14 +3649,16 @@ static ALWAYS_INLINE JSValue getByValMegamorphic(JSGlobalObject* globalObject, V
     bool shouldGiveUp = false;
     bool cacheable = true;
     while (true) {
-        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) [[unlikely]] {
-            if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
-                repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
-            bool result = object->getNonIndexPropertySlot(globalObject, uid, slot);
-            RETURN_IF_EXCEPTION(scope, { });
-            if (result)
-                RELEASE_AND_RETURN(scope, slot.getValue(globalObject, uid));
-            return jsUndefined();
+        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags())) {
+            if ((object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) || (uid == vm.propertyNames->length || uid == vm.propertyNames->name)) [[unlikely]] {
+                if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
+                    repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
+                bool result = object->getNonIndexPropertySlot(globalObject, uid, slot);
+                RETURN_IF_EXCEPTION(scope, { });
+                if (result)
+                    RELEASE_AND_RETURN(scope, slot.getValue(globalObject, uid));
+                return jsUndefined();
+            }
         }
 
         Structure* structure = object->structure();


### PR DESCRIPTION
#### 35e75c4978ec427aa89bc58e12b2401d8b3a63c6
<pre>
[JSC] Allow &quot;length&quot; and &quot;name&quot; megamorphic cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=296516">https://bugs.webkit.org/show_bug.cgi?id=296516</a>
<a href="https://rdar.apple.com/156761038">rdar://156761038</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::tryFoldToMegamorphic):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
(JSC::canUseMegamorphicGetByIdExcludingIndex):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::getByIdMegamorphic):
(JSC::inByIdMegamorphic):
(JSC::inByValMegamorphic):
(JSC::getByValMegamorphic):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35e75c4978ec427aa89bc58e12b2401d8b3a63c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119479 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64241 "An unexpected error occured. Recent messages:Running configuration") | ✅ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86209 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41344 "Unexpected infrastructure issue, retrying build") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66535 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63233 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105788 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122696 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111887 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95055 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94801 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36485 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45734 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136117 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39876 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36522 "Found 2 new JSC stress test failures: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention-2.js.default (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41613 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->