### PR TITLE
[JSC] Remove JS `Set.prototype.intersection` Implementation

### DIFF
--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -100,54 +100,6 @@ function union(other)
     return result;
 }
 
-function intersection(other)
-{
-    "use strict";
-
-    if (!@isSet(this))
-        @throwTypeError("Set operation called on non-Set object");
-
-    // Get Set Record
-    var size = @getSetSizeAsInt(other);
-
-    var has = other.has;
-    if (!@isCallable(has))
-        @throwTypeError("Set.prototype.intersection expects other.has to be callable");
-
-    var keys = other.keys;
-    if (!@isCallable(keys))
-        @throwTypeError("Set.prototype.intersection expects other.keys to be callable");
-
-    var result = new @Set();
-    if (this.@size <= size) {
-        var storage = @setStorage(this);
-        var entry = 0;
-
-        do {
-            storage = @setIterationNext(storage, entry);
-            if (storage == @orderedHashTableSentinel)
-                break;
-            entry = @setIterationEntry(storage) + 1;
-            var key = @setIterationEntryKey(storage);
-
-            if (has.@call(other, key))
-                result.@add(key);
-        } while (true);
-    } else {
-        var iterator = keys.@call(other);
-        var wrapper = {
-            @@iterator: function () { return iterator; }
-        };
-
-        for (var key of wrapper) {
-            if (this.@has(key))
-                result.@add(key);
-        }
-    }
-
-    return result;
-}
-
 function difference(other)
 {
     "use strict";


### PR DESCRIPTION
#### d3088b6d7c31eecebe33826e11b4695de96df73d
<pre>
[JSC] Remove JS `Set.prototype.intersection` Implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=296518">https://bugs.webkit.org/show_bug.cgi?id=296518</a>

Reviewed by Sosuke Suzuki and Yusuke Suzuki.

This patch removes the JS implementation of `Set.prototype.intersection`
because the C++ implementation has been landed [1].

[1]: <a href="https://github.com/WebKit/WebKit/commit/736aa4a741da8973040b68b30bb002d3752ef89b">https://github.com/WebKit/WebKit/commit/736aa4a741da8973040b68b30bb002d3752ef89b</a>

* Source/JavaScriptCore/builtins/SetPrototype.js:
(intersection.else.wrapper.iterator): Deleted.
(intersection): Deleted.

Canonical link: <a href="https://commits.webkit.org/297896@main">https://commits.webkit.org/297896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ecf0650dd2dbdef89c7b977e9f4c8b565395936

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/63954 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86212 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20025 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63240 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105795 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122703 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111894 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94807 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/24191 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36492 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18206 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45741 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136124 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39883 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36526 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->