### PR TITLE
[JSC] Do not use reference for changing cursor

### DIFF
--- a/JSTests/stress/set-iteration-reference.js
+++ b/JSTests/stress/set-iteration-reference.js
@@ -1,0 +1,42 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let emptyValue = null;
+
+    try {
+        const set = new Set([1, 2, 3, 4, 5]);
+
+        let cnt = 0;
+        set.intersection({
+            size: 10,
+            has: key => {
+                cnt++;
+
+                if (cnt === 1) {
+                    set.delete(1);
+                    set.delete(2);
+                    set.delete(3);
+                    set.delete(4);
+                } else {
+                    emptyValue = key;
+                    throw 1;
+                }
+
+                return false;
+            },
+
+            keys() {
+
+            }
+        });
+    } catch {
+
+    }
+
+    shouldBe(emptyValue, 5);
+}
+
+main();

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -92,6 +92,8 @@ template<typename T> void* tryAllocateCell(VM&, GCDeferralContext*, size_t = siz
 
 class JSCell : public HeapCell {
     WTF_ALLOW_COMPACT_POINTERS;
+    WTF_MAKE_NONCOPYABLE(JSCell);
+    WTF_MAKE_NONMOVABLE(JSCell);
     friend class JSValue;
     friend class MarkedBlock;
     template<typename T>

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -225,17 +225,17 @@ static EncodedJSValue fastSetIntersection(JSGlobalObject* globalObject, JSSet* t
     if (sourceStorageCell == vm.orderedHashTableSentinel())
         return JSValue::encode(result);
 
-    JSSet::Storage& sourceStorage = *jsCast<JSSet::Storage*>(sourceStorageCell);
+    auto* sourceStorage = jsCast<JSSet::Storage*>(sourceStorageCell);
     JSSet::Helper::Entry entry = 0;
 
     while (true) {
-        sourceStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, sourceStorage, entry);
+        sourceStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *sourceStorage, entry);
         if (sourceStorageCell == vm.orderedHashTableSentinel())
             break;
 
-        JSSet::Storage& currentStorage = *jsCast<JSSet::Storage*>(sourceStorageCell);
-        entry = JSSet::Helper::iterationEntry(currentStorage) + 1;
-        JSValue entryKey = JSSet::Helper::getIterationEntryKey(currentStorage);
+        auto* currentStorage = jsCast<JSSet::Storage*>(sourceStorageCell);
+        entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+        JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
 
         bool targetHasEntry = targetSet->has(globalObject, entryKey);
         RETURN_IF_EXCEPTION(scope, { });
@@ -290,7 +290,7 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
         if (storageCell == vm.orderedHashTableSentinel())
             return JSValue::encode(result);
 
-        JSSet::Storage& storage = *jsCast<JSSet::Storage*>(storageCell);
+        auto* storage = jsCast<JSSet::Storage*>(storageCell);
         JSSet::Helper::Entry entry = 0;
         CallData hasCallData = JSC::getCallData(has);
 
@@ -301,13 +301,13 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
         }
 
         while (true) {
-            storageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, storage, entry);
+            storageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *storage, entry);
             if (storageCell == vm.orderedHashTableSentinel())
                 break;
 
-            storage = *jsCast<JSSet::Storage*>(storageCell);
-            entry = JSSet::Helper::iterationEntry(storage) + 1;
-            JSValue entryKey = JSSet::Helper::getIterationEntryKey(storage);
+            storage = jsCast<JSSet::Storage*>(storageCell);
+            entry = JSSet::Helper::iterationEntry(*storage) + 1;
+            JSValue entryKey = JSSet::Helper::getIterationEntryKey(*storage);
 
             JSValue hasResult;
             if (cachedHasCall) [[likely]] {


### PR DESCRIPTION
#### 668407b7a5b90fdf39bbc850a98b278981f63f76
<pre>
[JSC] Do not use reference for changing cursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=296576">https://bugs.webkit.org/show_bug.cgi?id=296576</a>
<a href="https://rdar.apple.com/156890845">rdar://156890845</a>

Reviewed by Mark Lam.

Using reference is not the same to using pointer. It copies when
assignment happens. We should use a pointer instead of a reference in
new Set#intersection implementation.

* JSTests/stress/set-iteration-reference.js: Added.
(shouldBe):
(main.try.set intersection):
(main.set catch):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::fastSetIntersection):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/297952@main">https://commits.webkit.org/297952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ae00ab027b3cf75973f059746ec8fb1cbc6defa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64313 "Built successfully") | ✅ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/33866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66724 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63449 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106014 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/122958 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112114 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95234 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/40946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/94987 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17923 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18225 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40438 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/45940 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136322 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40097 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36558 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->