### PR TITLE
[Style] Convert more SVG length properties to strong style types

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3230,7 +3230,10 @@ style/values/size-adjust/StyleTextSizeAdjust.cpp
 style/values/sizing/StyleAspectRatio.cpp
 style/values/sizing/StyleContainIntrinsicSize.cpp
 style/values/sizing/StylePreferredSize.cpp
+style/values/svg/StyleSVGBaselineShift.cpp
 style/values/svg/StyleSVGPaint.cpp
+style/values/svg/StyleSVGStrokeDasharray.cpp
+style/values/svg/StyleSVGStrokeDashoffset.cpp
 style/values/text/StyleTextIndent.cpp
 style/values/text-decoration/StyleTextDecorationThickness.cpp
 style/values/text-decoration/StyleTextEmphasisStyle.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2272,10 +2272,9 @@
                 "super"
             ],
             "codegen-properties": {
-                "animation-wrapper": "BaselineShiftWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-builder-custom": "Inherit|Value",
-                "style-extractor-custom": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "animation-wrapper-requires-render-style": true,
+                "style-converter": "StyleType<SVGBaselineShift>",
                 "svg": true,
                 "parser-grammar": "baseline | sub | super | <length-percentage>"
             },
@@ -4318,10 +4317,8 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage'",
-                "render-style-initial": "zeroLength",
-                "style-converter": "Length",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGCenterCoordinateComponent>",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -4333,10 +4330,8 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage'",
-                "render-style-initial": "zeroLength",
-                "style-converter": "Length",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGCenterCoordinateComponent>",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -7316,10 +7311,8 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage, NegativeLengthsAreInvalid'",
-                "render-style-initial": "zeroLength",
-                "style-converter": "Length",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGRadius>",
                 "parser-grammar": "<length-percentage [0,inf]>"
             },
             "specification": {
@@ -7421,10 +7414,8 @@
                 "auto"
             ],
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage, NegativeLengthsAreInvalid'",
-                "render-style-initial": "initialRadius",
-                "style-converter": "LengthOrAuto",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGRadiusComponent>",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -7439,10 +7430,8 @@
                 "auto"
             ],
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage, NegativeLengthsAreInvalid'",
-                "render-style-initial": "initialRadius",
-                "style-converter": "LengthOrAuto",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGRadiusComponent>",
                 "parser-grammar": "auto | <length-percentage [0,inf]>"
             },
             "specification": {
@@ -7538,11 +7527,11 @@
                 "none"
             ],
             "codegen-properties": {
-                "animation-wrapper": "Wrapper",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
                 "animation-wrapper-requires-non-additive-or-cumulative-interpolation": true,
                 "render-style-name-for-methods": "StrokeDashArray",
-                "style-converter": "StrokeDashArray",
+                "style-converter": "StyleType<SVGStrokeDasharray>",
                 "svg": true,
                 "parser-function": "consumeStrokeDasharray",
                 "parser-function-allows-number-or-integer-input": true,
@@ -7560,11 +7549,9 @@
             "inherited": true,
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage'",
-                "render-style-initial": "zeroLength",
+                "animation-wrapper": "StyleTypeWrapper",
                 "render-style-name-for-methods": "StrokeDashOffset",
-                "style-converter": "LengthAllowingNumber",
+                "style-converter": "StyleType<SVGStrokeDashoffset>",
                 "parser-grammar": "<length-percentage> | <number>"
             },
             "specification": {
@@ -8474,10 +8461,8 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage'",
-                "render-style-initial": "zeroLength",
-                "style-converter": "Length",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGCoordinateComponent>",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {
@@ -8489,10 +8474,8 @@
             "animation-type": "by computed value",
             "initial": "0",
             "codegen-properties": {
-                "animation-wrapper": "LengthWrapper",
-                "animation-wrapper-comment": "FIXME: Should probably pass 'IsLengthPercentage'",
-                "render-style-initial": "zeroLength",
-                "style-converter": "Length",
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<SVGCoordinateComponent>",
                 "parser-grammar": "<length-percentage>"
             },
             "specification": {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -313,7 +313,14 @@ struct ProgressTimelineAxes;
 struct ProgressTimelineNames;
 struct Quotes;
 struct Rotate;
+struct SVGBaselineShift;
+struct SVGCenterCoordinateComponent;
+struct SVGCoordinateComponent;
 struct SVGPaint;
+struct SVGRadius;
+struct SVGRadiusComponent;
+struct SVGStrokeDasharray;
+struct SVGStrokeDashoffset;
 struct Scale;
 struct ScopedName;
 struct ScrollMarginEdge;
@@ -1759,6 +1766,9 @@ public:
     inline void setStrokeMiterLimit(float);
     static constexpr float initialStrokeMiterLimit();
 
+    static inline Style::SVGStrokeDasharray initialStrokeDashArray();
+    static inline Style::SVGStrokeDashoffset initialStrokeDashOffset();
+
     const SVGRenderStyle& svgStyle() const { return m_svgStyle; }
     inline SVGRenderStyle& accessSVGStyle();
 
@@ -1777,25 +1787,25 @@ public:
     inline void setVisitedLinkStroke(Style::SVGPaint&&);
     inline float strokeOpacity() const;
     inline void setStrokeOpacity(float);
-    inline const FixedVector<Length>& strokeDashArray() const;
-    inline void setStrokeDashArray(FixedVector<Length>&&);
-    inline const Length& strokeDashOffset() const;
-    inline void setStrokeDashOffset(Length&&);
+    inline const Style::SVGStrokeDasharray& strokeDashArray() const;
+    inline void setStrokeDashArray(Style::SVGStrokeDasharray&&);
+    inline const Style::SVGStrokeDashoffset& strokeDashOffset() const;
+    inline void setStrokeDashOffset(Style::SVGStrokeDashoffset&&);
 
-    inline const Length& cx() const;
-    inline void setCx(Length&&);
-    inline const Length& cy() const;
-    inline void setCy(Length&&);
-    inline const Length& r() const;
-    inline void setR(Length&&);
-    inline const Length& rx() const;
-    inline void setRx(Length&&);
-    inline const Length& ry() const;
-    inline void setRy(Length&&);
-    inline const Length& x() const;
-    inline void setX(Length&&);
-    inline const Length& y() const;
-    inline void setY(Length&&);
+    inline const Style::SVGCenterCoordinateComponent& cx() const;
+    inline void setCx(Style::SVGCenterCoordinateComponent&&);
+    inline const Style::SVGCenterCoordinateComponent& cy() const;
+    inline void setCy(Style::SVGCenterCoordinateComponent&&);
+    inline const Style::SVGRadius& r() const;
+    inline void setR(Style::SVGRadius&&);
+    inline const Style::SVGRadiusComponent& rx() const;
+    inline void setRx(Style::SVGRadiusComponent&&);
+    inline const Style::SVGRadiusComponent& ry() const;
+    inline void setRy(Style::SVGRadiusComponent&&);
+    inline const Style::SVGCoordinateComponent& x() const;
+    inline void setX(Style::SVGCoordinateComponent&&);
+    inline const Style::SVGCoordinateComponent& y() const;
+    inline void setY(Style::SVGCoordinateComponent&&);
 
     inline void setD(RefPtr<StylePathData>&&);
     inline StylePathData* d() const;
@@ -1811,10 +1821,8 @@ public:
     inline void setFloodColor(Style::Color&&);
     inline void setLightingColor(Style::Color&&);
 
-    inline const Length& baselineShiftValue() const;
-    inline void setBaselineShiftValue(Length&&);
-    inline SVGLengthValue kerning() const;
-    inline void setKerning(SVGLengthValue);
+    inline const Style::SVGBaselineShift& baselineShift() const;
+    inline void setBaselineShift(Style::SVGBaselineShift&&);
 
     inline void setShapeOutside(RefPtr<ShapeValue>&&);
     inline ShapeValue* shapeOutside() const; // Defined in RenderStyleInlines.h.
@@ -1938,6 +1946,8 @@ public:
 
     static constexpr Clear initialClear();
     static inline Style::Clip initialClip();
+    static inline Style::SVGCenterCoordinateComponent initialCx();
+    static inline Style::SVGCenterCoordinateComponent initialCy();
     static constexpr DisplayType initialDisplay();
     static constexpr UnicodeBidi initialUnicodeBidi();
     static constexpr PositionType initialPosition();
@@ -1984,7 +1994,9 @@ public:
     static inline Style::MinimumSize initialMinSize();
     static inline Style::MaximumSize initialMaxSize();
     static inline Style::InsetEdge initialInset();
-    static inline Length initialRadius();
+    static inline Style::SVGRadius initialR();
+    static inline Style::SVGRadiusComponent initialRx();
+    static inline Style::SVGRadiusComponent initialRy();
     static inline Style::MarginEdge initialMargin();
     static constexpr OptionSet<MarginTrimType> initialMarginTrim();
     static inline Style::PaddingEdge initialPadding();
@@ -2106,6 +2118,8 @@ public:
     static StyleImage* initialMaskBorderSource() { return nullptr; }
     static constexpr PrintColorAdjust initialPrintColorAdjust();
     static inline Style::Quotes initialQuotes();
+    static inline Style::SVGCoordinateComponent initialX();
+    static inline Style::SVGCoordinateComponent initialY();
 
 #if ENABLE(DARK_MODE_CSS)
     static inline Style::ColorScheme initialColorScheme();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -466,7 +466,6 @@ constexpr OptionSet<PositionVisibility> RenderStyle::initialPositionVisibility()
 constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
 inline Style::Quotes RenderStyle::initialQuotes() { return CSS::Keyword::Auto { }; }
 constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
-inline Length RenderStyle::initialRadius() { return LengthType::Auto; }
 constexpr Resize RenderStyle::initialResize() { return Resize::None; }
 inline Style::GapGutter RenderStyle::initialRowGap() { return CSS::Keyword::Normal { }; }
 constexpr RubyPosition RenderStyle::initialRubyPosition() { return RubyPosition::Over; }

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -157,12 +157,11 @@ bool SVGRenderStyle::changeRequiresLayout(const SVGRenderStyle& other) const
         || m_inheritedFlags.glyphOrientationHorizontal != other.m_inheritedFlags.glyphOrientationHorizontal
         || m_inheritedFlags.glyphOrientationVertical != other.m_inheritedFlags.glyphOrientationVertical
         || m_nonInheritedFlags.flagBits.alignmentBaseline != other.m_nonInheritedFlags.flagBits.alignmentBaseline
-        || m_nonInheritedFlags.flagBits.dominantBaseline != other.m_nonInheritedFlags.flagBits.dominantBaseline
-        || m_nonInheritedFlags.flagBits.baselineShift != other.m_nonInheritedFlags.flagBits.baselineShift)
+        || m_nonInheritedFlags.flagBits.dominantBaseline != other.m_nonInheritedFlags.flagBits.dominantBaseline)
         return true;
 
     // Text related properties influence layout.
