### PR TITLE
Don't create fragmented blob made of other blobs with fetch data

### DIFF
--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -182,6 +182,18 @@ Blob::Blob(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, { BlobPart(WTFMove(data)) }, contentType);
 }
 
+Blob::Blob(ScriptExecutionContext* context, Ref<FragmentedSharedBuffer>&& buffer, const String& contentType)
+    : ActiveDOMObject(context)
+    , m_type(contentType)
+    , m_size(buffer->size())
+    , m_memoryCost(buffer->size())
+    , m_internalURL(BlobURL::createInternalURL())
+{
+    BlobBuilder builder(EndingType::Transparent);
+    builder.append(WTFMove(buffer));
+    ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, builder.finalize(), contentType);
+}
+
 Blob::Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext* context, const Blob& blob)
     : ActiveDOMObject(context)
     , m_type(blob.type())

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -53,6 +53,7 @@ namespace WebCore {
 class Blob;
 class BlobLoader;
 class DeferredPromise;
+class FragmentedSharedBuffer;
 class ReadableStream;
 class ScriptExecutionContext;
 class FragmentedSharedBuffer;
@@ -73,21 +74,28 @@ public:
 
     static Ref<Blob> create(ScriptExecutionContext* context)
     {
-        auto blob = adoptRef(*new Blob(context));
+        Ref blob = adoptRef(*new Blob(context));
         blob->suspendIfNeeded();
         return blob;
     }
 
     static Ref<Blob> create(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const BlobPropertyBag& propertyBag)
     {
-        auto blob = adoptRef(*new Blob(context, WTFMove(blobPartVariants), propertyBag));
+        Ref blob = adoptRef(*new Blob(context, WTFMove(blobPartVariants), propertyBag));
         blob->suspendIfNeeded();
         return blob;
     }
 
     static Ref<Blob> create(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String& contentType)
     {
-        auto blob = adoptRef(*new Blob(context, WTFMove(data), contentType));
+        Ref blob = adoptRef(*new Blob(context, WTFMove(data), contentType));
+        blob->suspendIfNeeded();
+        return blob;
+    }
+
+    static Ref<Blob> create(ScriptExecutionContext* context, Ref<FragmentedSharedBuffer>&& buffer, const String& contentType)
+    {
+        Ref blob = adoptRef(*new Blob(context, WTFMove(buffer), contentType));
         blob->suspendIfNeeded();
         return blob;
     }
@@ -95,7 +103,7 @@ public:
     static Ref<Blob> deserialize(ScriptExecutionContext* context, const URL& srcURL, const String& type, long long size, long long memoryCost, const String& fileBackedPath)
     {
         ASSERT(Blob::isNormalizedContentType(type));
-        auto blob = adoptRef(*new Blob(deserializationContructor, context, srcURL, type, size, memoryCost, fileBackedPath));
+        Ref blob = adoptRef(*new Blob(deserializationContructor, context, srcURL, type, size, memoryCost, fileBackedPath));
         blob->suspendIfNeeded();
         return blob;
     }
@@ -138,6 +146,7 @@ protected:
     WEBCORE_EXPORT explicit Blob(ScriptExecutionContext*);
     Blob(ScriptExecutionContext&, Vector<BlobPartVariant>&&, const BlobPropertyBag&);
     Blob(ScriptExecutionContext*, Vector<uint8_t>&&, const String& contentType);
+    Blob(ScriptExecutionContext*, Ref<FragmentedSharedBuffer>&&, const String& contentType);
 
     enum ReferencingExistingBlobConstructor { referencingExistingBlobConstructor };
     Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext*, const Blob&);

