### PR TITLE
[Win] WebKit Windows port cannot receive window size change event

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -70,10 +70,10 @@ RefPtr<DrawingArea> DrawingArea::create(WebPage& webPage, const WebPageCreationP
     return RemoteLayerTreeDrawingAreaMac::create(webPage, parameters);
 #elif PLATFORM(IOS_FAMILY)
     return RemoteLayerTreeDrawingArea::create(webPage, parameters);
-#elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    return DrawingAreaCoordinatedGraphics::create(webPage, parameters);
 #elif USE(GRAPHICS_LAYER_WC)
     return DrawingAreaWC::create(webPage, parameters);
+#elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
+    return DrawingAreaCoordinatedGraphics::create(webPage, parameters);
 #endif
 }
 
@@ -151,10 +151,10 @@ bool DrawingArea::supportsGPUProcessRendering()
 {
 #if PLATFORM(COCOA)
     return true;
-#elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    return false;
 #elif USE(GRAPHICS_LAYER_WC)
     return true;
+#elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
+    return false;
 #endif
 }
 


### PR DESCRIPTION
#### 075399932937baee256808fd2f2a1b57b8ed4ed6
<pre>
[Win] WebKit Windows port cannot receive window size change event
<a href="https://bugs.webkit.org/show_bug.cgi?id=296159">https://bugs.webkit.org/show_bug.cgi?id=296159</a>

Reviewed by Ross Kirsling.

GraphicsLayerWC uses TextureMapper.
Therefore, #elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
is selected in DrawingArea.cpp.
This is wrong for GraphicsLayerWC.
The assumption is to select #elif USE(GRAPHICS_LAYER_WC).
So, I changed two of the orders.
 #elif USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
and
 #elif USE(GRAPHICS_LAYER_WC)

* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::create):
(WebKit::DrawingArea::supportsGPUProcessRendering):

Canonical link: <a href="https://commits.webkit.org/297911@main">https://commits.webkit.org/297911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fde2f33d733da599ca35b420af1b690f57950091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119602 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64180 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86303 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26231 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94908 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17843 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36617 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40338 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/39990 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->