### PR TITLE
WPT webrtc-encoded-transform simulcast test video resolution is too low

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7775,8 +7775,7 @@ imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-001.tentative.
 imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-002.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-003.tentative.html [ ImageOnlyFailure ]
 
-# WebRTC Encoded Transform - Test Expectation - Crashes on 'mac-wk2' debug and gtk-wk2 / wpe-wk2
-webkit.org/b/275663 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html [ Pass Failure ]
 
 # https://bugs.webkit.org/show_bug.cgi?id=276663

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS generateKeyFrame works with simulcast rids
-FAIL generateKeyFrame for rid that was negotiated away fails assert_equals: expected "failure" but got "success"
+PASS generateKeyFrame for rid that was negotiated away fails
 FAIL generateKeyFrame with rid after simulcast->unicast negotiation fails assert_equals: expected "failure" but got "success"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html
@@ -29,7 +29,7 @@ promise_test(async (test) => {
   const receiverPc = new RTCPeerConnection();
   // This will only work if first rid is 0
   exchangeIceCandidates(senderPc, receiverPc);
-  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  const stream = await navigator.mediaDevices.getUserMedia({video: { width: 1280 } });
   const {sender} = senderPc.addTransceiver(stream.getTracks()[0], {sendEncodings: [{rid: '0'}, {rid: '1'}, {rid: '2'}]});
   sender.transform = transform;
   await doOfferToSendSimulcastAndAnswer(senderPc, receiverPc, ['0', '1', '2']);
@@ -58,7 +58,7 @@ promise_test(async (test) => {
   const receiverPc = new RTCPeerConnection();
   // This will only work if first rid is 0
   exchangeIceCandidates(senderPc, receiverPc);
-  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  const stream = await navigator.mediaDevices.getUserMedia({video: { width: 1280 } });
   const {sender} = senderPc.addTransceiver(stream.getTracks()[0], {sendEncodings: [{rid: '0'}, {rid: '1'}, {rid: '2'}]});
   sender.transform = transform;
   await doOfferToSendSimulcastAndAnswer(senderPc, receiverPc, ['0', '1', '2']);
@@ -91,7 +91,7 @@ promise_test(async (test) => {
   const receiverPc = new RTCPeerConnection();
   // This will only work if first rid is 0
   exchangeIceCandidates(senderPc, receiverPc);
-  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  const stream = await navigator.mediaDevices.getUserMedia({video: { width: 1280 } });
   const {sender} = senderPc.addTransceiver(stream.getTracks()[0], {sendEncodings: [{rid: '0'}, {rid: '1'}, {rid: '2'}]});
   sender.transform = transform;
   await doOfferToSendSimulcastAndAnswer(senderPc, receiverPc, ['0', '1', '2']);


### PR DESCRIPTION
#### 4eb8f2739d5ba6050622ed4f6313b35c2bee8f21
<pre>
WPT webrtc-encoded-transform simulcast test video resolution is too low
<a href="https://rdar.apple.com/156909624">rdar://156909624</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296564">https://bugs.webkit.org/show_bug.cgi?id=296564</a>

Reviewed by Jean-Yves Avenard.

The libwebrtc backend may limit the number of actual simulcast layers if the video stream has a small resolution.
640x480 will result in max 2 simulcast layers.
As the test requires 3 simulcast layers, we increase the size of the video to 720p.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html:

Canonical link: <a href="https://commits.webkit.org/298076@main">https://commits.webkit.org/298076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d99b43a6fb12259266a798bfbd9711924f4107f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86343 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41430 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20147 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122902 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95205 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40074 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36669 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40389 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->