### PR TITLE
MediaQueryEvaluator::evaluate has repeated computation of RenderStyle

### DIFF
--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -82,16 +82,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        auto defaultStyle = RenderStyle::create();
-        auto size = Style::fontSizeForKeyword(CSSValueMedium, false, *document);
-        if (size != defaultStyle.fontDescription().specifiedSize()) {
-            auto fontDescription = defaultStyle.fontDescription();
-            fontDescription.setSpecifiedSize(size);
-            fontDescription.setComputedSize(size);
-            defaultStyle.setFontDescription(WTFMove(fontDescription));
-        }
-
-        FeatureEvaluationContext context { *document, { *m_rootElementStyle, &defaultStyle, nullptr, document->renderView() }, nullptr };
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, m_rootElementStyle, nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 


### PR DESCRIPTION
#### 2304769b774b38cd60627bfb50d88e5259bda370
<pre>
MediaQueryEvaluator::evaluate has repeated computation of RenderStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=293538">https://bugs.webkit.org/show_bug.cgi?id=293538</a>
<a href="https://rdar.apple.com/152366637">rdar://152366637</a>

Reviewed by Sam Weinig.

The MediaQueryEvaluator is creating a new RenderStyle each time.
But this is unnecessary; we don&apos;t need a style based on the document&apos;s
medium font size to correctly evaluate a media query.

* Source/WebCore/css/query/MediaQueryEvaluator.cpp:
(WebCore::MQ::MediaQueryEvaluator::evaluate const): Use the root element
style instead of creating a new RenderStyle each time.

Canonical link: <a href="https://commits.webkit.org/297928@main">https://commits.webkit.org/297928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e3c4804584b638f19c3e4e705f81fc3e117e12e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86291 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122816 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95149 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24220 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40020 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17835 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45825 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->