-    if (m_miscData->baselineShiftValue != other.m_miscData->baselineShiftValue)
+    if (m_miscData->baselineShift != other.m_miscData->baselineShift)
         return true;
 
     // The x or y properties require relayout.
@@ -271,7 +270,7 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
             changingProperties.m_properties.set(CSSPropertyFloodColor);
         if (first.lightingColor != second.lightingColor)
             changingProperties.m_properties.set(CSSPropertyLightingColor);
-        if (first.baselineShiftValue != second.baselineShiftValue)
+        if (first.baselineShift != second.baselineShift)
             changingProperties.m_properties.set(CSSPropertyBaselineShift);
     };
 
@@ -325,8 +324,6 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
     auto conservativelyCollectChangedAnimatablePropertiesViaNonInheritedFlags = [&](auto& first, auto& second) {
         if (first.flagBits.alignmentBaseline != second.flagBits.alignmentBaseline)
             changingProperties.m_properties.set(CSSPropertyAlignmentBaseline);
-        if (first.flagBits.baselineShift != second.flagBits.baselineShift)
-            changingProperties.m_properties.set(CSSPropertyBaselineShift);
         if (first.flagBits.bufferedRendering != second.flagBits.bufferedRendering)
             changingProperties.m_properties.set(CSSPropertyBufferedRendering);
         if (first.flagBits.dominantBaseline != second.flagBits.dominantBaseline)
@@ -373,7 +370,6 @@ void SVGRenderStyle::NonInheritedFlags::dumpDifferences(TextStream& ts, const SV
 {
     LOG_IF_DIFFERENT_WITH_CAST(AlignmentBaseline, flagBits.alignmentBaseline);
     LOG_IF_DIFFERENT_WITH_CAST(DominantBaseline, flagBits.dominantBaseline);
-    LOG_IF_DIFFERENT_WITH_CAST(BaselineShift, flagBits.baselineShift);
     LOG_IF_DIFFERENT_WITH_CAST(VectorEffect, flagBits.vectorEffect);
     LOG_IF_DIFFERENT_WITH_CAST(BufferedRendering, flagBits.bufferedRendering);
     LOG_IF_DIFFERENT_WITH_CAST(MaskType, flagBits.maskType);

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -37,6 +37,8 @@ class TextStream;
 
 namespace WebCore {
 
+using namespace CSS::Literals;
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SVGRenderStyle);
 class SVGRenderStyle : public RefCounted<SVGRenderStyle> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SVGRenderStyle, SVGRenderStyle);
@@ -64,7 +66,6 @@ public:
     // Initial values for all the properties
     static AlignmentBaseline initialAlignmentBaseline() { return AlignmentBaseline::Baseline; }
     static DominantBaseline initialDominantBaseline() { return DominantBaseline::Auto; }
-    static BaselineShift initialBaselineShift() { return BaselineShift::Baseline; }
     static VectorEffect initialVectorEffect() { return VectorEffect::None; }
     static BufferedRendering initialBufferedRendering() { return BufferedRendering::Auto; }
     static WindRule initialClipRule() { return WindRule::NonZero; }
@@ -80,7 +81,8 @@ public:
     static Style::SVGPaint initialFill() { return Style::SVGPaint { Style::SVGPaintType::RGBColor, Style::URL::none(), Color::black }; }
     static float initialStrokeOpacity() { return 1; }
     static Style::SVGPaint initialStroke() { return Style::SVGPaint { Style::SVGPaintType::None, Style::URL::none(), Color { } }; }
-    static FixedVector<Length> initialStrokeDashArray() { return { }; }
+    static inline Style::SVGStrokeDasharray initialStrokeDashArray();
+    static inline Style::SVGStrokeDashoffset initialStrokeDashOffset();
     static float initialStopOpacity() { return 1; }
     static Style::Color initialStopColor() { return Color::black; }
     static float initialFloodOpacity() { return 1; }
@@ -90,12 +92,11 @@ public:
     static Style::URL initialMarkerMidResource() { return Style::URL::none(); }
     static Style::URL initialMarkerEndResource() { return Style::URL::none(); }
     static MaskType initialMaskType() { return MaskType::Luminance; }
-    static Length initialBaselineShiftValue() { return Length(0, LengthType::Fixed); }
+    static Style::SVGBaselineShift initialBaselineShift() { return CSS::Keyword::Baseline { }; }
 
     // SVG CSS Property setters
     void setAlignmentBaseline(AlignmentBaseline val) { m_nonInheritedFlags.flagBits.alignmentBaseline = static_cast<unsigned>(val); }
     void setDominantBaseline(DominantBaseline val) { m_nonInheritedFlags.flagBits.dominantBaseline = static_cast<unsigned>(val); }
-    void setBaselineShift(BaselineShift val) { m_nonInheritedFlags.flagBits.baselineShift = static_cast<unsigned>(val); }
     void setVectorEffect(VectorEffect val) { m_nonInheritedFlags.flagBits.vectorEffect = static_cast<unsigned>(val); }
     void setBufferedRendering(BufferedRendering val) { m_nonInheritedFlags.flagBits.bufferedRendering = static_cast<unsigned>(val); }
     void setClipRule(WindRule val) { m_inheritedFlags.clipRule = static_cast<unsigned>(val); }
@@ -107,13 +108,13 @@ public:
     void setGlyphOrientationHorizontal(GlyphOrientation val) { m_inheritedFlags.glyphOrientationHorizontal = static_cast<unsigned>(val); }
     void setGlyphOrientationVertical(GlyphOrientation val) { m_inheritedFlags.glyphOrientationVertical = static_cast<unsigned>(val); }
     void setMaskType(MaskType val) { m_nonInheritedFlags.flagBits.maskType = static_cast<unsigned>(val); }
-    void setCx(Length&&);
-    void setCy(Length&&);
-    void setR(Length&&);
-    void setRx(Length&&);
-    void setRy(Length&&);
-    void setX(Length&&);
-    void setY(Length&&);
+    void setCx(Style::SVGCenterCoordinateComponent&&);
+    void setCy(Style::SVGCenterCoordinateComponent&&);
+    void setR(Style::SVGRadius&&);
+    void setRx(Style::SVGRadiusComponent&&);
+    void setRy(Style::SVGRadiusComponent&&);
+    void setX(Style::SVGCoordinateComponent&&);
+    void setY(Style::SVGCoordinateComponent&&);
     void setD(RefPtr<StylePathData>&&);
     void setFillOpacity(float);
     void setFill(Style::SVGPaint&&);
@@ -122,14 +123,14 @@ public:
     void setStroke(Style::SVGPaint&&);
     void setVisitedLinkStroke(Style::SVGPaint&&);
 
-    void setStrokeDashArray(FixedVector<Length>&&);
-    void setStrokeDashOffset(Length&&);
+    void setStrokeDashArray(Style::SVGStrokeDasharray&&);
+    void setStrokeDashOffset(Style::SVGStrokeDashoffset&&);
     void setStopOpacity(float);
     void setStopColor(Style::Color&&);
     void setFloodOpacity(float);
     void setFloodColor(Style::Color&&);
     void setLightingColor(Style::Color&&);
-    void setBaselineShiftValue(Length&&);
+    void setBaselineShift(Style::SVGBaselineShift&&);
 
     // Setters for inherited resources
     void setMarkerStartResource(Style::URL&&);
@@ -139,7 +140,6 @@ public:
     // Read accessors for all the properties
     AlignmentBaseline alignmentBaseline() const { return static_cast<AlignmentBaseline>(m_nonInheritedFlags.flagBits.alignmentBaseline); }
     DominantBaseline dominantBaseline() const { return static_cast<DominantBaseline>(m_nonInheritedFlags.flagBits.dominantBaseline); }
-    BaselineShift baselineShift() const { return static_cast<BaselineShift>(m_nonInheritedFlags.flagBits.baselineShift); }
     VectorEffect vectorEffect() const { return static_cast<VectorEffect>(m_nonInheritedFlags.flagBits.vectorEffect); }
     BufferedRendering bufferedRendering() const { return static_cast<BufferedRendering>(m_nonInheritedFlags.flagBits.bufferedRendering); }
     WindRule clipRule() const { return static_cast<WindRule>(m_inheritedFlags.clipRule); }
@@ -154,21 +154,21 @@ public:
     float fillOpacity() const { return m_fillData->opacity; }
     const Style::SVGPaint& stroke() const { return m_strokeData->paint; }
     float strokeOpacity() const { return m_strokeData->opacity; }
-    const FixedVector<Length>& strokeDashArray() const { return m_strokeData->dashArray; }
-    const Length& strokeDashOffset() const { return m_strokeData->dashOffset; }
+    const Style::SVGStrokeDasharray& strokeDashArray() const { return m_strokeData->dashArray; }
+    const Style::SVGStrokeDashoffset& strokeDashOffset() const { return m_strokeData->dashOffset; }
     float stopOpacity() const { return m_stopData->opacity; }
     const Style::Color& stopColor() const { return m_stopData->color; }
     float floodOpacity() const { return m_miscData->floodOpacity; }
     const Style::Color& floodColor() const { return m_miscData->floodColor; }
     const Style::Color& lightingColor() const { return m_miscData->lightingColor; }
-    const Length& baselineShiftValue() const { return m_miscData->baselineShiftValue; }
-    const Length& cx() const { return m_layoutData->cx; }
-    const Length& cy() const { return m_layoutData->cy; }
-    const Length& r() const { return m_layoutData->r; }
-    const Length& rx() const { return m_layoutData->rx; }
-    const Length& ry() const { return m_layoutData->ry; }
-    const Length& x() const { return m_layoutData->x; }
-    const Length& y() const { return m_layoutData->y; }
+    const Style::SVGBaselineShift& baselineShift() const { return m_miscData->baselineShift; }
+    const Style::SVGCenterCoordinateComponent& cx() const { return m_layoutData->cx; }
+    const Style::SVGCenterCoordinateComponent& cy() const { return m_layoutData->cy; }
+    const Style::SVGRadius& r() const { return m_layoutData->r; }
+    const Style::SVGRadiusComponent& rx() const { return m_layoutData->rx; }
+    const Style::SVGRadiusComponent& ry() const { return m_layoutData->ry; }
+    const Style::SVGCoordinateComponent& x() const { return m_layoutData->x; }
+    const Style::SVGCoordinateComponent& y() const { return m_layoutData->y; }
     StylePathData* d() const { return m_layoutData->d.get(); }
     const Style::URL& markerStartResource() const { return m_inheritedResourceData->markerStart; }
     const Style::URL& markerMidResource() const { return m_inheritedResourceData->markerMid; }
@@ -222,11 +222,10 @@ private:
             struct {
                 unsigned alignmentBaseline : 4; // AlignmentBaseline
                 unsigned dominantBaseline : 4; // DominantBaseline
-                unsigned baselineShift : 2; // BaselineShift
                 unsigned vectorEffect : 1; // VectorEffect
                 unsigned bufferedRendering : 2; // BufferedRendering
                 unsigned maskType : 1; // MaskType
-                // 18 bits unused
+                // 20 bits unused
             } flagBits;
             uint32_t flags;
         };
@@ -247,9 +246,9 @@ private:
 };
 
 inline SVGRenderStyle& RenderStyle::accessSVGStyle() { return m_svgStyle.access(); }
