### PR TITLE
AX: AXProperty::TextEmissionBehavior can be expressed as a few AXPropertyFlags, greatly reducing the memory required to store it

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -806,7 +806,6 @@ enum class AXDebugStringOption {
 
 enum class TextEmissionBehavior : uint8_t {
     None,
-    Space,
     Tab,
     Newline,
     DoubleNewline

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -748,9 +748,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::EmbeddedImageDescription:
         stream << "EmbeddedImageDescription";
         break;
-    case AXProperty::TextEmissionBehavior:
-        stream << "TextEmissionBehavior";
-        break;
     case AXProperty::ExpandedTextValue:
         stream << "ExpandedTextValue";
         break;
@@ -965,6 +962,15 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::IsTableRow:
         stream << "IsTableRow";
+        break;
+    case AXProperty::IsTextEmissionBehaviorDoubleNewline:
+        stream << "IsTextEmissionBehaviorDoubleNewline";
+        break;
+    case AXProperty::IsTextEmissionBehaviorNewline:
+        stream << "IsTextEmissionBehaviorNewline";
+        break;
+    case AXProperty::IsTextEmissionBehaviorTab:
+        stream << "IsTextEmissionBehaviorTab";
         break;
     case AXProperty::IsTree:
         stream << "IsTree";

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -152,7 +152,6 @@ static bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
         [](std::shared_ptr<AXTextRuns> typedValue) { return !typedValue || !typedValue->size(); },
         [](RetainPtr<CTFontRef>& typedValue) { return !typedValue; },
         [](FontOrientation typedValue) { return typedValue == FontOrientation::Horizontal; },
-        [](TextEmissionBehavior typedValue) { return typedValue == TextEmissionBehavior::None; },
         [](AXTextRunLineID typedValue) { return !typedValue; },
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
         [] (WallTime& time) { return !time; },
@@ -563,6 +562,18 @@ AXIsolatedObject* AXIsolatedObject::accessibilityHitTest(const IntPoint& point) 
     });
 
     return tree()->objectForID(axID);
+}
+
+TextEmissionBehavior AXIsolatedObject::textEmissionBehavior() const
+{
+    if (hasPropertyFlag(AXProperty::IsTextEmissionBehaviorNewline))
+        return TextEmissionBehavior::Newline;
+    if (hasPropertyFlag(AXProperty::IsTextEmissionBehaviorDoubleNewline))
+        return TextEmissionBehavior::DoubleNewline;
+    if (hasPropertyFlag(AXProperty::IsTextEmissionBehaviorTab))
+        return TextEmissionBehavior::Tab;
+
+    return TextEmissionBehavior::None;
 }
 
 IntPoint AXIsolatedObject::intPointAttributeValue(AXProperty property) const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -93,7 +93,7 @@ public:
         const auto* runs = textRuns();
         return runs && runs->size();
     }
-    TextEmissionBehavior textEmissionBehavior() const final { return propertyValue<TextEmissionBehavior>(AXProperty::TextEmissionBehavior); }
+    TextEmissionBehavior textEmissionBehavior() const final;
     AXTextRunLineID listMarkerLineID() const final { return propertyValue<AXTextRunLineID>(AXProperty::ListMarkerLineID); };
     String listMarkerText() const final { return stringAttributeValue(AXProperty::ListMarkerText); }
     FontOrientation fontOrientation() const final { return propertyValue<FontOrientation>(AXProperty::FontOrientation); }
@@ -154,6 +154,7 @@ private:
 
     void setPropertyFlag(AXPropertyFlag, bool);
     bool hasPropertyFlag(AXPropertyFlag) const;
+    bool hasPropertyFlag(AXProperty) const;
 
     // FIXME: consolidate all AttributeValue retrieval in a single template method.
     bool boolAttributeValue(AXProperty) const;
