### PR TITLE
[JSC] Fix "trap: SIGINT: bad trap" error on Linux when running JSC stress tests

### DIFF
--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -289,7 +289,7 @@ class Plan < BasePlan
                 outp.puts "START_TIME=$(($(date +%s%N)/1000000))"
             end
             outp.puts "echo Running #{Shellwords.shellescape(@name)}"
-            outp.puts "trap 'echo \"Killing #{@name}\" 1>&2' SIGINT"
+            outp.puts "trap 'echo \"Killing #{@name}\" 1>&2' INT"
             #
             # +--------------------------------------------------------------------+
             # | +-----------------------------------------------+                  |


### PR DESCRIPTION
#### 791f09bcd20151294f35424a65530066495e30c2
<pre>
[JSC] Fix &quot;trap: SIGINT: bad trap&quot; error on Linux when running JSC stress tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=296568">https://bugs.webkit.org/show_bug.cgi?id=296568</a>

Reviewed by Justin Michaud.

Since 297732@main, run-javascriptcore-tests displays &quot;trap: SIGINT: bad trap&quot;
error messages on Linux. This is because the trap command uses &apos;SIGINT&apos; which
is not POSIX-compliant.[1]

This patch changes &apos;SIGINT&apos; to &apos;INT&apos; in the trap command to make it
POSIX-compliant.

[1]: <a href="https://pubs.opengroup.org/onlinepubs/009604399/utilities/trap.html">https://pubs.opengroup.org/onlinepubs/009604399/utilities/trap.html</a>

* Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb:

Canonical link: <a href="https://commits.webkit.org/297966@main">https://commits.webkit.org/297966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c242afbf832050ae9b4ec7b9b49444ceffa95531

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119704 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86366 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41449 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20168 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63430 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/105995 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122939 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112091 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95224 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94976 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40095 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40419 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136302 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40078 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36555 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->