### PR TITLE
[Style] Convert vertical-align property to use strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2803,6 +2803,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/images/StyleObjectPosition.h
 
     style/values/inline/StyleLineBoxContain.h
+    style/values/inline/StyleVerticalAlign.h
 
     style/values/line-grid/StyleWebKitLineGrid.h
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3190,6 +3190,7 @@ style/values/grid/StyleGridTrackBreadth.cpp
 style/values/grid/StyleGridTrackSize.cpp
 style/values/grid/StyleGridTrackSizes.cpp
 style/values/images/StyleGradient.cpp
+style/values/inline/StyleVerticalAlign.cpp
 style/values/lists/StyleListStyleType.cpp
 style/values/masking/StyleClip.cpp
 style/values/masking/StyleClipPath.cpp

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -231,13 +232,13 @@ Color AccessibilityObject::backgroundColor() const
 bool AccessibilityObject::isSubscript() const
 {
     const auto* style = this->style();
-    return style && style->verticalAlign() == VerticalAlign::Sub;
+    return style && WTF::holdsAlternative<CSS::Keyword::Sub>(style->verticalAlign());
 }
 
 bool AccessibilityObject::isSuperscript() const
 {
     const auto* style = this->style();
-    return style && style->verticalAlign() == VerticalAlign::Super;
+    return style && WTF::holdsAlternative<CSS::Keyword::Super>(style->verticalAlign());
 }
 
 bool AccessibilityObject::hasTextShadow() const
@@ -258,13 +259,13 @@ AttributedStringStyle AccessibilityObject::stylesForAttributedString() const
     if (!style)
         return { };
 
-    auto alignment = style->verticalAlign();
+    auto& alignment = style->verticalAlign();
     return {
         fontFrom(*style),
         textColorFrom(*style),
         backgroundColorFrom(*style),
-        alignment == VerticalAlign::Sub,
-        alignment == VerticalAlign::Super,
+        WTF::holdsAlternative<CSS::Keyword::Sub>(alignment),
+        WTF::holdsAlternative<CSS::Keyword::Super>(alignment),
         style->hasTextShadow(),
         lineDecorationStyle()
     };

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2009 Jeff Schiller <codedread@gmail.com>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1338,62 +1339,6 @@ template<> constexpr UserSelect fromCSSValueID(CSSValueID valueID)
     }
     ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
     return UserSelect::Text;
-}
-
-constexpr CSSValueID toCSSValueID(VerticalAlign a)
-{
-    switch (a) {
-    case VerticalAlign::Top:
-        return CSSValueTop;
-    case VerticalAlign::Bottom:
-        return CSSValueBottom;
-    case VerticalAlign::Middle:
-        return CSSValueMiddle;
-    case VerticalAlign::Baseline:
-        return CSSValueBaseline;
-    case VerticalAlign::TextBottom:
-        return CSSValueTextBottom;
-    case VerticalAlign::TextTop:
-        return CSSValueTextTop;
-    case VerticalAlign::Sub:
-        return CSSValueSub;
-    case VerticalAlign::Super:
-        return CSSValueSuper;
-    case VerticalAlign::BaselineMiddle:
-        return CSSValueWebkitBaselineMiddle;
-    case VerticalAlign::Length:
-        return CSSValueInvalid;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return CSSValueInvalid;
-}
-
-template<> constexpr VerticalAlign fromCSSValueID(CSSValueID valueID)
-{
-    switch (valueID) {
-    case CSSValueTop:
-        return VerticalAlign::Top;
-    case CSSValueBottom:
-        return VerticalAlign::Bottom;
-    case CSSValueMiddle:
-        return VerticalAlign::Middle;
-    case CSSValueBaseline:
-        return VerticalAlign::Baseline;
-    case CSSValueTextBottom:
-        return VerticalAlign::TextBottom;
-    case CSSValueTextTop:
-        return VerticalAlign::TextTop;
-    case CSSValueSub:
-        return VerticalAlign::Sub;
-    case CSSValueSuper:
-        return VerticalAlign::Super;
-    case CSSValueWebkitBaselineMiddle:
-        return VerticalAlign::BaselineMiddle;
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return VerticalAlign::Top;
 }
 
 #define TYPE Visibility

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8239,16 +8239,16 @@
             ],
             "codegen-properties": {
                 "accepts-quirky-length": true,
-                "animation-wrapper": "VerticalAlignWrapper",
-                "animation-wrapper-requires-override-parameters": [],
-                "style-builder-custom": "Inherit|Value",
-                "style-extractor-custom": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<VerticalAlign>",
                 "parser-grammar": "<<values>> | <length-percentage>",
                 "parser-grammar-comment": "Current spec has 'vertical-align' specified as a shorthand with grammar '[ first | last] || <<'alignment-baseline'>> || <<'baseline-shift'>>'"
             },
             "specification": {
-                "category": "css-22",
-                "url": "https://www.w3.org/TR/CSS22/visudet.html#propdef-vertical-align"
+                "category": "css-inline",
+                "url": "https://drafts.csswg.org/css-inline/#propdef-vertical-align",
+                "obsolete-category": "css-22",
+                "obsolete-url": "https://www.w3.org/TR/CSS22/visudet.html#propdef-vertical-align"
             }
         },
         "visibility": {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,11 +68,8 @@ public:
     bool hasContent() const { return m_hasContent; }
     void setHasContent();
 
-    struct VerticalAlignment {
-        VerticalAlign type { VerticalAlign::Baseline };
-        std::optional<InlineLayoutUnit> baselineOffset;
-    };
-    VerticalAlignment verticalAlign() const { return m_style.verticalAlignment; }
+    using VerticalAlignment = Variant<CSS::Keyword::Baseline, CSS::Keyword::Sub, CSS::Keyword::Super, CSS::Keyword::Top, CSS::Keyword::TextTop, CSS::Keyword::Middle, CSS::Keyword::Bottom, CSS::Keyword::TextBottom, CSS::Keyword::WebkitBaselineMiddle, InlineLayoutUnit>;
+    const VerticalAlignment& verticalAlign() const { return m_style.verticalAlignment; }
     bool hasLineBoxRelativeAlignment() const;
 
     InlineLayoutUnit preferredLineHeight() const;
@@ -200,8 +198,8 @@ inline InlineLayoutUnit InlineLevelBox::preferredLineHeight() const
 
 inline bool InlineLevelBox::hasLineBoxRelativeAlignment() const
 {
-    auto verticalAlignment = verticalAlign().type;
-    return verticalAlignment == VerticalAlign::Top || verticalAlignment == VerticalAlign::Bottom;
+    return WTF::holdsAlternative<CSS::Keyword::Top>(m_style.verticalAlignment)
+        || WTF::holdsAlternative<CSS::Keyword::Bottom>(m_style.verticalAlignment);
 }
 
 inline void InlineLevelBox::AscentAndDescent::round()
@@ -212,4 +210,3 @@ inline void InlineLevelBox::AscentAndDescent::round()
 
 }
 }
