### PR TITLE
AX: AXProperty::HasUnderline is redundant as it can be represented by a default-value AXProperty::UnderlineColor

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1744,6 +1744,12 @@ bool inRenderTreeOrStyleUpdate(const Document& document)
     return view && view->layoutContext().isInRenderTreeLayout();
 }
 
+Color defaultColor()
+{
+    static NeverDestroyed<Color> color = Color().toColorTypeLossy<SRGBA<uint8_t>>();
+    return color.get();
+}
+
 } // namespace Accessibility
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -2004,6 +2004,7 @@ String roleToPlatformString(AccessibilityRole);
 #if ENABLE(AX_THREAD_TEXT_APIS)
 std::optional<AXTextMarkerRange> markerRangeFrom(NSRange, const AXCoreObject&);
 #endif
+Color defaultColor();
 
 // Intended to work with size-types (like IntSize) or rect-types (like LayoutRect).
 template <typename SizeOrRectType>

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -816,9 +816,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::HasTextShadow:
         stream << "HasTextShadow";
         break;
-    case AXProperty::HasUnderline:
-        stream << "HasUnderline";
-        break;
     case AXProperty::HorizontalScrollBar:
         stream << "HorizontalScrollBar";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2231,7 +2231,7 @@ void AXObjectCache::onStyleChange(RenderText& renderText, StyleDifference differ
     auto oldDecor = oldStyle->textDecorationLineInEffect();
     auto newDecor = newStyle.textDecorationLineInEffect();
     if ((oldDecor & TextDecorationLine::Underline) != (newDecor & TextDecorationLine::Underline))
-        tree->queueNodeUpdate(object->objectID(), { AXProperty::HasUnderline });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::UnderlineColor });
 
     if ((oldDecor & TextDecorationLine::LineThrough) != (newDecor & TextDecorationLine::LineThrough))
         tree->queueNodeUpdate(object->objectID(), { AXProperty::HasLinethrough });

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -119,7 +119,7 @@ static bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
                 return typedValue == Color::black;
             if (property == AXProperty::TextColor)
                 return false;
-            return typedValue.toColorTypeLossy<SRGBA<uint8_t>>() == Color().toColorTypeLossy<SRGBA<uint8_t>>();
+            return typedValue.toColorTypeLossy<SRGBA<uint8_t>>() == Accessibility::defaultColor();
         },
         [](std::shared_ptr<URL>& typedValue) { return !typedValue || *typedValue == URL(); },
         [](LayoutRect& typedValue) { return typedValue == LayoutRect(); },
@@ -751,7 +751,7 @@ Color AXIsolatedObject::colorAttributeValue(AXProperty property) const
             if (RefPtr parent = parentObject())
                 return parent->textColor();
         }
-        return Color();
+        return Accessibility::defaultColor();
     }
 
 #ifndef NDEBUG

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -513,7 +513,7 @@ private:
     bool hasSameFont(AXCoreObject&) final;
     bool hasSameFontColor(AXCoreObject&) final;
     bool hasSameStyle(AXCoreObject&) final;
-    bool hasUnderline() const final { return boolAttributeValue(AXProperty::HasUnderline); }
+    bool hasUnderline() const final { return colorAttributeValue(AXProperty::UnderlineColor) != Accessibility::defaultColor(); }
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;
     Element* element() const final;
     Node* node() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -179,7 +179,6 @@ enum class AXProperty : uint16_t {
     IsSubscript,
     IsSuperscript,
     HasTextShadow,
-    HasUnderline,
     HorizontalScrollBar,
     IdentifierAttribute,
     IncrementButton,

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -67,11 +67,11 @@ void appendPlatformProperties(AXPropertyVector& properties, OptionSet<AXProperty
         setProperty(AXProperty::BackgroundColor, WTFMove(style.backgroundColor));
         setProperty(AXProperty::HasLinethrough, style.hasLinethrough());
         setProperty(AXProperty::HasTextShadow, style.hasTextShadow);
-        setProperty(AXProperty::HasUnderline, style.hasUnderline());
         setProperty(AXProperty::IsSubscript, style.isSubscript);
         setProperty(AXProperty::IsSuperscript, style.isSuperscript);
         setProperty(AXProperty::LinethroughColor, style.linethroughColor());
-        setProperty(AXProperty::UnderlineColor, style.underlineColor());
+        if (style.hasUnderline())
+            setProperty(AXProperty::UnderlineColor, style.underlineColor());
         setProperty(AXProperty::FontOrientation, object->fontOrientation());
     }
     // FIXME: Can we compute this off the main-thread with our cached text runs?
@@ -127,6 +127,9 @@ void appendPlatformProperties(AXPropertyVector& properties, OptionSet<AXProperty
 
 AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
 {
+    auto underlineColor = colorAttributeValue(AXProperty::UnderlineColor);
+    bool hasUnderlineColor = underlineColor != Accessibility::defaultColor();
+
     return {
         font(),
         textColor(),
@@ -135,8 +138,8 @@ AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
         boolAttributeValue(AXProperty::IsSuperscript),
         boolAttributeValue(AXProperty::HasTextShadow),
         LineDecorationStyle(
-            boolAttributeValue(AXProperty::HasUnderline),
-            colorAttributeValue(AXProperty::UnderlineColor),
+            hasUnderlineColor,
+            WTFMove(underlineColor),
             boolAttributeValue(AXProperty::HasLinethrough),
             colorAttributeValue(AXProperty::LinethroughColor)
         )


### PR DESCRIPTION
#### 420c2ea09844edadd13db15f7880fc4e9b5ef0cd
<pre>
AX: AXProperty::HasUnderline is redundant as it can be represented by a default-value AXProperty::UnderlineColor
<a href="https://bugs.webkit.org/show_bug.cgi?id=296553">https://bugs.webkit.org/show_bug.cgi?id=296553</a>
<a href="https://rdar.apple.com/156881960">rdar://156881960</a>

Reviewed by Chris Fleizach.

This commit eliminates AXProperty:HasUnderline, instead using the presencen of a non-default AXProperty::UnderlineColor
to indicate whether the object has an underline. This means we cache 36,691 less properties on <a href="http://html.spec.whatwg.org">http://html.spec.whatwg.org</a>,
saving 0.88mb.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::Accessibility::defaultColor):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onStyleChange):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::isDefaultValue):
(WebCore::AXIsolatedObject::colorAttributeValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::appendPlatformProperties):
(WebCore::AXIsolatedObject::stylesForAttributedString const):

Canonical link: <a href="https://commits.webkit.org/297932@main">https://commits.webkit.org/297932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8471b6fa464af03e5ea92f8006bc6237635a65a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86307 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/26976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/101990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63356 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95169 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94915 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45850 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40004 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->