### PR TITLE
Update rejection of RTCRtpScriptTransformer generateKeyFrame/sendKeyFrameRequest according specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt
@@ -4,10 +4,10 @@ PASS generateKeyFrame() throws for audio
 PASS generateKeyFrame(null) resolves for video sender, and throws for video receiver
 PASS generateKeyFrame throws NotAllowedError for invalid rid
 PASS generateKeyFrame throws NotFoundError for unknown rid
-PASS generateKeyFrame throws for unset transforms
+PASS generateKeyFrame does not throw for unset transforms
 PASS generateKeyFrame timestamp should advance
 PASS await generateKeyFrame, await generateKeyFrame should see an increase in count of keyframes
-FAIL generateKeyFrame rejects when the sender is negotiated inactive, and resumes succeeding when negotiated back to active assert_equals: Message: Timed out after waiting for 8000 ms expected "InvalidStateError" but got "TimeoutError"
-PASS generateKeyFrame rejects when the sender is stopped, even without negotiation
-FAIL generateKeyFrame rejects with a null track assert_equals: Message: Timed out after waiting for 8000 ms expected "InvalidStateError" but got "TimeoutError"
+PASS generateKeyFrame does not reject when the sender is negotiated inactive, and resumes succeeding when negotiated back to active
+PASS generateKeyFrame does not reject when the sender is stopped, even without negotiation
+PASS generateKeyFrame does not reject with a null track
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https.html
@@ -20,6 +20,7 @@
     <script>
 
 const generateKeyFrame = (port, opts) => postMethod(port, 'generateKeyFrame', opts);
