### PR TITLE
[WebCore] Use C++23's `std::unreachable()` instead of `WTF_UNREACHABLE()`

### DIFF
--- a/Source/WTF/wtf/dtoa/bignum-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/bignum-dtoa.cc
@@ -158,7 +158,7 @@ void BignumDtoa(double v, BignumDtoaMode mode, int requested_digits,
       GenerateCountedDigits(requested_digits, decimal_point, numerator, denominator, buffer, length);
       break;
     default:
-      UNREACHABLE();
+      std::unreachable();
   }
   buffer[length] = '\0';
 }

--- a/Source/WTF/wtf/dtoa/bignum.h
+++ b/Source/WTF/wtf/dtoa/bignum.h
@@ -29,6 +29,7 @@
 #define DOUBLE_CONVERSION_BIGNUM_H_
 
 #include <array>
+#include <utility>
 #include <wtf/dtoa/utils.h>
 
 namespace WTF {
@@ -114,7 +115,7 @@ class Bignum {
 
   void EnsureCapacity(int size) {
     if (size > kBigitCapacity) {
-      UNREACHABLE();
+      std::unreachable();
     }
   }
   void Align(const Bignum& other);

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -373,7 +373,7 @@ static BignumDtoaMode DtoaToBignumDtoaMode(
     case DoubleToStringConverter::FIXED:     return BIGNUM_DTOA_FIXED;
     case DoubleToStringConverter::PRECISION: return BIGNUM_DTOA_PRECISION;
     default:
-      UNREACHABLE();
+      std::unreachable();
   }
 }
 
@@ -426,7 +426,7 @@ void DoubleToStringConverter::DoubleToAscii(double v,
       break;
     default:
       fast_worked = false;
-      UNREACHABLE();
+      std::unreachable();
   }
   if (fast_worked) return;
 

--- a/Source/WTF/wtf/dtoa/fast-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/fast-dtoa.cc
@@ -650,7 +650,7 @@ bool FastDtoa(double v,
       result = Grisu3Counted(v, requested_digits, buffer, length, decimal_exponent);
       break;
     default:
-      UNREACHABLE();
+      std::unreachable();
   }
   if (result) {
     decimal_point = length + decimal_exponent;

--- a/Source/WTF/wtf/dtoa/strtod.cc
+++ b/Source/WTF/wtf/dtoa/strtod.cc
@@ -270,7 +270,7 @@ static DiyFp AdjustmentPowerOfTen(int exponent) {
     case 6: return DiyFp(UINT64_2PART_C(0xf4240000, 00000000), -44);
     case 7: return DiyFp(UINT64_2PART_C(0x98968000, 00000000), -40);
     default:
-      UNREACHABLE();
+      std::unreachable();
   }
 }
 

--- a/Source/WTF/wtf/dtoa/utils.h
+++ b/Source/WTF/wtf/dtoa/utils.h
@@ -37,22 +37,6 @@
 #ifndef UNIMPLEMENTED
 #define UNIMPLEMENTED() ASSERT_NOT_REACHED()
 #endif
-#ifndef DOUBLE_CONVERSION_NO_RETURN
-#ifdef _MSC_VER
-#define DOUBLE_CONVERSION_NO_RETURN __declspec(noreturn)
-#else
-#define DOUBLE_CONVERSION_NO_RETURN __attribute__((noreturn))
-#endif
-#endif
-#ifndef UNREACHABLE
-#ifdef _MSC_VER
-void DOUBLE_CONVERSION_NO_RETURN abort_noreturn();
-inline void abort_noreturn() { abort(); }
-#define UNREACHABLE()   (abort_noreturn())
-#else
-#define UNREACHABLE()   (abort())
-#endif
-#endif
 
 // Double operations detection based on target architecture.
 // Linux uses a 80bit wide floating point stack on x86. This induces double

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -539,7 +539,7 @@ ALWAYS_INLINE String accessibilityRoleToString(AccessibilityRole role)
     case AccessibilityRole::WebArea:
         return "WebArea"_s;
     }