-inline const Length& RenderStyle::baselineShiftValue() const { return svgStyle().baselineShiftValue(); }
-inline const Length& RenderStyle::cx() const { return svgStyle().cx(); }
-inline const Length& RenderStyle::cy() const { return svgStyle().cy(); }
+inline const Style::SVGBaselineShift& RenderStyle::baselineShift() const { return svgStyle().baselineShift(); }
+inline const Style::SVGCenterCoordinateComponent& RenderStyle::cx() const { return svgStyle().cx(); }
+inline const Style::SVGCenterCoordinateComponent& RenderStyle::cy() const { return svgStyle().cy(); }
 inline StylePathData* RenderStyle::d() const { return svgStyle().d(); }
 inline float RenderStyle::fillOpacity() const { return svgStyle().fillOpacity(); }
 inline const Style::SVGPaint& RenderStyle::fill() const { return svgStyle().fill(); }
@@ -259,12 +258,12 @@ inline float RenderStyle::floodOpacity() const { return svgStyle().floodOpacity(
 inline bool RenderStyle::hasExplicitlySetStrokeWidth() const { return m_rareInheritedData->hasSetStrokeWidth; }
 inline bool RenderStyle::hasVisibleStroke() const { return svgStyle().hasStroke() && !strokeWidth().isZero(); }
 inline const Style::Color& RenderStyle::lightingColor() const { return svgStyle().lightingColor(); }
-inline const Length& RenderStyle::r() const { return svgStyle().r(); }
-inline const Length& RenderStyle::rx() const { return svgStyle().rx(); }
-inline const Length& RenderStyle::ry() const { return svgStyle().ry(); }
-inline void RenderStyle::setBaselineShiftValue(Length&& s) { accessSVGStyle().setBaselineShiftValue(WTFMove(s)); }
-inline void RenderStyle::setCx(Length&& cx) { accessSVGStyle().setCx(WTFMove(cx)); }
-inline void RenderStyle::setCy(Length&& cy) { accessSVGStyle().setCy(WTFMove(cy)); }
+inline const Style::SVGRadius& RenderStyle::r() const { return svgStyle().r(); }
+inline const Style::SVGRadiusComponent& RenderStyle::rx() const { return svgStyle().rx(); }
+inline const Style::SVGRadiusComponent& RenderStyle::ry() const { return svgStyle().ry(); }
+inline void RenderStyle::setBaselineShift(Style::SVGBaselineShift&& baselineShift) { accessSVGStyle().setBaselineShift(WTFMove(baselineShift)); }
+inline void RenderStyle::setCx(Style::SVGCenterCoordinateComponent&& cx) { accessSVGStyle().setCx(WTFMove(cx)); }
+inline void RenderStyle::setCy(Style::SVGCenterCoordinateComponent&& cy) { accessSVGStyle().setCy(WTFMove(cy)); }
 inline void RenderStyle::setD(RefPtr<StylePathData>&& d) { accessSVGStyle().setD(WTFMove(d)); }
 inline void RenderStyle::setFillOpacity(float f) { accessSVGStyle().setFillOpacity(f); }
 inline void RenderStyle::setFill(Style::SVGPaint&& paint) { accessSVGStyle().setFill(WTFMove(paint)); }
@@ -272,66 +271,79 @@ inline void RenderStyle::setVisitedLinkFill(Style::SVGPaint&& paint) { accessSVG
 inline void RenderStyle::setFloodColor(Style::Color&& c) { accessSVGStyle().setFloodColor(WTFMove(c)); }
 inline void RenderStyle::setFloodOpacity(float f) { accessSVGStyle().setFloodOpacity(f); }
 inline void RenderStyle::setLightingColor(Style::Color&& c) { accessSVGStyle().setLightingColor(WTFMove(c)); }
-inline void RenderStyle::setR(Length&& r) { accessSVGStyle().setR(WTFMove(r)); }
-inline void RenderStyle::setRx(Length&& rx) { accessSVGStyle().setRx(WTFMove(rx)); }
-inline void RenderStyle::setRy(Length&& ry) { accessSVGStyle().setRy(WTFMove(ry)); }
+inline void RenderStyle::setR(Style::SVGRadius&& r) { accessSVGStyle().setR(WTFMove(r)); }
+inline void RenderStyle::setRx(Style::SVGRadiusComponent&& rx) { accessSVGStyle().setRx(WTFMove(rx)); }
+inline void RenderStyle::setRy(Style::SVGRadiusComponent&& ry) { accessSVGStyle().setRy(WTFMove(ry)); }
 inline void RenderStyle::setStopColor(Style::Color&& c) { accessSVGStyle().setStopColor(WTFMove(c)); }
 inline void RenderStyle::setStopOpacity(float f) { accessSVGStyle().setStopOpacity(f); }
-inline void RenderStyle::setStrokeDashArray(FixedVector<Length>&& array) { accessSVGStyle().setStrokeDashArray(WTFMove(array)); }
-inline void RenderStyle::setStrokeDashOffset(Length&& d) { accessSVGStyle().setStrokeDashOffset(WTFMove(d)); }
+inline void RenderStyle::setStrokeDashArray(Style::SVGStrokeDasharray&& array) { accessSVGStyle().setStrokeDashArray(WTFMove(array)); }
+inline void RenderStyle::setStrokeDashOffset(Style::SVGStrokeDashoffset&& offset) { accessSVGStyle().setStrokeDashOffset(WTFMove(offset)); }
 inline void RenderStyle::setStrokeOpacity(float f) { accessSVGStyle().setStrokeOpacity(f); }
 inline void RenderStyle::setStroke(Style::SVGPaint&& paint) { accessSVGStyle().setStroke(WTFMove(paint)); }
 inline void RenderStyle::setVisitedLinkStroke(Style::SVGPaint&& paint) { accessSVGStyle().setVisitedLinkStroke(WTFMove(paint)); }
-inline void RenderStyle::setX(Length&& x) { accessSVGStyle().setX(WTFMove(x)); }
-inline void RenderStyle::setY(Length&& y) { accessSVGStyle().setY(WTFMove(y)); }
+inline void RenderStyle::setX(Style::SVGCoordinateComponent&& x) { accessSVGStyle().setX(WTFMove(x)); }
+inline void RenderStyle::setY(Style::SVGCoordinateComponent&& y) { accessSVGStyle().setY(WTFMove(y)); }
 inline const Style::Color& RenderStyle::stopColor() const { return svgStyle().stopColor(); }
 inline float RenderStyle::stopOpacity() const { return svgStyle().stopOpacity(); }
-inline const FixedVector<Length>& RenderStyle::strokeDashArray() const { return svgStyle().strokeDashArray(); }
-inline const Length& RenderStyle::strokeDashOffset() const { return svgStyle().strokeDashOffset(); }
+inline const Style::SVGStrokeDasharray& RenderStyle::strokeDashArray() const { return svgStyle().strokeDashArray(); }
+inline const Style::SVGStrokeDashoffset& RenderStyle::strokeDashOffset() const { return svgStyle().strokeDashOffset(); }
 inline float RenderStyle::strokeOpacity() const { return svgStyle().strokeOpacity(); }
 inline const Style::SVGPaint& RenderStyle::stroke() const { return svgStyle().stroke(); }
 inline const Style::SVGPaint& RenderStyle::visitedLinkStroke() const { return svgStyle().visitedLinkStroke(); }
 inline const Style::StrokeWidth& RenderStyle::strokeWidth() const { return m_rareInheritedData->strokeWidth; }
-inline const Length& RenderStyle::x() const { return svgStyle().x(); }
-inline const Length& RenderStyle::y() const { return svgStyle().y(); }
+inline const Style::SVGCoordinateComponent& RenderStyle::x() const { return svgStyle().x(); }
+inline const Style::SVGCoordinateComponent& RenderStyle::y() const { return svgStyle().y(); }
 
-inline void SVGRenderStyle::setCx(Length&& length)
+inline Style::SVGCenterCoordinateComponent RenderStyle::initialCx() { return 0_css_px; }
+inline Style::SVGCenterCoordinateComponent RenderStyle::initialCy() { return 0_css_px; }
+inline Style::SVGRadius RenderStyle::initialR() { return 0_css_px; }
+inline Style::SVGRadiusComponent RenderStyle::initialRx() { return CSS::Keyword::Auto { }; }
+inline Style::SVGRadiusComponent RenderStyle::initialRy() { return CSS::Keyword::Auto { }; }
+inline Style::SVGCoordinateComponent RenderStyle::initialX() { return 0_css_px; }
+inline Style::SVGCoordinateComponent RenderStyle::initialY() { return 0_css_px; }
+inline Style::SVGStrokeDasharray RenderStyle::initialStrokeDashArray() { return CSS::Keyword::None { }; }
+inline Style::SVGStrokeDashoffset RenderStyle::initialStrokeDashOffset() { return 0_css_px; }
+
+inline Style::SVGStrokeDasharray SVGRenderStyle::initialStrokeDashArray() { return RenderStyle::initialStrokeDashArray(); }
+inline Style::SVGStrokeDashoffset SVGRenderStyle::initialStrokeDashOffset() { return RenderStyle::initialStrokeDashOffset(); }
+
+inline void SVGRenderStyle::setCx(Style::SVGCenterCoordinateComponent&& length)
 {
     if (!(m_layoutData->cx == length))
         m_layoutData.access().cx = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setCy(Length&& length)
+inline void SVGRenderStyle::setCy(Style::SVGCenterCoordinateComponent&& length)
 {
     if (!(m_layoutData->cy == length))
         m_layoutData.access().cy = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setR(Length&& length)
+inline void SVGRenderStyle::setR(Style::SVGRadius&& length)
 {
     if (!(m_layoutData->r == length))
         m_layoutData.access().r = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setRx(Length&& length)
+inline void SVGRenderStyle::setRx(Style::SVGRadiusComponent&& length)
 {
     if (!(m_layoutData->rx == length))
         m_layoutData.access().rx = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setRy(Length&& length)
+inline void SVGRenderStyle::setRy(Style::SVGRadiusComponent&& length)
 {
     if (!(m_layoutData->ry == length))
         m_layoutData.access().ry = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setX(Length&& length)
+inline void SVGRenderStyle::setX(Style::SVGCoordinateComponent&& length)
 {
     if (!(m_layoutData->x == length))
         m_layoutData.access().x = WTFMove(length);
 }
 
-inline void SVGRenderStyle::setY(Length&& length)
+inline void SVGRenderStyle::setY(Style::SVGCoordinateComponent&& length)
 {
     if (!(m_layoutData->y == length))
         m_layoutData.access().y = WTFMove(length);
@@ -381,13 +393,13 @@ inline void SVGRenderStyle::setVisitedLinkStroke(Style::SVGPaint&& paint)
         m_strokeData.access().visitedLinkPaint = WTFMove(paint);
 }
 
-inline void SVGRenderStyle::setStrokeDashArray(FixedVector<Length>&& array)
+inline void SVGRenderStyle::setStrokeDashArray(Style::SVGStrokeDasharray&& array)
 {
     if (!(m_strokeData->dashArray == array))
         m_strokeData.access().dashArray = WTFMove(array);
 }
 
-inline void SVGRenderStyle::setStrokeDashOffset(Length&& offset)
+inline void SVGRenderStyle::setStrokeDashOffset(Style::SVGStrokeDashoffset&& offset)
 {
     if (!(m_strokeData->dashOffset == offset))
         m_strokeData.access().dashOffset = WTFMove(offset);
@@ -425,10 +437,10 @@ inline void SVGRenderStyle::setLightingColor(Style::Color&& color)
         m_miscData.access().lightingColor = WTFMove(color);
 }
 
-inline void SVGRenderStyle::setBaselineShiftValue(Length&& shiftValue)
+inline void SVGRenderStyle::setBaselineShift(Style::SVGBaselineShift&& baselineShift)
 {
-    if (!(m_miscData->baselineShiftValue == shiftValue))
-        m_miscData.access().baselineShiftValue = WTFMove(shiftValue);
+    if (!(m_miscData->baselineShift == baselineShift))
+        m_miscData.access().baselineShift = WTFMove(baselineShift);
 }
 
 inline void SVGRenderStyle::setMarkerStartResource(Style::URL&& resource)
@@ -463,7 +475,6 @@ inline void SVGRenderStyle::setBitDefaults()
     m_nonInheritedFlags.flags = 0;
     m_nonInheritedFlags.flagBits.alignmentBaseline = static_cast<unsigned>(initialAlignmentBaseline());
     m_nonInheritedFlags.flagBits.dominantBaseline = static_cast<unsigned>(initialDominantBaseline());
-    m_nonInheritedFlags.flagBits.baselineShift = static_cast<unsigned>(initialBaselineShift());
     m_nonInheritedFlags.flagBits.vectorEffect = static_cast<unsigned>(initialVectorEffect());
     m_nonInheritedFlags.flagBits.bufferedRendering = static_cast<unsigned>(initialBufferedRendering());
     m_nonInheritedFlags.flagBits.maskType = static_cast<unsigned>(initialMaskType());

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp
@@ -82,7 +82,7 @@ StyleStrokeData::StyleStrokeData()
     : opacity(SVGRenderStyle::initialStrokeOpacity())
     , paint(SVGRenderStyle::initialStroke())
     , visitedLinkPaint(SVGRenderStyle::initialStroke())
-    , dashOffset(RenderStyle::zeroLength())
+    , dashOffset(SVGRenderStyle::initialStrokeDashOffset())
     , dashArray(SVGRenderStyle::initialStrokeDashArray())
 {
 }
@@ -162,7 +162,7 @@ StyleMiscData::StyleMiscData()
     : floodOpacity(SVGRenderStyle::initialFloodOpacity())
     , floodColor(SVGRenderStyle::initialFloodColor())
     , lightingColor(SVGRenderStyle::initialLightingColor())
-    , baselineShiftValue(SVGRenderStyle::initialBaselineShiftValue())
+    , baselineShift(SVGRenderStyle::initialBaselineShift())
 {
 }
 
@@ -171,7 +171,7 @@ inline StyleMiscData::StyleMiscData(const StyleMiscData& other)
     , floodOpacity(other.floodOpacity)
     , floodColor(other.floodColor)
     , lightingColor(other.lightingColor)
-    , baselineShiftValue(other.baselineShiftValue)
+    , baselineShift(other.baselineShift)
 {
 }
 
@@ -185,7 +185,7 @@ bool StyleMiscData::operator==(const StyleMiscData& other) const
     return floodOpacity == other.floodOpacity
         && floodColor == other.floodColor
         && lightingColor == other.lightingColor
-        && baselineShiftValue == other.baselineShiftValue;
+        && baselineShift == other.baselineShift;
 }
 
 #if !LOG_DISABLED
@@ -194,7 +194,7 @@ void StyleMiscData::dumpDifferences(TextStream& ts, const StyleMiscData& other) 
     LOG_IF_DIFFERENT(floodOpacity);
     LOG_IF_DIFFERENT(floodColor);
     LOG_IF_DIFFERENT(lightingColor);
-    LOG_IF_DIFFERENT(baselineShiftValue);
+    LOG_IF_DIFFERENT(baselineShift);
 }
 #endif
 
@@ -269,13 +269,13 @@ void StyleInheritedResourceData::dumpDifferences(TextStream& ts, const StyleInhe
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleLayoutData);
 
 StyleLayoutData::StyleLayoutData()
-    : cx(RenderStyle::zeroLength())
-    , cy(RenderStyle::zeroLength())
-    , r(RenderStyle::zeroLength())
-    , rx(RenderStyle::initialRadius())
-    , ry(RenderStyle::initialRadius())
-    , x(RenderStyle::zeroLength())
-    , y(RenderStyle::zeroLength())
+    : cx(RenderStyle::initialCx())
+    , cy(RenderStyle::initialCy())
+    , r(RenderStyle::initialR())
+    , rx(RenderStyle::initialRx())
+    , ry(RenderStyle::initialRy())
+    , x(RenderStyle::initialX())
+    , y(RenderStyle::initialY())
     , d(nullptr)
 {
 }
@@ -338,17 +338,6 @@ TextStream& operator<<(TextStream& ts, AlignmentBaseline value)
     case AlignmentBaseline::Alphabetic: ts << "alphabetic"_s; break;
     case AlignmentBaseline::Hanging: ts << "hanging"_s; break;
     case AlignmentBaseline::Mathematical: ts << "mathematical"_s; break;
-    }
-    return ts;
-}
-
-TextStream& operator<<(TextStream& ts, BaselineShift value)
-{
-    switch (value) {
-    case BaselineShift::Baseline: ts << "baseline"_s; break;
-    case BaselineShift::Sub: ts << "sub"_s; break;
-    case BaselineShift::Super: ts << "super"_s; break;
-    case BaselineShift::Length: ts << "length"_s; break;
     }
     return ts;
 }
@@ -483,7 +472,7 @@ TextStream& operator<<(TextStream& ts, const StyleMiscData& data)
     ts.dumpProperty("flood-opacity"_s, data.floodOpacity);
     ts.dumpProperty("flood-color"_s, data.floodColor);
     ts.dumpProperty("lighting-color"_s, data.lightingColor);
-    ts.dumpProperty("baseline-shift"_s, data.baselineShiftValue);
+    ts.dumpProperty("baseline-shift"_s, data.baselineShift);
     return ts;
 }
 

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -3,6 +3,7 @@
                   2004, 2005 Rob Buis <buis@kde.org>
     Copyright (C) Research In Motion Limited 2010. All rights reserved.
     Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
+    Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
 
     Based on khtml code by:
     Copyright (C) 2000-2003 Lars Knoll (knoll@kde.org)
@@ -33,7 +34,14 @@
 #include "StyleBoxShadow.h"
 #include "StyleColor.h"
 #include "StylePathData.h"
+#include "StyleSVGBaselineShift.h"
+#include "StyleSVGCenterCoordinateComponent.h"
+#include "StyleSVGCoordinateComponent.h"
 #include "StyleSVGPaint.h"
+#include "StyleSVGRadius.h"
+#include "StyleSVGRadiusComponent.h"
+#include "StyleSVGStrokeDasharray.h"
+#include "StyleSVGStrokeDashoffset.h"
 #include "StyleURL.h"
 #include <wtf/FixedVector.h>
 #include <wtf/RefCounted.h>
@@ -47,13 +55,6 @@ namespace WebCore {
 
 class CSSValue;
 class CSSValueList;
-
-enum class BaselineShift : uint8_t {
-    Baseline,
-    Sub,
-    Super,
-    Length
-};
 
 enum class TextAnchor : uint8_t {
     Start,
@@ -172,8 +173,8 @@ public:
     float opacity;
     Style::SVGPaint paint;
     Style::SVGPaint visitedLinkPaint;
-    Length dashOffset;
-    FixedVector<Length> dashArray;
+    Style::SVGStrokeDashoffset dashOffset;
+    Style::SVGStrokeDasharray dashArray;
 
 private:
     StyleStrokeData();
@@ -219,7 +220,7 @@ public:
     Style::Color floodColor;
     Style::Color lightingColor;
 
-    Length baselineShiftValue;
+    Style::SVGBaselineShift baselineShift;
 
 private:
     StyleMiscData();
@@ -283,13 +284,13 @@ public:
     void dumpDifferences(TextStream&, const StyleLayoutData&) const;
 #endif
 
-    Length cx;
-    Length cy;
-    Length r;
-    Length rx;
-    Length ry;
-    Length x;
-    Length y;
+    Style::SVGCenterCoordinateComponent cx;
+    Style::SVGCenterCoordinateComponent cy;
+    Style::SVGRadius r;
+    Style::SVGRadiusComponent rx;
+    Style::SVGRadiusComponent ry;
+    Style::SVGCoordinateComponent x;
+    Style::SVGCoordinateComponent y;
     RefPtr<StylePathData> d;
 
 private:
@@ -299,7 +300,6 @@ private:
 
 
 WTF::TextStream& operator<<(WTF::TextStream&, AlignmentBaseline);
-WTF::TextStream& operator<<(WTF::TextStream&, BaselineShift);
 WTF::TextStream& operator<<(WTF::TextStream&, BufferedRendering);
 WTF::TextStream& operator<<(WTF::TextStream&, ColorInterpolation);
 WTF::TextStream& operator<<(WTF::TextStream&, ColorRendering);

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -95,8 +95,8 @@ void RenderSVGEllipse::calculateRadiiAndCenter()
 
     ASSERT(is<SVGEllipseElement>(graphicsElement));
 
-    Length rx = style().svgStyle().rx();
-    Length ry = style().svgStyle().ry();
+    auto& rx = style().svgStyle().rx();
+    auto& ry = style().svgStyle().ry();
     m_radii = FloatSize(
         lengthContext.valueForLength(rx.isAuto() ? ry : rx, SVGLengthMode::Width),
         lengthContext.valueForLength(ry.isAuto() ? rx : ry, SVGLengthMode::Height));
@@ -134,7 +134,7 @@ bool RenderSVGEllipse::canUseStrokeHitTestFastPath() const
 
     // We can compute intersections with continuous strokes on circles
     // without using a Path.
-    return m_shapeType == ShapeType::Circle && style().svgStyle().strokeDashArray().isEmpty();
+    return m_shapeType == ShapeType::Circle && style().svgStyle().strokeDashArray().isNone();
 }
 
 bool RenderSVGEllipse::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -151,7 +151,9 @@ bool RenderSVGRect::definitelyHasSimpleStroke() const
     // miterlimits, the join style used might not be correct (e.g. a miterlimit
     // of 1.4142135 should result in bevel joins, but may be drawn using miter
     // joins).
-    return style().svgStyle().strokeDashArray().isEmpty() && style().joinStyle() == LineJoin::Miter && style().strokeMiterLimit() >= 1.5;
+    return style().svgStyle().strokeDashArray().isNone()
+        && style().joinStyle() == LineJoin::Miter
+        && style().strokeMiterLimit() >= 1.5;
 }
 
 void RenderSVGRect::strokeShape(GraphicsContext& context) const

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -488,7 +488,7 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         context.setMiterLimit(style.strokeMiterLimit());
 
     auto& dashes = svgStyle.strokeDashArray();
-    if (dashes.isEmpty())
+    if (dashes.isNone())
         context.setStrokeStyle(StrokeStyle::SolidStroke);
     else {
         float scaleFactor = 1;
@@ -505,7 +505,7 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         }
         
         bool canSetLineDash = false;
-        auto dashArray = WTF::map(dashes, [&](auto& dash) -> DashArrayElement {
+        auto dashArray = DashArray::map(dashes, [&](auto& dash) -> DashArrayElement {
             auto value = lengthContext.valueForLength(dash) * scaleFactor;
             if (value > 0)
                 canSetLineDash = true;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -208,7 +208,7 @@ static void writeSVGStrokePaintingResource(TextStream& ts, const RenderElement& 
     SVGLengthContext lengthContext(&shape);
     double dashOffset = lengthContext.valueForLength(svgStyle.strokeDashOffset());
     double strokeWidth = lengthContext.valueForLength(style.strokeWidth());
-    auto dashArray = WTF::map(svgStyle.strokeDashArray(), [&](auto& length) -> DashArrayElement {
+    auto dashArray = DashArray::map(svgStyle.strokeDashArray(), [&](auto& length) -> DashArrayElement {
         return lengthContext.valueForLength(length);
     });
 

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp
@@ -38,18 +38,20 @@ SVGTextLayoutEngineBaseline::SVGTextLayoutEngineBaseline(const FontCascade& font
 
 float SVGTextLayoutEngineBaseline::calculateBaselineShift(const SVGRenderStyle& style) const
 {
-    switch (style.baselineShift()) {
-    case BaselineShift::Baseline:
-        return 0;
-    case BaselineShift::Sub:
-        return -m_font->metricsOfPrimaryFont().height() / 2;
-    case BaselineShift::Super:
-        return m_font->metricsOfPrimaryFont().height() / 2;
-    case BaselineShift::Length:
-        return floatValueForLength(style.baselineShiftValue(), m_font->size());
-    }
-    ASSERT_NOT_REACHED();
-    return 0;
+    return WTF::switchOn(style.baselineShift(),
+        [](const CSS::Keyword::Baseline&) -> float {
+            return 0;
+        },
+        [&](const CSS::Keyword::Sub&) -> float {
+            return -m_font->metricsOfPrimaryFont().height() / 2;
+        },
+        [&](const CSS::Keyword::Super&) -> float {
+            return m_font->metricsOfPrimaryFont().height() / 2;
+        },
+        [&](const Style::SVGBaselineShift::Length& length) -> float {
+            return Style::evaluate(length, m_font->size());
+        }
+    );
 }
 
 AlignmentBaseline SVGTextLayoutEngineBaseline::dominantBaselineToAlignmentBaseline(bool isVerticalText, const RenderElement& textRenderer) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -95,8 +95,8 @@ void LegacyRenderSVGEllipse::calculateRadiiAndCenter()
 
     ASSERT(is<SVGEllipseElement>(graphicsElement));
 
-    Length rx = style().svgStyle().rx();
-    Length ry = style().svgStyle().ry();
+    auto& rx = style().svgStyle().rx();
+    auto& ry = style().svgStyle().ry();
     m_radii = FloatSize(
         lengthContext.valueForLength(rx.isAuto() ? ry : rx, SVGLengthMode::Width),
         lengthContext.valueForLength(ry.isAuto() ? rx : ry, SVGLengthMode::Height));
@@ -134,7 +134,7 @@ bool LegacyRenderSVGEllipse::canUseStrokeHitTestFastPath() const
 
     // We can compute intersections with continuous strokes on circles
     // without using a Path.
-    return m_shapeType == ShapeType::Circle && style().svgStyle().strokeDashArray().isEmpty();
+    return m_shapeType == ShapeType::Circle && style().svgStyle().strokeDashArray().isNone();
 }
 
 bool LegacyRenderSVGEllipse::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -162,7 +162,9 @@ bool LegacyRenderSVGRect::definitelyHasSimpleStroke() const
     // miterlimits, the join style used might not be correct (e.g. a miterlimit
     // of 1.4142135 should result in bevel joins, but may be drawn using miter
     // joins).
-    return style().svgStyle().strokeDashArray().isEmpty() && style().joinStyle() == LineJoin::Miter && style().strokeMiterLimit() >= 1.5;
+    return style().svgStyle().strokeDashArray().isNone()
+        && style().joinStyle() == LineJoin::Miter
+        && style().strokeMiterLimit() >= 1.5;
 }
 
 bool LegacyRenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -180,7 +180,6 @@ public:
     static FontSelectionValue convertFontStyle(BuilderState&, const CSSValue&);
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
-    static FixedVector<WebCore::Length> convertStrokeDashArray(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
     static float convertOpacity(BuilderState&, const CSSValue&);
     static URL convertSVGURIReference(BuilderState&, const CSSValue&);
@@ -987,25 +986,6 @@ inline bool BuilderConverter::convertOverflowScrolling(BuilderState&, const CSSV
     return value.valueID() == CSSValueTouch;
 }
 #endif
-
-inline FixedVector<WebCore::Length> BuilderConverter::convertStrokeDashArray(BuilderState& builderState, const CSSValue& value)
-{
-    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
-        if (primitiveValue->valueID() == CSSValueNone)
-            return SVGRenderStyle::initialStrokeDashArray();
-
-        // Values coming from CSS-Typed-OM may not have been converted to a CSSValueList yet.
-        return FixedVector<WebCore::Length> { convertLengthAllowingNumber(builderState, *primitiveValue) };
-    }
-
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
-        return { };
-
-    return FixedVector<WebCore::Length>::map(*list, [&](auto& item) {
-        return convertLengthAllowingNumber(builderState, item);
-    });
-}
 
 inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState& builderState, const CSSValue& value)
 {

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -120,7 +120,14 @@ inline OffsetRotate forwardInheritedValue(const OffsetRotate& value) { auto copy
 inline Position forwardInheritedValue(const Position& value) { auto copy = value; return copy; }
 inline PositionX forwardInheritedValue(const PositionX& value) { auto copy = value; return copy; }
 inline PositionY forwardInheritedValue(const PositionY& value) { auto copy = value; return copy; }
+inline SVGBaselineShift forwardInheritedValue(const SVGBaselineShift& value) { auto copy = value; return copy; }
+inline SVGCenterCoordinateComponent forwardInheritedValue(const SVGCenterCoordinateComponent& value) { auto copy = value; return copy; }
+inline SVGCoordinateComponent forwardInheritedValue(const SVGCoordinateComponent& value) { auto copy = value; return copy; }
 inline SVGPaint forwardInheritedValue(const SVGPaint& value) { auto copy = value; return copy; }
+inline SVGRadius forwardInheritedValue(const SVGRadius& value) { auto copy = value; return copy; }
+inline SVGRadiusComponent forwardInheritedValue(const SVGRadiusComponent& value) { auto copy = value; return copy; }
+inline SVGStrokeDasharray forwardInheritedValue(const SVGStrokeDasharray& value) { auto copy = value; return copy; }
+inline SVGStrokeDashoffset forwardInheritedValue(const SVGStrokeDashoffset& value) { auto copy = value; return copy; }
 inline ScrollbarColor forwardInheritedValue(const ScrollbarColor& value) { auto copy = value; return copy; }
 inline ScrollbarGutter forwardInheritedValue(const ScrollbarGutter& value) { auto copy = value; return copy; }
 inline StrokeWidth forwardInheritedValue(const StrokeWidth& value) { auto copy = value; return copy; }
@@ -188,8 +195,6 @@ public:
     // Custom handling of inherit + value setting only.
     static void applyInheritVerticalAlign(BuilderState&);
     static void applyValueVerticalAlign(BuilderState&, CSSValue&);
-    static void applyInheritBaselineShift(BuilderState&);
-    static void applyValueBaselineShift(BuilderState&, CSSValue&);
 
     // Custom handling of inherit setting only.
     static void applyInheritWordSpacing(BuilderState&);
@@ -770,41 +775,6 @@ inline void BuilderCustom::applyValueBorderTopRightRadius(BuilderState& builderS
 {
     builderState.style().setBorderTopRightRadius(BuilderConverter::convertStyleType<BorderRadiusValue>(builderState, value));
     builderState.style().setHasExplicitlySetBorderTopRightRadius(true);
-}
-
-inline void BuilderCustom::applyInheritBaselineShift(BuilderState& builderState)
-{
-    auto& svgStyle = builderState.style().accessSVGStyle();
-    auto& svgParentStyle = builderState.parentStyle().svgStyle();
-    svgStyle.setBaselineShift(forwardInheritedValue(svgParentStyle.baselineShift()));
-    svgStyle.setBaselineShiftValue(forwardInheritedValue(svgParentStyle.baselineShiftValue()));
-}
-
-inline void BuilderCustom::applyValueBaselineShift(BuilderState& builderState, CSSValue& value)
-{
-    auto& svgStyle = builderState.style().accessSVGStyle();
-    auto primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return;
-
-    if (primitiveValue->isValueID()) {
-        switch (primitiveValue->valueID()) {
-        case CSSValueBaseline:
-            svgStyle.setBaselineShift(BaselineShift::Baseline);
-            break;
-        case CSSValueSub:
-            svgStyle.setBaselineShift(BaselineShift::Sub);
-            break;
-        case CSSValueSuper:
-            svgStyle.setBaselineShift(BaselineShift::Super);
-            break;
-        default:
-            break;
-        }
-    } else {
-        svgStyle.setBaselineShift(BaselineShift::Length);
-        svgStyle.setBaselineShiftValue(BuilderConverter::convertLength(builderState, *primitiveValue));
-    }
 }
 
 template<BuilderCustom::CounterBehavior counterBehavior>

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -51,7 +51,6 @@ public:
     static Ref<CSSValue> extractWritingMode(ExtractorState&);
     static Ref<CSSValue> extractFloat(ExtractorState&);
     static Ref<CSSValue> extractContent(ExtractorState&);
-    static Ref<CSSValue> extractBaselineShift(ExtractorState&);
     static Ref<CSSValue> extractVerticalAlign(ExtractorState&);
     static Ref<CSSValue> extractLetterSpacing(ExtractorState&);
     static Ref<CSSValue> extractWordSpacing(ExtractorState&);
@@ -151,7 +150,6 @@ public:
     static void extractWritingModeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractFloatSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractContentSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractBaselineShiftSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractVerticalAlignSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractLetterSpacingSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractWordSpacingSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1263,40 +1261,6 @@ inline Ref<CSSValue> ExtractorCustom::extractContent(ExtractorState& state)
 inline void ExtractorCustom::extractContentSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     extractSerialization<CSSPropertyContent>(state, builder, context);
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractBaselineShift(ExtractorState& state)
-{
-    switch (state.style.svgStyle().baselineShift()) {
-    case BaselineShift::Baseline:
-        return CSSPrimitiveValue::create(CSSValueBaseline);
-    case BaselineShift::Super:
-        return CSSPrimitiveValue::create(CSSValueSuper);
-    case BaselineShift::Sub:
-        return CSSPrimitiveValue::create(CSSValueSub);
-    case BaselineShift::Length:
-        return ExtractorConverter::convertLength(state, state.style.svgStyle().baselineShiftValue());
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline void ExtractorCustom::extractBaselineShiftSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    switch (state.style.svgStyle().baselineShift()) {
-    case BaselineShift::Baseline:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Baseline { });
-        return;
-    case BaselineShift::Super:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Super { });
-        return;
-    case BaselineShift::Sub:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Sub { });
-        return;
-    case BaselineShift::Length:
-        ExtractorSerializer::serializeLength(state, builder, context, state.style.svgStyle().baselineShiftValue());
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractVerticalAlign(ExtractorState& state)

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -246,25 +246,6 @@ inline LengthBox blendFunc(const LengthBox& from, const LengthBox& to, const Con
     };
 }
 
-inline FixedVector<WebCore::Length> blendFunc(const FixedVector<WebCore::Length>& from, const FixedVector<WebCore::Length>& to, const Context& context)
-{
-    size_t fromLength = from.size();
-    size_t toLength = to.size();
-    if (!fromLength || !toLength)
-        return context.progress < 0.5 ? from : to;
-
-    size_t resultLength = fromLength;
-    if (fromLength != toLength) {
-        if (!remainder(std::max(fromLength, toLength), std::min(fromLength, toLength)))
-            resultLength = std::max(fromLength, toLength);
-        else
-            resultLength = fromLength * toLength;
-    }
-    return FixedVector<WebCore::Length>::createWithSizeFromGenerator(resultLength, [&](auto i) {
-        return blendFunc(from[i % fromLength], to[i % toLength], context);
-    });
-}
-
 inline RefPtr<StyleImage> crossfadeBlend(StyleCachedImage& fromStyleImage, StyleCachedImage& toStyleImage, const Context& context)
 {
     // If progress is at one of the extremes, we want getComputedStyle to show the image,

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -1304,53 +1304,6 @@ public:
     }
 };
 
-class BaselineShiftWrapper final : public WrapperWithGetter<const WebCore::Length&> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(BaselineShiftWrapper, Animation);
-public:
-    BaselineShiftWrapper()
-        : WrapperWithGetter(CSSPropertyBaselineShift, &RenderStyle::baselineShiftValue)
-    {
-    }
-
-    bool equals(const RenderStyle& a, const RenderStyle& b) const final
-    {
-        if (&a == &b)
-            return true;
-        if (a.svgStyle().baselineShift() != b.svgStyle().baselineShift())
-            return false;
-        if (a.svgStyle().baselineShift() != BaselineShift::Length)
-            return true;
-        return value(a) == value(b);
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
-    {
-        if (from.svgStyle().baselineShift() != to.svgStyle().baselineShift())
-            return false;
-        if (from.svgStyle().baselineShift() != BaselineShift::Length)
-            return true;
-        return canInterpolateLengths(value(from), value(to), true);
-    }
-
-    bool requiresInterpolationForAccumulativeIteration(const RenderStyle& from, const RenderStyle& to) const final
-    {
-        if (from.svgStyle().baselineShift() != to.svgStyle().baselineShift() || from.svgStyle().baselineShift() != BaselineShift::Length)
-            return false;
-        return lengthsRequireInterpolationForAccumulativeIteration(value(from), value(to));
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        auto& srcSVGStyle = !context.progress ? from.svgStyle() : to.svgStyle();
-        destination.accessSVGStyle().setBaselineShift(srcSVGStyle.baselineShift());
-
-        if (srcSVGStyle.baselineShift() != BaselineShift::Length)
-            return;
-
-        destination.accessSVGStyle().setBaselineShiftValue(blendFunc(value(from), value(to), context, ValueRange::All));
-    }
-};
-
 class LineHeightWrapper final : public LengthWrapper {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LineHeightWrapper, Animation);
 public:

--- a/Source/WebCore/style/values/svg/StyleSVGBaselineShift.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGBaselineShift.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSVGBaselineShift.h"
+
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<SVGBaselineShift>::operator()(BuilderState& state, const CSSValue& value) -> SVGBaselineShift
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Baseline { };
+
+    if (primitiveValue->isValueID()) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueBaseline:
+            return CSS::Keyword::Baseline { };
+        case CSSValueSub:
+            return CSS::Keyword::Sub { };
+        case CSSValueSuper:
+            return CSS::Keyword::Super { };
+        default:
+            break;
+        }
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Baseline { };
+    }
+
+    return toStyleFromCSSValue<SVGBaselineShiftLength>(state, *primitiveValue);
+}
+
+// MARK: - Blending
+
+auto Blending<SVGBaselineShift>::canBlend(const SVGBaselineShift& a, const SVGBaselineShift& b) -> bool
+{
+    return a.m_value.index() == b.m_value.index();
+}
+
+auto Blending<SVGBaselineShift>::requiresInterpolationForAccumulativeIteration(const SVGBaselineShift& a, const SVGBaselineShift& b) -> bool
+{
+    if (a.m_value.index() != b.m_value.index())
+        return true;
+    if (!a.isLength())
+        return false;
+    return Style::requiresInterpolationForAccumulativeIteration(*a.tryLength(), *b.tryLength());
+}
+
+auto Blending<SVGBaselineShift>::blend(const SVGBaselineShift& a, const SVGBaselineShift& b, const BlendingContext& context) -> SVGBaselineShift
+{
+    if (!a.isLength() || !b.isLength())
+        return context.progress < 0.5 ? a : b;
+
+    ASSERT(canBlend(a, b));
+    return Style::blend(*a.tryLength(), *b.tryLength(), context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGBaselineShift.h
+++ b/Source/WebCore/style/values/svg/StyleSVGBaselineShift.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+struct SVGBaselineShiftLength : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+// <'baseline-shift'> = baseline | sub | super | <length-percentage>
+struct SVGBaselineShift {
+    using Length = SVGBaselineShiftLength;
+
+    SVGBaselineShift(CSS::Keyword::Baseline keyword)
+        : m_value { keyword }
+    {
+    }
+
+    SVGBaselineShift(CSS::Keyword::Sub keyword)
+        : m_value { keyword }
+    {
+    }
+
+    SVGBaselineShift(CSS::Keyword::Super keyword)
+        : m_value { keyword }
+    {
+    }
+
+    SVGBaselineShift(Length&& length)
+        : m_value { WTFMove(length) }
+    {
+    }
+
+    bool isBaseline() const { return WTF::holdsAlternative<CSS::Keyword::Baseline>(m_value); }
+    bool isSub() const { return WTF::holdsAlternative<CSS::Keyword::Sub>(m_value); }
+    bool isSuper() const { return WTF::holdsAlternative<CSS::Keyword::Super>(m_value); }
+    bool isLength() const { return WTF::holdsAlternative<Length>(m_value); }
+    std::optional<Length> tryLength() const { return isLength() ? std::make_optional(std::get<Length>(m_value)) : std::nullopt; }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const SVGBaselineShift&) const = default;
+
+private:
+    friend struct Blending<SVGBaselineShift>;
+
+    Variant<CSS::Keyword::Baseline, CSS::Keyword::Sub, CSS::Keyword::Super, SVGBaselineShiftLength> m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<SVGBaselineShift> { auto operator()(BuilderState&, const CSSValue&) -> SVGBaselineShift; };
+
+// MARK: - Blending
+
+template<> struct Blending<SVGBaselineShift> {
+    auto canBlend(const SVGBaselineShift&, const SVGBaselineShift&) -> bool;
+    auto requiresInterpolationForAccumulativeIteration(const SVGBaselineShift&, const SVGBaselineShift&) -> bool;
+    auto blend(const SVGBaselineShift&, const SVGBaselineShift&, const BlendingContext&) -> SVGBaselineShift;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGBaselineShiftLength)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGBaselineShift)

--- a/Source/WebCore/style/values/svg/StyleSVGCenterCoordinateComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGCenterCoordinateComponent.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'cx'/'cy'> = <length-percentage>
+// https://svgwg.org/svg2-draft/geometry.html#CX
+// https://svgwg.org/svg2-draft/geometry.html#CY
+struct SVGCenterCoordinateComponent : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGCenterCoordinateComponent)

--- a/Source/WebCore/style/values/svg/StyleSVGCoordinateComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGCoordinateComponent.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'x'/'y'> = <length-percentage>
+// https://svgwg.org/svg2-draft/geometry.html#X
+// https://svgwg.org/svg2-draft/geometry.html#Y
+struct SVGCoordinateComponent : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGCoordinateComponent)

--- a/Source/WebCore/style/values/svg/StyleSVGRadius.h
+++ b/Source/WebCore/style/values/svg/StyleSVGRadius.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'r'> = <length-percentage [0,∞]>
+// https://svgwg.org/svg2-draft/geometry.html#R
+struct SVGRadius : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>> {
+    using Base::Base;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGRadius)

--- a/Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'rx'/'ry'> = <length-percentage [0,∞]> | auto
+// https://svgwg.org/svg2-draft/geometry.html#RX
+// https://svgwg.org/svg2-draft/geometry.html#RY
+struct SVGRadiusComponent : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
+    using Base::Base;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGRadiusComponent)

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSVGStrokeDasharray.h"
+
+#include "AnimationUtilities.h"
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+using namespace CSS::Literals;
+
+// MARK: - Conversion
+
+auto CSSValueConversion<SVGStrokeDasharrayValue>::operator()(BuilderState& state, const CSSValue& value) -> SVGStrokeDasharrayValue
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return 0_css_px;
+
+    if (primitiveValue->isNumberOrInteger()) {
+        return SVGStrokeDasharrayValueLength { SVGStrokeDasharrayValueLength::Fixed {
+            toStyleFromCSSValue<Number<CSS::All, float>>(state, *primitiveValue).value
+        } };
+    }
+    return toStyleFromCSSValue<SVGStrokeDasharrayValueLength>(state, *primitiveValue);
+}
+
+// MARK: - Blending
+
+auto Blending<SVGStrokeDasharray>::blend(const SVGStrokeDasharray& a, const SVGStrokeDasharray& b, const BlendingContext& context) -> SVGStrokeDasharray
+{
+    auto aLength = a.size();
+    auto bLength = b.size();
+    if (!aLength || !bLength)
+        return context.progress < 0.5 ? a : b;
+
+    auto resultLength = aLength;
+    if (aLength != bLength) {
+        if (!remainder(std::max(aLength, bLength), std::min(aLength, bLength)))
+            resultLength = std::max(aLength, bLength);
+        else
+            resultLength = aLength * bLength;
+    }
+
+    return { SVGStrokeDasharrayList::Container::createWithSizeFromGenerator(resultLength, [&](auto i) {
+        return Style::blend(a[i % aLength], b[i % bLength], context);
+    }) };
+
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// <dasharray-value> = [ <length-percentage [0,∞]> | <number [0,∞]>@(converted-to-px) ]
+struct SVGStrokeDasharrayValueLength : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>> {
+    using Base::Base;
+};
+struct SVGStrokeDasharrayValue {
+    using Fixed = SVGStrokeDasharrayValueLength::Fixed;
+    using Percentage = SVGStrokeDasharrayValueLength::Percentage;
+    using Calc = SVGStrokeDasharrayValueLength::Calc;
+
+    SVGStrokeDasharrayValueLength value;
+
+    SVGStrokeDasharrayValue(SVGStrokeDasharrayValueLength&& length) : value { WTFMove(length) } { }
+    SVGStrokeDasharrayValue(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
+    SVGStrokeDasharrayValue(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : value { literal } { }
+
+    bool isZero() const { return value.isZero(); }
+    bool isPositive() const { return value.isPositive(); }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const SVGStrokeDasharrayValue&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(SVGStrokeDasharrayValue, value);
+
+// <dasharray> = [ <dasharray-value>+ ]#
+using SVGStrokeDasharrayList = CommaSeparatedFixedVector<SVGStrokeDasharrayValue>;
+
+// <'stroke-dasharray'> = none | <dasharray>
+// https://svgwg.org/svg2-draft/painting.html#StrokeDashing
+struct SVGStrokeDasharray : ListOrNone<SVGStrokeDasharrayList> { using ListOrNone<SVGStrokeDasharrayList>::ListOrNone; };
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<SVGStrokeDasharrayValue> { auto operator()(BuilderState&, const CSSValue&) -> SVGStrokeDasharrayValue; };
+
+// MARK: - Blending
+
+template<> struct Blending<SVGStrokeDasharray> {
+    auto blend(const SVGStrokeDasharray&, const SVGStrokeDasharray&, const BlendingContext&) -> SVGStrokeDasharray;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::SVGStrokeDasharrayValue)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGStrokeDasharrayValueLength)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGStrokeDasharray)

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleSVGStrokeDashoffset.h"
+
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+using namespace CSS::Literals;
+
+// MARK: - Conversion
+
+auto CSSValueConversion<SVGStrokeDashoffset>::operator()(BuilderState& state, const CSSValue& value) -> SVGStrokeDashoffset
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return 0_css_px;
+
+    if (primitiveValue->isNumberOrInteger()) {
+        return SVGStrokeDashoffsetLength { SVGStrokeDashoffsetLength::Fixed {
+            toStyleFromCSSValue<Number<CSS::All, float>>(state, *primitiveValue).value
+        } };
+    }
+    return toStyleFromCSSValue<SVGStrokeDashoffsetLength>(state, *primitiveValue);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+struct SVGStrokeDashoffsetLength : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+// <'stroke-dashoffset'> = <length-percentage> | <number>@(converted-to-px)
+// https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty
+struct SVGStrokeDashoffset {
+    using Fixed = SVGStrokeDashoffsetLength::Fixed;
+    using Percentage = SVGStrokeDashoffsetLength::Percentage;
+    using Calc = SVGStrokeDashoffsetLength::Calc;
+
+    SVGStrokeDashoffsetLength value;
+
+    SVGStrokeDashoffset(SVGStrokeDashoffsetLength&& length) : value { WTFMove(length) } { }
+    SVGStrokeDashoffset(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : value { literal } { }
+    SVGStrokeDashoffset(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : value { literal } { }
+
+    bool isZero() const { return value.isZero(); }
+    bool isPositive() const { return value.isPositive(); }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const SVGStrokeDashoffset&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(SVGStrokeDashoffset, value);
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<SVGStrokeDashoffset> { auto operator()(BuilderState&, const CSSValue&) -> SVGStrokeDashoffset; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::SVGStrokeDashoffsetLength)
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::SVGStrokeDashoffset)

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -36,6 +36,12 @@
 #include "SVGSVGElement.h"
 #include "StylePreferredSize.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "StyleSVGCenterCoordinateComponent.h"
+#include "StyleSVGCoordinateComponent.h"
+#include "StyleSVGRadius.h"
+#include "StyleSVGRadiusComponent.h"
+#include "StyleSVGStrokeDasharray.h"
+#include "StyleSVGStrokeDashoffset.h"
 #include "StyleStrokeWidth.h"
 #include <numbers>
 #include <wtf/MathExtras.h>
@@ -126,19 +132,19 @@ float SVGLengthContext::valueForLength(const Length& length, SVGLengthMode lengt
     }
 }
 
-float SVGLengthContext::valueForLength(const Style::PreferredSize& size, SVGLengthMode lengthMode)
+template<typename SizeType> float SVGLengthContext::valueForSizeType(const SizeType& size, SVGLengthMode lengthMode)
 {
     return WTF::switchOn(size,
-        [&](const Style::PreferredSize::Fixed& fixed) -> float {
+        [&](const typename SizeType::Fixed& fixed) -> float {
             return fixed.value;
         },
-        [&](const Style::PreferredSize::Percentage& percentage) -> float {
+        [&](const typename SizeType::Percentage& percentage) -> float {
             auto result = convertValueFromPercentageToUserUnits(percentage.value / 100, lengthMode);
             if (result.hasException())
                 return 0;
             return result.releaseReturnValue();
         },
-        [&](const Style::PreferredSize::Calc& calc) -> float {
+        [&](const typename SizeType::Calc& calc) -> float {
             auto viewportSize = this->viewportSize().value_or(FloatSize { });
             return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize));
         },
@@ -146,25 +152,46 @@ float SVGLengthContext::valueForLength(const Style::PreferredSize& size, SVGLeng
             return 0;
         }
     );
+
+}
+float SVGLengthContext::valueForLength(const Style::PreferredSize& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::StrokeWidth& strokeWidth, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::SVGCenterCoordinateComponent& size, SVGLengthMode lengthMode)
 {
-    return WTF::switchOn(strokeWidth,
-        [&](const Style::StrokeWidth::Fixed& fixed) -> float {
-            return fixed.value;
-        },
-        [&](const Style::StrokeWidth::Percentage& percentage) -> float {
-            auto result = convertValueFromPercentageToUserUnits(percentage.value / 100, lengthMode);
-            if (result.hasException())
-                return 0;
-            return result.releaseReturnValue();
-        },
-        [&](const Style::StrokeWidth::Calc& calc) -> float {
-            auto viewportSize = this->viewportSize().value_or(FloatSize { });
-            return Style::evaluate(calc, dimensionForLengthMode(lengthMode, viewportSize));
-        }
-    );
+    return valueForSizeType(size, lengthMode);
+}
+
+float SVGLengthContext::valueForLength(const Style::SVGCoordinateComponent& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
+}
+
+float SVGLengthContext::valueForLength(const Style::SVGRadius& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
+}
+
+float SVGLengthContext::valueForLength(const Style::SVGRadiusComponent& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
+}
+
+float SVGLengthContext::valueForLength(const Style::SVGStrokeDasharrayValue& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
+}
+
+float SVGLengthContext::valueForLength(const Style::SVGStrokeDashoffset& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
+}
+
+float SVGLengthContext::valueForLength(const Style::StrokeWidth& size, SVGLengthMode lengthMode)
+{
+    return valueForSizeType(size, lengthMode);
 }
 
 ExceptionOr<float> SVGLengthContext::convertValueToUserUnits(float value, SVGLengthType lengthType, SVGLengthMode lengthMode) const

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -35,6 +35,12 @@ template<typename> class ExceptionOr;
 
 namespace Style {
 struct PreferredSize;
+struct SVGCenterCoordinateComponent;
+struct SVGCoordinateComponent;
+struct SVGRadius;
+struct SVGRadiusComponent;
+struct SVGStrokeDasharrayValue;
+struct SVGStrokeDashoffset;
 struct StrokeWidth;
 }
 
@@ -55,6 +61,12 @@ public:
 
     float valueForLength(const Length&, SVGLengthMode = SVGLengthMode::Other);
     float valueForLength(const Style::PreferredSize&, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGCenterCoordinateComponent&, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGCoordinateComponent&, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGRadius&, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGRadiusComponent&, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGStrokeDasharrayValue&, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::SVGStrokeDashoffset&, SVGLengthMode = SVGLengthMode::Other);
     float valueForLength(const Style::StrokeWidth&, SVGLengthMode = SVGLengthMode::Other);
 
     ExceptionOr<float> convertValueToUserUnits(float, SVGLengthType, SVGLengthMode) const;
@@ -82,6 +94,8 @@ private:
     std::optional<FloatSize> computeViewportSize() const;
 
     RefPtr<const SVGElement> protectedContext() const;
+
+    template<typename SizeType> float valueForSizeType(const SizeType&, SVGLengthMode = SVGLengthMode::Other);
 
     WeakPtr<const SVGElement, WeakPtrImplWithEventTargetData> m_context;
     mutable std::optional<FloatSize> m_viewportSize;


### PR DESCRIPTION
#### de7c13fec64754ecc10dd34d502c1743eaab1373
<pre>
[Style] Convert more SVG length properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296536">https://bugs.webkit.org/show_bug.cgi?id=296536</a>

Reviewed by Darin Adler.

Converts the remaining SVG properties that contain a &lt;length&gt; to use
strong style types. These include `baseline-shift`, `cx`, `cy`, `r`,
`rx`, `ry`, `x`, `y`, `stroke-dasharray` and `stroke-dashoffset`.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.cpp:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/svg/StyleSVGBaselineShift.cpp: Added.
* Source/WebCore/style/values/svg/StyleSVGBaselineShift.h: Added.
* Source/WebCore/style/values/svg/StyleSVGCenterCoordinateComponent.h: Added.
* Source/WebCore/style/values/svg/StyleSVGCoordinateComponent.h: Added.
* Source/WebCore/style/values/svg/StyleSVGRadius.h: Added.
* Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h: Added.
* Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.cpp: Added.
* Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.h: Added.
* Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.cpp: Added.
* Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.h: Added.
* Source/WebCore/svg/SVGLengthContext.cpp:
* Source/WebCore/svg/SVGLengthContext.h:

Canonical link: <a href="https://commits.webkit.org/297909@main">https://commits.webkit.org/297909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78d993c14461c945acaf07757cb7eba34ac1fb05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113325 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20060 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122750 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95103 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/39987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36555 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->