+const generateKeyFrameDoesNotThrow = (port, opts) => postMethod(port, 'generateKeyFrameDoesNotThrow', opts);
 const waitForFrame = port => postMethod(port, 'waitForFrame');
 
 promise_test(async (test) => {
@@ -119,10 +120,9 @@ promise_test(async (test) => {
   const senderTransform = sender.transform;
   sender.transform = null;
 
-  message = await generateKeyFrame(senderTransform.port);
-  assert_equals(message.result, 'failure');
-  assert_equals(message.value, 'InvalidStateError', `Message: ${message.message}`);
-}, 'generateKeyFrame throws for unset transforms');
+  message = await generateKeyFrameDoesNotThrow(senderTransform.port);
+  assert_equals(message.result, 'success');
+}, 'generateKeyFrame does not throw for unset transforms');
 
 promise_test(async (test) => {
   const {sender, receiver} = await createConnectionWithTransform(test, 'script-transform-generateKeyFrame.js', {video: true});
@@ -171,9 +171,8 @@ promise_test(async (test) => {
   await receiverPc.setLocalDescription();
   await senderPc.setRemoteDescription(receiverPc.localDescription);
 
-  message = await generateKeyFrame(sender.transform.port);
-  assert_equals(message.result, 'failure');
-  assert_equals(message.value, 'InvalidStateError', `Message: ${message.message}`);
+  message = await generateKeyFrameDoesNotThrow(sender.transform.port);
+  assert_equals(message.result, 'success');
 
   senderPc.getTransceivers()[0].direction = 'sendonly';
   await senderPc.setLocalDescription();
@@ -183,7 +182,7 @@ promise_test(async (test) => {
 
   message = await generateKeyFrame(sender.transform.port);
   assert_equals(message.result, 'success');
-}, 'generateKeyFrame rejects when the sender is negotiated inactive, and resumes succeeding when negotiated back to active');
+}, 'generateKeyFrame does not reject when the sender is negotiated inactive, and resumes succeeding when negotiated back to active');
 
 promise_test(async (test) => {
   const {sender, receiver, senderPc, receiverPc} = await createConnectionWithTransform(test, 'script-transform-generateKeyFrame.js', {video: true});
@@ -195,10 +194,9 @@ promise_test(async (test) => {
 
   senderPc.getTransceivers()[0].stop();
 
-  message = await generateKeyFrame(sender.transform.port);
-  assert_equals(message.result, 'failure');
-  assert_equals(message.value, 'InvalidStateError', `Message: ${message.message}`);
-}, 'generateKeyFrame rejects when the sender is stopped, even without negotiation');
+  message = await generateKeyFrameDoesNotThrow(sender.transform.port);
+  assert_equals(message.result, 'success');
+}, 'generateKeyFrame does not reject when the sender is stopped, even without negotiation');
 
 promise_test(async (test) => {
   const {sender, receiver, senderPc, receiverPc} = await createConnectionWithTransform(test, 'script-transform-generateKeyFrame.js', {video: true});
@@ -210,10 +208,9 @@ promise_test(async (test) => {
 
   await senderPc.getTransceivers()[0].sender.replaceTrack(null);
 
-  message = await generateKeyFrame(sender.transform.port);
-  assert_equals(message.result, 'failure');
-  assert_equals(message.value, 'InvalidStateError', `Message: ${message.message}`);
-}, 'generateKeyFrame rejects with a null track');
+  message = await generateKeyFrameDoesNotThrow(sender.transform.port);
+  assert_equals(message.result, 'success');
+}, 'generateKeyFrame does not reject with a null track');
 
 // TODO: It would be nice to be able to test that pending generateKeyFrame
 // promises are _rejected_ when the transform is unset, or the sender stops

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.js
@@ -8,6 +8,8 @@ onrtctransform = event => {
     // Maybe refactor to have transaction ids?
     if (method == 'generateKeyFrame') {
       generateKeyFrame(rid);
+    } else if (method == 'generateKeyFrameDoesNotThrow') {
+      generateKeyFrameDoesNothThrow(rid);
     } else if (method == 'waitForFrame') {
       waitForFrame();
     }
@@ -23,12 +25,28 @@ onrtctransform = event => {
     });
   }
 
+  async function resolveInMs(timeout) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, timeout);
+    });
+  }
+
   async function generateKeyFrame(rid) {
     try {
       const timestamp = await Promise.race([transformer.generateKeyFrame(rid), rejectInMs(8000)]);
       transformer.options.port.postMessage({result: 'success', value: timestamp, count: keyFrameCount});
     } catch (e) {
       // TODO: This does not work if we send e.name, why?
+      transformer.options.port.postMessage({result: 'failure', value: `${e.name}`, message: `${e.message}`});
+    }
+  }
+
+
+  async function generateKeyFrameDoesNothThrow(rid) {
+    try {
+      const timestamp = await Promise.race([transformer.generateKeyFrame(rid), resolveInMs(50)]);
+      transformer.options.port.postMessage({result: 'success', value: timestamp, count: keyFrameCount});
+    } catch (e) {
       transformer.options.port.postMessage({result: 'failure', value: `${e.name}`, message: `${e.message}`});
     }
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https-expected.txt
@@ -3,7 +3,7 @@
 PASS sendKeyFrameRequest resolves for video receiver, and throws for video sender
 PASS sendKeyFrameRequest throws for audio sender/receiver
 PASS sendKeyFrameRequest throws for unused transforms
-PASS sendKeyFrameRequest throws for unset transforms
+PASS sendKeyFrameRequest does not throw for unset transforms
 PASS sendKeyFrameRequest does not reject when the receiver is negotiated inactive, and resumes succeeding when negotiated back to active
-FAIL sendKeyFrameRequest does not rejects when the receiver is stopped assert_equals: expected "success" but got "failure: InvalidStateError"
+PASS sendKeyFrameRequest does not reject when the receiver is stopped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https.html
@@ -17,6 +17,7 @@
     <script>
 
 const sendKeyFrameRequest = (port, opts) => postMethod(port, 'sendKeyFrameRequest', opts);
+const sendKeyFrameRequestDoesNotThrow = (port, opts) => postMethod(port, 'sendKeyFrameRequestDoesNotThrow', opts);
 const waitForFrame = port => postMethod(port, 'waitForFrame');
 
 promise_test(async (test) => {
@@ -61,8 +62,8 @@ promise_test(async (test) => {
   // to stop working. This may change.
   receiver.transform = null;
 
-  assert_equals(await sendKeyFrameRequest(receiverTransform.port), 'failure: InvalidStateError');
-}, 'sendKeyFrameRequest throws for unset transforms');
+  assert_equals(await sendKeyFrameRequestDoesNotThrow(receiverTransform.port), 'success');
+}, 'sendKeyFrameRequest does not throw for unset transforms');
 
 promise_test(async (test) => {
   const {sender, receiver, senderPc, receiverPc} = await createConnectionWithTransform(test, 'script-transform-sendKeyFrameRequest.js', {video: true});
@@ -95,8 +96,8 @@ promise_test(async (test) => {
 
   receiverPc.getTransceivers()[0].stop();
 
-  assert_equals(await sendKeyFrameRequest(receiver.transform.port), 'success');
-}, 'sendKeyFrameRequest does not rejects when the receiver is stopped');
+  assert_equals(await sendKeyFrameRequestDoesNotThrow(receiver.transform.port), 'success');
+}, 'sendKeyFrameRequest does not reject when the receiver is stopped');
 
 // Testing that sendKeyFrameRequest actually results in the sending of keyframe
 // requests is effectively impossible, because there is no API to expose the

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.js
@@ -6,6 +6,8 @@ onrtctransform = event => {
     const {method} = event.data;
     if (method == 'sendKeyFrameRequest') {
       sendKeyFrameRequest();
+    } else if (method == 'sendKeyFrameRequestDoesNotThrow') {
+      sendKeyFrameRequestDoesNotThrow();
     } else if (method == 'waitForFrame') {
       waitForFrame();
     }
@@ -21,9 +23,25 @@ onrtctransform = event => {
     });
   }
 