-

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -751,7 +752,7 @@ InlineLayoutUnit LineBoxBuilder::applyTextBoxTrimOnLineBoxIfNeeded(InlineLayoutU
             // When trimming makes the line box move up, bottom aligned boxes has to follow the root inline box.
             // All other boxes can keep their vertical positions relative to the line box top.
             for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
-                if (inlineLevelBox.verticalAlign().type != VerticalAlign::Bottom)
+                if (!WTF::holdsAlternative<CSS::Keyword::Bottom>(inlineLevelBox.verticalAlign()))
                     continue;
                 inlineLevelBox.setLogicalTop(inlineLevelBox.logicalTop() - needToTrimThisMuch);
             }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ InlineLayoutUnit LineBoxVerticalAligner::computeLogicalHeightAndAlign(LineBox& l
         if (rootBox().style().lineBoxContain() != RenderStyle::initialLineBoxContain())
             return false;
         auto& rootInlineBox = lineBox.rootInlineBox();
-        if (!layoutState().inStandardsMode() || rootInlineBox.verticalAlign().type != VerticalAlign::Baseline)
+        if (!layoutState().inStandardsMode() || !WTF::holdsAlternative<CSS::Keyword::Baseline>(rootInlineBox.verticalAlign()))
             return false;
         if (rootInlineBox.hasTextEmphasis())
             return false;
@@ -59,7 +60,7 @@ InlineLayoutUnit LineBoxVerticalAligner::computeLogicalHeightAndAlign(LineBox& l
                     return false;
                 // Baseline aligned, non-stretchy direct children are considered to be simple for now.
                 auto& layoutBox = inlineLevelBox.layoutBox();
-                if (&layoutBox.parent() != &rootInlineBox.layoutBox() || inlineLevelBox.verticalAlign().type != VerticalAlign::Baseline)
+                if (&layoutBox.parent() != &rootInlineBox.layoutBox() || !WTF::holdsAlternative<CSS::Keyword::Baseline>(inlineLevelBox.verticalAlign()))
                     return false;
 
                 if (inlineLevelBox.isAtomicInlineBox()) {
@@ -128,42 +129,53 @@ InlineLayoutUnit LineBoxVerticalAligner::simplifiedVerticalAlignment(LineBox& li
     return lineBoxLogicalBottom - lineBoxLogicalTop;
 }
 
-InlineLayoutUnit LineBoxVerticalAligner::logicalTopOffsetFromParentBaseline(const InlineLevelBox& inlineLevelBox, const InlineLevelBox& parentInlineBox, IsInlineLeveBoxAlignment isInlineLeveBoxAlignment) const
+InlineLayoutUnit LineBoxVerticalAligner::logicalTopOffsetFromParentBaseline(const InlineLevelBox& inlineLevelBox, const InlineLevelBox& parentInlineBox, IsInlineLevelBoxAlignment isInlineLevelBoxAlignment) const
 {
     ASSERT(parentInlineBox.isInlineBox());
 
-    auto verticalAlign = inlineLevelBox.verticalAlign();
-    auto ascent = isInlineLeveBoxAlignment == IsInlineLeveBoxAlignment::Yes ? inlineLevelBox.ascent() : inlineLevelBox.layoutBounds().ascent;
-    auto height = isInlineLeveBoxAlignment == IsInlineLeveBoxAlignment::Yes ? inlineLevelBox.logicalHeight() : inlineLevelBox.layoutBounds().height();
+    auto ascent = isInlineLevelBoxAlignment == IsInlineLevelBoxAlignment::Yes ? inlineLevelBox.ascent() : inlineLevelBox.layoutBounds().ascent;
+    auto height = isInlineLevelBoxAlignment == IsInlineLevelBoxAlignment::Yes ? inlineLevelBox.logicalHeight() : inlineLevelBox.layoutBounds().height();
 
-    switch (verticalAlign.type) {
-    case VerticalAlign::Baseline:
-        return ascent;
-    case VerticalAlign::Middle:
-        return height / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight().value_or(0) / 2;
-    case VerticalAlign::BaselineMiddle:
-        return height / 2;
-    case VerticalAlign::Length:
-        return *verticalAlign.baselineOffset + ascent;
-    case VerticalAlign::TextTop:
-        if (isInlineLeveBoxAlignment == IsInlineLeveBoxAlignment::No)
-            return parentInlineBox.ascent();
-        // Note that text-top aligns with the inline box's font metrics top (ascent) and not the layout bounds top.
-        return parentInlineBox.ascent() + (inlineLevelBox.ascent() - inlineLevelBox.layoutBounds().ascent);
-    case VerticalAlign::TextBottom:
-        if (isInlineLeveBoxAlignment == IsInlineLeveBoxAlignment::No)
-            return height - parentInlineBox.descent();
-        // Note that text-bottom aligns with the inline box's font metrics bottom (descent) and not the layout bounds bottom.
-        return (inlineLevelBox.ascent() + inlineLevelBox.layoutBounds().descent) - parentInlineBox.descent();
-    case VerticalAlign::Sub:
-        return ascent - (parentInlineBox.fontSize() / 5 + 1);
-    case VerticalAlign::Super:
-        return ascent + parentInlineBox.fontSize() / 3 + 1;
-    default:
-        ASSERT_NOT_IMPLEMENTED_YET();
-        break;
-    }
-    return { };
+    return WTF::switchOn(inlineLevelBox.verticalAlign(),
+        [&](const CSS::Keyword::Baseline&) -> InlineLayoutUnit {
+            return ascent;
+        },
+        [&](const CSS::Keyword::Sub&) -> InlineLayoutUnit {
+            return ascent - (parentInlineBox.fontSize() / 5 + 1);
+        },
+        [&](const CSS::Keyword::Super&) -> InlineLayoutUnit {
+            return ascent + parentInlineBox.fontSize() / 3 + 1;
+        },
+        [&](const CSS::Keyword::Top&) -> InlineLayoutUnit {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        },
+        [&](const CSS::Keyword::TextTop&) -> InlineLayoutUnit {
+            if (isInlineLevelBoxAlignment == IsInlineLevelBoxAlignment::No)
+                return parentInlineBox.ascent();
+            // Note that text-top aligns with the inline box's font metrics top (ascent) and not the layout bounds top.
+            return parentInlineBox.ascent() + (inlineLevelBox.ascent() - inlineLevelBox.layoutBounds().ascent);
+        },
+        [&](const CSS::Keyword::Middle&) -> InlineLayoutUnit {
+            return height / 2 + parentInlineBox.primarymetricsOfPrimaryFont().xHeight().value_or(0) / 2;
+        },
+        [&](const CSS::Keyword::Bottom&) -> InlineLayoutUnit {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        },
+        [&](const CSS::Keyword::TextBottom&) -> InlineLayoutUnit {
+            if (isInlineLevelBoxAlignment == IsInlineLevelBoxAlignment::No)
+                return height - parentInlineBox.descent();
+            // Note that text-bottom aligns with the inline box's font metrics bottom (descent) and not the layout bounds bottom.
+            return (inlineLevelBox.ascent() + inlineLevelBox.layoutBounds().descent) - parentInlineBox.descent();
+        },
+        [&](const CSS::Keyword::WebkitBaselineMiddle&) -> InlineLayoutUnit {
+            return height / 2;
+        },
+        [&](const InlineLayoutUnit& baselineOffset) -> InlineLayoutUnit {
+            return baselineOffset + ascent;
+        }
+    );
 }
 
 LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeLineBoxLogicalHeight(LineBox& lineBox) const
@@ -229,11 +241,11 @@ LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeL
             continue;
         // This line box relative aligned inline level box stretches the line box.
         auto inlineLevelBoxHeight = lineBoxRelativeInlineLevelBox->layoutBounds().height();
-        if (lineBoxRelativeInlineLevelBox->verticalAlign().type == VerticalAlign::Top) {
+        if (WTF::holdsAlternative<CSS::Keyword::Top>(lineBoxRelativeInlineLevelBox->verticalAlign())) {
             topAlignedBoxesMaximumHeight = std::max(inlineLevelBoxHeight, topAlignedBoxesMaximumHeight.value_or(0.f));
             continue;
         }
-        if (lineBoxRelativeInlineLevelBox->verticalAlign().type == VerticalAlign::Bottom) {
+        if (WTF::holdsAlternative<CSS::Keyword::Bottom>(lineBoxRelativeInlineLevelBox->verticalAlign())) {
             bottomAlignedBoxesMaximumHeight = std::max(inlineLevelBoxHeight, bottomAlignedBoxesMaximumHeight.value_or(0.f));
             continue;
         }
@@ -263,11 +275,11 @@ void LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition(LineBox& lineB
         auto layoutBounds = inlineLevelBox.layoutBounds();
 
         if (inlineLevelBox.hasLineBoxRelativeAlignment()) {
-            auto verticalAlign = inlineLevelBox.verticalAlign();
-            if (verticalAlign.type == VerticalAlign::Top) {
+            auto& verticalAlign = inlineLevelBox.verticalAlign();
+            if (WTF::holdsAlternative<CSS::Keyword::Top>(verticalAlign)) {
                 hasTopAlignedInlineLevelBox = hasTopAlignedInlineLevelBox || affectsRootInlineBoxVerticalPosition(inlineLevelBox);
                 inlineLevelBoxAbsoluteBaselineOffsetMap.add(&inlineLevelBox, rootInlineBox.layoutBounds().ascent - layoutBounds.ascent);
-            } else if (verticalAlign.type == VerticalAlign::Bottom)
+            } else if (WTF::holdsAlternative<CSS::Keyword::Bottom>(verticalAlign))
                 inlineLevelBoxAbsoluteBaselineOffsetMap.add(&inlineLevelBox, layoutBounds.descent - rootInlineBox.layoutBounds().descent);
             else
                 ASSERT_NOT_REACHED();
@@ -368,7 +380,7 @@ void LineBoxVerticalAligner::alignInlineLevelBoxes(LineBox& lineBox, InlineLayou
             continue;
         }
         auto& parentInlineBox = lineBox.parentInlineBox(inlineLevelBox);
-        auto inlineBoxTopOffsetFromParentBaseline = logicalTopOffsetFromParentBaseline(inlineLevelBox, parentInlineBox, IsInlineLeveBoxAlignment::Yes);
+        auto inlineBoxTopOffsetFromParentBaseline = logicalTopOffsetFromParentBaseline(inlineLevelBox, parentInlineBox, IsInlineLevelBoxAlignment::Yes);
         auto inlineLevelBoxLogicalTop = parentInlineBox.ascent() - inlineBoxTopOffsetFromParentBaseline;
         inlineLevelBox.setLogicalTop(inlineLevelBoxLogicalTop);
     }
@@ -376,31 +388,29 @@ void LineBoxVerticalAligner::alignInlineLevelBoxes(LineBox& lineBox, InlineLayou
     for (auto index : lineBoxRelativeInlineLevelBoxes) {
         auto& inlineLevelBox = nonRootInlineLevelBoxes[index];
         auto logicalTop = InlineLayoutUnit { };
-        switch (inlineLevelBox.verticalAlign().type) {
-        case VerticalAlign::Top: {
-            auto ascent = inlineLevelBox.layoutBounds().ascent;
-            if (inlineLevelBox.isInlineBox()) {
-                if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(nonRootInlineLevelBoxes, index))
-                    ascent = !inlineLevelBox.hasContent() ? descendantsEnclosingGeometry->ascent : std::max(descendantsEnclosingGeometry->ascent, ascent);
+        WTF::switchOn(inlineLevelBox.verticalAlign(),
+            [&](const CSS::Keyword::Top&) {
+                auto ascent = inlineLevelBox.layoutBounds().ascent;
+                if (inlineLevelBox.isInlineBox()) {
+                    if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(nonRootInlineLevelBoxes, index))
+                        ascent = !inlineLevelBox.hasContent() ? descendantsEnclosingGeometry->ascent : std::max(descendantsEnclosingGeometry->ascent, ascent);
+                }
+                // Note that this logical top is not relative to the parent inline box.
+                logicalTop = ascent - inlineLevelBox.ascent();
+            },
+            [&](const CSS::Keyword::Bottom&) {
+                auto descent = inlineLevelBox.layoutBounds().descent;
+                if (inlineLevelBox.isInlineBox()) {
+                    if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(nonRootInlineLevelBoxes, index))
+                        descent = !inlineLevelBox.hasContent() ? descendantsEnclosingGeometry->descent : std::max(descendantsEnclosingGeometry->descent, descent);
+                }
+                // Note that this logical top is not relative to the parent inline box.
+                logicalTop = lineBoxLogicalHeight - (inlineLevelBox.ascent() + descent);
+            },
+            [](const auto&) {
+                ASSERT_NOT_REACHED();
             }
-            // Note that this logical top is not relative to the parent inline box.
-            logicalTop = ascent - inlineLevelBox.ascent();
-            break;
-        }
-        case VerticalAlign::Bottom: {
-            auto descent = inlineLevelBox.layoutBounds().descent;
-            if (inlineLevelBox.isInlineBox()) {
-                if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(nonRootInlineLevelBoxes, index))
-                    descent = !inlineLevelBox.hasContent() ? descendantsEnclosingGeometry->descent : std::max(descendantsEnclosingGeometry->descent, descent);
-            }
-            // Note that this logical top is not relative to the parent inline box.
-            logicalTop = lineBoxLogicalHeight - (inlineLevelBox.ascent() + descent);
-            break;
-        }
-        default:
-            ASSERT_NOT_REACHED();
-            break;
-        }
+        );
         inlineLevelBox.setLogicalTop(logicalTop);
     }
 }
@@ -416,31 +426,47 @@ InlineLayoutUnit LineBoxVerticalAligner::adjustForAnnotationIfNeeded(LineBox& li
             auto inlineBoxTop = lineBox.inlineLevelBoxAbsoluteTop(inlineLevelBox);
             auto inlineBoxBottom = inlineBoxTop + inlineLevelBox.logicalHeight();
 
-            switch (inlineLevelBox.verticalAlign().type) {
-            case VerticalAlign::Baseline:
-            case VerticalAlign::Middle:
-            case VerticalAlign::BaselineMiddle:
-            case VerticalAlign::Length:
-            case VerticalAlign::Sub:
-            case VerticalAlign::Super:
-            case VerticalAlign::TextTop:
-            case VerticalAlign::TextBottom:
-            case VerticalAlign::Bottom:
+            auto defaultCase = [&] {
                 if (auto aboveSpace = inlineLevelBox.textEmphasisAbove())
                     lineBoxTop = std::min(lineBoxTop, inlineBoxTop - *aboveSpace);
                 if (auto belowSpace = inlineLevelBox.textEmphasisBelow())
                     lineBoxBottom = std::max(lineBoxBottom, inlineBoxBottom + *belowSpace);
-                break;
-            case VerticalAlign::Top: {
-                // FIXME: Check if horizontal vs. vertical writing mode should be taking into account.
-                auto annotationSpace = inlineLevelBox.textEmphasisAbove().value_or(0.f) + inlineLevelBox.textEmphasisBelow().value_or(0.f);
-                lineBoxBottom = std::max(lineBoxBottom, inlineBoxBottom + annotationSpace);
-                break;
-            }
-            default:
-                ASSERT_NOT_IMPLEMENTED_YET();
-                break;
-            }
+            };
+
+            WTF::switchOn(inlineLevelBox.verticalAlign(),
+                [&](const CSS::Keyword::Baseline&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::Sub&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::Super&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::Top&) {
+                    // FIXME: Check if horizontal vs. vertical writing mode should be taking into account.
+                    auto annotationSpace = inlineLevelBox.textEmphasisAbove().value_or(0.f) + inlineLevelBox.textEmphasisBelow().value_or(0.f);
+                    lineBoxBottom = std::max(lineBoxBottom, inlineBoxBottom + annotationSpace);
+                },
+                [&](const CSS::Keyword::TextTop&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::Middle&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::Bottom&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::TextBottom&) {
+                    defaultCase();
+                },
+                [&](const CSS::Keyword::WebkitBaselineMiddle&) {
+                    defaultCase();
+                },
+                [&](const InlineLayoutUnit&) {
+                    defaultCase();
+                }
+            );
         };
 
         adjustLineBoxTopAndBottomForInlineBox(lineBox.rootInlineBox());
@@ -462,21 +488,19 @@ InlineLayoutUnit LineBoxVerticalAligner::adjustForAnnotationIfNeeded(LineBox& li
             rootInlineBox.setLogicalTop(annotationOffset + rootInlineBoxTop);
 
             for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
-                switch (inlineLevelBox.verticalAlign().type) {
-                case VerticalAlign::Top: {
-                    auto inlineBoxTop = inlineLevelBox.layoutBounds().ascent - inlineLevelBox.ascent();
-                    inlineLevelBox.setLogicalTop(inlineLevelBox.textEmphasisAbove().value_or(0.f) + inlineBoxTop);
-                    break;
-                }
-                case VerticalAlign::Bottom: {
-                    auto inlineBoxTop = adjustedLineBoxHeight - (inlineLevelBox.layoutBounds().descent + inlineLevelBox.ascent());
-                    inlineLevelBox.setLogicalTop(inlineBoxTop - inlineLevelBox.textEmphasisBelow().value_or(0.f));
-                    break;
-                }
-                default:
-                    // These alignment positions are relative to the root inline box's baseline.
-                    break;
-                }
+                WTF::switchOn(inlineLevelBox.verticalAlign(),
+                    [&](const CSS::Keyword::Top&) {
+                        auto inlineBoxTop = inlineLevelBox.layoutBounds().ascent - inlineLevelBox.ascent();
+                        inlineLevelBox.setLogicalTop(inlineLevelBox.textEmphasisAbove().value_or(0.f) + inlineBoxTop);
+                    },
+                    [&](const CSS::Keyword::Bottom&) {
+                        auto inlineBoxTop = adjustedLineBoxHeight - (inlineLevelBox.layoutBounds().descent + inlineLevelBox.ascent());
+                        inlineLevelBox.setLogicalTop(inlineBoxTop - inlineLevelBox.textEmphasisBelow().value_or(0.f));
+                    },
+                    [](const auto&) {
+                        // These alignment positions are relative to the root inline box's baseline.
+                    }
+                );
             }
         };
         adjustContentTopWithAnnotationSpace();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,8 +56,8 @@ private:
     void alignInlineLevelBoxes(LineBox&, InlineLayoutUnit lineBoxLogicalHeight) const;
     InlineLayoutUnit adjustForAnnotationIfNeeded(LineBox&, InlineLayoutUnit lineBoxHeight) const;
     std::optional<InlineLevelBox::AscentAndDescent> layoutBoundsForInlineBoxSubtree(const LineBox::InlineLevelBoxList& nonRootInlineLevelBoxes, size_t inlineBoxIndex) const;
-    enum class IsInlineLeveBoxAlignment : bool { No, Yes };
-    InlineLayoutUnit logicalTopOffsetFromParentBaseline(const InlineLevelBox&, const InlineLevelBox& parentInlineBox, IsInlineLeveBoxAlignment = IsInlineLeveBoxAlignment::No) const;
+    enum class IsInlineLevelBoxAlignment : bool { No, Yes };
+    InlineLayoutUnit logicalTopOffsetFromParentBaseline(const InlineLevelBox&, const InlineLevelBox& parentInlineBox, IsInlineLevelBoxAlignment = IsInlineLevelBoxAlignment::No) const;
 
     const InlineFormattingUtils& formattingUtils() const { return formattingContext().formattingUtils(); }
     const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -127,24 +128,22 @@ void TableFormattingContext::setUsedGeometryForCells(LayoutUnit availableHorizon
             auto intrinsicPaddingTop = LayoutUnit { };
             auto intrinsicPaddingBottom = LayoutUnit { };
 
-            switch (cellBox.style().verticalAlign()) {
-            case VerticalAlign::Middle: {
-                auto intrinsicVerticalPadding = std::max(0_lu, cellLogicalHeight - cellBoxGeometry.verticalMarginBorderAndPadding() - cellBoxGeometry.contentBoxHeight());
-                intrinsicPaddingTop = intrinsicVerticalPadding / 2;
-                intrinsicPaddingBottom = intrinsicVerticalPadding / 2;
-                break;
-            }
-            case VerticalAlign::Baseline: {
-                auto rowBaseline = LayoutUnit { rowList[cell->startRow()].baseline() };
-                auto cellBaseline = LayoutUnit { cell->baseline() };
-                intrinsicPaddingTop = std::max(0_lu, rowBaseline - cellBaseline - cellBoxGeometry.borderBefore());
-                intrinsicPaddingBottom = std::max(0_lu, cellLogicalHeight - cellBoxGeometry.verticalMarginBorderAndPadding() - intrinsicPaddingTop - cellBoxGeometry.contentBoxHeight());
-                break;
-            }
-            default:
-                ASSERT_NOT_IMPLEMENTED_YET();
-                break;
-            }
+            WTF::switchOn(cellBox.style().verticalAlign(),
+                [&](const CSS::Keyword::Middle&) {
+                    auto intrinsicVerticalPadding = std::max(0_lu, cellLogicalHeight - cellBoxGeometry.verticalMarginBorderAndPadding() - cellBoxGeometry.contentBoxHeight());
+                    intrinsicPaddingTop = intrinsicVerticalPadding / 2;
+                    intrinsicPaddingBottom = intrinsicVerticalPadding / 2;
+                },
+                [&](const CSS::Keyword::Baseline&) {
+                    auto rowBaseline = LayoutUnit { rowList[cell->startRow()].baseline() };
+                    auto cellBaseline = LayoutUnit { cell->baseline() };
+                    intrinsicPaddingTop = std::max(0_lu, rowBaseline - cellBaseline - cellBoxGeometry.borderBefore());
+                    intrinsicPaddingBottom = std::max(0_lu, cellLogicalHeight - cellBoxGeometry.verticalMarginBorderAndPadding() - intrinsicPaddingTop - cellBoxGeometry.contentBoxHeight());
+                },
+                [&](const auto&) {
+                    ASSERT_NOT_IMPLEMENTED_YET();
+                }
+            );
             if (intrinsicPaddingTop && cellBox.hasInFlowOrFloatingChild()) {
                 auto adjustCellContentWithInstrinsicPaddingBefore = [&] {
                     // Child boxes (and runs) are always in the coordinate system of the containing block's border box.

--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -418,7 +419,7 @@ TableFormattingContext::TableLayout::DistributedSpaces TableFormattingContext::T
             auto& cell = slot.cell();
             auto& cellBox = cell.box();
             auto height = formattingContext().geometryForBox(cellBox).borderBoxHeight();
-            if (cellBox.style().verticalAlign() == VerticalAlign::Baseline) {
+            if (WTF::holdsAlternative<CSS::Keyword::Baseline>(cellBox.style().verticalAlign())) {
                 maximumColumnAscent = std::max(maximumColumnAscent, cell.baseline());
                 maximumColumnDescent = std::max(maximumColumnDescent, height - cell.baseline());
                 rowHeight[rowIndex] = std::max(rowHeight[rowIndex], LayoutUnit { maximumColumnAscent + maximumColumnDescent });

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -215,7 +216,7 @@ public:
 
     const RenderStyle& lineStyle() const { return m_bitfields.firstLine() ? renderer().firstLineStyle() : renderer().style(); }
     
-    VerticalAlign verticalAlign() const { return lineStyle().verticalAlign(); }
+    const Style::VerticalAlign& verticalAlign() const { return lineStyle().verticalAlign(); }
 
     // Use with caution! The type is not checked!
     RenderBoxModelObject* boxModelObject() const

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -3,6 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -210,8 +211,8 @@ bool RenderInline::mayAffectLayout() const
     auto hasHardLineBreakChildOnly = firstChild() && firstChild() == lastChild() && firstChild()->isBR();
     bool checkFonts = document().inNoQuirksMode();
     auto mayAffectLayout = (parentRenderInline && parentRenderInline->mayAffectLayout())
-        || (parentRenderInline && parentStyle->verticalAlign() != VerticalAlign::Baseline)
-        || style().verticalAlign() != VerticalAlign::Baseline
+        || (parentRenderInline && !WTF::holdsAlternative<CSS::Keyword::Baseline>(parentStyle->verticalAlign()))
+        || !WTF::holdsAlternative<CSS::Keyword::Baseline>(style().verticalAlign())
         || !style().textEmphasisStyle().isNone()
         || (checkFonts && (!parentStyle->fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(style().fontCascade().metricsOfPrimaryFont())
         || parentStyle->lineHeight() != style().lineHeight()))
@@ -222,7 +223,7 @@ bool RenderInline::mayAffectLayout() const
         parentStyle = &parent()->firstLineStyle();
         auto& childStyle = firstLineStyle();
         mayAffectLayout = !parentStyle->fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(childStyle.fontCascade().metricsOfPrimaryFont())
-            || childStyle.verticalAlign() != VerticalAlign::Baseline
+            || !WTF::holdsAlternative<CSS::Keyword::Baseline>(childStyle.verticalAlign())
             || parentStyle->lineHeight() != childStyle.lineHeight();
     }
     return mayAffectLayout;

--- a/Source/WebCore/rendering/RenderTableCellInlines.h
+++ b/Source/WebCore/rendering/RenderTableCellInlines.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -79,8 +80,13 @@ inline bool RenderTableCell::isBaselineAligned() const
     if (auto alignContent = style().alignContent(); !alignContent.isNormal())
         return alignContent.position() == ContentPosition::Baseline;
 
-    VerticalAlign va = style().verticalAlign();
-    return va == VerticalAlign::Baseline || va == VerticalAlign::TextBottom || va == VerticalAlign::TextTop || va == VerticalAlign::Super || va == VerticalAlign::Sub || va == VerticalAlign::Length;
+    auto& verticalAlign = style().verticalAlign();
+    return WTF::holdsAlternative<CSS::Keyword::Baseline>(verticalAlign)
+        || WTF::holdsAlternative<CSS::Keyword::TextBottom>(verticalAlign)
+        || WTF::holdsAlternative<CSS::Keyword::TextTop>(verticalAlign)
+        || WTF::holdsAlternative<CSS::Keyword::Super>(verticalAlign)
+        || WTF::holdsAlternative<CSS::Keyword::Sub>(verticalAlign)
+        || WTF::holdsAlternative<Style::VerticalAlign::Length>(verticalAlign);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -997,8 +997,7 @@ bool RenderStyle::changeRequiresLayout(const RenderStyle& other, OptionSet<Style
                 || m_nonInheritedData->boxData->maxHeight() != other.m_nonInheritedData->boxData->maxHeight())
                 return true;
 
-            if (m_nonInheritedData->boxData->verticalAlign() != other.m_nonInheritedData->boxData->verticalAlign()
-                || m_nonInheritedData->boxData->verticalAlignLength() != other.m_nonInheritedData->boxData->verticalAlignLength())
+            if (m_nonInheritedData->boxData->verticalAlign() != other.m_nonInheritedData->boxData->verticalAlign())
                 return true;
 
             if (m_nonInheritedData->boxData->boxSizing() != other.m_nonInheritedData->boxData->boxSizing())
@@ -1637,7 +1636,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyMinHeight);
         if (first.maxHeight() != second.maxHeight())
             changingProperties.m_properties.set(CSSPropertyMaxHeight);
-        if (first.verticalAlign() != second.verticalAlign() || first.verticalAlignLength() != second.verticalAlignLength())
+        if (first.verticalAlign() != second.verticalAlign())
             changingProperties.m_properties.set(CSSPropertyVerticalAlign);
         if (first.specifiedZIndex() != second.specifiedZIndex() || first.hasAutoSpecifiedZIndex() != second.hasAutoSpecifiedZIndex())
             changingProperties.m_properties.set(CSSPropertyZIndex);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -225,7 +225,6 @@ enum class UsedFloat : uint8_t;
 enum class UserDrag : uint8_t;
 enum class UserModify : uint8_t;
 enum class UserSelect : uint8_t;
-enum class VerticalAlign : uint8_t;
 enum class Visibility : uint8_t;
 enum class WhiteSpace : uint8_t;
 enum class WhiteSpaceCollapse : uint8_t;
@@ -337,6 +336,7 @@ struct TextSizeAdjust;
 struct TextUnderlineOffset;
 struct TransformOrigin;
 struct Translate;
+struct VerticalAlign;
 struct ViewTimelineInsets;
 struct ViewTimelines;
 struct ViewTransitionClasses;
@@ -661,8 +661,7 @@ public:
     Visibility visibility() const { return static_cast<Visibility>(m_inheritedFlags.visibility); }
     inline Visibility usedVisibility() const;
 
-    VerticalAlign verticalAlign() const;
-    const Length& verticalAlignLength() const;
+    const Style::VerticalAlign& verticalAlign() const;
 
     inline const Style::Clip& clip() const;
     inline bool hasClip() const;
@@ -1327,8 +1326,7 @@ public:
     inline void setOverscrollBehaviorX(OverscrollBehavior);
     inline void setOverscrollBehaviorY(OverscrollBehavior);
     void setVisibility(Visibility v) { m_inheritedFlags.visibility = static_cast<unsigned>(v); }
-    void setVerticalAlign(VerticalAlign);
-    void setVerticalAlignLength(Length&&);
+    void setVerticalAlign(Style::VerticalAlign&&);
 
     inline void setClip(Style::Clip&&);
 
@@ -1951,7 +1949,7 @@ public:
     static constexpr DisplayType initialDisplay();
     static constexpr UnicodeBidi initialUnicodeBidi();
     static constexpr PositionType initialPosition();
-    static constexpr VerticalAlign initialVerticalAlign();
+    static inline Style::VerticalAlign initialVerticalAlign();
     static constexpr Float initialFloating();
     static constexpr BreakBetween initialBreakBetween();
     static constexpr BreakInside initialBreakInside();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1419,23 +1419,6 @@ TextStream& operator<<(TextStream& ts, UserSelect userSelect)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, VerticalAlign verticalAlign)
-{
-    switch (verticalAlign) {
-    case VerticalAlign::Baseline: ts << "baseline"_s; break;
-    case VerticalAlign::Middle: ts << "middle"_s; break;
-    case VerticalAlign::Sub: ts << "sub"_s; break;
-    case VerticalAlign::Super: ts << "super"_s; break;
-    case VerticalAlign::TextTop: ts << "text-top"_s; break;
-    case VerticalAlign::TextBottom: ts << "text-bottom"_s; break;
-    case VerticalAlign::Top: ts << "top"_s; break;
-    case VerticalAlign::Bottom: ts << "bottom"_s; break;
-    case VerticalAlign::BaselineMiddle: ts << "baseline-middle"_s; break;
-    case VerticalAlign::Length: ts << "length"_s; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, Visibility visibility)
 {
     switch (visibility) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -305,19 +305,6 @@ enum class Overflow : uint8_t {
     PagedY
 };
 
-enum class VerticalAlign : uint8_t {
-    Baseline,
-    Middle,
-    Sub,
-    Super,
-    TextTop,
-    TextBottom,
-    Top,
-    Bottom,
-    BaselineMiddle,
-    Length
-};
-
 enum class Clear : uint8_t {
     None,
     Left,
@@ -1360,7 +1347,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, TransformStyle3D);
 WTF::TextStream& operator<<(WTF::TextStream&, UserDrag);
 WTF::TextStream& operator<<(WTF::TextStream&, UserModify);
 WTF::TextStream& operator<<(WTF::TextStream&, UserSelect);
-WTF::TextStream& operator<<(WTF::TextStream&, VerticalAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, Visibility);
 WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpace);
 WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpaceCollapse);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -532,7 +532,7 @@ constexpr UnicodeBidi RenderStyle::initialUnicodeBidi() { return UnicodeBidi::No
 constexpr UserDrag RenderStyle::initialUserDrag() { return UserDrag::Auto; }
 constexpr UserModify RenderStyle::initialUserModify() { return UserModify::ReadOnly; }
 constexpr UserSelect RenderStyle::initialUserSelect() { return UserSelect::Text; }
-constexpr VerticalAlign RenderStyle::initialVerticalAlign() { return VerticalAlign::Baseline; }
+inline Style::VerticalAlign RenderStyle::initialVerticalAlign() { return CSS::Keyword::Baseline { }; }
 inline Style::ProgressTimelineAxes RenderStyle::initialViewTimelineAxes() { return CSS::Keyword::Block { };}
 inline Style::ViewTimelineInsets RenderStyle::initialViewTimelineInsets() { return CSS::Keyword::Auto { };}
 inline Style::ProgressTimelineNames RenderStyle::initialViewTimelineNames() { return CSS::Keyword::None { }; }
@@ -773,8 +773,7 @@ inline int RenderStyle::usedZIndex() const { return m_nonInheritedData->boxData-
 inline UserDrag RenderStyle::userDrag() const { return static_cast<UserDrag>(m_nonInheritedData->miscData->userDrag); }
 inline UserModify RenderStyle::userModify() const { return static_cast<UserModify>(m_rareInheritedData->userModify); }
 inline UserSelect RenderStyle::userSelect() const { return static_cast<UserSelect>(m_rareInheritedData->userSelect); }
-inline VerticalAlign RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
-inline const Length& RenderStyle::verticalAlignLength() const { return m_nonInheritedData->boxData->verticalAlignLength(); }
+inline const Style::VerticalAlign& RenderStyle::verticalAlign() const { return m_nonInheritedData->boxData->verticalAlign(); }
 inline const Style::ViewTransitionClasses& RenderStyle::viewTransitionClasses() const { return m_nonInheritedData->rareData->viewTransitionClasses; }
 inline const Style::ViewTransitionName& RenderStyle::viewTransitionName() const { return m_nonInheritedData->rareData->viewTransitionName; }
 inline const Style::Color& RenderStyle::visitedLinkBackgroundColor() const { return m_nonInheritedData->miscData->visitedLinkColor->background; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -276,6 +276,7 @@ inline void RenderStyle::setScale(Style::Scale&& scale) { SET_NESTED(m_nonInheri
 inline void RenderStyle::setScrollBehavior(Style::ScrollBehavior behavior) { SET_NESTED(m_nonInheritedData, rareData, scrollBehavior, static_cast<unsigned>(behavior)); }
 inline void RenderStyle::setScrollTimelineAxes(Style::ProgressTimelineAxes&& axes) { SET_NESTED(m_nonInheritedData, rareData, scrollTimelineAxes, WTFMove(axes)); }
 inline void RenderStyle::setScrollTimelineNames(Style::ProgressTimelineNames&& names) { SET_NESTED(m_nonInheritedData, rareData, scrollTimelineNames, WTFMove(names)); }
+inline void RenderStyle::setVerticalAlign(Style::VerticalAlign&& align) { SET_NESTED(m_nonInheritedData, boxData, m_verticalAlign, WTFMove(align)); }
 inline void RenderStyle::setViewTimelineAxes(Style::ProgressTimelineAxes&& axes) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineAxes, WTFMove(axes)); }
 inline void RenderStyle::setViewTimelineInsets(Style::ViewTimelineInsets&& insets) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineInsets, WTFMove(insets)); }
 inline void RenderStyle::setViewTimelineNames(Style::ProgressTimelineNames&& names) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineNames, WTFMove(names)); }
@@ -611,17 +612,6 @@ inline bool RenderStyle::setTextOrientation(TextOrientation textOrientation)
         return false;
     m_inheritedFlags.writingMode.setTextOrientation(textOrientation);
     return true;
-}
-
-inline void RenderStyle::setVerticalAlign(VerticalAlign align)
-{
-    SET_NESTED(m_nonInheritedData, boxData, m_verticalAlign, static_cast<unsigned>(align));
-}
-
-inline void RenderStyle::setVerticalAlignLength(Length&& length)
-{
-    setVerticalAlign(VerticalAlign::Length);
-    SET_NESTED(m_nonInheritedData, boxData, m_verticalAlignLength, WTFMove(length));
 }
 
 inline void RenderStyle::setWidows(unsigned short count)

--- a/Source/WebCore/rendering/style/StyleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleBoxData.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -29,11 +30,11 @@
 namespace WebCore {
 
 struct SameSizeAsStyleBoxData : public RefCounted<SameSizeAsStyleBoxData> {
-    Length length[7];
+    Length length[6];
+    Style::VerticalAlign verticalAlign;
+    uint8_t bitfield;
     int m_zIndex[2];
-    uint32_t bitfields;
 };
-
 static_assert(sizeof(StyleBoxData) == sizeof(SameSizeAsStyleBoxData), "StyleBoxData should not grow");
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleBoxData);
@@ -45,13 +46,13 @@ StyleBoxData::StyleBoxData()
     , m_maxWidth(RenderStyle::initialMaxSize())
     , m_minHeight(RenderStyle::initialMinSize())
     , m_maxHeight(RenderStyle::initialMaxSize())
-    , m_specifiedZIndex(0)
-    , m_usedZIndex(0)
+    , m_verticalAlign(RenderStyle::initialVerticalAlign())
     , m_hasAutoSpecifiedZIndex(true)
     , m_hasAutoUsedZIndex(true)
     , m_boxSizing(static_cast<unsigned>(BoxSizing::ContentBox))
     , m_boxDecorationBreak(static_cast<unsigned>(BoxDecorationBreak::Slice))
-    , m_verticalAlign(static_cast<unsigned>(RenderStyle::initialVerticalAlign()))
+    , m_specifiedZIndex(0)
+    , m_usedZIndex(0)
 {
 }
 
@@ -63,14 +64,13 @@ inline StyleBoxData::StyleBoxData(const StyleBoxData& o)
     , m_maxWidth(o.m_maxWidth)
     , m_minHeight(o.m_minHeight)
     , m_maxHeight(o.m_maxHeight)
-    , m_verticalAlignLength(o.m_verticalAlignLength)
-    , m_specifiedZIndex(o.m_specifiedZIndex)
-    , m_usedZIndex(o.m_usedZIndex)
+    , m_verticalAlign(o.m_verticalAlign)
     , m_hasAutoSpecifiedZIndex(o.m_hasAutoSpecifiedZIndex)
     , m_hasAutoUsedZIndex(o.m_hasAutoUsedZIndex)
     , m_boxSizing(o.m_boxSizing)
     , m_boxDecorationBreak(o.m_boxDecorationBreak)
-    , m_verticalAlign(o.m_verticalAlign)
+    , m_specifiedZIndex(o.m_specifiedZIndex)
+    , m_usedZIndex(o.m_usedZIndex)
 {
 }
 
@@ -87,14 +87,13 @@ bool StyleBoxData::operator==(const StyleBoxData& o) const
         && m_maxWidth == o.m_maxWidth
         && m_minHeight == o.m_minHeight
         && m_maxHeight == o.m_maxHeight
-        && m_verticalAlignLength == o.m_verticalAlignLength
-        && m_specifiedZIndex == o.m_specifiedZIndex
-        && m_hasAutoSpecifiedZIndex == o.m_hasAutoSpecifiedZIndex
+        && m_verticalAlign == o.m_verticalAlign
         && m_usedZIndex == o.m_usedZIndex
         && m_hasAutoUsedZIndex == o.m_hasAutoUsedZIndex
         && m_boxSizing == o.m_boxSizing
         && m_boxDecorationBreak == o.m_boxDecorationBreak
-        && m_verticalAlign == o.m_verticalAlign;
+        && m_specifiedZIndex == o.m_specifiedZIndex
+        && m_hasAutoSpecifiedZIndex == o.m_hasAutoSpecifiedZIndex;
 }
 
 #if !LOG_DISABLED
@@ -109,17 +108,16 @@ void StyleBoxData::dumpDifferences(TextStream& ts, const StyleBoxData& other) co
     LOG_IF_DIFFERENT(m_minHeight);
     LOG_IF_DIFFERENT(m_maxHeight);
 
-    LOG_IF_DIFFERENT(m_verticalAlignLength);
-
-    LOG_IF_DIFFERENT(m_specifiedZIndex);
-    LOG_IF_DIFFERENT(m_usedZIndex);
+    LOG_IF_DIFFERENT(m_verticalAlign);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, m_hasAutoSpecifiedZIndex);
     LOG_IF_DIFFERENT_WITH_CAST(bool, m_hasAutoUsedZIndex);
 
     LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, m_boxSizing);
     LOG_IF_DIFFERENT_WITH_CAST(BoxDecorationBreak, m_boxDecorationBreak);