--- a/Source/WebCore/fileapi/BlobBuilder.h
+++ b/Source/WebCore/fileapi/BlobBuilder.h
@@ -41,6 +41,7 @@ class ArrayBufferView;
 namespace WebCore {
 
 class Blob;
+class FragmentedSharedBuffer;
 
 class BlobBuilder {
 public:
@@ -50,6 +51,7 @@ public:
     void append(RefPtr<JSC::ArrayBufferView>&&);
     void append(RefPtr<Blob>&&);
     void append(const String& text);
+    void append(Ref<FragmentedSharedBuffer>&&);
 
     Vector<BlobPart> finalize();
 

--- a/Source/WebCore/platform/network/BlobPart.h
+++ b/Source/WebCore/platform/network/BlobPart.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "SharedBuffer.h"
 #include <wtf/URL.h>
 
 namespace IPC {
@@ -37,6 +38,8 @@ class BlobPart {
 private:
     friend struct IPC::ArgumentCoder<BlobPart, void>;
 public:
+    using VariantType = Variant<Vector<uint8_t>, Ref<SharedBuffer>, URL>;
+
     enum class Type : bool {
         Data,
         Blob
@@ -47,12 +50,17 @@ public:
     {
     }
 
-    BlobPart(Vector<uint8_t>&& data)
+    explicit BlobPart(Vector<uint8_t>&& data)
         : m_dataOrURL(WTFMove(data))
     {
     }
 
-    BlobPart(const URL& url)
+    explicit BlobPart(Ref<SharedBuffer>&& data)
+        : m_dataOrURL(WTFMove(data))
+    {
+    }
+
+    explicit BlobPart(const URL& url)
         : m_dataOrURL(url)
     {
     }
@@ -62,10 +70,17 @@ public:
         return std::holds_alternative<URL>(m_dataOrURL) ? Type::Blob : Type::Data;
     }
 
-    Vector<uint8_t>&& moveData()
+    Vector<uint8_t> takeData()
     {
-        ASSERT(std::holds_alternative<Vector<uint8_t>>(m_dataOrURL));
-        return WTFMove(std::get<Vector<uint8_t>>(m_dataOrURL));
+        auto blobPartVariant = std::exchange(m_dataOrURL, Vector<uint8_t> { });
+        return switchOn(WTFMove(blobPartVariant), [](Ref<SharedBuffer>&& buffer) {
+            return buffer->extractData();
+        }, [](Vector<uint8_t>&& vector) {
+            return WTFMove(vector);
+        }, [](URL&&) {
+            ASSERT_NOT_REACHED();
+            return Vector<uint8_t> { };
+        });
     }
 
     const URL& url() const
@@ -81,12 +96,12 @@ public:
     }
 
 private:
-    BlobPart(Variant<Vector<uint8_t>, URL>&& dataOrURL)
+    explicit BlobPart(VariantType&& dataOrURL)
         : m_dataOrURL(WTFMove(dataOrURL))
     {
     }
 
-    Variant<Vector<uint8_t>, URL> m_dataOrURL;
+    VariantType m_dataOrURL;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -190,7 +190,7 @@ void BlobRegistryImpl::registerInternalBlobURL(const URL& url, Vector<BlobPart>&
     for (BlobPart& part : blobParts) {
         switch (part.type()) {
         case BlobPart::Type::Data: {
-            blobData->appendData(createDataSegment(part.moveData(), blobData));
+            blobData->appendData(createDataSegment(part.takeData(), blobData));
             break;
         }
         case BlobPart::Type::Blob: {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2298,7 +2298,7 @@ header: <WebCore/VP9Utilities.h>
 }
 
 class WebCore::BlobPart {
-    Variant<Vector<uint8_t>, URL> m_dataOrURL;
+    Variant<Vector<uint8_t>, Ref<WebCore::SharedBuffer>, URL> m_dataOrURL;
 };
 
 [WebKitPlatform] enum class WebCore::ColorSpace : uint8_t {


### PR DESCRIPTION
#### fcddb4ea71423066c6f2d9a4ab4bd0b268a962df
<pre>
Don&apos;t create fragmented blob made of other blobs with fetch data
<a href="https://bugs.webkit.org/show_bug.cgi?id=296531">https://bugs.webkit.org/show_bug.cgi?id=296531</a>
<a href="https://rdar.apple.com/156827880">rdar://156827880</a>

Reviewed by Youenn Fablet.

Follow-up on 297885@main. Instead of constructing a Blob
made of multiple blobs, which would create a lot of Blob URLs, we instead
add the ability to create a Blob from a FragmentedSharedBuffer. A BlobPart
is also amended to allow for holding a SharedBuffer.

No change in JS observable behaviours. Covered by existing tests.

* Source/WebCore/platform/network/BlobPart.h:
(WebCore::BlobPart::BlobPart): Add SharedBuffer as variant, clean-up
code to follow SaferCPP coding guidelines.
(WebCore::BlobPart::takeData): Renamed for consistency and better indicate how the code was used.
(WebCore::BlobPart::moveData): Deleted.

Canonical link: <a href="https://commits.webkit.org/297920@main">https://commits.webkit.org/297920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15717b5cff5d45805a523d095a6c22e33dab90fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119652 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64239 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86335 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/64239 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102017 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66663 "Found 144 new API test failures: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestBackForwardList:/webkit/WebKitWebView/navigation-after-session-restore, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WPE/TestLoaderClient:/webkit/WebKitWebView/unfinished-subresource-load, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cookies ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63385 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95196 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94942 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17878 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36661 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45879 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->