### PR TITLE
AX: AXProperty::StringValue can be served via AXProperty::TextRuns for rendered text, making it redundant to cache

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -659,6 +659,7 @@ enum class AccessibilityOrientation : uint8_t {
     Vertical
 };
 
+enum class IncludeListMarkerText : bool { No, Yes };
 enum class TrimWhitespace : bool { No, Yes };
 
 struct TextUnderElementMode {

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -546,8 +546,12 @@ String listMarkerTextOnSameLine(const AXTextMarker& marker)
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-String AXTextMarkerRange::toString() const
+String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText) const
 {
+#if !ENABLE(AX_THREAD_TEXT_APIS)
+    UNUSED_PARAM(includeListMarkerText);
+#endif // !ENABLE(AX_THREAD_TEXT_APIS)
+
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (!isMainThread() && AXObjectCache::useAXThreadTextApis()) {
         // Traverses from m_start to m_end, collecting all text along the way.
@@ -559,7 +563,8 @@ String AXTextMarkerRange::toString() const
             return emptyString();
 
         StringBuilder result;
-        result.append(listMarkerTextOnSameLine(start));
+        if (includeListMarkerText == IncludeListMarkerText::Yes)
+            result.append(listMarkerTextOnSameLine(start));
 
         if (start.isolatedObject() == end.isolatedObject()) {
             size_t minOffset = std::min(start.offset(), end.offset());

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -410,7 +410,7 @@ public:
     bool isCollapsed() const { return m_start.isEqual(m_end); }
     bool isConfinedTo(std::optional<AXID>) const;
     bool isConfined() const;
-    String toString() const;
+    String toString(IncludeListMarkerText = IncludeListMarkerText::Yes) const;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     // Returns the bounds (frame) of the text in this range relative to the viewport.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -372,6 +372,8 @@ public:
 
     // Methods for determining accessibility text.
     bool isARIAStaticText() const { return ariaRoleAttribute() == AccessibilityRole::StaticText; }
+    // Whether this object should cache a string value when an isolated object is created for it.
+    bool shouldCacheStringValue() const;
     String stringValue() const override { return { }; }
     bool dependsOnTextUnderElement() const;
     String textUnderElement(TextUnderElementMode = { }) const override { return { }; }

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -74,8 +74,9 @@ void appendPlatformProperties(AXPropertyVector& properties, OptionSet<AXProperty
             setProperty(AXProperty::UnderlineColor, style.underlineColor());
         setProperty(AXProperty::FontOrientation, object->fontOrientation());
     }
-    // FIXME: Can we compute this off the main-thread with our cached text runs?
-    setProperty(AXProperty::StringValue, object->stringValue().isolatedCopy());
+
+    if (object->shouldCacheStringValue())
+        setProperty(AXProperty::StringValue, object->stringValue().isolatedCopy());
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
 #if !ENABLE(AX_THREAD_TEXT_APIS)


### PR DESCRIPTION
#### 6310e2954c76f811445a37efbe7845fb0d9e2679
<pre>
AX: AXProperty::StringValue can be served via AXProperty::TextRuns for rendered text, making it redundant to cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=296542">https://bugs.webkit.org/show_bug.cgi?id=296542</a>
<a href="https://rdar.apple.com/156859533">rdar://156859533</a>

Reviewed by Joshua Hoffman.

This optimization means we cache 3.9mb less `String`s on <a href="http://html.spec.whatwg.org.">http://html.spec.whatwg.org.</a> Furthermore, it means we cache
301599 less properties, and sizeof(AXPropertyValueVariant) is 24 bytes, so this is a further 7.2mb reduction in memory
usage. Caching less properties means every other property lookup is faster, too, since our properties are stored in a
Vector.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::shouldCacheStringValue const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::stringValue const):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::appendPlatformProperties):

Canonical link: <a href="https://commits.webkit.org/297933@main">https://commits.webkit.org/297933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02337f58b469a652ffe4ef3317de8977f9b20b0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86272 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20078 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63310 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96323 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122790 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95131 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40003 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17823 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36589 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45809 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->