-    LOG_IF_DIFFERENT_WITH_CAST(VerticalAlign, m_verticalAlign);
+
+    LOG_IF_DIFFERENT(m_specifiedZIndex);
+    LOG_IF_DIFFERENT(m_usedZIndex);
 }
 #endif
 

--- a/Source/WebCore/rendering/style/StyleBoxData.h
+++ b/Source/WebCore/rendering/style/StyleBoxData.h
@@ -4,6 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003, 2005, 2006, 2007, 2008 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -29,6 +30,7 @@
 #include "StyleMaximumSize.h"
 #include "StyleMinimumSize.h"
 #include "StylePreferredSize.h"
+#include "StyleVerticalAlign.h"
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -60,7 +62,7 @@ public:
     const Style::MaximumSize& maxWidth() const { return m_maxWidth; }
     const Style::MaximumSize& maxHeight() const { return m_maxHeight; }
     
-    const Length& verticalAlignLength() const { return m_verticalAlignLength; }
+    const Style::VerticalAlign& verticalAlign() const { return m_verticalAlign; }
     
     int specifiedZIndex() const { return m_specifiedZIndex; }
     bool hasAutoSpecifiedZIndex() const { return m_hasAutoSpecifiedZIndex; }
@@ -70,7 +72,6 @@ public:
 
     BoxSizing boxSizing() const { return static_cast<BoxSizing>(m_boxSizing); }
     BoxDecorationBreak boxDecorationBreak() const { return static_cast<BoxDecorationBreak>(m_boxDecorationBreak); }
