### PR TITLE
[Safer C++] Improve smart pointer adoption in some WebCoreSupport/* files

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -105,9 +105,6 @@ WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
 WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/WebEditorClient.cpp
-WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
-WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
-WebProcess/WebCoreSupport/WebNotificationClient.cpp
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
 WebProcess/WebPage/Cocoa/TextAnimationController.mm

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -74,29 +74,32 @@ void WebFileSystemStorageConnection::connectionClosed()
 
 void WebFileSystemStorageConnection::closeHandle(WebCore::FileSystemHandleIdentifier identifier)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return;
 
-    m_connection->send(Messages::NetworkStorageManager::CloseHandle(identifier), 0);
+    connection->send(Messages::NetworkStorageManager::CloseHandle(identifier), 0);
 }
 
 void WebFileSystemStorageConnection::isSameEntry(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier otherIdentifier, WebCore::FileSystemStorageConnection::SameEntryCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
     if (identifier == otherIdentifier)
         return completionHandler(true);
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::IsSameEntry(identifier, otherIdentifier), WTFMove(completionHandler));
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::IsSameEntry(identifier, otherIdentifier), WTFMove(completionHandler));
 }
 
 void WebFileSystemStorageConnection::getFileHandle(WebCore::FileSystemHandleIdentifier identifier, const String& name, bool createIfNecessary, WebCore::FileSystemStorageConnection::GetHandleCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetFileHandle(identifier, name, createIfNecessary), [this, protectedThis = Ref { *this }, name, completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetFileHandle(identifier, name, createIfNecessary), [this, protectedThis = Ref { *this }, name, completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 
@@ -106,10 +109,11 @@ void WebFileSystemStorageConnection::getFileHandle(WebCore::FileSystemHandleIden
 
 void WebFileSystemStorageConnection::getDirectoryHandle(WebCore::FileSystemHandleIdentifier identifier, const String& name, bool createIfNecessary, WebCore::FileSystemStorageConnection::GetHandleCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetDirectoryHandle(identifier, name, createIfNecessary), [this, protectedThis = Ref { *this }, name, completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetDirectoryHandle(identifier, name, createIfNecessary), [this, protectedThis = Ref { *this }, name, completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 
@@ -119,20 +123,22 @@ void WebFileSystemStorageConnection::getDirectoryHandle(WebCore::FileSystemHandl
 
 void WebFileSystemStorageConnection::removeEntry(WebCore::FileSystemHandleIdentifier identifier, const String& name, bool deleteRecursively, WebCore::FileSystemStorageConnection::VoidCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::RemoveEntry(identifier, name, deleteRecursively), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::RemoveEntry(identifier, name, deleteRecursively), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
         return completionHandler(convertToExceptionOr(error));
     });
 }
 
 void WebFileSystemStorageConnection::resolve(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier otherIdentifier, WebCore::FileSystemStorageConnection::ResolveCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::Resolve(identifier, otherIdentifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::Resolve(identifier, otherIdentifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 
@@ -142,10 +148,11 @@ void WebFileSystemStorageConnection::resolve(WebCore::FileSystemHandleIdentifier
 
 void WebFileSystemStorageConnection::getFile(WebCore::FileSystemHandleIdentifier identifier, StringCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetFile(identifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetFile(identifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 
@@ -155,10 +162,11 @@ void WebFileSystemStorageConnection::getFile(WebCore::FileSystemHandleIdentifier
 
 void WebFileSystemStorageConnection::createSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemStorageConnection::GetAccessHandleCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::CreateSyncAccessHandle(identifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::CreateSyncAccessHandle(identifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 
@@ -168,18 +176,20 @@ void WebFileSystemStorageConnection::createSyncAccessHandle(WebCore::FileSystemH
 
 void WebFileSystemStorageConnection::closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, FileSystemStorageConnection::EmptyCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler();
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::CloseSyncAccessHandle(identifier, accessHandleIdentifier), WTFMove(completionHandler));
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::CloseSyncAccessHandle(identifier, accessHandleIdentifier), WTFMove(completionHandler));
 }
 
 void WebFileSystemStorageConnection::getHandleNames(WebCore::FileSystemHandleIdentifier identifier, FileSystemStorageConnection::GetHandleNamesCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetHandleNames(identifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetHandleNames(identifier), [completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
 
@@ -189,10 +199,11 @@ void WebFileSystemStorageConnection::getHandleNames(WebCore::FileSystemHandleIde
 
 void WebFileSystemStorageConnection::getHandle(WebCore::FileSystemHandleIdentifier identifier, const String& name, FileSystemStorageConnection::GetHandleCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetHandle(identifier, name), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::GetHandle(identifier, name), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (!result)
             return completionHandler(convertToException(result.error()));
         
@@ -203,10 +214,11 @@ void WebFileSystemStorageConnection::getHandle(WebCore::FileSystemHandleIdentifi
 
 void WebFileSystemStorageConnection::move(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemHandleIdentifier destinationIdentifier, const String& newName, VoidCallback&& completionHandler)
 {
-    if (!m_connection)
+    RefPtr connection = m_connection;
+    if (!connection)
         return completionHandler(WebCore::Exception { WebCore::ExceptionCode::UnknownError, "Connection is lost"_s });
 
-    m_connection->sendWithAsyncReply(Messages::NetworkStorageManager::Move(identifier, destinationIdentifier, newName), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
+    connection->sendWithAsyncReply(Messages::NetworkStorageManager::Move(identifier, destinationIdentifier, newName), [completionHandler = WTFMove(completionHandler)](auto error) mutable {
         completionHandler(convertToExceptionOr(error));
     });
 }


### PR DESCRIPTION
#### 79d5f5b7c5d49289ab8b029f3daf5dbeeedd0534
<pre>
[Safer C++] Improve smart pointer adoption in some WebCoreSupport/* files
<a href="https://bugs.webkit.org/show_bug.cgi?id=296543">https://bugs.webkit.org/show_bug.cgi?id=296543</a>
<a href="https://rdar.apple.com/156862046">rdar://156862046</a>

Reviewed by Chris Dumez and Vitor Roriz.

Fix failing files:

- WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
- WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
- WebProcess/WebCoreSupport/WebNotificationClient.cpp

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::closeHandle):
(WebKit::WebFileSystemStorageConnection::isSameEntry):
(WebKit::WebFileSystemStorageConnection::getFileHandle):
(WebKit::WebFileSystemStorageConnection::getDirectoryHandle):
(WebKit::WebFileSystemStorageConnection::removeEntry):
(WebKit::WebFileSystemStorageConnection::resolve):
(WebKit::WebFileSystemStorageConnection::getFile):
(WebKit::WebFileSystemStorageConnection::createSyncAccessHandle):
(WebKit::WebFileSystemStorageConnection::closeSyncAccessHandle):
(WebKit::WebFileSystemStorageConnection::getHandleNames):
(WebKit::WebFileSystemStorageConnection::getHandle):
(WebKit::WebFileSystemStorageConnection::move):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::protectedNetworkProcessConnection):
(WebKit::WebMessagePortChannelProvider::createNewMessagePortChannel):
(WebKit::WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote):
(WebKit::WebMessagePortChannelProvider::messagePortDisentangled):
(WebKit::WebMessagePortChannelProvider::messagePortClosed):
(WebKit::WebMessagePortChannelProvider::takeAllMessagesForPort):
(WebKit::WebMessagePortChannelProvider::postMessageToRemote):
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::show):
(WebKit::WebNotificationClient::cancel):
(WebKit::WebNotificationClient::notificationObjectDestroyed):
(WebKit::WebNotificationClient::requestPermission):
(WebKit::WebNotificationClient::checkPermission):

Canonical link: <a href="https://commits.webkit.org/299273@main">https://commits.webkit.org/299273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f724a0ae2f8ea29f941bd357b2cd9fd0d1dd300b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70341 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8519f77a-f2b6-431f-9e57-0c5b2ea38f51) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89770 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59406 "Found 3 new test failures: storage/domstorage/localstorage/index-get-and-set.html storage/domstorage/localstorage/missing-arguments.html storage/indexeddb/modern/cursor-5.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc0e5e96-6087-4da1-b83f-30b2b9900835) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70262 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/126b0972-b1bc-4a1b-b32c-39e6596ed49e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29866 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68117 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127526 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98450 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98236 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50743 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44529 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->