@@ -631,6 +632,13 @@ inline void AXIsolatedObject::setPropertyFlag(AXPropertyFlag flag, bool set)
 inline bool AXIsolatedObject::hasPropertyFlag(AXPropertyFlag flag) const
 {
     return m_propertyFlags.contains(flag);
+}
+
+inline bool AXIsolatedObject::hasPropertyFlag(AXProperty property) const
+{
+    ASSERT(static_cast<uint16_t>(property) <= lastPropertyFlagIndex);
+    uint16_t propertyIndex = static_cast<uint16_t>(property);
+    return hasPropertyFlag(static_cast<AXPropertyFlag>(1 << propertyIndex));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1778,7 +1778,19 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
         setProperty(AXProperty::TextRuns, std::make_shared<AXTextRuns>(object.textRuns()));
-        setProperty(AXProperty::TextEmissionBehavior, object.textEmissionBehavior());
+        switch (object.textEmissionBehavior()) {
+        case TextEmissionBehavior::DoubleNewline:
+            propertyFlags.add(AXPropertyFlag::IsTextEmissionBehaviorDoubleNewline);
+            break;
+        case TextEmissionBehavior::Newline:
+            propertyFlags.add(AXPropertyFlag::IsTextEmissionBehaviorNewline);
+            break;
+        case TextEmissionBehavior::Tab:
+            propertyFlags.add(AXPropertyFlag::IsTextEmissionBehaviorTab);
+            break;
+        case TextEmissionBehavior::None:
+            break;
+        }
         if (object.role() == AccessibilityRole::ListMarker) {
             setProperty(AXProperty::ListMarkerText, object.listMarkerText().isolatedCopy());
             setProperty(AXProperty::ListMarkerLineID, object.listMarkerLineID());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -55,7 +55,7 @@ class AccessibilityObject;
 class Page;
 enum class AXStreamOptions : uint16_t;
 
-static constexpr uint16_t lastPropertyFlagIndex = 21;
+static constexpr uint16_t lastPropertyFlagIndex = 24;
 // The most common boolean properties are stored in a bitfield rather than in a HashMap.
 // If you edit these, make sure the corresponding AXProperty is ordered correctly in that
 // enum, and update lastPropertyFlagIndex above.
@@ -75,12 +75,16 @@ enum class AXPropertyFlag : uint32_t {
     IsKeyboardFocusable                           = 1 << 12,
     IsNonLayerSVGObject                           = 1 << 13,
     IsTableRow                                    = 1 << 14,
-    IsVisited                                     = 1 << 15,
-    SupportsCheckedState                          = 1 << 16,
-    SupportsDragging                              = 1 << 17,
-    SupportsExpanded                              = 1 << 18,
-    SupportsPath                                  = 1 << 19,
-    SupportsPosInSet                              = 1 << 20,
+    // These IsTextEmissionBehavior flags are the variants of enum TextEmissionBehavior.
+    IsTextEmissionBehaviorTab                     = 1 << 15,
+    IsTextEmissionBehaviorNewline                 = 1 << 16,
+    IsTextEmissionBehaviorDoubleNewline           = 1 << 17,
+    IsVisited                                     = 1 << 18,
+    SupportsCheckedState                          = 1 << 19,
+    SupportsDragging                              = 1 << 20,
+    SupportsExpanded                              = 1 << 21,
+    SupportsPath                                  = 1 << 22,
+    SupportsPosInSet                              = 1 << 23,
     SupportsSetSize                               = 1 << lastPropertyFlagIndex
 };
 
@@ -100,12 +104,15 @@ enum class AXProperty : uint16_t {
     IsKeyboardFocusable = 12,
     IsNonLayerSVGObject = 13,
     IsTableRow = 14,
-    IsVisited = 15,
-    SupportsCheckedState = 16,
-    SupportsDragging = 17,
-    SupportsExpanded = 18,
-    SupportsPath = 19,
-    SupportsPosInSet = 20,
+    IsTextEmissionBehaviorTab = 15,
+    IsTextEmissionBehaviorNewline = 16,
+    IsTextEmissionBehaviorDoubleNewline = 17,
+    IsVisited = 18,
+    SupportsCheckedState = 19,
+    SupportsDragging = 20,
+    SupportsExpanded = 21,
+    SupportsPath = 22,
+    SupportsPosInSet = 23,
     SupportsSetSize = lastPropertyFlagIndex,
     // End bool attributes that are matched in order by AXPropertyFlag.
 
@@ -281,7 +288,6 @@ enum class AXProperty : uint16_t {
     // synthesize it on-the-fly using AXProperty::TextRuns.
     TextContent,
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
-    TextEmissionBehavior,
     TextInputMarkedTextMarkerRange,
 #if ENABLE(AX_THREAD_TEXT_APIS)
     TextRuns,
@@ -315,7 +321,6 @@ using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, b
     , RetainPtr<CTFontRef>
     , FontOrientation
     , std::shared_ptr<AXTextRuns>
-    , TextEmissionBehavior
     , AXTextRunLineID
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 >;


### PR DESCRIPTION
#### 28ee5e0fd1a849877187df0d0c21a25c9eac66a8
<pre>
AX: AXProperty::TextEmissionBehavior can be expressed as a few AXPropertyFlags, greatly reducing the memory required to store it
<a href="https://bugs.webkit.org/show_bug.cgi?id=296544">https://bugs.webkit.org/show_bug.cgi?id=296544</a>
<a href="https://rdar.apple.com/156863651">rdar://156863651</a>

Reviewed by Joshua Hoffman.

With this commit, we represent the three variants of TextEmissionBehavior as AXPropertyFlags, greatly reducing the memory
required to store the value. On gmail.com, AXProperty::TextEmissionBehavior was 25% of all properties cached (3719 of 14890 total properties).
On <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a>, this property is cached 67515 times.

With AXPropertyValueVariants current size of 24 bytes, this means we save 1.6mb on html.spec.whatwg.org and 0.1mb on gmail.com.

TextEmissionBehavior::Space was removed with this commit, as it was never used.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::isDefaultValue):
(WebCore::AXIsolatedObject::textEmissionBehavior const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
(WebCore::AXIsolatedObject::hasPropertyFlag const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/297930@main">https://commits.webkit.org/297930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f48fc018c3b801d69579a05b4c302567ed99fcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64138 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20080 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122915 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30176 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94961 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24221 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40004 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45811 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->