-    VerticalAlign verticalAlign() const { return static_cast<VerticalAlign>(m_verticalAlign); }
 
 private:
     friend class RenderStyle;
@@ -87,15 +88,15 @@ private:
     Style::MinimumSize m_minHeight;
     Style::MaximumSize m_maxHeight;
 
-    Length m_verticalAlignLength;
+    Style::VerticalAlign m_verticalAlign;
+
+    PREFERRED_TYPE(bool) uint8_t m_hasAutoSpecifiedZIndex : 1;
+    PREFERRED_TYPE(bool) uint8_t m_hasAutoUsedZIndex : 1;
+    PREFERRED_TYPE(BoxSizing) uint8_t m_boxSizing : 1;
+    PREFERRED_TYPE(BoxDecorationBreak) uint8_t m_boxDecorationBreak : 1;
 
     int m_specifiedZIndex;
     int m_usedZIndex;
-    PREFERRED_TYPE(bool) unsigned m_hasAutoSpecifiedZIndex : 1;
-    PREFERRED_TYPE(bool) unsigned m_hasAutoUsedZIndex : 1;
-    PREFERRED_TYPE(BoxSizing) unsigned m_boxSizing : 1;
-    PREFERRED_TYPE(BoxDecorationBreak) unsigned m_boxDecorationBreak : 1;
-    PREFERRED_TYPE(VerticalAlign) unsigned m_verticalAlign : 4;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -142,6 +142,7 @@ inline FixedVector<PositionTryFallback> forwardInheritedValue(const FixedVector<
 inline ProgressTimelineAxes forwardInheritedValue(const ProgressTimelineAxes& value) { auto copy = value; return copy; }
 inline ProgressTimelineNames forwardInheritedValue(const ProgressTimelineNames& value) { auto copy = value; return copy; }
 inline ScrollTimelines forwardInheritedValue(const ScrollTimelines& value) { auto copy = value; return copy; }
+inline VerticalAlign forwardInheritedValue(const VerticalAlign& value) { auto copy = value; return copy; }
 inline ViewTimelineInsets forwardInheritedValue(const ViewTimelineInsets& value) { auto copy = value; return copy; }
 inline ViewTimelines forwardInheritedValue(const ViewTimelines& value) { auto copy = value; return copy; }
 inline ViewTransitionClasses forwardInheritedValue(const ViewTransitionClasses& value) { auto copy = value; return copy; }
@@ -191,10 +192,6 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(OutlineStyle);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Stroke);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Zoom);
-
-    // Custom handling of inherit + value setting only.
-    static void applyInheritVerticalAlign(BuilderState&);
-    static void applyValueVerticalAlign(BuilderState&, CSSValue&);
 
     // Custom handling of inherit setting only.
     static void applyInheritWordSpacing(BuilderState&);
