### PR TITLE
REGRESSION(iOS 26): Trackpad swipes are often ignored in Books.app (touch-action swipe GRs should not receive UIScrollEvent)

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2273,6 +2273,18 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
 }
 #endif // ENABLE(TOUCH_EVENTS)
 
+- (BOOL)_isTouchActionSwipeGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+    return gestureRecognizer == _touchActionLeftSwipeGestureRecognizer || gestureRecognizer == _touchActionRightSwipeGestureRecognizer || gestureRecognizer == _touchActionUpSwipeGestureRecognizer || gestureRecognizer == _touchActionDownSwipeGestureRecognizer;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveEvent:(UIEvent *)event
+{
+    if ([self _isTouchActionSwipeGestureRecognizer:gestureRecognizer])
+        return event.type != UIEventTypeScroll;
+    return YES;
+}
+
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
 #if HAVE(LOOKUP_GESTURE_RECOGNIZER)
@@ -2292,7 +2304,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
         return touch.type != UITouchTypeIndirectPointer;
 #endif
 
-    if (gestureRecognizer == _touchActionLeftSwipeGestureRecognizer || gestureRecognizer == _touchActionRightSwipeGestureRecognizer || gestureRecognizer == _touchActionUpSwipeGestureRecognizer || gestureRecognizer == _touchActionDownSwipeGestureRecognizer) {
+    if ([self _isTouchActionSwipeGestureRecognizer:gestureRecognizer]) {
         // We update the enabled state of the various swipe gesture recognizers such that if we have a unidirectional touch-action
         // specified (only pan-x or only pan-y) we enable the two recognizers in the opposite axis to prevent scrolling from starting
         // if the initial gesture is such a swipe. Since the recognizers are specified to use a single finger for recognition, we don't


### PR DESCRIPTION
#### 5e767ee74317d2248dda0d02550677b553b4b744
<pre>
REGRESSION(iOS 26): Trackpad swipes are often ignored in Books.app (touch-action swipe GRs should not receive UIScrollEvent)
<a href="https://bugs.webkit.org/show_bug.cgi?id=296530">https://bugs.webkit.org/show_bug.cgi?id=296530</a>
<a href="https://rdar.apple.com/152190863">rdar://152190863</a>

Reviewed by Wenson Hsieh.

UISwipeGestureRecognizer has recently started responding to/being
forwarded UIScrollEvent instances. This change means that touch-action
swipe GRs can now exclude UIScrollView&apos;s default pan GR from responding
to the scroll events resulting from a trackpad swipe.

This patch prevents this exclusion by simply asking UIKit to not send
UIScrollEvent instances to the touch-action swipe GRs.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _isTouchActionSwipeGestureRecognizer:]):
  Refactor: the check to match against any of the touch-action swipe GRs
  is unwieldly and should not be repeated.
(-[WKContentView gestureRecognizer:shouldReceiveEvent:]):
(-[WKContentView gestureRecognizer:shouldReceiveTouch:]):

Canonical link: <a href="https://commits.webkit.org/297935@main">https://commits.webkit.org/297935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa0f6d0adcfe5c2cd1c7b7b509076e1504595744

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64164 "Built successfully") | ✅ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86239 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26919 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66566 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26184 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63267 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95085 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94831 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36538 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39910 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->