### PR TITLE
[JSC] Cacheable Dictionary hit in prototype should be allowed

### DIFF
--- a/JSTests/stress/cacheable-dictionary-prototype-hit.js
+++ b/JSTests/stress/cacheable-dictionary-prototype-hit.js
@@ -1,0 +1,55 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+class Base {
+    constructor() {
+    }
+
+    test() { return 42; }
+}
+
+class Derived0 extends Base {
+    constructor() {
+        super();
+    }
+}
+
+class Derived1 extends Base {
+    constructor() {
+        super();
+    }
+
+    ok() { }
+}
+
+class Derived2 extends Base {
+    constructor() {
+        super();
+    }
+
+    test() { return 42; }
+}
+
+let array = [];
+for (let i = 0; i < 10; ++i)
+    array.push(new Derived0);
+for (let i = 0; i < 10; ++i)
+    array.push(new Derived1);
+for (let i = 0; i < 10; ++i)
+    array.push(new Derived2);
+
+$vm.toCacheableDictionary(Base.prototype);
+
+function test(derived)
+{
+    return derived.test();
+}
+noInline(test);
+
+for (let i = 0; i < 1e3; ++i) {
+    for (let derived of array)
+        shouldBe(test(derived), 42);
+}

--- a/JSTests/stress/cacheable-dictionary-prototype-miss.js
+++ b/JSTests/stress/cacheable-dictionary-prototype-miss.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+noInline(shouldBe);
+
+class Base {
+    constructor() {
+    }
+
+    test() { return 42; }
+}
+
+class Middle extends Base {
+}
+
+class Derived0 extends Middle {
+    constructor() {
+        super();
+    }
+}
+
+class Derived1 extends Middle {
+    constructor() {
+        super();
+    }
+
+    ok() { }
+}
+
+class Derived2 extends Middle {
+    constructor() {
+        super();
+    }
+
+    test() { return 42; }
+}
+
+let array = [];
+for (let i = 0; i < 10; ++i)
+    array.push(new Derived0);
+for (let i = 0; i < 10; ++i)
+    array.push(new Derived1);
+for (let i = 0; i < 10; ++i)
+    array.push(new Derived2);
+
+$vm.toCacheableDictionary(Middle.prototype);
+
+function test(derived)
+{
+    return derived.test();
+}
+noInline(test);
+
+for (let i = 0; i < 100; ++i) {
+    for (let derived of array)
+        shouldBe(test(derived), 42);
+}
+
+$vm.toCacheableDictionary(Middle.prototype);
+Middle.prototype.test = function () { return 20; }
+Derived2.prototype.test = function () { return 20; }
+
+for (let i = 0; i < 1e3; ++i) {
+    for (let derived of array)
+        shouldBe(test(derived), 20);
+}

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -579,8 +579,19 @@ static std::optional<PrototypeChainCachingStatus> prepareChainForCaching(JSGloba
                 return std::nullopt;
 
             ASSERT(structure->isObject());
-            if (structure->hasBeenFlattenedBefore())
+            if (structure->hasBeenFlattenedBefore()) {
+                if (structure->isUncacheableDictionary())
+                    return std::nullopt;
+                if (!structure->propertyAccessesAreCacheable())
+                    return std::nullopt;
+                if (structure->isProxy())
+                    return std::nullopt;
+                if (current == target) {
+                    found = true;
+                    break;
+                }
                 return std::nullopt;
+            }
 
             structure->flattenDictionaryStructure(vm, asObject(current));
             flattenedDictionary = true;


### PR DESCRIPTION
#### d9744ee1ad7ce2fe753137b327870667931e8973
<pre>
[JSC] Cacheable Dictionary hit in prototype should be allowed
<a href="https://bugs.webkit.org/show_bug.cgi?id=296517">https://bugs.webkit.org/show_bug.cgi?id=296517</a>
<a href="https://rdar.apple.com/156762120">rdar://156762120</a>

Reviewed by Yijia Huang.

If the *hitting* (not miss case) Structure is CacheableDictionary,
we do not need to give up IC. This patch fixes prepareChainForCaching
so that we can return found = true when we are hitting the cacheable
dictionary.

* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::prepareChainForCaching):

Canonical link: <a href="https://commits.webkit.org/297943@main">https://commits.webkit.org/297943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dc0caa630aa8c4788ba78b03836e6e58387918a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64280 "Built successfully") | ❌ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ❌ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66592 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63297 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105868 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122777 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111951 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95123 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94869 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36578 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45798 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136181 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39950 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36537 "Found 2 new JSC stress test failures: stress/builtin-function-is-construct-type-none.js.dfg-eager, wasm.yaml/wasm/stress/jitless-wasm-to-js-should-follow-to-wasm-call-frame-convention.js.default (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41692 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->