@@ -273,20 +270,6 @@ inline void BuilderCustom::applyValueZoom(BuilderState& builderState, CSSValue& 
         if (float number = primitiveValue->resolveAsNumber<float>(builderState.cssToLengthConversionData()))
             builderState.setZoom(number);
     }
-}
-
-inline void BuilderCustom::applyInheritVerticalAlign(BuilderState& builderState)
-{
-    builderState.style().setVerticalAlignLength(forwardInheritedValue(builderState.parentStyle().verticalAlignLength()));
-    builderState.style().setVerticalAlign(forwardInheritedValue(builderState.parentStyle().verticalAlign()));
-}
-
-inline void BuilderCustom::applyValueVerticalAlign(BuilderState& builderState, CSSValue& value)
-{
-    if (auto valueID = value.valueID(); valueID != CSSValueInvalid)
-        builderState.style().setVerticalAlign(fromCSSValueID<VerticalAlign>(valueID));
-    else
-        builderState.style().setVerticalAlignLength(BuilderConverter::convertLength(builderState, value));
 }
 
 enum BorderImageType { BorderImage, MaskBorder };

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -51,7 +51,6 @@ public:
     static Ref<CSSValue> extractWritingMode(ExtractorState&);
     static Ref<CSSValue> extractFloat(ExtractorState&);
     static Ref<CSSValue> extractContent(ExtractorState&);
