### PR TITLE
[WPE] Can't select texts by using mouse drag

### DIFF
--- a/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
+++ b/Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp
@@ -75,6 +75,17 @@ static WebMouseEventButton buttonForWPEButton(guint button)
     return WebMouseEventButton::None;
 }
 
+static WebMouseEventButton buttonForWPEModifiers(WPEModifiers modifiers)
+{
+    if (modifiers & WPE_MODIFIER_POINTER_BUTTON1)
+        return WebMouseEventButton::Left;
+    if (modifiers & WPE_MODIFIER_POINTER_BUTTON2)
+        return WebMouseEventButton::Middle;
+    if (modifiers & WPE_MODIFIER_POINTER_BUTTON3)
+        return WebMouseEventButton::Right;
+    return WebMouseEventButton::None;
+}
+
 static FloatPoint movementDeltaFromEvent(WPEEvent* event)
 {
     double x, y;
@@ -138,6 +149,7 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(WPEEvent* event)
     case WPE_EVENT_POINTER_ENTER:
     case WPE_EVENT_POINTER_LEAVE:
         type = WebEventType::MouseMove;
+        button = buttonForWPEModifiers(modifiers);
         movementDelta = movementDeltaFromEvent(event);
         break;
     default:


### PR DESCRIPTION
#### f096e78cb4ff56a386551eb2ef79f261dc75a1a5
<pre>
[WPE] Can&apos;t select texts by using mouse drag
<a href="https://bugs.webkit.org/show_bug.cgi?id=296547">https://bugs.webkit.org/show_bug.cgi?id=296547</a>

Reviewed by NOBODY (OOPS!).

m_button member of WebMouseEvent was always WebMouseEventButton::None
for mouse drag. It should be set even for WebEventType::MouseMove type.

* Source/WebKit/Shared/wpe/WebEventFactoryWPE.cpp:
(WebKit::buttonForWPEModifiers): Added.
(WebKit::WebEventFactory::createWebMouseEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f096e78cb4ff56a386551eb2ef79f261dc75a1a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41695 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86297 "Found 1 new test failure: imported/w3c/web-platform-tests/uievents/mouse/mouseevent_move_button.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26960 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101973 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToDevToolsBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26226 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122825 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94901 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36611 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45831 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39983 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->