### PR TITLE
[GLIB] Fix segfault in MediaSessionManagerGLib.cpp after 297837@main

### DIFF
--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -313,6 +313,10 @@ void MediaSessionManagerGLib::updateNowPlayingInfo()
         return;
     }
 
+    auto session = m_sessions.get(platformSession->mediaSessionIdentifier());
+    if (!session)
+        return;
+
     auto nowPlayingInfo = platformSession->nowPlayingInfo();
     if (!nowPlayingInfo)
         return;
@@ -342,7 +346,6 @@ void MediaSessionManagerGLib::updateNowPlayingInfo()
 
     m_nowPlayingActive = nowPlayingInfo->allowsNowPlayingControlsVisibility;
 
-    auto session = m_sessions.get(platformSession->mediaSessionIdentifier());
     session->updateNowPlaying(*nowPlayingInfo);
 }
 


### PR DESCRIPTION
#### a916580d58308d118259a4885600d694a5b3395c
<pre>
[GLIB] Fix segfault in MediaSessionManagerGLib.cpp after 297837@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=296563">https://bugs.webkit.org/show_bug.cgi?id=296563</a>

Reviewed by Philippe Normand.

* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::updateNowPlayingInfo): Early exit if
session doesn&apos;t exit.

Canonical link: <a href="https://commits.webkit.org/297925@main">https://commits.webkit.org/297925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/081cfdafd2245ac7bcc7a6e32e364890005c05ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86337 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63388 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95200 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94946 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40065 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17881 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36662 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18213 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45882 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->