-    static Ref<CSSValue> extractVerticalAlign(ExtractorState&);
     static Ref<CSSValue> extractLetterSpacing(ExtractorState&);
     static Ref<CSSValue> extractWordSpacing(ExtractorState&);
     static Ref<CSSValue> extractLineHeight(ExtractorState&);
@@ -150,7 +149,6 @@ public:
     static void extractWritingModeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractFloatSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractContentSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
-    static void extractVerticalAlignSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractLetterSpacingSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractWordSpacingSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractLineHeightSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1261,70 +1259,6 @@ inline Ref<CSSValue> ExtractorCustom::extractContent(ExtractorState& state)
 inline void ExtractorCustom::extractContentSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     extractSerialization<CSSPropertyContent>(state, builder, context);
-}
-
-inline Ref<CSSValue> ExtractorCustom::extractVerticalAlign(ExtractorState& state)
-{
-    switch (state.style.verticalAlign()) {
-    case VerticalAlign::Baseline:
-        return CSSPrimitiveValue::create(CSSValueBaseline);
-    case VerticalAlign::Middle:
-        return CSSPrimitiveValue::create(CSSValueMiddle);
-    case VerticalAlign::Sub:
-        return CSSPrimitiveValue::create(CSSValueSub);
-    case VerticalAlign::Super:
-        return CSSPrimitiveValue::create(CSSValueSuper);
-    case VerticalAlign::TextTop:
-        return CSSPrimitiveValue::create(CSSValueTextTop);
-    case VerticalAlign::TextBottom:
-        return CSSPrimitiveValue::create(CSSValueTextBottom);
-    case VerticalAlign::Top:
-        return CSSPrimitiveValue::create(CSSValueTop);
-    case VerticalAlign::Bottom:
-        return CSSPrimitiveValue::create(CSSValueBottom);
-    case VerticalAlign::BaselineMiddle:
-        return CSSPrimitiveValue::create(CSSValueWebkitBaselineMiddle);
-    case VerticalAlign::Length:
-        return ExtractorConverter::convertLength(state, state.style.verticalAlignLength());
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline void ExtractorCustom::extractVerticalAlignSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
-{
-    switch (state.style.verticalAlign()) {
-    case VerticalAlign::Baseline:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Baseline { });
-        return;
-    case VerticalAlign::Middle:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Middle { });
-        return;
-    case VerticalAlign::Sub:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Sub { });
-        return;
-    case VerticalAlign::Super:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Super { });
-        return;
-    case VerticalAlign::TextTop:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::TextTop { });
-        return;
-    case VerticalAlign::TextBottom:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::TextBottom { });
-        return;
-    case VerticalAlign::Top:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Top { });
-        return;
-    case VerticalAlign::Bottom:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::Bottom { });
-        return;
-    case VerticalAlign::BaselineMiddle:
-        CSS::serializationForCSS(builder, context, CSS::Keyword::WebkitBaselineMiddle { });
-        return;
-    case VerticalAlign::Length:
-        ExtractorSerializer::serializeLength(state, builder, context, state.style.verticalAlignLength());
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractLetterSpacing(ExtractorState& state)

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -1331,27 +1331,6 @@ public:
     }
 };
 