+  async function resolveInMs(timeout) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, timeout);
+    });
+  }
+
   async function sendKeyFrameRequest() {
     try {
       await Promise.race([transformer.sendKeyFrameRequest(), rejectInMs(8000)]);;
+      transformer.options.port.postMessage('success');
+    } catch (e) {
+      // TODO: This does not work if we send e.name, why?
+      transformer.options.port.postMessage(`failure: ${e.name}`);
+    }
+  }
+
+  async function sendKeyFrameRequestDoesNotThrow() {
+    try {
+      await Promise.race([transformer.sendKeyFrameRequest(), resolveInMs(50)]);;
       transformer.options.port.postMessage('success');
     } catch (e) {
       // TODO: This does not work if we send e.name, why?

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -99,6 +99,8 @@ private:
     RefPtr<PendingActivity<RTCRtpScriptTransformer>> m_pendingActivity;
 
     Deque<Ref<DeferredPromise>> m_pendingKeyFramePromises;
+    bool m_isVideo { false };
+    bool m_isSender { false };
 
 #if !RELEASE_LOG_DISABLED
     bool m_enableAdditionalLogging { false };

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -18,7 +18,6 @@ Modules/mediasource/SourceBuffer.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCController.cpp
 Modules/mediastream/RTCPeerConnection.cpp
-Modules/mediastream/RTCRtpScriptTransformer.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/model-element/HTMLModelElement.cpp


### PR DESCRIPTION
#### ed59c78e5bd3db487ecc42221bc6bd07396b3a72
<pre>
Update rejection of RTCRtpScriptTransformer generateKeyFrame/sendKeyFrameRequest according specification
<a href="https://rdar.apple.com/156899358">rdar://156899358</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296559">https://bugs.webkit.org/show_bug.cgi?id=296559</a>

Reviewed by Jean-Yves Avenard.

The spec states that if [[encoder]] slot is null, we should reject the promise.
This applies to unused transforms but does not apply to stopped/inactive senders/receivers or unset transforms.
We update the implementation accordingly and update the WPT tests as well.

* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.js:
(onrtctransform.event.transformer.options.port.onmessage.event.else):
(onrtctransform.event.async resolveInMs):
(onrtctransform.event.async generateKeyFrameDoesNothThrow):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.js:
(onrtctransform.event.transformer.options.port.onmessage.event.else):
(onrtctransform.event.async resolveInMs):
(onrtctransform.event.async sendKeyFrameRequest):
(onrtctransform.event.async sendKeyFrameRequestDoesNotThrow):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::start):
(WebCore::RTCRtpScriptTransformer::clear):
(WebCore::RTCRtpScriptTransformer::enqueueFrame):
(WebCore::RTCRtpScriptTransformer::generateKeyFrame):
(WebCore::RTCRtpScriptTransformer::sendKeyFrameRequest):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:

Canonical link: <a href="https://commits.webkit.org/298075@main">https://commits.webkit.org/298075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/683a354e7cfefc16cade0ca634ed37f66de784bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119764 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64360 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86397 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41465 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95013 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36852 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45982 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->