### PR TITLE
[JSC] Abstract Interpreter incorrectly optimized comparison nodes into constants when two operands are the same symbols

### DIFF
--- a/JSTests/stress/fold-compare-greater-eq-symbols.js
+++ b/JSTests/stress/fold-compare-greater-eq-symbols.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+let count = 0;
+const x = Symbol();
+for (let i = 0; i < testLoopCount; i++) {
+  try {
+      x >= x;
+  } catch {
+      count++;
+  }
+}
+
+shouldBe(count, testLoopCount);

--- a/JSTests/stress/fold-compare-greater-symbols.js
+++ b/JSTests/stress/fold-compare-greater-symbols.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+let count = 0;
+const x = Symbol();
+for (let i = 0; i < testLoopCount; i++) {
+  try {
+      x > x;
+  } catch {
+      count++;
+  }
+}
+
+shouldBe(count, testLoopCount);

--- a/JSTests/stress/fold-compare-less-eq-symbols.js
+++ b/JSTests/stress/fold-compare-less-eq-symbols.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+let count = 0;
+const x = Symbol();
+for (let i = 0; i < testLoopCount; i++) {
+  try {
+      x <= x;
+  } catch {
+      count++;
+  }
+}
+
+shouldBe(count, testLoopCount);

--- a/JSTests/stress/fold-compare-less-symbols.js
+++ b/JSTests/stress/fold-compare-less-symbols.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+let count = 0;
+const x = Symbol();
+for (let i = 0; i < testLoopCount; i++) {
+  try {
+      x < x;
+  } catch {
+      count++;
+  }
+}
+
+shouldBe(count, testLoopCount);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2406,12 +2406,18 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 switch (node->op()) {
                 case CompareLess:
                 case CompareGreater:
+                    // symbol < symbol, symbol > symbol throws TypeError
+                    if (value.isType(SpecSymbol))
+                        break;
                     setConstant(node, jsBoolean(false));
                     break;
                 case CompareLessEq:
                 case CompareGreaterEq: {
                     // null <= null is true, but undefined <= undefined is false.
                     if (value.isType(SpecOther))
+                        break;
+                    // symbol <= symbol, symbol >= symbol throws TypeError
+                    if (value.isType(SpecSymbol))
                         break;
                     [[fallthrough]];
                 }


### PR DESCRIPTION
#### 71cedad38d10fbcb08beaffae8243ceed2afbfb4
<pre>
[JSC] Abstract Interpreter incorrectly optimized comparison nodes into constants when two operands are the same symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=296316">https://bugs.webkit.org/show_bug.cgi?id=296316</a>

Reviewed by Yusuke Suzuki.

According to the specification, symbol &lt; symbol, symbol &gt; symbol, symbol &lt;= symbol,
and symbol &gt;= symbol should throw a TypeError during type conversion to Number[1].

Therefore, the DFG AI should not fold these operations into constants.

[1]: <a href="https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation">https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation</a>

* JSTests/stress/fold-compare-greater-eq-symbols.js: Added.
(shouldBe):
* JSTests/stress/fold-compare-greater-symbols.js: Added.
(shouldBe):
* JSTests/stress/fold-compare-less-eq-symbols.js: Added.
(shouldBe):
* JSTests/stress/fold-compare-less-symbols.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/297910@main">https://commits.webkit.org/297910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77b2a42569167d64badcd248999341328325c807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86289 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20088 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63325 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105893 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122809 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/111980 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95147 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94893 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36601 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40322 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45821 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136204 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39974 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36540 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->