-class VerticalAlignWrapper final : public LengthWrapper {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(VerticalAlignWrapper, Animation);
-public:
-    VerticalAlignWrapper()
-        : LengthWrapper(CSSPropertyVerticalAlign, &RenderStyle::verticalAlignLength, &RenderStyle::setVerticalAlignLength, LengthWrapper::Flags::IsLengthPercentage)
-    {
-    }
-
-    bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation compositeOperation) const final
-    {
-        return from.verticalAlign() == VerticalAlign::Length && to.verticalAlign() == VerticalAlign::Length && LengthWrapper::canInterpolate(from, to, compositeOperation);
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        LengthWrapper::interpolate(destination, from, to, context);
-        auto& blendingStyle = context.isDiscrete && context.progress ? to : from;
-        destination.setVerticalAlign(blendingStyle.verticalAlign());
-    }
-};
-
 class TabSizeWrapper final : public Wrapper<const TabSize&> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(TabSizeWrapper, Animation);
 public:

--- a/Source/WebCore/style/values/inline/StyleVerticalAlign.cpp
+++ b/Source/WebCore/style/values/inline/StyleVerticalAlign.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleVerticalAlign.h"
+
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+CSSValueConversion.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+auto CSSValueConversion<VerticalAlign>::operator()(BuilderState& state, const CSSValue& value) -> VerticalAlign
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return CSS::Keyword::Baseline { };
+
+    if (primitiveValue->isValueID()) {
+        switch (primitiveValue->valueID()) {
+        case CSSValueBaseline:
+            return CSS::Keyword::Baseline { };
+        case CSSValueSub:
+            return CSS::Keyword::Sub { };
+        case CSSValueSuper:
+            return CSS::Keyword::Super { };
+        case CSSValueTop:
+            return CSS::Keyword::Top { };
+        case CSSValueTextTop:
+            return CSS::Keyword::TextTop { };
+        case CSSValueMiddle:
+            return CSS::Keyword::Middle { };
+        case CSSValueBottom:
+            return CSS::Keyword::Bottom { };
+        case CSSValueTextBottom:
+            return CSS::Keyword::TextBottom { };
+        case CSSValueWebkitBaselineMiddle:
+            return CSS::Keyword::WebkitBaselineMiddle { };
+        default:
+            break;
+        }
+
+        state.setCurrentPropertyInvalidAtComputedValueTime();
+        return CSS::Keyword::Baseline { };
+    }
+
+    return toStyleFromCSSValue<VerticalAlignLength>(state, *primitiveValue);
+}
+
+// MARK: - Blending
+
+auto Blending<VerticalAlign>::canBlend(const VerticalAlign& a, const VerticalAlign& b) -> bool
+{
+    return a.m_value.index() == b.m_value.index();
+}
+
+auto Blending<VerticalAlign>::requiresInterpolationForAccumulativeIteration(const VerticalAlign& a, const VerticalAlign& b) -> bool
+{
+    if (a.m_value.index() != b.m_value.index())
+        return true;
+    if (!a.isLength())
+        return false;
+    return Style::requiresInterpolationForAccumulativeIteration(*a.tryLength(), *b.tryLength());
+}
+
+auto Blending<VerticalAlign>::blend(const VerticalAlign& a, const VerticalAlign& b, const BlendingContext& context) -> VerticalAlign
+{
+    if (!a.isLength() || !b.isLength())
+        return context.progress < 0.5 ? a : b;
+
+    ASSERT(canBlend(a, b));
+    return Style::blend(*a.tryLength(), *b.tryLength(), context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/inline/StyleVerticalAlign.h
+++ b/Source/WebCore/style/values/inline/StyleVerticalAlign.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+struct VerticalAlignLength : LengthWrapperBase<LengthPercentage<>> {
+    using Base::Base;
+};
+
+// <'vertical-align'> = baseline | sub | super | top | text-top | middle | bottom | text-bottom | -webkit-baseline-middle | <length-percentage>
+// https://www.w3.org/TR/CSS22/visudet.html#propdef-vertical-align
+
+// FIXME: We implement the version of `vertical-align` from CSS 2. In CSS Inline 3, it has been changed to a shorthand property with grammar `[ first | last] || <'alignment-baseline'> || <'baseline-shift'>`.
+// https://drafts.csswg.org/css-inline/#propdef-vertical-align
+
+struct VerticalAlign {
+    using Length = VerticalAlignLength;
+
+    VerticalAlign(CSS::Keyword::Baseline keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::Sub keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::Super keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::Top keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::TextTop keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::Middle keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::Bottom keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::TextBottom keyword) : m_value { keyword } { }
+    VerticalAlign(CSS::Keyword::WebkitBaselineMiddle keyword) : m_value { keyword } { }
+    VerticalAlign(Length&& length) : m_value { WTFMove(length) } { }
+
+    bool isBaseline() const { return WTF::holdsAlternative<CSS::Keyword::Baseline>(m_value); }
+    bool isSub() const { return WTF::holdsAlternative<CSS::Keyword::Sub>(m_value); }
+    bool isSuper() const { return WTF::holdsAlternative<CSS::Keyword::Super>(m_value); }
+    bool isTop() const { return WTF::holdsAlternative<CSS::Keyword::Top>(m_value); }
+    bool isTextTop() const { return WTF::holdsAlternative<CSS::Keyword::TextTop>(m_value); }
+    bool isMiddle() const { return WTF::holdsAlternative<CSS::Keyword::Middle>(m_value); }
+    bool isBottom() const { return WTF::holdsAlternative<CSS::Keyword::Bottom>(m_value); }
+    bool isTextBottom() const { return WTF::holdsAlternative<CSS::Keyword::TextBottom>(m_value); }
+    bool isWebkitBaselineMiddle() const { return WTF::holdsAlternative<CSS::Keyword::WebkitBaselineMiddle>(m_value); }
+    bool isLength() const { return WTF::holdsAlternative<Length>(m_value); }
+    std::optional<Length> tryLength() const { return isLength() ? std::make_optional(std::get<Length>(m_value)) : std::nullopt; }
+
+    template<typename U> bool holdsAlternative() const
+    {
+        return WTF::holdsAlternative<U>(m_value);
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return WTF::switchOn(m_value, std::forward<F>(f)...);
+    }
+
+    bool operator==(const VerticalAlign&) const = default;
+
+private:
+    friend struct Blending<VerticalAlign>;
+
+    Variant<CSS::Keyword::Baseline, CSS::Keyword::Sub, CSS::Keyword::Super, CSS::Keyword::Top, CSS::Keyword::TextTop, CSS::Keyword::Middle, CSS::Keyword::Bottom, CSS::Keyword::TextBottom, CSS::Keyword::WebkitBaselineMiddle, VerticalAlignLength> m_value;
+};
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<VerticalAlign> { auto operator()(BuilderState&, const CSSValue&) -> VerticalAlign; };
+
+// MARK: - Blending
+
+template<> struct Blending<VerticalAlign> {
+    auto canBlend(const VerticalAlign&, const VerticalAlign&) -> bool;
+    auto requiresInterpolationForAccumulativeIteration(const VerticalAlign&, const VerticalAlign&) -> bool;
+    auto blend(const VerticalAlign&, const VerticalAlign&, const BlendingContext&) -> VerticalAlign;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::VerticalAlignLength)
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::VerticalAlign)

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -235,6 +235,10 @@ template<LengthWrapperBaseDerived T> struct Evaluation<T> {
     {
         return valueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(toPlatform(value), lazyMaximumValueFunctor);
     }
+    auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor) -> float
+    {
+        return valueForLengthWithLazyMaximum<float, float>(toPlatform(value), lazyMaximumValueFunctor);
+    }
     auto operator()(const T& value, LayoutUnit referenceLength) -> LayoutUnit
     {
         return valueForLength(toPlatform(value), referenceLength);

--- a/Source/WebCore/style/values/svg/StyleSVGBaselineShift.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGBaselineShift.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleSVGBaselineShift.h"
 
+#include "AnimationUtilities.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"


### PR DESCRIPTION
#### 68124e64d3a8b5db314727e9982f5847fd01ee00
<pre>
[Style] Convert vertical-align property to use strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296537">https://bugs.webkit.org/show_bug.cgi?id=296537</a>

Reviewed by Darin Adler.

Converts the `vertical-align` property to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h:
* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
* Source/WebCore/rendering/LegacyInlineBox.h:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderTableCellInlines.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleBoxData.cpp:
* Source/WebCore/rendering/style/StyleBoxData.h:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/inline/StyleVerticalAlign.cpp: Added.
* Source/WebCore/style/values/inline/StyleVerticalAlign.h: Added.
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:

Canonical link: <a href="https://commits.webkit.org/297941@main">https://commits.webkit.org/297941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09f7b0263fc1fb5ebdbc86f08cacca5f5f97f02d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113522 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122933 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40530 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30282 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94975 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24226 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36693 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45914 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->