-    UNREACHABLE();
+    std::unreachable();
     return ""_s;
 }
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.cpp
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.cpp
@@ -41,7 +41,7 @@ ASCIILiteral unitString(AngleUnit angleUnit)
     case Turn:   return "turn"_s;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 ASCIILiteral unitString(LengthUnit lengthUnit)
@@ -101,7 +101,7 @@ ASCIILiteral unitString(LengthUnit lengthUnit)
     case Cqmax:     return "cqmax"_s;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 
 }
 
@@ -114,7 +114,7 @@ ASCIILiteral unitString(TimeUnit timeUnit)
     case Ms:   return "ms"_s;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 ASCIILiteral unitString(FrequencyUnit frequencyUnit)
@@ -126,7 +126,7 @@ ASCIILiteral unitString(FrequencyUnit frequencyUnit)
     case Khz:   return "khz"_s;;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 ASCIILiteral unitString(ResolutionUnit resolutionUnit)
@@ -140,7 +140,7 @@ ASCIILiteral unitString(ResolutionUnit resolutionUnit)
     case Dpcm:   return "dpcm"_s;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 // Ensure the angle units in `AngleUnit` and `AnglePercentageUnit` are all equal.

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.h
@@ -382,7 +382,7 @@ constexpr CSSUnitType toCSSUnitType(AngleUnit angleUnit)
     case Turn:   return CSSUnitType::CSS_TURN;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<AngleUnit> toAngleUnit(CSSUnitType cssUnit)
@@ -421,7 +421,7 @@ template<AngleUnit To, typename T> constexpr T convertAngle(T value, AngleUnit u
             return turn2deg(value);
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Rad) {
         switch (unit) {
         case Deg:
@@ -434,7 +434,7 @@ template<AngleUnit To, typename T> constexpr T convertAngle(T value, AngleUnit u
             return turn2rad(value);
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Grad) {
         switch (unit) {
         case Deg:
@@ -447,7 +447,7 @@ template<AngleUnit To, typename T> constexpr T convertAngle(T value, AngleUnit u
             return turn2grad(value);
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Turn) {
         switch (unit) {
         case Deg:
@@ -460,7 +460,7 @@ template<AngleUnit To, typename T> constexpr T convertAngle(T value, AngleUnit u
             return value;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     }
 }
 
@@ -602,7 +602,7 @@ constexpr CSSUnitType toCSSUnitType(LengthUnit lengthUnit)
     case Cqmax:     return CSSUnitType::CSS_CQMAX;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<LengthUnit> toLengthUnit(CSSUnitType cssUnit)
@@ -725,7 +725,7 @@ constexpr bool conversionToCanonicalUnitRequiresConversionData(LengthUnit unit)
         return true;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr bool isFontRelativeLength(LengthUnit lengthUnit)
@@ -901,7 +901,7 @@ constexpr CSSUnitType toCSSUnitType(TimeUnit timeUnit)
     case Ms:   return CSSUnitType::CSS_MS;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<TimeUnit> toTimeUnit(CSSUnitType cssUnit)
@@ -934,7 +934,7 @@ template<TimeUnit To, typename T> constexpr T convertTime(T value, TimeUnit unit
             return value * secondsPerMillisecond;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Ms) {
         switch (unit) {
         case S:
@@ -943,7 +943,7 @@ template<TimeUnit To, typename T> constexpr T convertTime(T value, TimeUnit unit
             return value;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     }
 }
 
@@ -979,7 +979,7 @@ constexpr CSSUnitType toCSSUnitType(FrequencyUnit frequencyUnit)
     case Khz:   return CSSUnitType::CSS_KHZ;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<FrequencyUnit> toFrequencyUnit(CSSUnitType cssUnit)
@@ -1012,7 +1012,7 @@ template<FrequencyUnit To, typename T> constexpr T convertFrequency(T value, Fre
             return value * hertzPerKilohertz;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Khz) {
         switch (unit) {
         case Hz:
@@ -1021,7 +1021,7 @@ template<FrequencyUnit To, typename T> constexpr T convertFrequency(T value, Fre
             return value;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     }
 }
 
@@ -1061,7 +1061,7 @@ constexpr CSSUnitType toCSSUnitType(ResolutionUnit resolutionUnit)
     case Dpcm:   return CSSUnitType::CSS_DPCM;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<ResolutionUnit> toResolutionUnit(CSSUnitType cssUnit)
@@ -1100,7 +1100,7 @@ template<ResolutionUnit To, typename T> constexpr T convertResolution(T value, R
             return value * dppxPerDpcm;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == X) {
         switch (unit) {
         case Dppx:
@@ -1113,7 +1113,7 @@ template<ResolutionUnit To, typename T> constexpr T convertResolution(T value, R
             return value * dppxPerDpcm / dppxPerX;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Dpi) {
         switch (unit) {
         case Dppx:
@@ -1126,7 +1126,7 @@ template<ResolutionUnit To, typename T> constexpr T convertResolution(T value, R
             return value * dppxPerDpcm / dppxPerDpi;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     } else if constexpr (To == Dpcm) {
         switch (unit) {
         case Dppx:
@@ -1139,7 +1139,7 @@ template<ResolutionUnit To, typename T> constexpr T convertResolution(T value, R
             return value;
         }
 
-        WTF_UNREACHABLE();
+        std::unreachable();
     }
 }
 
@@ -1237,7 +1237,7 @@ constexpr CSSUnitType toCSSUnitType(AnglePercentageUnit anglePercentageUnit)
     case Percentage:    return CSSUnitType::CSS_PERCENTAGE;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<AnglePercentageUnit> toAnglePercentageUnit(CSSUnitType cssUnit)
@@ -1434,7 +1434,7 @@ constexpr CSSUnitType toCSSUnitType(LengthPercentageUnit lengthPercentageUnit)
     case Percentage:    return CSSUnitType::CSS_PERCENTAGE;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 constexpr std::optional<LengthPercentageUnit> toLengthPercentageUnit(CSSUnitType cssUnit)
@@ -1559,7 +1559,7 @@ constexpr bool conversionToCanonicalUnitRequiresConversionData(LengthPercentageU
         return true;
     }
 
-    WTF_UNREACHABLE();
+    std::unreachable();
 }
 
 template<> struct UnitTraits<LengthPercentageUnit> {


### PR DESCRIPTION
#### 6a48e356f60722b5e076a31e5bd8ecbc53b9aa4f
<pre>
[WebCore] Use C++23&apos;s `std::unreachable()` instead of `WTF_UNREACHABLE()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=296532">https://bugs.webkit.org/show_bug.cgi?id=296532</a>

Reviewed by Sam Weinig.

Use C++23&apos;s `std::unreachable()` instead of `WTF_UNREACHABLE()` and `UNREACHABLE()` if applicable.

* Source/WTF/wtf/dtoa/bignum-dtoa.cc:
* Source/WTF/wtf/dtoa/bignum.h:
(WTF::double_conversion::Bignum::EnsureCapacity):
* Source/WTF/wtf/dtoa/double-conversion.cc:
* Source/WTF/wtf/dtoa/fast-dtoa.cc:
* Source/WTF/wtf/dtoa/strtod.cc:
* Source/WTF/wtf/dtoa/utils.h:
(abort_noreturn): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::accessibilityRoleToString):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.cpp:
(WebCore::CSS::unitString):
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericUnits.h:
(WebCore::CSS::toCSSUnitType):
(WebCore::CSS::convertAngle):
(WebCore::CSS::conversionToCanonicalUnitRequiresConversionData):
(WebCore::CSS::convertTime):
(WebCore::CSS::convertFrequency):
(WebCore::CSS::convertResolution):

Canonical link: <a href="https://commits.webkit.org/297948@main">https://commits.webkit.org/297948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad6fa1f6f4866082296a55ff9aba7c202c3da3f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113372 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63315 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105883 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122795 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111970 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95135 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94881 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/24232 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40008 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17826 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36591 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40313 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45812 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136195 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39964 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36539 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->