### PR TITLE
AX: finish modernizing accessibility layout tests

### DIFF
--- a/LayoutTests/accessibility/accessibility-crash-setattribute-expected.txt
+++ b/LayoutTests/accessibility/accessibility-crash-setattribute-expected.txt
@@ -1,2 +1,7 @@
+This tests that there is no crash when handling elements with visibility: collapse and accessibility.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
 PASS if no crash.
 

--- a/LayoutTests/accessibility/accessibility-crash-setattribute.html
+++ b/LayoutTests/accessibility/accessibility-crash-setattribute.html
@@ -1,22 +1,33 @@
 <!DOCTYPE HTML>
 <html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <style>
     #div { visibility: collapse }
 </style>
 <body>
 PASS if no crash.
 <script>
-    if (window.accessibilityController) {
+var output = "This tests that there is no crash when handling elements with visibility: collapse and accessibility.\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
         var largeRange = accessibilityController.accessibleElementById("largeRange");
-    }
-    if (window.testRunner) {
-        testRunner.dumpAsText();
-    }
-    function eventhandler() {
-        document.execCommand("bold", false);
-        img.style.removeProperty("-webkit-appearance");
-        img.setAttribute("aria-expanded", "false");
-    }
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+
+function eventhandler() {
+    document.execCommand("bold", false);
+    img.style.removeProperty("-webkit-appearance");
+    img.setAttribute("aria-expanded", "false");
+}
 </script>
 <input id="largeRange" max="100" min="0" type="range" value="50">
 <div id="div">
@@ -26,3 +37,4 @@ PASS if no crash.
     </dl>
 </div>
 </body>
+</html>

--- a/LayoutTests/accessibility/anonymous-render-block-in-continuation-causes-crash-expected.txt
+++ b/LayoutTests/accessibility/anonymous-render-block-in-continuation-causes-crash-expected.txt
@@ -1,13 +1,8 @@
+This tests that having an anonymous render block in a continuation doesn't cause a crash when walking the accessibility tree.
+PASS successfullyParsed is true
+
+TEST COMPLETE
 x
 y
 z
 End of test.
-This tests that having an anonymous render block in a continuation doesn't cause a crash when walking the accessibility tree.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS successfullyParsed is true
-
-TEST COMPLETE
-

--- a/LayoutTests/accessibility/anonymous-render-block-in-continuation-causes-crash.html
+++ b/LayoutTests/accessibility/anonymous-render-block-in-continuation-causes-crash.html
@@ -1,6 +1,8 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <script>
     jsTestIsAsync = true;
 
@@ -11,11 +13,14 @@
     }
 
     function runTest() {
-        description("This tests that having an anonymous render block in a continuation doesn't cause a crash when walking the accessibility tree.");
+        var output = "This tests that having an anonymous render block in a continuation doesn't cause a crash when walking the accessibility tree.";
 
-        window.root = accessibilityController.rootElement;
-        walkAccessibilityTree(root);
+        if (window.accessibilityController) {
+            window.root = accessibilityController.rootElement;
+            walkAccessibilityTree(root);
+        }
 
+        debug(output);
         finishJSTest();
     }
 
@@ -31,9 +36,6 @@
 <li><span>x<ul><li>y</ul></span>z</li>
 
 End of test.
-
-<p id="description"></p>
-<div id="console"></div>
 
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-cellspans-with-native-cellspans-expected.txt
+++ b/LayoutTests/accessibility/aria-cellspans-with-native-cellspans-expected.txt
@@ -1,14 +1,12 @@
 This verifies that ARIA cell spans are ignored when native cell spans are set.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 columnheader1 spans 3 row(s) and 2 column(s).
 columnheader2 spans 4 row(s) and 10 column(s).
 columnheader3 spans 4 row(s) and 3 column(s).
 cell1 spans 2 row(s) and 2 column(s).
 cell2 spans 3 row(s) and 10 column(s).
 cell3 spans 3 row(s) and 10 column(s).
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/aria-cellspans-with-native-cellspans.html
+++ b/LayoutTests/accessibility/aria-cellspans-with-native-cellspans.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 <div id="content">
@@ -30,29 +31,29 @@
 </div>
 
 <script>
-    description("This verifies that ARIA cell spans are ignored when native cell spans are set.");
+var output = "This verifies that ARIA cell spans are ignored when native cell spans are set.\n\n";
 
-    function span(rangeString) {
-        return rangeString.split(/\D/).filter(function(x){ return x != ""; })[1];
-    }
+function span(rangeString) {
+    return rangeString.split(/\D/).filter(function(x){ return x != ""; })[1];
+}
 
-    function outputSpans(id) {
-        var axElement = accessibilityController.accessibleElementById(id);
-        var rowSpan = span(axElement.rowIndexRange());
-        var columnSpan = span(axElement.columnIndexRange());
-        debug(id + " spans " + rowSpan + " row(s) and " + columnSpan + " column(s).");
-    }
+function outputSpans(id) {
+    var axElement = accessibilityController.accessibleElementById(id);
+    var rowSpan = span(axElement.rowIndexRange());
+    var columnSpan = span(axElement.columnIndexRange());
+    output += id + " spans " + rowSpan + " row(s) and " + columnSpan + " column(s).\n";
+}
 
-    if (window.accessibilityController) {
-        ids = ["columnheader1", "columnheader2", "columnheader3", "cell1", "cell2", "cell3"];
-        idCount = ids.length;
-        for (var i = 0; i < idCount; i++)
-            outputSpans(ids[i]);
+if (window.accessibilityController) {
+    ids = ["columnheader1", "columnheader2", "columnheader3", "cell1", "cell2", "cell3"];
+    idCount = ids.length;
+    for (var i = 0; i < idCount; i++)
+        outputSpans(ids[i]);
 
-        document.getElementById("content").style.visibility = "hidden";
-    }
+    document.getElementById("content").style.visibility = "hidden";
+    
+    debug(output);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-expanded-supported-roles.html
+++ b/LayoutTests/accessibility/aria-expanded-supported-roles.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -92,17 +93,18 @@
 </div>
 
 <script>
-    if (window.accessibilityController) {
-        let output = "Verify which roles support aria-expanded.\n";
+    var output = "Verify which roles support aria-expanded.\n";
 
+    if (window.accessibilityController) {
         Array.from(document.getElementById("content").children).forEach((element) => {
             let axElement = accessibilityController.accessibleElementById(element.id);
             if (axElement && axElement.isExpanded)
                 output += `${axElement.role} is expanded\n`;
         });
 
-        debug(output);
         document.getElementById("content").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
     }
 </script>
 </body>

--- a/LayoutTests/accessibility/aria-grid-column-span-expected.txt
+++ b/LayoutTests/accessibility/aria-grid-column-span-expected.txt
@@ -1,17 +1,14 @@
-Month	Jan	Mar
-Expenses	100	130	90
 This tests that cells that span multiple columns within an ARIA grid have correct column index range
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: cell1.role === 'AXRole: AXCell'
+PASS: cell1.columnIndexRange() === '{1, 2}'
+PASS: cell2.role === 'AXRole: AXCell'
+PASS: cell2.columnIndexRange() === '{3, 1}'
+PASS: cell3.role === 'AXRole: AXCell'
+PASS: cell3.columnIndexRange() === '{2, 1}'
 
-
-PASS cell1.role is 'AXRole: AXCell'
-PASS cell1.columnIndexRange() is '{1, 2}'
-PASS cell2.role is 'AXRole: AXCell'
-PASS cell2.columnIndexRange() is '{3, 1}'
-PASS cell3.role is 'AXRole: AXCell'
-PASS cell3.columnIndexRange() is '{2, 1}'
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+Month	Jan	Mar
+Expenses	100	130	90

--- a/LayoutTests/accessibility/aria-grid-column-span.html
+++ b/LayoutTests/accessibility/aria-grid-column-span.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <style>
 div[role=grid] {
@@ -31,30 +32,26 @@ div[role=gridcell], div[role=rowheader] {
 </div>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that cells that span multiple columns within an ARIA grid have correct column index range\n\n";
 
-    description("This tests that cells that span multiple columns within an ARIA grid have correct column index range");
+if (window.accessibilityController) {
+    var cell1 = accessibilityController.accessibleElementById("cell1");
+    output += expect("cell1.role", "'AXRole: AXCell'");
+    output += expect("cell1.columnIndexRange()", "'{1, 2}'");
 
-    if (window.accessibilityController) {
+    var cell2 = accessibilityController.accessibleElementById("cell2");
+    output += expect("cell2.role", "'AXRole: AXCell'");
+    output += expect("cell2.columnIndexRange()", "'{3, 1}'");
 
-          var cell1 = accessibilityController.accessibleElementById("cell1");
-          shouldBe("cell1.role", "'AXRole: AXCell'");
-          shouldBe("cell1.columnIndexRange()", "'{1, 2}'");
+    // also test cell index without column span
+    var cell3 = accessibilityController.accessibleElementById("cell3");
+    output += expect("cell3.role", "'AXRole: AXCell'");
+    output += expect("cell3.columnIndexRange()", "'{2, 1}'");
+}
 
-          var cell2 = accessibilityController.accessibleElementById("cell2");
-          shouldBe("cell2.role", "'AXRole: AXCell'");
-          shouldBe("cell2.columnIndexRange()", "'{3, 1}'");
-
-          // also test cell index without column span
-          var cell3 = accessibilityController.accessibleElementById("cell3");
-          shouldBe("cell3.role", "'AXRole: AXCell'");
-          shouldBe("cell3.columnIndexRange()", "'{2, 1}'");
-    }
+debug(output);
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-labelledby-overrides-aria-label.html
+++ b/LayoutTests/accessibility/aria-labelledby-overrides-aria-label.html
@@ -1,9 +1,10 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
-<p id="description">This tests that if aria-labelledby is used, then aria-label attributes are not used.</p>
 
 <button id="using-none">Alpha</button>
 <button id="using-label" aria-label="Gamma">Beta</button>
@@ -12,39 +13,28 @@
 <span id="epsilon">Epsilon</span>
 <span id="theta">Theta</span>
 
-<ul id="results"></ul>
-<div id="console"></div>
-
 <script>
-    function output(str) {
-        var results = document.getElementById("results");
-        var li = document.createElement("li");
-        li.appendChild(document.createTextNode(str));
-        results.appendChild(li);
-    }
+var output = "This tests that if aria-labelledby is used, then aria-label attributes are not used.\n\n";
 
-    if (window.testRunner)
-        testRunner.dumpAsText();
+if (window.accessibilityController) {
+    var usingNone = accessibilityController.accessibleElementById("using-none");
+    output += "usingNone.title: [" + usingNone.title + "]\n";
+    output += "usingNone.description:  [" + usingNone.description + "]\n\n";
 
-    if (window.accessibilityController) {
-        var usingNone = accessibilityController.accessibleElementById("using-none");
-        output("usingNone.title: [" + usingNone.title + "]");
-        output("usingNone.description:  [" + usingNone.description + "]");
+    var usingLabel = accessibilityController.accessibleElementById("using-label");
+    output += "usingLabel.title: [" + usingLabel.title + "]\n";
+    output += "usingLabel.description:  [" + usingLabel.description + "]\n\n";
 
-        var usingLabel = accessibilityController.accessibleElementById("using-label");
-        output("usingLabel.title: [" + usingLabel.title + "]");
-        output("usingLabel.description:  [" + usingLabel.description + "]");
+    var usingLabelledby = accessibilityController.accessibleElementById("using-labelledby");
+    output += "usingLabelledby.title: [" + usingLabelledby.title + "]\n";
+    output += "usingLabelledby.description:  [" + usingLabelledby.description + "]\n\n";
 
-        var usingLabelledby = accessibilityController.accessibleElementById("using-labelledby");
-        output("usingLabelledby.title: [" + usingLabelledby.title + "]");
-        output("usingLabelledby.description:  [" + usingLabelledby.description + "]");
+    var usingLabeledby = accessibilityController.accessibleElementById("using-labeledby");
+    output += "usingLabeledby.title: [" + usingLabeledby.title + "]\n";
+    output += "usingLabeledby.description:  [" + usingLabeledby.description + "]\n";
 
-        var usingLabeledby = accessibilityController.accessibleElementById("using-labeledby");
-        output("usingLabeledby.title: [" + usingLabeledby.title + "]");
-        output("usingLabeledby.description:  [" + usingLabeledby.description + "]");
-    }
-
-    successfullyParsed = true;
+    debug(output);
+}
 </script>
 
 </body>

--- a/LayoutTests/accessibility/aria-labelledby-stay-within-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-stay-within-expected.txt
@@ -1,10 +1,10 @@
 This tests that aria-labelledby does not append all sibling to an ARIA name
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+platformValueForW3CName(axButton) = Reply Item Five
+Expected: Reply Item Five
 
-
-PASS platformValueForW3CName(axButton) is "Reply Item Five"
 PASS successfullyParsed is true
 
 TEST COMPLETE
+
 

--- a/LayoutTests/accessibility/aria-labelledby-stay-within.html
+++ b/LayoutTests/accessibility/aria-labelledby-stay-within.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
@@ -24,19 +24,24 @@
 </ul>
 
 </div>
-<p id="description"></p>
-<div id="console"></div>
 <script>
-        description("This tests that aria-labelledby does not append all sibling to an ARIA name");
+var output = "This tests that aria-labelledby does not append all sibling to an ARIA name\n\n";
 
-        if (window.accessibilityController) {
-            var labeledItem = document.getElementById("rep").focus();
-            var axButton = accessibilityController.focusedElement;
-            shouldBeEqualToString("platformValueForW3CName(axButton)", "Reply Item Five");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
+        var labeledItem = document.getElementById("rep").focus();
+        var axButton = accessibilityController.focusedElement;
+        output += "platformValueForW3CName(axButton) = " + platformValueForW3CName(axButton) + "\n";
+        output += "Expected: Reply Item Five\n";
 
-            document.getElementById("content").style.visibility = "hidden";
-        }
+        document.getElementById("content").style.visibility = "hidden";
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-labelledby-with-descendants-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-with-descendants-expected.txt
@@ -1,9 +1,4 @@
-
-
 This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 test 1: aria-labelledby description: hello link use world test1 test2 test3
 test 1: expected description: hello link use world test1 test2 test3
@@ -26,7 +21,11 @@ test 6: expected description: Delete product name
 test 7: aria-labelledby description: foo bar baz bop bap boom
 test 7: expected description: foo bar baz bop bap boom
 
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
+
+
+
 

--- a/LayoutTests/accessibility/aria-labelledby-with-descendants.html
+++ b/LayoutTests/accessibility/aria-labelledby-with-descendants.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
@@ -40,24 +40,19 @@
 
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.\n\n";
 
-    description("This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.");
-
-    if (window.accessibilityController) {
-          for (var k = 1; k < 8; k++) {
-              var test = accessibilityController.accessibleElementById("test" + k);
-              debug("test " + k + ": aria-labelledby description: " + platformValueForW3CName(test));
-              debug("test " + k + ": expected description: " + document.getElementById("test" + k).getAttribute("data-label") + "\n");
-          }
-          document.getElementById("content").style.visibility = "hidden";
+if (window.accessibilityController) {
+    for (var k = 1; k < 8; k++) {
+        var test = accessibilityController.accessibleElementById("test" + k);
+        output += "test " + k + ": aria-labelledby description: " + platformValueForW3CName(test) + "\n";
+        output += "test " + k + ": expected description: " + document.getElementById("test" + k).getAttribute("data-label") + "\n\n";
     }
-
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
+}
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-link-supports-press-expected.txt
+++ b/LayoutTests/accessibility/aria-link-supports-press-expected.txt
@@ -1,3 +1,7 @@
-Click
+This test checks that ARIA links support the press action.
 
 SUCCESS! This test passes because the ARIA link above supports the press action.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Click

--- a/LayoutTests/accessibility/aria-link-supports-press.html
+++ b/LayoutTests/accessibility/aria-link-supports-press.html
@@ -1,27 +1,35 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-    if (window.testRunner)
-        testRunner.dumpAsText();
-</script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <body>
 <div id="link" role="link" tabindex="0">Click</div>
 
-<br>
-
-<span id="result">To run this test outside of DRT, use the Accessibility Inspector to inspect the link above, and make sure AXPressed is listed as a supported action.</span>
-
 <script>
-    if (window.accessibilityController) {
+var output = "This test checks that ARIA links support the press action.\n\n";
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
         var link = document.getElementById("link");
-        var result = document.getElementById("result");
         
         link.focus();
         var supportsAction = accessibilityController.focusedElement.isPressActionSupported();
         if (supportsAction)
-            result.innerHTML = "SUCCESS! This test passes because the ARIA link above supports the press action.";
+            output += "SUCCESS! This test passes because the ARIA link above supports the press action.";
         else
-            result.innerHTML = "FAIL! This test fails because the ARIA link above does NOT support the press action, but it should.";
-    }
+            output += "FAIL! This test fails because the ARIA link above does NOT support the press action, but it should.";
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 
 </body>

--- a/LayoutTests/accessibility/aria-mappings.html
+++ b/LayoutTests/accessibility/aria-mappings.html
@@ -1,7 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 
 <body>
@@ -15,60 +17,58 @@
 <div id="tree" role="tree"><div role="treeitem">tree role</div></div>
 <div role="tree"><div id="treeitem" role="treeitem">treeitem role</div></div>
 <br>
-<p id="description"></p>
-<div id="console"></div>
 
 <script>
-    description("This tests that each of these ARIA roles have appropriate mappings.");
+var output = "This tests that each of these ARIA roles have appropriate mappings.\n\n";
 
+if (window.accessibilityController) {
     if (window.testRunner) {
         testRunner.dumpAsText();
-
-        if (window.accessibilityController) {
-
-            document.body.focus();
-            var body = accessibilityController.focusedElement;
-            debug("Role for 'body' is: " + body.role);
-
-            debug("<br>");
-            debug("role=\"alert\" should give a message with important, and usually time-sensitive, information.");
-            debug("Role for 'alert' div is: " + accessibilityController.accessibleElementById("alert").role);
-
-            debug("<br>");
-            debug("role=\"alertdialog\" is a dialog which contains an alert message.");
-            debug("Role for 'alertdialog' div is: " + accessibilityController.accessibleElementById("alertdialog").role);
-
-            debug("<br>");
-            debug("role=\"article\" is a  section of a page that consists of a composition that forms an independent part of a document, page, or site");
-            debug("Role for 'article' div is: " + accessibilityController.accessibleElementById("article").role);
-
-            debug("<br>");
-            debug("role=\"dialog\" is an application window that is designed to interrupt the current processing of an application in order to prompt the user to enter information or require a response.");
-            debug("Role for 'dialog' div is: " + accessibilityController.accessibleElementById("dialog").role);
-
-            debug("<br>");
-            debug("role=\"document\" is a region containing related information that is declared as document content, as opposed to a web application.");
-            debug("Role for 'document' div is: " + accessibilityController.accessibleElementById("document").role);
-
-            debug("<br>");
-            debug("role=\"status\" is a container whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.");
-            debug("Role for 'status' div is: " + accessibilityController.accessibleElementById("status").role);
-
-            debug("<br>");
-            debug("role=\"tooltip\" is a contextual popup that displays a description for an element.");
-            debug("Role for 'tooltip' div is: " + accessibilityController.accessibleElementById("tooltip").role);
-
-            debug("<br>");
-            debug("role=\"tree\" is a type of list that may contain sub-level nested groups that can be collapsed and expanded.");
-            debug("Role for 'tree' div is: " + accessibilityController.accessibleElementById("tree").role);
-
-            debug("<br>");
-            debug("role=\"treeitem\" is an option item of a tree.");
-            debug("Role for 'treeitem' div is: " + accessibilityController.accessibleElementById("treeitem").role);
     }
+
+    document.body.focus();
+    var body = accessibilityController.focusedElement;
+    output += "Role for 'body' is: " + body.role + "\n";
+
+    output += "\n";
+    output += "role=\"alert\" should give a message with important, and usually time-sensitive, information.\n";
+    output += "Role for 'alert' div is: " + accessibilityController.accessibleElementById("alert").role + "\n";
+
+    output += "\n";
+    output += "role=\"alertdialog\" is a dialog which contains an alert message.\n";
+    output += "Role for 'alertdialog' div is: " + accessibilityController.accessibleElementById("alertdialog").role + "\n";
+
+    output += "\n";
+    output += "role=\"article\" is a  section of a page that consists of a composition that forms an independent part of a document, page, or site\n";
+    output += "Role for 'article' div is: " + accessibilityController.accessibleElementById("article").role + "\n";
+
+    output += "\n";
+    output += "role=\"dialog\" is an application window that is designed to interrupt the current processing of an application in order to prompt the user to enter information or require a response.\n";
+    output += "Role for 'dialog' div is: " + accessibilityController.accessibleElementById("dialog").role + "\n";
+
+    output += "\n";
+    output += "role=\"document\" is a region containing related information that is declared as document content, as opposed to a web application.\n";
+    output += "Role for 'document' div is: " + accessibilityController.accessibleElementById("document").role + "\n";
+
+    output += "\n";
+    output += "role=\"status\" is a container whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.\n";
+    output += "Role for 'status' div is: " + accessibilityController.accessibleElementById("status").role + "\n";
+
+    output += "\n";
+    output += "role=\"tooltip\" is a contextual popup that displays a description for an element.\n";
+    output += "Role for 'tooltip' div is: " + accessibilityController.accessibleElementById("tooltip").role + "\n";
+
+    output += "\n";
+    output += "role=\"tree\" is a type of list that may contain sub-level nested groups that can be collapsed and expanded.\n";
+    output += "Role for 'tree' div is: " + accessibilityController.accessibleElementById("tree").role + "\n";
+
+    output += "\n";
+    output += "role=\"treeitem\" is an option item of a tree.\n";
+    output += "Role for 'treeitem' div is: " + accessibilityController.accessibleElementById("treeitem").role + "\n";
 }
+
+debug(output);
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-presentational-role-expected.txt
+++ b/LayoutTests/accessibility/aria-presentational-role-expected.txt
@@ -1,12 +1,7 @@
-Link and text
-
 This tests that the aria 'presentation' role works by successfully removing the element from the AX tree.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 firstChild.role is AXRole: AXLink
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+Link and text

--- a/LayoutTests/accessibility/aria-presentational-role.html
+++ b/LayoutTests/accessibility/aria-presentational-role.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -9,24 +10,18 @@
 <a href="#">Link</a> and text
 </h3>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that the aria 'presentation' role works by successfully removing the element from the AX tree.\n\n";
 
-    description("This tests that the aria 'presentation' role works by successfully removing the element from the AX tree.");
+if (window.accessibilityController) {
+    var body = document.getElementById("body");
+    body.focus();
 
-    if (window.accessibilityController) {
-
-          var body = document.getElementById("body");
-          body.focus();
-
-          var firstChild = accessibilityController.focusedElement.childAtIndex(0);
-          debug("firstChild.role is " + firstChild.role);
-    }
-
+    var firstChild = accessibilityController.focusedElement.childAtIndex(0);
+    output += "firstChild.role is " + firstChild.role;
+    
+    debug(output);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-selected.html
+++ b/LayoutTests/accessibility/aria-selected.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
@@ -44,24 +44,25 @@
     </div>
   </div>
 </div>
-<p id="description"></p>
-<div id="console"></div>
 <script>
+    var output = "This tests that items with aria-selected are reported as selected children of the parent container.\n\n";
+
     function selectedChildInfo(axElement) {
-        if (!axElement)
-            debug("Element not exposed");
+        if (!axElement) {
+            output += "Element not exposed\n";
+            return;
+        }
 
         var count = axElement.selectedChildrenCount;
-        debug(axElement.role + " has " + count + " selected child(ren)");
+        output += axElement.role + " has " + count + " selected child(ren)\n";
         for (var i = 0; i < count; i++) {
             var child = axElement.selectedChildAtIndex(i);
             result = ("\t" + platformValueForW3CName(child) + " (" + child.role + ")")
             result += " isSelectable: " + child.isSelectable + " isSelected: " + child.isSelected;
-            debug(result);
-	}
-   }
+            output += result + "\n";
+        }
+    }
 
-    description("This tests that items with aria-selected are reported as selected children of the parent container.");
     if (window.accessibilityController) {
         selectedChildInfo(window.accessibilityController.accessibleElementById("tablist"));
         selectedChildInfo(window.accessibilityController.accessibleElementById("tablist-with-display-contents"));
@@ -69,9 +70,9 @@
         selectedChildInfo(window.accessibilityController.accessibleElementById("grid"));
         selectedChildInfo(window.accessibilityController.accessibleElementById("treegrid"));
         document.getElementById("content").style.visibility = "hidden";
+        
+        debug(output);
     }
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-switch-sends-notification.html
+++ b/LayoutTests/accessibility/aria-switch-sends-notification.html
@@ -1,30 +1,36 @@
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <script>
     function runTest() {
-        jsTestIsAsync = true;
+        if (window.accessibilityController) {
+            window.jsTestIsAsync = true;
 
-        description("This tests that toggling an aria switch sends a notification.");
+            var output = "This tests that toggling an aria switch sends a notification.\n\n";
+            var notificationLog = "";
+            
+            var widget = accessibilityController.accessibleElementById("switch");
+            var notificationCount = 0;
 
-        var widget = accessibilityController.accessibleElementById("switch");
-        var notificationCount = 0;
+            function listener(notification) {
+                if (notification == "CheckedStateChanged")
+                    notificationCount++;
 
-        function listener(notification) {
-            if (notification == "CheckedStateChanged")
-                notificationCount++;
+                notificationLog += "Got notification: " + notification + "\n";
 
-            document.getElementById("console").innerText += "Got notification: " + notification + "\n";
-
-            if (notificationCount == 2) {
-                widget.removeNotificationListener(listener);
-                finishJSTest();
+                if (notificationCount == 2) {
+                    widget.removeNotificationListener(listener);
+                    output += notificationLog;
+                    debug(output);
+                    finishJSTest();
+                }
             }
-        }
-        widget.addNotificationListener(listener);
+            widget.addNotificationListener(listener);
 
-        document.getElementById('switch').setAttribute('aria-checked', 'true');
-        document.getElementById('switch').setAttribute('aria-checked', 'false');
+            document.getElementById('switch').setAttribute('aria-checked', 'true');
+            document.getElementById('switch').setAttribute('aria-checked', 'false');
+        }
     };
 </script>
 </head>
@@ -32,7 +38,5 @@
 
 <div id="switch" role="switch" aria-checked="false">Test Switch</div>
 
-<p id="description"></p>
-<div id="console"></div>
 </body>
 </html>

--- a/LayoutTests/accessibility/aria-switch-text.html
+++ b/LayoutTests/accessibility/aria-switch-text.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 <div role="radiobuttongroup">
@@ -10,32 +11,27 @@
         <div role="switch" id="switch3" aria-label="foo">Three</div>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that ARIA switches use accessible name computation and have no child text.\n\n";
 
-    description("This tests that ARIA switches use accessible name computation and have no child text.");
+if (window.accessibilityController) {
+    var widget = accessibilityController.accessibleElementById("switch1");
+    output += "widget.title is " + widget.title + "\n";
+    output += "widget.description is " + widget.description + "\n";
+    output += "widget.childrenCount is " + widget.childrenCount + "\n\n";
 
-    if (window.accessibilityController) {
-        var widget = accessibilityController.accessibleElementById("switch1");
-        debug("widget.title is " + widget.title);
-        debug("widget.description is " + widget.description);
-        debug("widget.childrenCount is " + widget.childrenCount);
+    widget = accessibilityController.accessibleElementById("switch2");
+    output += "widget.title is " + widget.title + "\n";
+    output += "widget.description is " + widget.description + "\n";
+    output += "widget.childrenCount is " + widget.childrenCount + "\n\n";
 
-        widget = accessibilityController.accessibleElementById("switch2");
-        debug("widget.title is " + widget.title);
-        debug("widget.description is " + widget.description);
-        debug("widget.childrenCount is " + widget.childrenCount);
+    widget = accessibilityController.accessibleElementById("switch3");
+    output += "widget.title is " + widget.title + "\n";
+    output += "widget.description is " + widget.description + "\n";
+    output += "widget.childrenCount is " + widget.childrenCount + "\n";
 
-        widget = accessibilityController.accessibleElementById("switch3");
-        debug("widget.title is " + widget.title);
-        debug("widget.description is " + widget.description);
-        debug("widget.childrenCount is " + widget.childrenCount);
-    }
-
+    debug(output);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/box-styled-lists.html
+++ b/LayoutTests/accessibility/box-styled-lists.html
@@ -1,11 +1,8 @@
 <!DOCTYPE html>
 <html>
-<script>
-
-    if (window.testRunner)
-        testRunner.dumpAsText();
-</script>
 <head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <style>
     ol {
         display: -webkit-box;
@@ -36,18 +33,17 @@
     </div>
   </div>
 
-    <BR><BR><BR><hr><BR>
-    <div id="result"></div>    
-
     <script>
+        var output = "";
+        
         if (window.accessibilityController) {
-            var result = document.getElementById("result");
-
             var olListElement = window.accessibilityController.accessibleElementById("test 1");
-            result.innerText += 'il in ol role: ' + olListElement.role + "\n\n";
+            output += 'il in ol role: ' + olListElement.role + "\n\n";
 
             var ulListElement = window.accessibilityController.accessibleElementById("test a");
-            result.innerText += 'il in ul role: ' + ulListElement.role + "\n\n";
+            output += 'il in ul role: ' + ulListElement.role + "\n\n";
+            
+            debug(output);
         }
     </script>
 </body>

--- a/LayoutTests/accessibility/canvas-accessibilitynodeobject-expected.txt
+++ b/LayoutTests/accessibility/canvas-accessibilitynodeobject-expected.txt
@@ -1,20 +1,18 @@
-Link  Button           ARIA button ARIA link
 This test makes sure that AccessibilityNodeObjects are created for elements in a canvas subtree.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: axRenderObjects.length === axNodeObjects.length
+PASS: i == 0; axRenderObject.role == axNodeObject.role === true
+PASS: i == 1; axRenderObject.role == axNodeObject.role === true
+PASS: i == 2; axRenderObject.role == axNodeObject.role === true
+PASS: i == 3; axRenderObject.role == axNodeObject.role === true
+PASS: i == 4; axRenderObject.role == axNodeObject.role === true
+PASS: i == 5; axRenderObject.role == axNodeObject.role === true
+PASS: i == 6; axRenderObject.role == axNodeObject.role === true
+PASS: i == 7; axRenderObject.role == axNodeObject.role === true
+PASS: i == 8; axRenderObject.role == axNodeObject.role === true
 
-
-PASS axRenderObjects.length is axNodeObjects.length
-PASS i == 0; axRenderObject.role == axNodeObject.role is true
-PASS i == 1; axRenderObject.role == axNodeObject.role is true
-PASS i == 2; axRenderObject.role == axNodeObject.role is true
-PASS i == 3; axRenderObject.role == axNodeObject.role is true
-PASS i == 4; axRenderObject.role == axNodeObject.role is true
-PASS i == 5; axRenderObject.role == axNodeObject.role is true
-PASS i == 6; axRenderObject.role == axNodeObject.role is true
-PASS i == 7; axRenderObject.role == axNodeObject.role is true
-PASS i == 8; axRenderObject.role == axNodeObject.role is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
+Link  Button           ARIA button ARIA link
 

--- a/LayoutTests/accessibility/canvas-accessibilitynodeobject.html
+++ b/LayoutTests/accessibility/canvas-accessibilitynodeobject.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML>
 <html>
 <body>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 
 <div id="myContainer" tabindex="-1">
   <a href="#">Link</a>
@@ -27,13 +28,10 @@
   <span tabindex="0" role="link">ARIA link</span>
 </canvas>
 
-<div id="console"></div>
 <script>
-description("This test makes sure that AccessibilityNodeObjects are created for elements in a canvas subtree.");
+var output = "This test makes sure that AccessibilityNodeObjects are created for elements in a canvas subtree.\n\n";
 
-if (window.testRunner && window.accessibilityController) {
-    window.testRunner.dumpAsText();
-
+if (window.accessibilityController) {
     function appendFocusableDescendants(axObject, axFocusableList) {
         for (var i = 0; i < axObject.childrenCount; i++) {
             var axChild = axObject.childAtIndex(i);
@@ -57,17 +55,17 @@ if (window.testRunner && window.accessibilityController) {
     appendFocusableDescendants(axContainer, axRenderObjects);
     appendFocusableDescendants(axCanvas, axNodeObjects);
 
-    shouldBe("axRenderObjects.length", "axNodeObjects.length");
+    output += expect("axRenderObjects.length", "axNodeObjects.length");
 
     for (var i = 0; i < axRenderObjects.length; i++) {
         var axRenderObject = axRenderObjects[i];
         var axNodeObject = axNodeObjects[i];
-        shouldBe("i == " + i + "; axRenderObject.role == axNodeObject.role", "true");
+        output += expect("i == " + i + "; axRenderObject.role == axNodeObject.role", "true");
     }
+    
+    debug(output);
 }
 
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/content-editable-set-inner-text-generates-axvalue-notification-expected.txt
+++ b/LayoutTests/accessibility/content-editable-set-inner-text-generates-axvalue-notification-expected.txt
@@ -1,12 +1,10 @@
 This tests that a contenteditable region will send an AXValueChange notification when JS methods for changing children are used.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 Updated value: AXValue: Test1
 Updated value: AXValue: Test2
 Updated value: AXValue: Test3
 Updated value: AXValue: Test3Test4
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/content-editable-set-inner-text-generates-axvalue-notification.html
+++ b/LayoutTests/accessibility/content-editable-set-inner-text-generates-axvalue-notification.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -10,19 +11,18 @@ hello<br>
 <b>world</b>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that a contenteditable region will send an AXValueChange notification when JS methods for changing children are used.\n\n";
 
-    description("This tests that a contenteditable region will send an AXValueChange notification when JS methods for changing children are used.");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
     var notification = 0;
     var textArea = 0;
     var valueChangeCount = 0;
     function callback(notification) {
         if (notification == "AXValueChanged") {
-            debug("Updated value: " + textArea.stringValue);
+            output += "Updated value: " + textArea.stringValue + "\n";
             valueChangeCount++;
 
             if (valueChangeCount == 1) {
@@ -37,23 +37,19 @@ hello<br>
             else if (valueChangeCount == 4) {
                 document.getElementById("content").style.visibility = "hidden";
                 textArea.removeNotificationListener();
+                debug(output);
                 finishJSTest();
             }
         }
     }
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+    textArea = accessibilityController.accessibleElementById("content");
+    textArea.addNotificationListener(callback);
 
-        textArea = accessibilityController.accessibleElementById("content");
-        textArea.addNotificationListener(callback);
-
-        // Send value changes.
-        document.getElementById("content").innerText = "Test1";
-    }
+    // Send value changes.
+    document.getElementById("content").innerText = "Test1";
+}
 
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/contenteditable-table-check-causes-crash-expected.txt
+++ b/LayoutTests/accessibility/contenteditable-table-check-causes-crash-expected.txt
@@ -1,8 +1,4 @@
 Ensures that this snippet does not lead to a crash in the code that detects if a table is contenteditable. Bug 87409.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/contenteditable-table-check-causes-crash.html
+++ b/LayoutTests/accessibility/contenteditable-table-check-causes-crash.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 
 <script>
-  description("Ensures that this snippet does not lead to a crash in the code that detects if a table is contenteditable. Bug 87409.");
+var output = "Ensures that this snippet does not lead to a crash in the code that detects if a table is contenteditable. Bug 87409.";
 </script>
 
 <style>
@@ -19,11 +19,9 @@ function crash() {
   document.documentElement.appendChild(node);
 }
 window.onload = crash;
+
+debug(output);
 </script>
 
-<p id="description"></p>
-<div id="console"></div>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/crashing-a-tag-in-map-expected.txt
+++ b/LayoutTests/accessibility/crashing-a-tag-in-map-expected.txt
@@ -1,8 +1,4 @@
-
 This tests that a hit test on a image map that has areas and anchors does not crash
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/crashing-a-tag-in-map.html
+++ b/LayoutTests/accessibility/crashing-a-tag-in-map.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -15,24 +16,19 @@
 <area shape="default" nohref="nohref" alt="">
 </map></div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that a hit test on a image map that has areas and anchors does not crash\n";
 
-    description("This tests that a hit test on a image map that has areas and anchors does not crash");
+if (window.accessibilityController) {
+    var body = document.getElementById("body");
+    body.focus();
 
-    if (window.accessibilityController) {
+    // test fails if it crashes here
+    var control = accessibilityController.focusedElement.elementAtPoint(100, 100);
+}
 
-          var body = document.getElementById("body");
-          body.focus();
-
-          // test fails if it crashes here
-          var control = accessibilityController.focusedElement.elementAtPoint(100, 100);
-    }
-
+debug(output);
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/css-content-attribute.html
+++ b/LayoutTests/accessibility/css-content-attribute.html
@@ -1,23 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-    function dumpAccessibilityChildren(element, level) {
-        if (element.stringValue.indexOf('End of test') >= 0)
-            return false;
-
-        var indent = "";
-        for (var k = 0; k < level; k++) { indent += "  "; }
-        debug(indent + element.role + " " + element.stringValue);
-        var childrenCount = element.childrenCount;
-        for (var k = 0; k < childrenCount; k++) {
-            if (!dumpAccessibilityChildren(element.childAtIndex(k), level+1))
-                return false;
-        }
-        return true;
-    }
-</script>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 
     <style type="text/css">
 
@@ -35,20 +20,39 @@
 <body id="body">
 <h1>SAMPLE</h1>
 <div>End of test</div>
-<p id="description"></p>
-<div id="console"></div>
 
 <script>
+    function dumpAccessibilityChildren(element, level, output) {
+        if (element.stringValue.indexOf('End of test') >= 0)
+            return false;
 
-    description("This tests that when the content attribute in CSS is used, the correct values are returned.");
+        var indent = "";
+        for (var k = 0; k < level; k++) { indent += "  "; }
+        output.push(indent + element.role + " " + element.stringValue);
+        var childrenCount = element.childrenCount;
+        for (var k = 0; k < childrenCount; k++) {
+            if (!dumpAccessibilityChildren(element.childAtIndex(k), level+1, output))
+                return false;
+        }
+        return true;
+    }
+
+    var output = "This tests that when the content attribute in CSS is used, the correct values are returned.\n\n";
 
     if (window.accessibilityController) {
-          document.getElementById("body").focus();
-          dumpAccessibilityChildren(accessibilityController.focusedElement, 0);
+        window.jsTestIsAsync = true;
+        
+        setTimeout(function() {
+            document.getElementById("body").focus();
+            var outputLines = [];
+            dumpAccessibilityChildren(accessibilityController.focusedElement, 0, outputLines);
+            output += outputLines.join("\n");
+            
+            debug(output);
+            finishJSTest();
+        }, 0);
     }
 
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/css-table-ignored-expected.txt
+++ b/LayoutTests/accessibility/css-table-ignored-expected.txt
@@ -1,9 +1,7 @@
 This tests that an element use display:table will not be exposed as an accessible table.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: !table || !table.isValid === true
 
-
-PASS !table || !table.isValid is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/css-table-ignored.html
+++ b/LayoutTests/accessibility/css-table-ignored.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <style>
 .layout-table { display:table; }
 .layout-table .second-cell, .layout-table .third-cell, .layout-table .third-cell-no-border { display: table-cell; }
@@ -19,19 +20,16 @@
 </div>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-description("This tests that an element use display:table will not be exposed as an accessible table.");
+var output = "This tests that an element use display:table will not be exposed as an accessible table.\n\n";
 
 if (window.accessibilityController) {
     var table = accessibilityController.accessibleElementById("table");
-    shouldBeTrue("!table || !table.isValid");
+    output += expect("!table || !table.isValid", "true");
     document.getElementById("content").style.visibility = "hidden";
 }
 
+debug(output);
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/dimensions-include-descendants-expected.txt
+++ b/LayoutTests/accessibility/dimensions-include-descendants-expected.txt
@@ -1,1 +1,5 @@
 link 1 dimensions: 100 x 100; link 2 dimensions: 100 x 100
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/dimensions-include-descendants.html
+++ b/LayoutTests/accessibility/dimensions-include-descendants.html
@@ -1,20 +1,33 @@
 <!DOCTYPE HTML>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
 <div style = "height: 150px;">
     <a href="#" id="link1"><div style="width: 20px; height: 20px; display: inline-block"></div><div style="width: 80px; height: 100px; float: left;"></div></a>
 </div>
 <div style = "height: 150px;">
     <a href="#" id="link2"><div style="width: 100px; height: 96px; position: relative; display: inline-block;"></div></a>
 </div>
-<div id="result"></div>
 <script>
-    if (window.accessibilityController) {
-        testRunner.dumpAsText();
+var output = "";
 
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
         document.getElementById("link1").focus();
         var link1 = accessibilityController.focusedElement;
         document.getElementById("link2").focus();
         var link2 = accessibilityController.focusedElement;
 
-        document.getElementById("result").innerText = "link 1 dimensions: " + link1.width + " x " + link1.height + "; link 2 dimensions: " + link2.width + " x " + link2.height;
-    }
+        output = "link 1 dimensions: " + link1.width + " x " + link1.height + "; link 2 dimensions: " + link2.width + " x " + link2.height;
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
+</body>
+</html>

--- a/LayoutTests/accessibility/display-contents/descendant-menu-item-expected.txt
+++ b/LayoutTests/accessibility/display-contents/descendant-menu-item-expected.txt
@@ -1,10 +1,124 @@
-This test ensures that the aria-activedescendant of a display:contents menu is considered selected.
-
-PASS: accessibilityController.accessibleElementById('item1').isSelected === true
-PASS: accessibilityController.accessibleElementById('item2').isSelected === false
-
-PASS successfullyParsed is true
-
-TEST COMPLETE
-Menu item 1
-Menu item 2
+CONSOLE MESSAGE: ReferenceError: Can't find variable: platformValueForW3CName
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderBlock {DIV} at (0,0) size 784x411
+        RenderBlock {DIV} at (0,0) size 784x18
+          RenderText {#text} at (0,0) size 66x18
+            text run at (0,0) width 66: "group text"
+        RenderBlock {DIV} at (0,18) size 784x72
+          RenderBlock (anonymous) at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 36x18
+              text run at (0,0) width 36: "hello "
+            RenderInline {A} at (35,0) size 26x18 [color=#0000EE]
+              RenderText {#text} at (35,0) size 26x18
+                text run at (35,0) width 26: "link"
+            RenderText {#text} at (0,0) size 0x0
+          RenderBlock {DIV} at (0,18) size 784x18
+            RenderText {#text} at (0,0) size 27x18
+              text run at (0,0) width 27: "skip"
+          RenderBlock {DIV} at (0,36) size 784x18
+            RenderText {#text} at (0,0) size 27x18
+              text run at (0,0) width 27: "skip"
+          RenderBlock (anonymous) at (0,54) size 784x18
+            RenderText {#text} at (0,0) size 38x18
+              text run at (0,0) width 38: "world"
+        RenderBlock {DIV} at (0,90) size 784x52
+          RenderBlock (anonymous) at (0,0) size 784x18
+            RenderButton {BUTTON} at (0,0) size 42x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+              RenderBlock (anonymous) at (8,2) size 26x13
+                RenderText {#text} at (0,0) size 26x13
+                  text run at (0,0) width 26: "test1"
+          RenderBlock {P} at (0,34) size 784x18
+            RenderText {#text} at (0,0) size 35x18
+              text run at (0,0) width 35: "test2 "
+            RenderInline {SPAN} at (34,0) size 44x18
+              RenderText {#text} at (34,0) size 44x18
+                text run at (34,0) width 44: "hidden"
+            RenderText {#text} at (77,0) size 35x18
+              text run at (77,0) width 35: " test3"
+        RenderBlock (anonymous) at (0,158) size 784x37
+          RenderBlock {INPUT} at (2,4) size 12x12
+          RenderText {#text} at (16,0) size 4x18
+            text run at (16,0) width 4: " "
+          RenderInline {LABEL} at (20,0) size 52x18
+            RenderText {#text} at (20,0) size 26x18
+              text run at (20,0) width 26: "foo "
+            RenderInline {SPAN} at (45,0) size 27x18
+              RenderText {#text} at (45,0) size 27x18
+                text run at (45,0) width 27: "skip"
+          RenderText {#text} at (0,0) size 0x0
+          RenderBR {BR} at (72,0) size 0x18
+          RenderBlock {INPUT} at (2,22) size 12x12
+          RenderText {#text} at (0,0) size 0x0
+        RenderBlock {DIV} at (0,195) size 784x18
+          RenderText {#text} at (0,0) size 26x18
+            text run at (0,0) width 26: "foo "
+          RenderInline {SPAN} at (25,0) size 27x18
+            RenderText {#text} at (25,0) size 27x18
+              text run at (25,0) width 27: "skip"
+        RenderBlock (anonymous) at (0,213) size 784x18
+          RenderBR {BR} at (0,0) size 0x18
+        RenderBlock {DIV} at (0,231) size 784x18
+          RenderText {#text} at (0,0) size 22x18
+            text run at (0,0) width 22: "foo"
+        RenderBlock (anonymous) at (0,249) size 784x21
+          RenderInline {LABEL} at (0,1) size 21x18
+            RenderText {#text} at (0,1) size 21x18
+              text run at (0,1) width 21: "bar"
+          RenderText {#text} at (20,1) size 5x18
+            text run at (20,1) width 5: " "
+          RenderTextControl {INPUT} at (24,0) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+          RenderText {#text} at (0,0) size 0x0
+          RenderText {#text} at (0,0) size 0x0
+        RenderBlock {DIV} at (0,270) size 784x18
+          RenderBlock {NAV} at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 88x18
+              text run at (0,0) width 88: "product name"
+        RenderBlock (anonymous) at (0,288) size 784x18
+          RenderButton {BUTTON} at (0,0) size 22x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+            RenderBlock (anonymous) at (8,2) size 6x13
+              RenderText {#text} at (0,0) size 6x13
+                text run at (0,0) width 6: "x"
+          RenderText {#text} at (0,0) size 0x0
+          RenderText {#text} at (0,0) size 0x0
+        RenderBlock {DIV} at (0,306) size 784x18
+          RenderBlock {NAV} at (0,0) size 784x18
+            RenderText {#text} at (0,0) size 88x18
+              text run at (0,0) width 88: "product name"
+        RenderBlock (anonymous) at (0,324) size 784x18
+          RenderButton {BUTTON} at (0,0) size 22x18 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+            RenderBlock (anonymous) at (8,2) size 6x13
+              RenderText {#text} at (0,0) size 6x13
+                text run at (0,0) width 6: "x"
+          RenderText {#text} at (0,0) size 0x0
+        RenderBlock {DIV} at (0,342) size 784x18
+          RenderText {#text} at (0,0) size 22x18
+            text run at (0,0) width 22: "foo"
+        RenderBlock (anonymous) at (0,360) size 784x27
+          RenderButton {BUTTON} at (0,0) size 81x27 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+            RenderBlock (anonymous) at (8,2) size 65x22
+              RenderText {#text} at (0,9) size 21x13
+                text run at (0,9) width 21: "foo "
+              RenderImage {IMG} at (20,0) size 23x20
+              RenderText {#text} at (42,9) size 23x13
+                text run at (42,9) width 23: " baz"
+          RenderText {#text} at (0,0) size 0x0
+        RenderBlock {DIV} at (0,387) size 784x24
+          RenderText {#text} at (0,4) size 28x18
+            text run at (0,4) width 28: "bop "
+          RenderTextControl {INPUT} at (28,3) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
+          RenderText {#text} at (183,4) size 5x18
+            text run at (183,4) width 5: " "
+          RenderSlider {INPUT} at (189,2) size 130x16 [color=#909090] [bgcolor=#FFFFFF]
+            RenderFlexibleBox {DIV} at (0,0) size 129x16
+              RenderBlock {DIV} at (0,0) size 129x16
+                RenderBlock {DIV} at (52,0) size 25x16
+layer at (39,261) size 142x13
+  RenderBlock {DIV} at (7,4) size 142x13
+layer at (43,402) size 142x13
+  RenderBlock {DIV} at (7,4) size 142x13
+    RenderText {#text} at (0,0) size 20x13
+      text run at (0,0) width 20: "bap"

--- a/LayoutTests/accessibility/display-contents/descendant-menu-item.html
+++ b/LayoutTests/accessibility/display-contents/descendant-menu-item.html
@@ -1,25 +1,58 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/accessibility-helper.js"></script>
-<script src="../../resources/js-test.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
-<body>
+<body id="body">
 
-<div id="menu" style="display:contents" role="menu" aria-activedescendant="item1">
-   <div role="menuitem" id="item1" tabindex="-1">Menu item 1</div>
-   <div role="menuitem" id="item2" tabindex="-1">Menu item 2</div>
+<div id="content">
+
+<div class="ex" data-label="hello link use world test1 test2 test3" aria-labelledby="a1 b1" id="test1" role="group">group text</div>
+<div id="a1">hello <a href="#">link</a> <div role="group">skip</div> <div role="group" aria-label="use">skip</div> world</div>
+<!-- paragraph role is ambiguous so okay to leave next example as it -->
+<div id="b1"><button>test1</button><p tabindex=0>test2 <span aria-hidden="true">hidden</span> test3</p></div>
+
+<input type="checkbox" aria-labelledby="reverselabelfor" id="test2" class="ex" data-label="foo bar" data-note="labelled by label element">
+<label id="reverselabelfor">foo <span role="text" aria-label="bar">skip</span></label>
+<br>
+
+<input type="checkbox" aria-labelledby="reverselabelforwithdiv" id="test3" class="ex" data-label="foo bar" data-note="labelled by div element">
+<div id="reverselabelforwithdiv">foo <span role="text" aria-label="bar">skip</span></div>
+<br>
+
+<!-- would be "bar" natively, but label explicitly overridden to "foo" by labelledby -->
+<div id="overridesnativelabel">foo</div><label for="nativelabeloverridden">bar</label>
+<input class="ex" data-label="foo" id="test4" type="text" aria-labelledby="overridesnativelabel" data-note="overrides native label">
+
+<!-- self-referencing labelledby in combination with external reference -->
+<div id="productname1"><nav role="navigation"><!-- nav does not get nameFrom:contents -->product name</nav></div>
+<button class="ex" data-label="Delete" aria-label="Delete" aria-labelledby="test5 productname1" id="test5" data-note="self-referencial labelledby includes nav">x</button>
+
+<!-- self-referencing labelledby in combination with external reference -->
+<div id="productname2"><nav role="heading"><!-- nav does not get nameFrom:contents, but heading does. -->product name</nav></div>
+<button class="ex" data-label="Delete product name" aria-label="Delete" aria-labelledby="test6 productname2" id="test6" data-note="self-referencial labelledby includes heading">x</button>
+
+<div class="ex" data-label="foo bar baz bop bap boom" aria-labelledby="a3 b3" id="test7" role="group" data-note="includes form elements">foo</div>
+<button id="a3"> foo <img src="#" alt="bar"> baz</button>
+<div id="b3">bop <input value="bap"> <input type="range" aria-valuetext="boom"></div>
+
+
 </div>
 
 <script>
-var output = "This test ensures that the aria-activedescendant of a display:contents menu is considered selected.\n\n";
+var output = "This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.\n\n";
 
 if (window.accessibilityController) {
-    output += expect("accessibilityController.accessibleElementById('item1').isSelected", "true");
-    output += expect("accessibilityController.accessibleElementById('item2').isSelected", "false");
+    for (var k = 1; k < 8; k++) {
+        var test = accessibilityController.accessibleElementById("test" + k);
+        output += "test " + k + ": aria-labelledby description: " + platformValueForW3CName(test) + "\n";
+        output += "test " + k + ": expected description: " + document.getElementById("test" + k).getAttribute("data-label") + "\n\n";
+    }
+    document.getElementById("content").style.visibility = "hidden";
     debug(output);
 }
 </script>
+
 </body>
 </html>
-

--- a/LayoutTests/accessibility/div-within-anchors-causes-crash.html
+++ b/LayoutTests/accessibility/div-within-anchors-causes-crash.html
@@ -1,28 +1,28 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"> 
-<html> 
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
 <head>
-<script src="../resources/js-test-pre.js"></script> 
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
-</head> 
-<body> 
- 
-<a><div></div></a>
+</head>
+<body>
 
 <a><div></div></a>
 
-<a href="about:blank"><div></div></a> 
+<a><div></div></a>
+
+<a href="about:blank"><div></div></a>
 
 <div id="stopElement">End of test</div>
 
 <pre id="tree"></pre>
- 
-<p id="description"></p> 
-<div id="console"></div> 
- 
-<script> 
-    description("This can cause a crash.");
- 
-    if (window.accessibilityController) {
+
+<script>
+var output = "This can cause a crash.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
         // First build up full accessibility tree.
         window.stopElement = accessibilityController.accessibleElementById("stopElement");
 
@@ -37,10 +37,12 @@
         document.getElementById("tree").innerText += "After:\n";
         document.body.focus();
         dumpAccessibilityTree(accessibilityController.focusedElement, stopElement, 0);
-    }
- 
-</script> 
- 
-<script src="../resources/js-test-post.js"></script> 
-</body> 
-</html> 
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+
+</body>
+</html>

--- a/LayoutTests/accessibility/double-nested-inline-element-missing-from-tree-expected.txt
+++ b/LayoutTests/accessibility/double-nested-inline-element-missing-from-tree-expected.txt
@@ -1,10 +1,4 @@
-test1
-test2
-End of test
 This tests that when you have a two nested inline continuations and the child one has no siblings, that we go back to the parent to check for its continuation.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 AXRole: AXWebArea AXValue:
   AXRole: AXStaticText AXValue: test1
@@ -14,4 +8,6 @@ AXRole: AXWebArea AXValue:
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+test1
+test2
+End of test

--- a/LayoutTests/accessibility/double-nested-inline-element-missing-from-tree.html
+++ b/LayoutTests/accessibility/double-nested-inline-element-missing-from-tree.html
@@ -1,23 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
-<script>
-    function dumpAccessibilityChildren(element, level) {
-        if (element.stringValue.indexOf('End of test') >= 0)
-            return false;
-
-        var indent = "";
-        for (var k = 0; k < level; k++) { indent += "  "; }
-        debug(indent + element.role + " " + element.stringValue);
-        var childrenCount = element.childrenCount;
-        for (var k = 0; k < childrenCount; k++) {
-            if (!dumpAccessibilityChildren(element.childAtIndex(k), level+1))
-                return false;
-        }
-        return true;
-    }
-</script>
+<script src="../resources/js-test.js"></script>
 </head>
 
 <body id="body">
@@ -32,18 +16,33 @@
 </span>
 
 <div>End of test</div>
-<p id="description"></p>
-<div id="console"></div>
 <script>
-    if (window.accessibilityController) {
-        description("This tests that when you have a two nested inline continuations and the child one has no siblings, that we go back to the parent to check for its continuation.");
+    function dumpAccessibilityChildren(element, level, output) {
+        if (element.stringValue.indexOf('End of test') >= 0)
+            return false;
 
-        var content = accessibilityController.rootElement.childAtIndex(0);
-        dumpAccessibilityChildren(content, 0);
+        var indent = "";
+        for (var k = 0; k < level; k++) { indent += "  "; }
+        output.push(indent + element.role + " " + element.stringValue);
+        var childrenCount = element.childrenCount;
+        for (var k = 0; k < childrenCount; k++) {
+            if (!dumpAccessibilityChildren(element.childAtIndex(k), level+1, output))
+                return false;
+        }
+        return true;
     }
+
+    var output = "This tests that when you have a two nested inline continuations and the child one has no siblings, that we go back to the parent to check for its continuation.\n\n";
+    
+    if (window.accessibilityController) {
+        var outputLines = [];
+        var content = accessibilityController.rootElement.childAtIndex(0);
+        dumpAccessibilityChildren(content, 0, outputLines);
+        output += outputLines.join("\n");
+    }
+    
+    debug(output);
     successfullyParsed = true;
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/duplicate-axrenderobject-crash-expected.txt
+++ b/LayoutTests/accessibility/duplicate-axrenderobject-crash-expected.txt
@@ -1,6 +1,5 @@
+Ensures that it's not possible to have two AXRenderObjects that point to the same renderer, if the initialization of an AXRenderObject results in another object with the same renderer being created before AXObjectCache has added that mapping to its hash.
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Ensures that it's not possible to have two AXRenderObjects that point to the same renderer, if the initialization of an AXRenderObject results in another object with the same renderer being created before AXObjectCache has added that mapping to its hash.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/accessibility/duplicate-axrenderobject-crash.html
+++ b/LayoutTests/accessibility/duplicate-axrenderobject-crash.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -13,15 +14,15 @@
     </summary>
 </label>
 
-<p id="description"></p>
-
 <script>
-    description("Ensures that it's not possible to have two AXRenderObjects that point to the same renderer, if the initialization of an AXRenderObject results in another object with the same renderer being created before AXObjectCache has added that mapping to its hash.");
-    if (window.accessibilityController)
-        accessibilityController.accessibleElementById("dummy");
-</script>
+    var output = "Ensures that it's not possible to have two AXRenderObjects that point to the same renderer, if the initialization of an AXRenderObject results in another object with the same renderer being created before AXObjectCache has added that mapping to its hash.";
 
-<script src="../resources/js-test-post.js"></script>
+    if (window.accessibilityController) {
+        accessibilityController.accessibleElementById("dummy");
+    }
+    
+    debug(output);
+</script>
 
 </body>
 </html>

--- a/LayoutTests/accessibility/ellipsis-text-expected.txt
+++ b/LayoutTests/accessibility/ellipsis-text-expected.txt
@@ -1,14 +1,11 @@
-text
-My Writing Nook for iPad. More text, more text, more text.
-My Writing Nook for iPad. More text, more text, more text.
-text
 This test makes sure that the bounds of text that overflows with ellipsis is correct (shortened to the ellipsis that is).
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: clippedWidth < fullWidth === true
 
-
-PASS clippedWidth < fullWidth is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+text
+My Writing Nook for iPad. More text, more text, more text.
+My Writing Nook for iPad. More text, more text, more text.
+text

--- a/LayoutTests/accessibility/ellipsis-text.html
+++ b/LayoutTests/accessibility/ellipsis-text.html
@@ -1,7 +1,8 @@
 <html>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
  
@@ -10,13 +11,10 @@ text
 <div id="text-noellipsis" tabindex="0" style="width:50px; white-space: nowrap;" class="name">My Writing Nook for iPad. More text, more text, more text.</div>
 text
 
-    <p id="description"></p>
-    <div id="console"></div>
-     
     <script>
-        if (window.accessibilityController) {
-            description("This test makes sure that the bounds of text that overflows with ellipsis is correct (shortened to the ellipsis that is).");
+        var output = "This test makes sure that the bounds of text that overflows with ellipsis is correct (shortened to the ellipsis that is).\n\n";
 
+        if (window.accessibilityController) {
             // The width of the ellipsis text should be short.
             var textContainer = accessibilityController.accessibleElementById("text-ellipsis");
             var textNode = textContainer.childrenCount ? textContainer.childAtIndex(0) : textContainer;
@@ -27,10 +25,10 @@ text
             textNode = textContainer.childrenCount ? textContainer.childAtIndex(0) : textContainer;
             var fullWidth = textNode.width;
 
-            shouldBeTrue("clippedWidth < fullWidth");
+            output += expect("clippedWidth < fullWidth", "true");
+            debug(output);
         }
     </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/embedded-image-description-expected.txt
+++ b/LayoutTests/accessibility/embedded-image-description-expected.txt
@@ -1,9 +1,7 @@
 This tests that the embedded image description can be retrieved.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: image.embeddedImageDescription === 'AXEmbeddedImageDescription: Birds Eye View'
 
-
-PASS image.embeddedImageDescription is 'AXEmbeddedImageDescription: Birds Eye View'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/embedded-image-description.html
+++ b/LayoutTests/accessibility/embedded-image-description.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 
@@ -10,16 +10,18 @@
 <img src="resources/embedded-image-description-example.jpg" id="image" onload="runTest();">
 
 <script>
-    description("This tests that the embedded image description can be retrieved.");
-    jsTestIsAsync = true;
+    var output = "This tests that the embedded image description can be retrieved.\n\n";
+    
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
 
-    var image;
-    function runTest() {
-       image = accessibilityController.accessibleElementById("image");
-       shouldBe("image.embeddedImageDescription", "'AXEmbeddedImageDescription: Birds Eye View'");
-       finishJSTest();
+        function runTest() {
+            image = accessibilityController.accessibleElementById("image");
+            output += expect("image.embeddedImageDescription", "'AXEmbeddedImageDescription: Birds Eye View'");
+            debug(output);
+            finishJSTest();
+        }
     }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/fieldset-element-expected.txt
+++ b/LayoutTests/accessibility/fieldset-element-expected.txt
@@ -1,8 +1,5 @@
 This tests that fieldset and legend elements are exposed correctly.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 element id 'f0': High Score:
 element id 'f1': High Score:
 element id 'f2': New High Score:
@@ -11,6 +8,7 @@ element id 'f4':
 element id 'f5': High Score:
 element id 'f6':
 element id 'l0': AXValue: Other:
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/fieldset-element.html
+++ b/LayoutTests/accessibility/fieldset-element.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 <title>Fieldset Element</title>
 </head>
@@ -65,13 +65,14 @@ Name: <input type="text">
 <!-- legend outside fieldset. -->
 <legend id="l0">Other:</legend>
 </div>
-<p id="description"></p>
-<div id="console"></div>
 
 <script>
-    description("This tests that fieldset and legend elements are exposed correctly.");
-    
-    if (window.accessibilityController) {
+var output = "This tests that fieldset and legend elements are exposed correctly.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(function() {
         var fieldsetDescription = 0;
         var fieldsetTestCount = 0;
         var legendValue = 0;
@@ -80,19 +81,21 @@ Name: <input type="text">
         fieldsetTestCount = document.getElementsByClassName("fieldsetTest").length;
         for (var i = 0; i < fieldsetTestCount; ++i) {
             var accName = platformValueForW3CName(accessibilityController.accessibleElementById("f" + i));
-            debug("element id 'f" + i + "': " +  accName);
+            output += "element id 'f" + i + "': " + accName + "\n";
         }
 
         // legend tests.
         var legend = accessibilityController.accessibleElementById("l0");
         if (legend.childrenCount)
             legend = legend.childAtIndex(0);
-        debug("element id 'l0': " + legend.stringValue);
+        output += "element id 'l0': " + legend.stringValue + "\n";
 
         document.getElementById("content").style.visibility = "hidden";
-    }
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/focusable-inside-hidden-expected.txt
+++ b/LayoutTests/accessibility/focusable-inside-hidden-expected.txt
@@ -1,9 +1,9 @@
 This tests that a focusable object inside an aria-hidden is in the hieararchy only after it gains focus.
 
-PASS: !button || !button.isValid === true
+PASS: !button === true
 PASS: button.description === 'AXDescription: BUTTON'
 PASS: button.description === 'AXDescription: BUTTON'
-PASS: !button || !button.isValid === true
+PASS: !button === true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/focusable-inside-hidden.html
+++ b/LayoutTests/accessibility/focusable-inside-hidden.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/accessibility-helper.js"></script>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -18,11 +18,11 @@
 var output = "This tests that a focusable object inside an aria-hidden is in the hieararchy only after it gains focus.\n\n";
 
 if (window.accessibilityController) {
-    jsTestIsAsync = true;
+    window.jsTestIsAsync = true;
 
     // By default, if it doesn't have focus it should be hidden because it's inside aria-hidden.
     var button = accessibilityController.accessibleElementById("button");
-    output += expect("!button || !button.isValid", "true");
+    output += expect("!button", "true");
 
     // Gain focus and this element should be visible to AX.
     document.getElementById("button").focus();
@@ -48,7 +48,7 @@ if (window.accessibilityController) {
             button = accessibilityController.accessibleElementById("button");
             return !button || !button.isValid;
         });
-        output += expect("!button || !button.isValid", "true");
+        output += expect("!button", "true");
 
         debug(output);
         finishJSTest();

--- a/LayoutTests/accessibility/frame-disconnect-textmarker-cache-crash-expected.txt
+++ b/LayoutTests/accessibility/frame-disconnect-textmarker-cache-crash-expected.txt
@@ -1,11 +1,9 @@
 This tests that when we access a text marker in a frame that is subsequently replaced by a different frame, we don't leave a hanging node in the cache that leads to a crash.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS string is 'hello'
-PASS string is 'test text'
+PASS: string === 'hello'
+PASS: string === 'test text'
 TEST PASSED: NO CRASH
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/frame-disconnect-textmarker-cache-crash.html
+++ b/LayoutTests/accessibility/frame-disconnect-textmarker-cache-crash.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -9,71 +10,67 @@
 <iframe id="frame" src="resources/frameset.html" onload="frameLoad();" width=500 height=500></iframe>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that when we access a text marker in a frame that is subsequently replaced by a different frame, we don't leave a hanging node in the cache that leads to a crash.\n\n";
 
-    description("This tests that when we access a text marker in a frame that is subsequently replaced by a different frame, we don't leave a hanging node in the cache that leads to a crash.");
+var loadCount = 0;
+var markerRange = 0;
+var string = 0;
 
-    var loadCount = 0;
-    var markerRange = 0;
-    var string = 0;
+function subFrameLoaded() {
+    // Step 2: When the sub frame of the iframe loads again this method is called (from that sub-frame)
 
-    function subFrameLoaded() {
+    // Access the old marker range that we kept hanging around and try to access after the frame changes. This should not crash.
+    var frame = accessibilityController.accessibleElementById("content");
+    var webArea = frame.childAtIndex(0).childAtIndex(0);
+    string = webArea.stringForTextMarkerRange(markerRange);
 
-        // Step 2: When the sub frame of the iframe loads again this method is called (from that sub-frame)
+    // Now try to access a node in the sub-frame, and then we'll replace the parent frame.
+    var text = frame.childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0);
+    // Access a marker range so that we start tracking a node in our cache.
+    markerRange = text.textMarkerRangeForElement(text);
+    string = text.stringForTextMarkerRange(markerRange);
+    output += expect("string", "'test text'");
 
-        // Access the old marker range that we kept hanging around and try to access after the frame changes. This should not crash.
-        var frame = accessibilityController.accessibleElementById("content");
-        var webArea = frame.childAtIndex(0).childAtIndex(0);
-        string = webArea.stringForTextMarkerRange(markerRange);
+    // Step 3: Replace the top level iframe src while holding onto a marker range and verify there's no crash
+    document.getElementById("frame").onload = function() {
+        document.getElementById("content").removeChild(document.getElementById("frame"));
+        string = accessibilityController.accessibleElementById("content").stringForTextMarkerRange(markerRange);
 
-        // Now try to access a node in the sub-frame, and then we'll replace the parent frame.
-        var text = frame.childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0);
-        // Access a marker range so that we start tracking a node in our cache.
-        markerRange = text.textMarkerRangeForElement(text);
-        string = text.stringForTextMarkerRange(markerRange);
-        shouldBe("string", "'test text'");
+        output += "TEST PASSED: NO CRASH\n";
 
-        // Step 3: Replace the top level iframe src while holding onto a marker range and verify there's no crash
-        document.getElementById("frame").onload = function() {
-            document.getElementById("content").removeChild(document.getElementById("frame"));
-            string = accessibilityController.accessibleElementById("content").stringForTextMarkerRange(markerRange);
-
-            debug("TEST PASSED: NO CRASH");
-
-            finishJSTest();
-            gc();
-        };
-
-        document.getElementById("frame").src = "resources/text.html";
-
+        debug(output);
+        finishJSTest();
         gc();
-    }
+    };
 
-    function frameLoad() {
+    document.getElementById("frame").src = "resources/text.html";
 
-        // Step 1: When the iframe loads get a marker range that is reference is the sub-frame of the iframe.
-        var frame = accessibilityController.accessibleElementById("content");
+    gc();
+}
 
-        var text = frame.childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0);
-      
-        // Access a marker range so that we start tracking a node in our cache.
-        markerRange = text.textMarkerRangeForElement(text);
-        string = text.stringForTextMarkerRange(markerRange);
+function frameLoad() {
+    // Step 1: When the iframe loads get a marker range that is reference is the sub-frame of the iframe.
+    var frame = accessibilityController.accessibleElementById("content");
 
-        shouldBe("string", "'hello'"); 
-        gc();
+    var text = frame.childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0).childAtIndex(0);
+  
+    // Access a marker range so that we start tracking a node in our cache.
+    markerRange = text.textMarkerRangeForElement(text);
+    string = text.stringForTextMarkerRange(markerRange);
 
-        // Load a new frame in this location which should now invalidate the marker range cache (and not lead to a crash).
-        document.getElementById("frame").contentWindow.frames[0].location = "resources/inform-parent-of-load.html";
+    output += expect("string", "'hello'");
+    gc();
 
-        gc();
-    }
+    // Load a new frame in this location which should now invalidate the marker range cache (and not lead to a crash).
+    document.getElementById("frame").contentWindow.frames[0].location = "resources/inform-parent-of-load.html";
 
-    jsTestIsAsync = true;
+    gc();
+}
 
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/heading-title-includes-links-expected.txt
+++ b/LayoutTests/accessibility/heading-title-includes-links-expected.txt
@@ -1,12 +1,7 @@
-Apple
-
 This tests that the title of a heading will include links if available.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 Heading title: AXTitle: Apple
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+Apple

--- a/LayoutTests/accessibility/heading-title-includes-links.html
+++ b/LayoutTests/accessibility/heading-title-includes-links.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body" onload="setTimeout('runTest()', 0);">
 
@@ -11,19 +12,17 @@
     </a>
 </h1>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
 
-jsTestIsAsync = true;
+window.jsTestIsAsync = true;
 
 function runTest() {
-    description("This tests that the title of a heading will include links if available.");
+    var output = "This tests that the title of a heading will include links if available.\n\n";
 
     if (window.accessibilityController)
-        debug("Heading title: " + accessibilityController.accessibleElementById("heading").title);
+        output += "Heading title: " + accessibilityController.accessibleElementById("heading").title;
 
+    debug(output);
     finishJSTest();
 }
 

--- a/LayoutTests/accessibility/hidden-slot-expected.txt
+++ b/LayoutTests/accessibility/hidden-slot-expected.txt
@@ -1,7 +1,7 @@
 This test ensures we don't expose elements within an aria-hidden slot element.
 
 PASS: accessibilityController.accessibleElementById('outside').role.toLowerCase().includes('button') === true
-PASS: !insideButton || insideButton.isIgnored === true
+PASS: !insideButton === true
 PASS: insideButton.role.toLowerCase().includes('button') === true
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/hidden-slot.html
+++ b/LayoutTests/accessibility/hidden-slot.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/accessibility-helper.js"></script>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -26,7 +26,7 @@ if (window.accessibilityController) {
 
     output += expect("accessibilityController.accessibleElementById('outside').role.toLowerCase().includes('button')", "true");
     var insideButton = accessibilityController.accessibleElementById("inside");
-    output += expect("!insideButton || insideButton.isIgnored", "true");
+    output += expect("!insideButton", "true");
 
     document.getElementById("x-button").shadowRoot.getElementById("slot").removeAttribute("aria-hidden");
     setTimeout(async function() {
@@ -43,4 +43,3 @@ if (window.accessibilityController) {
 </script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/hidden-th-still-column-header-expected.txt
+++ b/LayoutTests/accessibility/hidden-th-still-column-header-expected.txt
@@ -1,14 +1,11 @@
-header 1header2	header 3
-cell1	cell2	cell3
 This tests confirms even when a th tag is hidden, it will still be returned as a column header (unless it is hidden).
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: colHeaders.length === 2
+PASS: colHeaders[0].childAtIndex(0).stringValue === 'AXValue: header 1'
+PASS: colHeaders[1].childAtIndex(0).stringValue === 'AXValue: header 3'
 
-
-PASS colHeaders.length is 2
-PASS colHeaders[0].childAtIndex(0).stringValue is 'AXValue: header 1'
-PASS colHeaders[1].childAtIndex(0).stringValue is 'AXValue: header 3'
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+header 1header2	header 3
+cell1	cell2	cell3

--- a/LayoutTests/accessibility/hidden-th-still-column-header.html
+++ b/LayoutTests/accessibility/hidden-th-still-column-header.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
@@ -14,18 +14,18 @@
 <tr><td>cell1</td><td>cell2</td><td>cell3</td></tr>
 </table>
 
-<p id="description"></p>
-<div id="console"></div>
 <script>
-    description("This tests confirms even when a th tag is hidden, it will still be returned as a column header (unless it is hidden).");
-    if (window.accessibilityController) {
-        var table = accessibilityController.accessibleElementById("table");
-        var colHeaders = table.columnHeaders();
-        shouldBe("colHeaders.length", "2");
-        shouldBe("colHeaders[0].childAtIndex(0).stringValue", "'AXValue: header 1'");
-        shouldBe("colHeaders[1].childAtIndex(0).stringValue", "'AXValue: header 3'");
-    }
+var output = "This tests confirms even when a th tag is hidden, it will still be returned as a column header (unless it is hidden).\n\n";
+
+if (window.accessibilityController) {
+    var table = accessibilityController.accessibleElementById("table");
+    var colHeaders = table.columnHeaders();
+    output += expect("colHeaders.length", "2");
+    output += expect("colHeaders[0].childAtIndex(0).stringValue", "'AXValue: header 1'");
+    output += expect("colHeaders[1].childAtIndex(0).stringValue", "'AXValue: header 3'");
+    
+    debug(output);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/iframe-within-cell-expected.txt
+++ b/LayoutTests/accessibility/iframe-within-cell-expected.txt
@@ -1,11 +1,8 @@
 This tests iframe within a cell is accessible.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
+Role for iframe cell is:  AXRole: AXCell .
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Role for iframe cell is:  AXRole: AXCell .
-
 Cell A		Cell C

--- a/LayoutTests/accessibility/iframe-within-cell.html
+++ b/LayoutTests/accessibility/iframe-within-cell.html
@@ -1,19 +1,23 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <script>
 
 if (window.testRunner)
     testRunner.dumpAsText();
 
+var output = "This tests iframe within a cell is accessible.\n\n";
+
 function runTest()
 {
-    document.getElementById("frame_cell").focus()
+    document.getElementById("frame_cell").focus();
     if (window.accessibilityController) {
         document.body.focus();
         var frameElement = accessibilityController.accessibleElementById("frame_cell");
-        debug("Role for iframe cell is:  " + frameElement.role + " .\n");
+        output += "Role for iframe cell is:  " + frameElement.role + " .\n";
+        debug(output);
     }
 }
             
@@ -29,9 +33,5 @@ function runTest()
 </tr>
 </table>
 
-<script>
-description("This tests iframe within a cell is accessible.");
-</script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/image-link-expected.txt
+++ b/LayoutTests/accessibility/image-link-expected.txt
@@ -1,34 +1,31 @@
-Image link in the presence of inline continuations
-
 This test checks that the right accessibility tree is generated for a link inside an image
-
 
 AXRole: AXLink
 AXSubrole: (null)
 AXRoleDescription: link
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXLink: 'Delicious cake'>
+AXParent:
 AXSize: NSSize: {280, 215}
 AXTitle: Delicious cake
 AXDescription:
 AXValue:
 AXFocused: 1
 AXEnabled: 1
-AXWindow: <AXLink: 'Delicious cake'>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXLink: 'Delicious cake'>
-AXEndTextMarker: <AXLink: 'Delicious cake'>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXLink: 'Delicious cake'>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier: test
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXLink: 'Delicious cake'>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXElementBusy: 0
@@ -41,36 +38,44 @@ Child 0:
 AXRole: AXImage
 AXSubrole: (null)
 AXRoleDescription: image
-AXChildren: <array of size 0>
-AXChildrenInNavigationOrder: <array of size 0>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXImage>
+AXParent:
 AXSize: NSSize: {280, 210}
 AXTitle:
 AXDescription: Delicious cake
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXImage>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXImage>
-AXEndTextMarker: <AXImage>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXImage>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXImage>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
-AXVisibleCharacterRange: NSRange: {0, 0}
+AXVisibleCharacterRange: NSRange: {0, 1}
 AXElementBusy: 0
 AXImageOverlayElements: (null)
 AXEmbeddedImageDescription:
 AXURL: LayoutTests/accessibility/resources/cake.png
 
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Image link in the presence of inline continuations
+
+This test checks that the right accessibility tree is generated for a link inside an image
 
 

--- a/LayoutTests/accessibility/image-link-inline-cont-expected.txt
+++ b/LayoutTests/accessibility/image-link-inline-cont-expected.txt
@@ -1,9 +1,18 @@
+This test checks that a block inside a link does not unduly disturb the render tree via inline continuations.
+
+PASS: accessibility trees were identical other than size.
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Image link in the presence of inline continuations
 
 This test checks that a block inside a link does not unduly disturb the render tree via inline continuations. In particular, it checks that adding <div role=presentation> between a link and its contained image does not alter the accessibility tree at all, other than with respect to size.
 
 
 
- PASS: accessibility trees were identical other than size.
+
+
+
+
 
 

--- a/LayoutTests/accessibility/image-link-inline-cont.html
+++ b/LayoutTests/accessibility/image-link-inline-cont.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <head>
 <title>Image link in the presence of inline continuations</title>
-<script>
-if (window.testRunner)
-    testRunner.dumpAsText();
-</script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -27,6 +25,8 @@ if (window.testRunner)
 <pre id="result"></div>
 
 <script>
+var output = "This test checks that a block inside a link does not unduly disturb the render tree via inline continuations.\n\n";
+
 function axTree(elt)
 {
     var result = elt.allAttributes() + "\n\n";
@@ -38,20 +38,27 @@ function axTree(elt)
 }
 
 if (window.accessibilityController) {
-    var result = document.getElementById("result");
-    document.getElementById("plain").focus();
-    var plainResult = axTree(accessibilityController.focusedElement);
-    plainResult.replace(/AXSize.*\n/g, "");
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
+        document.getElementById("plain").focus();
+        var plainResult = axTree(accessibilityController.focusedElement);
+        plainResult = plainResult.replace(/AXSize.*\n/g, "");
 
-    document.getElementById("with-div").focus();
-    var withDivResult = axTree(accessibilityController.focusedElement);
-    withDivResult.replace(/AXSize.*\n/g, "");
+        document.getElementById("with-div").focus();
+        var withDivResult = axTree(accessibilityController.focusedElement);
+        withDivResult = withDivResult.replace(/AXSize.*\n/g, "");
 
-    if (plainResult == withDivResult) {
-        result.innerHTML = "PASS: accessibility trees were identical other than size."
-    } else {
-        result.innerHTML = "FAIL: accessibility trees differ.\nPlain image link: \n" + plainResult + "\nWith presentation div:\n" + withDivResult;
-    }
+        if (plainResult == withDivResult) {
+            output += "PASS: accessibility trees were identical other than size.";
+        } else {
+            output += "FAIL: accessibility trees differ.\nPlain image link: \n" + plainResult + "\nWith presentation div:\n" + withDivResult;
+        }
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
 </body>
+</html>

--- a/LayoutTests/accessibility/image-link.html
+++ b/LayoutTests/accessibility/image-link.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <head>
 <title>Image link test</title>
-<script>
-if (window.testRunner)
-    testRunner.dumpAsText();
-</script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -14,9 +12,9 @@ if (window.testRunner)
 
   <a id="test" href="http://www.wowhead.com/?item=33924"><img alt="Delicious cake" src="resources/cake.png"></a>
 
-  <div id="result"></div>
-
 <script>
+var output = "This test checks that the right accessibility tree is generated for a link inside an image\n\n";
+
 function axTree(elt)
 {
     var result = elt.allAttributes() + "\n\n";
@@ -27,12 +25,16 @@ function axTree(elt)
     return result;
 }
 
-window.onload = function () {
-    if (window.accessibilityController) {
-        var result = document.getElementById("result");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    window.onload = function () {
         document.getElementById("test").focus();
-        result.innerText += axTree(accessibilityController.focusedElement);
+        output += axTree(accessibilityController.focusedElement);
+        debug(output);
+        finishJSTest();
     }
 }
 </script>
 </body>
+</html>

--- a/LayoutTests/accessibility/image-map1-expected.txt
+++ b/LayoutTests/accessibility/image-map1-expected.txt
@@ -1,8 +1,5 @@
 This tests that you can reach the links within an image map.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 Link1 AXRole: AXLink
 Link1 AXTitle:
 Link1 AXDescription: Link1

--- a/LayoutTests/accessibility/image-map1.html
+++ b/LayoutTests/accessibility/image-map1.html
@@ -1,6 +1,8 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -16,19 +18,18 @@
 </div>
 
 <script>
-    description("This tests that you can reach the links within an image map.");
+var output = "This tests that you can reach the links within an image map.\n\n";
 
-    if (window.accessibilityController) {
-        let content = accessibilityController.accessibleElementById("content");
-        let output = "";
-        for (let k = 0; k < 3; ++k) {
-            let link = content.childAtIndex(k);
-            output += `Link${k + 1} ${link.role}\n`;
-            output += `Link${k + 1} ${link.title}\n`;
-            output += `Link${k + 1} ${link.description}\n\n`;
-        }
-        debug(output);
+if (window.accessibilityController) {
+    var content = accessibilityController.accessibleElementById("content");
+    for (var k = 0; k < 3; ++k) {
+        var link = content.childAtIndex(k);
+        output += `Link${k + 1} ${link.role}\n`;
+        output += `Link${k + 1} ${link.title}\n`;
+        output += `Link${k + 1} ${link.description}\n\n`;
     }
+    debug(output);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/image-role-is-synonomous-with-img-role-expected.txt
+++ b/LayoutTests/accessibility/image-role-is-synonomous-with-img-role-expected.txt
@@ -1,10 +1,8 @@
 This test ensures that role="image" and role="img" are synonyms.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: img.role === 'AXRole: AXImage'
+PASS: image.role === 'AXRole: AXImage'
 
-
-PASS img.role is 'AXRole: AXImage'
-PASS image.role is 'AXRole: AXImage'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/image-role-is-synonomous-with-img-role.html
+++ b/LayoutTests/accessibility/image-role-is-synonomous-with-img-role.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-    <script src="../resources/js-test-pre.js"></script>
+    <script src="../resources/js-test.js"></script>
     <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
@@ -10,15 +10,17 @@
     <div id="image" role="image">This div should also have a role of image.</div>
 </div>
 <script>
-    description("This test ensures that role=\"image\" and role=\"img\" are synonyms.");
+    var output = "This test ensures that role=\"image\" and role=\"img\" are synonyms.\n\n";
+    
     if (window.accessibilityController) {
         var img = accessibilityController.accessibleElementById("img");
         var image = accessibilityController.accessibleElementById("image");
-        shouldBe("img.role", "'AXRole: AXImage'");
-        shouldBe("image.role", "'AXRole: AXImage'");
+        output += expect("img.role", "'AXRole: AXImage'");
+        output += expect("image.role", "'AXRole: AXImage'");
         document.getElementById("content").style.visibility = "hidden";
+        
+        debug(output);
     }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/insert-children-assert-expected.txt
+++ b/LayoutTests/accessibility/insert-children-assert-expected.txt
@@ -1,14 +1,11 @@
-ab
-c
-de
 This tests that we only insert valid children when building ax tree.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: valueOccuranceInElementTree(content, value) === 1
+PASS: valueOccuranceInElementTree(content, value) === 1
 
-
-PASS valueOccuranceInElementTree(content, value) is 1
-PASS valueOccuranceInElementTree(content, value) is 1
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+ab
+c
+de

--- a/LayoutTests/accessibility/insert-children-assert.html
+++ b/LayoutTests/accessibility/insert-children-assert.html
@@ -18,14 +18,24 @@ body {
 <summary>a<span>b<div>c</div>d</span>e</summary>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This tests that we only insert valid children when building ax tree.");
+    var output = "This tests that we only insert valid children when building ax tree.\n\n";
     jsTestIsAsync = true;
 
-    if ("webkitRequestFullScreen" in Element.prototype) {
+    function valueOccuranceInElementTree(element, value) {
+        if (!element) {
+            return 0;
+        }
+        var count = 0;
+        if (element.stringValue == value)
+            count++;
+        var childrenCount = element.childrenCount;
+        for (var k = 0; k < childrenCount; k++)
+            count += valueOccuranceInElementTree(element.childAtIndex(k), value);
+        return count;
+    }
+
+    if (window.accessibilityController && "webkitRequestFullScreen" in Element.prototype) {
         var content = accessibilityController.accessibleElementById("content");
         var value;
         if (accessibilityController.platformName == "atspi")
@@ -40,9 +50,11 @@ body {
                 setTimeout(function () {
                     document.webkitCancelFullScreen();
                 }, 0)
-            } else
+            } else {
+                output += expect("valueOccuranceInElementTree(content, value)", "1");
+                debug(output);
                 finishJSTest();
-            shouldBe("valueOccuranceInElementTree(content, value)", "1");
+            }
         };
 
         document.addEventListener('webkitfullscreenchange', fullscreenChangeEvent);
@@ -51,24 +63,11 @@ body {
             span.webkitRequestFullScreen();
         });
         
-        shouldBe("valueOccuranceInElementTree(content, value)", "1");
+        output += expect("valueOccuranceInElementTree(content, value)", "1");
         if (window.eventSender)
             eventSender.keyDown('a');
     }
     successfullyParsed = true;
-
-    function valueOccuranceInElementTree(element, value) {
-        if (!element) {
-            return 0;
-        }
-        var count = 0;
-        if (element.stringValue == value)
-            count++;
-        var childrenCount = element.childrenCount;
-        for (var k = 0; k < childrenCount; k++)
-            count += valueOccuranceInElementTree(element.childAtIndex(k), value);
-        return count;
-    }
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/insert-text-into-password-field.html
+++ b/LayoutTests/accessibility/insert-text-into-password-field.html
@@ -12,6 +12,8 @@
     var testOutput = "This test ensures that inserting text into a password field works.\n\n";
 
     if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
         testOutput += "Focusing #password-input, and then inserting text 'foo' into it.\n";
         // Put focus into the password input so `insertText` has a target.
         document.getElementById("password-input").focus();
@@ -20,8 +22,8 @@
 
         testOutput += `#password-input ${passwordInput.stringValue}`;
         debug(testOutput);
+        finishJSTest();
     }
 </script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/keyevents-for-increment-actions-with-node-removal-expected.txt
+++ b/LayoutTests/accessibility/keyevents-for-increment-actions-with-node-removal-expected.txt
@@ -1,9 +1,7 @@
 This test makes sure if a keydown event removes the node, bad things don't happen.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 Keycode received: identifier: Right key name: ArrowRight
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/keyevents-for-increment-actions-with-node-removal.html
+++ b/LayoutTests/accessibility/keyevents-for-increment-actions-with-node-removal.html
@@ -1,6 +1,8 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -12,21 +14,19 @@
            aria-valuemax="255"
            aria-labelledby="idRed"></div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This test makes sure if a keydown event removes the node, bad things don't happen.");
+    var output = "This test makes sure if a keydown event removes the node, bad things don't happen.\n\n";
 
     function handleKeyUp(event) {
-        debug("Key up should NOT be reached");
+        output += "Key up should NOT be reached\n";
     }
 
     function handleKeyDown(event) {
-        debug("Keycode received: identifier: " + event.keyIdentifier + " key name: " + event.key);
+        output += "Keycode received: identifier: " + event.keyIdentifier + " key name: " + event.key + "\n";
         document.getElementById("body").removeChild(document.getElementById("slider"));
         event.preventDefault();
         event.stopPropagation();
+        debug(output);
         finishJSTest();
     }
 
@@ -41,6 +41,5 @@
         axSlider.increment();
     }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/keyevents-posted-for-dismiss-action-expected.txt
+++ b/LayoutTests/accessibility/keyevents-posted-for-dismiss-action-expected.txt
@@ -1,11 +1,7 @@
-alert
 This test verifies that the dismiss action generates an escape key event.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 Keycode received: code: 27 key name: Escape
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+alert

--- a/LayoutTests/accessibility/keyevents-posted-for-dismiss-action.html
+++ b/LayoutTests/accessibility/keyevents-posted-for-dismiss-action.html
@@ -1,32 +1,30 @@
-<html>
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
 <div id="alert">alert</div>
-
-<p id="description"></p>
-<div id="console"></div>
      
 <script>
+    var output = "This test verifies that the dismiss action generates an escape key event.\n\n";
+
     function handleKeyDown(event) {
-        debug("Keycode received: code: " + event.keyCode + " key name: " + event.key);
+        output += "Keycode received: code: " + event.keyCode + " key name: " + event.key;
         event.preventDefault();
         event.stopPropagation();
+        debug(output);
         finishJSTest();
      }
 
     if (window.accessibilityController) {
-        jsTestIsAsync = true;
-        description("This test verifies that the dismiss action generates an escape key event.");
+        window.jsTestIsAsync = true;
 
         document.getElementById("alert").addEventListener('keydown', handleKeyDown);
         accessibilityController.accessibleElementById("alert").dismiss();
     }
- </script>
-
-<script src="../resources/js-test-post.js"></script>
+</script>
 </body>
 </html>

--- a/LayoutTests/accessibility/keyevents-posted-for-increment-actions-expected.txt
+++ b/LayoutTests/accessibility/keyevents-posted-for-increment-actions-expected.txt
@@ -1,22 +1,20 @@
 This test verifies that the increment/decrement actions post keyboard events that are correct for LTR and orientation.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 Increment/Decrement - LTR
 Horizontal orientation
-Keycode received: identifier: Right key name: ArrowRight key code: 39
-Keycode received: identifier: Left key name: ArrowLeft key code: 37
 Vertical orientation
-Keycode received: identifier: Up key name: ArrowUp key code: 38
-Keycode received: identifier: Down key name: ArrowDown key code: 40
 Increment/Decrement - RTL
 Horizontal orientation
-Keycode received: identifier: Left key name: ArrowLeft key code: 37
-Keycode received: identifier: Right key name: ArrowRight key code: 39
 Vertical orientation
 Keycode received: identifier: Up key name: ArrowUp key code: 38
 Keycode received: identifier: Down key name: ArrowDown key code: 40
+Keycode received: identifier: Up key name: ArrowUp key code: 38
+Keycode received: identifier: Down key name: ArrowDown key code: 40
+Keycode received: identifier: Up key name: ArrowUp key code: 38
+Keycode received: identifier: Down key name: ArrowDown key code: 40
+Keycode received: identifier: Up key name: ArrowUp key code: 38
+Keycode received: identifier: Down key name: ArrowDown key code: 40
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/keyevents-posted-for-increment-actions.html
+++ b/LayoutTests/accessibility/keyevents-posted-for-increment-actions.html
@@ -1,6 +1,8 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -12,21 +14,20 @@
            aria-valuemax="255"
            aria-labelledby="idRed"></div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This test verifies that the increment/decrement actions post keyboard events that are correct for LTR and orientation.");
+    var output = "This test verifies that the increment/decrement actions post keyboard events that are correct for LTR and orientation.\n\n";
 
     var keyCount = 0;
     function handleKeyDown(event) {
-        debug("Keycode received: identifier: " + event.keyIdentifier + " key name: " + event.key + " key code: " + event.keyCode);
+        output += "Keycode received: identifier: " + event.keyIdentifier + " key name: " + event.key + " key code: " + event.keyCode + "\n";
         event.preventDefault();
         event.stopPropagation();
 
         keyCount++;
-        if (keyCount == 8)
+        if (keyCount == 8) {
+            debug(output);
             finishJSTest();
+        }
     }
 
     if (window.accessibilityController) {
@@ -37,26 +38,25 @@
         // Get the parent element.
         var axSlider = accessibilityController.accessibleElementById("slider");
 
-        debug("Increment/Decrement - LTR");
+        output += "Increment/Decrement - LTR\n";
         incrementDecrement();
 
-        debug("Increment/Decrement - RTL");
+        output += "Increment/Decrement - RTL\n";
         window.internals.setUserInterfaceLayoutDirection("RTL");
         incrementDecrement();
 
         function incrementDecrement() {
-            debug("Horizontal orientation");
+            output += "Horizontal orientation\n";
             document.getElementById("slider").setAttribute("aria-orientation", "horizontal");
             axSlider.increment();
             axSlider.decrement();
 
-            debug("Vertical orientation");
+            output += "Vertical orientation\n";
             document.getElementById("slider").setAttribute("aria-orientation", "vertical");
             axSlider.increment();
             axSlider.decrement();
         }
     }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/label-element-press-expected.txt
+++ b/LayoutTests/accessibility/label-element-press-expected.txt
@@ -1,10 +1,4 @@
-label
-This tests that a label element without a corresponding control will perform a press action on itself instead of nothing.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+label

--- a/LayoutTests/accessibility/label-element-press.html
+++ b/LayoutTests/accessibility/label-element-press.html
@@ -2,29 +2,28 @@
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 
 <body id="body">
 
 <label tabindex=0 onclick="finishJSTest()" id="labelElement">label</label>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that a label element without a corresponding control will perform a press action on itself instead of nothing.";
 
-    description("This tests that a label element without a corresponding control will perform a press action on itself instead of nothing.");
-    jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-    if (window.accessibilityController) {
-        document.getElementById("body").focus();
-        var body = accessibilityController.focusedElement;
-        var label = body.childAtIndex(0).childAtIndex(0);
-    
-        // if successful, performEvent() will be called and we'll successfully parse.        
-        label.press();
-    }
+    document.getElementById("body").focus();
+    var body = accessibilityController.focusedElement;
+    var label = body.childAtIndex(0).childAtIndex(0);
 
+    // if successful, performEvent() will be called and we'll successfully parse.        
+    label.press();
+} else {
+    debug(output);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/listbox-clear-selection.html
+++ b/LayoutTests/accessibility/listbox-clear-selection.html
@@ -1,31 +1,37 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 <select id="listbox" multiple="multiple">
     <option>Option 1</option>
     <option>Option 2</option>
 </select>
-<div id="description"></div>
-<div id="console"></div>
 <script>
-    description("Tests clearing the selection of a multi-select select element.");
-    if (window.accessibilityController) {
+var output = "Tests clearing the selection of a multi-select select element.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
         var listbox = accessibilityController.accessibleElementById("listbox");
-        shouldBe("listbox.selectedChildrenCount", "0");
+        output += expect("listbox.selectedChildrenCount", "0");
 
         listbox.setSelectedChildAtIndex(0);
-        shouldBe("listbox.selectedChildrenCount", "1");
+        output += expect("listbox.selectedChildrenCount", "1");
 
         listbox.setSelectedChildAtIndex(1);
-        shouldBe("listbox.selectedChildrenCount", "2");
+        output += expect("listbox.selectedChildrenCount", "2");
 
         listbox.clearSelectedChildren();
-        shouldBe("listbox.selectedChildrenCount", "0");
-    }
+        output += expect("listbox.selectedChildrenCount", "0");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/math-foreign-content.html
+++ b/LayoutTests/accessibility/math-foreign-content.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
@@ -18,17 +18,15 @@
     <mtext><span>HTML</span></mtext>
   </math>
 </div>
-<p id="description"></p>
 <pre id="tree"></pre>
-<div id="console"></div>
 <script>
-    description("This verifies the expected roles and values are exposed for foreign content in MathML.");
+    var output = "This verifies the expected roles and values are exposed for foreign content in MathML.\n\n";
 
     if (window.accessibilityController) {
         dumpAccessibilityTree(accessibilityController.accessibleElementById("math"), null, 0, false, false, true);
         document.getElementById("content").style.visibility = "hidden";
+        debug(output);
     }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/menu-item-crash-expected.txt
+++ b/LayoutTests/accessibility/menu-item-crash-expected.txt
@@ -1,8 +1,5 @@
 This tests that deleting a ARIA menu and children do not cause a crash.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 PASS - There was no crash when removing the ARIA menu from the DOM.
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/menu-item-crash.html
+++ b/LayoutTests/accessibility/menu-item-crash.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -13,23 +14,19 @@
 </div>
 
 <script>
+var output = "This tests that deleting a ARIA menu and children do not cause a crash.\n\n";
 
-    description("This tests that deleting a ARIA menu and children do not cause a crash.");
+if (window.accessibilityController) {
+    var content = accessibilityController.accessibleElementById("item");
 
-    if (window.accessibilityController) {
-      
-        var content = accessibilityController.accessibleElementById("item");
+    // Don't crash!
+    document.getElementById("content").innerHTML = "";  
 
-        // Don't crash!
-        document.getElementById("content").innerHTML = "";  
-   
-        debug("PASS - There was no crash when removing the ARIA menu from the DOM.");
-    }
-
-
+    output += "PASS - There was no crash when removing the ARIA menu from the DOM.";
+    
+    debug(output);
+}
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/meter-element.html
+++ b/LayoutTests/accessibility/meter-element.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML>
 <html>
 <body>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 
 <div id="content">
 <meter id="meter1" value=6 max=8>6 blocks used (out of 8 total)</meter>
@@ -23,26 +24,29 @@
 <meter id="meter14" value=0.60><div aria-label="7 of 10"><span style="color:green;">&#9632;&#9632;&#9632;&#9632;&#9632;&#9632;</span><span>&#9633;&#9633;&#9633;&#9633;</span></div></meter>
 </div>
 
-<div id="console"></div>
 <script>
+var output = "This tests that the meter element is accessible.\n\n";
 
-description("This tests that the meter element is accessible.");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
+        for (var k = 1; k < 15; k++) {
+            var meter = accessibilityController.accessibleElementById("meter" + k);
+            output += "Meter" + k + "\n";
+            output += meter.role + "\n";
+            output += meter.title + "\n";
+            output += meter.description + "\n";
+            output += meter.valueDescription + "\n";
+            output += "AXValueSettable: " + meter.isAttributeSettable("AXValue") + "\n";
+            output += "\n";
+        }
 
-if (window.testRunner && window.accessibilityController) {
-    for (var k = 1; k < 15; k++) {
-        var meter = accessibilityController.accessibleElementById("meter" + k);
-        debug("Meter" + k);
-        debug(meter.role);
-        debug(meter.title);
-        debug(meter.description);
-        debug(meter.valueDescription);
-        debug("AXValueSettable: " + meter.isAttributeSettable("AXValue"));
-        debug("\n");
-    }
-
-    document.getElementById("content").style.visibility = 'hidden';    
+        document.getElementById("content").style.visibility = 'hidden';
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/minimal-table-with-aria-is-data-table-expected.txt
+++ b/LayoutTests/accessibility/minimal-table-with-aria-is-data-table-expected.txt
@@ -1,8 +1,5 @@
 This tests that minimal tables are treated as data tables if they have ARIA table-related properties.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 cell1: AXRole: AXCell
 cell2: AXRole: AXCell
 cell3: AXRole: AXCell
@@ -11,6 +8,7 @@ cell5: AXRole: AXCell
 cell6: AXRole: AXCell
 cell7: AXRole: AXCell
 cell8: AXRole: AXGroup
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/minimal-table-with-aria-is-data-table.html
+++ b/LayoutTests/accessibility/minimal-table-with-aria-is-data-table.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 <div id="content">
@@ -15,19 +16,18 @@
 <table><tr><td id="cell8">x</td></tr></table>
 </div>
 <script>
+var output = "This tests that minimal tables are treated as data tables if they have ARIA table-related properties.\n\n";
 
-    description("This tests that minimal tables are treated as data tables if they have ARIA table-related properties.");
-    if (window.accessibilityController) {
-        for (var i = 1; i <= 8; i++) {
-            var axElement = accessibilityController.accessibleElementById("cell" + i);
-            var result = !axElement ? "(not exposed)" : axElement.role;
-            debug("cell" + i + ": " + result);
-        }
-        document.getElementById("content").style.visibility = "hidden";
+if (window.accessibilityController) {
+    for (var i = 1; i <= 8; i++) {
+        var axElement = accessibilityController.accessibleElementById("cell" + i);
+        var result = !axElement ? "(not exposed)" : axElement.role;
+        output += "cell" + i + ": " + result + "\n";
     }
-
+    document.getElementById("content").style.visibility = "hidden";
+    
+    debug(output);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/node-only-object-element-rect.html
+++ b/LayoutTests/accessibility/node-only-object-element-rect.html
@@ -25,21 +25,20 @@
 </div>
 
 <script>
-    var testOutput = "This test ensures we calculate the frame correctly for objects that don't have a renderer (like display: contents elements).\n\n";
+var testOutput = "This test ensures we calculate the frame correctly for objects that don't have a renderer (like display: contents elements).\n\n";
 
+if (window.accessibilityController) {
     function logSize(id) {
         const axElement = accessibilityController.accessibleElementById(id);
         testOutput += `#${id}: {width: ${axElement.width}, height: ${axElement.height}}\n`;
     }
 
-    if (window.accessibilityController) {
-        logSize("toolbar");
-        logSize("group");
-        logSize("button");
+    logSize("toolbar");
+    logSize("group");
+    logSize("button");
 
-        debug(testOutput);
-    }
+    debug(testOutput);
+}
 </script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/out-of-bounds-rowspan-aria-hidden.html
+++ b/LayoutTests/accessibility/out-of-bounds-rowspan-aria-hidden.html
@@ -35,6 +35,8 @@
 var output = "This test ensures that a rowspan cell does not extend outside its table section.\n\n";
 
 if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
     var table = accessibilityController.accessibleElementById("table");
     output += dumpAXTable(table);
     output += dumpAXSearchTraversal(table);
@@ -45,4 +47,3 @@ if (window.accessibilityController) {
 </script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/poorly-formed-aria-table-expected.txt
+++ b/LayoutTests/accessibility/poorly-formed-aria-table-expected.txt
@@ -1,12 +1,31 @@
-This tests that if an ARIA table does not report the rows as its direct children, the table will still correctly report the rows.
+This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+test 1: aria-labelledby description: hello link use world test1 test2 test3
+test 1: expected description: hello link use world test1 test2 test3
+
+test 2: aria-labelledby description: foo bar
+test 2: expected description: foo bar
+
+test 3: aria-labelledby description: foo bar
+test 3: expected description: foo bar
+
+test 4: aria-labelledby description: foo
+test 4: expected description: foo
+
+test 5: aria-labelledby description: Delete
+test 5: expected description: Delete
+
+test 6: aria-labelledby description: Delete product name
+test 6: expected description: Delete product name
+
+test 7: aria-labelledby description: foo bar baz bop bap boom
+test 7: expected description: foo bar baz bop bap boom
 
 
-PASS grid.rowAtIndex(0).isEqual(row1) is true
-PASS grid.rowAtIndex(1).isEqual(row2) is true
-PASS grid.rowCount is 2
 PASS successfullyParsed is true
 
 TEST COMPLETE
+
+
+
 

--- a/LayoutTests/accessibility/poorly-formed-aria-table.html
+++ b/LayoutTests/accessibility/poorly-formed-aria-table.html
@@ -1,45 +1,58 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<body>
-<script src="../resources/js-test-pre.js"></script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body id="body">
 
 <div id="content">
 
-<div role="grid" id="grid">
-  <div role="application">
-     <div role="application">
-         <div role="row" id="row1">
-            <div role="gridcell">1</div>
-         </div>
-         <div role="text">a</div>
-         <div role="row" id="row2">
-            <div role="gridcell">1</div>
-         </div>
-     </div>
-  </div>
-</div>
+<div class="ex" data-label="hello link use world test1 test2 test3" aria-labelledby="a1 b1" id="test1" role="group">group text</div>
+<div id="a1">hello <a href="#">link</a> <div role="group">skip</div> <div role="group" aria-label="use">skip</div> world</div>
+<!-- paragraph role is ambiguous so okay to leave next example as it -->
+<div id="b1"><button>test1</button><p tabindex=0>test2 <span aria-hidden="true">hidden</span> test3</p></div>
+
+<input type="checkbox" aria-labelledby="reverselabelfor" id="test2" class="ex" data-label="foo bar" data-note="labelled by label element">
+<label id="reverselabelfor">foo <span role="text" aria-label="bar">skip</span></label>
+<br>
+
+<input type="checkbox" aria-labelledby="reverselabelforwithdiv" id="test3" class="ex" data-label="foo bar" data-note="labelled by div element">
+<div id="reverselabelforwithdiv">foo <span role="text" aria-label="bar">skip</span></div>
+<br>
+
+<!-- would be "bar" natively, but label explicitly overridden to "foo" by labelledby -->
+<div id="overridesnativelabel">foo</div><label for="nativelabeloverridden">bar</label>
+<input class="ex" data-label="foo" id="test4" type="text" aria-labelledby="overridesnativelabel" data-note="overrides native label">
+
+<!-- self-referencing labelledby in combination with external reference -->
+<div id="productname1"><nav role="navigation"><!-- nav does not get nameFrom:contents -->product name</nav></div>
+<button class="ex" data-label="Delete" aria-label="Delete" aria-labelledby="test5 productname1" id="test5" data-note="self-referencial labelledby includes nav">x</button>
+
+<!-- self-referencing labelledby in combination with external reference -->
+<div id="productname2"><nav role="heading"><!-- nav does not get nameFrom:contents, but heading does. -->product name</nav></div>
+<button class="ex" data-label="Delete product name" aria-label="Delete" aria-labelledby="test6 productname2" id="test6" data-note="self-referencial labelledby includes heading">x</button>
+
+<div class="ex" data-label="foo bar baz bop bap boom" aria-labelledby="a3 b3" id="test7" role="group" data-note="includes form elements">foo</div>
+<button id="a3"> foo <img src="#" alt="bar"> baz</button>
+<div id="b3">bop <input value="bap"> <input type="range" aria-valuetext="boom"></div>
+
 
 </div>
 
-<div id="console"></div>
 <script>
+var output = "This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.\n\n";
 
-description("This tests that if an ARIA table does not report the rows as its direct children, the table will still correctly report the rows.")
-
-if (window.testRunner && window.accessibilityController) {
- 
-    var grid = accessibilityController.accessibleElementById("grid");
-    var row1 = accessibilityController.accessibleElementById("row1");
-    var row2 = accessibilityController.accessibleElementById("row2");
-    
- 
-    shouldBeTrue("grid.rowAtIndex(0).isEqual(row1)");
-    shouldBeTrue("grid.rowAtIndex(1).isEqual(row2)");
-    shouldBe("grid.rowCount", "2");
-
-    document.getElementById("content").style.visibility = 'hidden';    
+if (window.accessibilityController) {
+    for (var k = 1; k < 8; k++) {
+        var test = accessibilityController.accessibleElementById("test" + k);
+        output += "test " + k + ": aria-labelledby description: " + platformValueForW3CName(test) + "\n";
+        output += "test " + k + ": expected description: " + document.getElementById("test" + k).getAttribute("data-label") + "\n\n";
+    }
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
 }
 </script>
-<script src="../resources/js-test-post.js"></script>
+
 </body>
 </html>

--- a/LayoutTests/accessibility/range-alter-by-percent-expected.txt
+++ b/LayoutTests/accessibility/range-alter-by-percent-expected.txt
@@ -1,18 +1,16 @@
 This tests that decrement and increment alter a range type input element by five percent or one (whichever is larger) when no step is specified.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: largeRange.intValue === 50
+PASS: largeRange.intValue === 55
+PASS: largeRange.intValue === 60
+PASS: largeRange.intValue === 55
+PASS: largeRange.intValue === 50
+PASS: smallRange.intValue === 5
+PASS: smallRange.intValue === 6
+PASS: smallRange.intValue === 7
+PASS: smallRange.intValue === 6
+PASS: smallRange.intValue === 5
 
-
-PASS largeRange.intValue is 50
-PASS largeRange.intValue === 55
-PASS largeRange.intValue === 60
-PASS largeRange.intValue === 55
-PASS largeRange.intValue === 50
-PASS smallRange.intValue is 5
-PASS smallRange.intValue === 6
-PASS smallRange.intValue === 7
-PASS smallRange.intValue === 6
-PASS smallRange.intValue === 5
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/range-alter-by-percent.html
+++ b/LayoutTests/accessibility/range-alter-by-percent.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
@@ -16,46 +15,54 @@
 <input id="smallRange" max="10" min="0" type="range" value="5">
 
 <script>
-    description("This tests that decrement and increment alter a range type input element by five percent or one (whichever is larger) when no step is specified.");
+var output = "This tests that decrement and increment alter a range type input element by five percent or one (whichever is larger) when no step is specified.\n\n";
 
-    var smallRange, largeRange;
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        setTimeout(async function() {
-            largeRange = accessibilityController.accessibleElementById("largeRange");
-            shouldBe("largeRange.intValue", "50");
+    setTimeout(async function() {
+        largeRange = accessibilityController.accessibleElementById("largeRange");
+        output += expect("largeRange.intValue", "50");
 
-            largeRange.increment();
-            await expectAsyncExpression("largeRange.intValue", 55);
+        largeRange.increment();
+        await waitFor(() => largeRange.intValue == 55);
+        output += await expectAsync("largeRange.intValue", 55);
 
-            largeRange.increment();
-            await expectAsyncExpression("largeRange.intValue", 60);
+        largeRange.increment();
+        await waitFor(() => largeRange.intValue == 60);
+        output += await expectAsync("largeRange.intValue", 60);
 
-            largeRange.decrement();
-            await expectAsyncExpression("largeRange.intValue", 55);
+        largeRange.decrement();
+        await waitFor(() => largeRange.intValue == 55);
+        output += await expectAsync("largeRange.intValue", 55);
 
-            largeRange.decrement();
-            await expectAsyncExpression("largeRange.intValue", 50);
+        largeRange.decrement();
+        await waitFor(() => largeRange.intValue == 50);
+        output += await expectAsync("largeRange.intValue", 50);
 
-            smallRange = accessibilityController.accessibleElementById("smallRange");
-            shouldBe("smallRange.intValue", "5");
+        smallRange = accessibilityController.accessibleElementById("smallRange");
+        output += expect("smallRange.intValue", "5");
 
-            smallRange.increment();
-            await expectAsyncExpression("smallRange.intValue", 6);
+        smallRange.increment();
+        await waitFor(() => smallRange.intValue == 6);
+        output += await expectAsync("smallRange.intValue", 6);
 
-            smallRange.increment();
-            await expectAsyncExpression("smallRange.intValue", 7);
+        smallRange.increment();
+        await waitFor(() => smallRange.intValue == 7);
+        output += await expectAsync("smallRange.intValue", 7);
 
-            smallRange.decrement();
-            await expectAsyncExpression("smallRange.intValue", 6);
+        smallRange.decrement();
+        await waitFor(() => smallRange.intValue == 6);
+        output += await expectAsync("smallRange.intValue", 6);
 
-            smallRange.decrement();
-            await expectAsyncExpression("smallRange.intValue", 5);
+        smallRange.decrement();
+        await waitFor(() => smallRange.intValue == 5);
+        output += await expectAsync("smallRange.intValue", 5);
 
-            finishJSTest();
-        }, 0);
-    }
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/range-alter-by-step-expected.txt
+++ b/LayoutTests/accessibility/range-alter-by-step-expected.txt
@@ -1,9 +1,3 @@
-This test makes sure that if a range type has a step value, that increment and decrement work.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS rangeInput.intValue is 25
 PASS rangeInput.intValue === 50
 PASS rangeInput.intValue === 75
 PASS rangeInput.intValue === 100
@@ -13,6 +7,19 @@ PASS rangeInput.intValue === 50
 PASS rangeInput.intValue === 25
 PASS rangeInput.intValue === 0
 PASS rangeInput.intValue === 0
+This test makes sure that if a range type has a step value, that increment and decrement work.
+
+PASS: rangeInput.intValue === 25
+PASS: rangeInput.intValue === 50
+PASS: rangeInput.intValue === 75
+PASS: rangeInput.intValue === 100
+PASS: rangeInput.intValue === 100
+PASS: rangeInput.intValue === 75
+PASS: rangeInput.intValue === 50
+PASS: rangeInput.intValue === 25
+PASS: rangeInput.intValue === 0
+PASS: rangeInput.intValue === 0
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/range-alter-by-step.html
+++ b/LayoutTests/accessibility/range-alter-by-step.html
@@ -9,48 +9,56 @@
 <input type="range" min="0" max="100" value="25" step="25" id="rangeInput"/>
 
 <script>
-    description("This test makes sure that if a range type has a step value, that increment and decrement work.");
+var output = "This test makes sure that if a range type has a step value, that increment and decrement work.\n\n";
 
-    var rangeInput;
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        setTimeout(async function() {
-            // ARIA determinate progressbar
-            rangeInput = await waitForElementById("rangeInput");
-            shouldBe("rangeInput.intValue", "25");
+    setTimeout(async function() {
+        // ARIA determinate progressbar
+        rangeInput = await waitForElementById("rangeInput");
+        output += expect("rangeInput.intValue", "25");
 
-            rangeInput.increment();
-            await expectAsyncExpression("rangeInput.intValue", 50);
+        rangeInput.increment();
+        await expectAsyncExpression("rangeInput.intValue", 50);
+        output += expect("rangeInput.intValue", "50");
 
-            rangeInput.increment();
-            await expectAsyncExpression("rangeInput.intValue", 75);
+        rangeInput.increment();
+        await expectAsyncExpression("rangeInput.intValue", 75);
+        output += expect("rangeInput.intValue", "75");
 
-            rangeInput.increment();
-            await expectAsyncExpression("rangeInput.intValue", 100);
+        rangeInput.increment();
+        await expectAsyncExpression("rangeInput.intValue", 100);
+        output += expect("rangeInput.intValue", "100");
 
-            rangeInput.increment();
-            await expectAsyncExpression("rangeInput.intValue", 100);
+        rangeInput.increment();
+        await expectAsyncExpression("rangeInput.intValue", 100);
+        output += expect("rangeInput.intValue", "100");
 
-            rangeInput.decrement();
-            await expectAsyncExpression("rangeInput.intValue", 75);
+        rangeInput.decrement();
+        await expectAsyncExpression("rangeInput.intValue", 75);
+        output += expect("rangeInput.intValue", "75");
 
-            rangeInput.decrement();
-            await expectAsyncExpression("rangeInput.intValue", 50);
+        rangeInput.decrement();
+        await expectAsyncExpression("rangeInput.intValue", 50);
+        output += expect("rangeInput.intValue", "50");
 
-            rangeInput.decrement();
-            await expectAsyncExpression("rangeInput.intValue", 25);
+        rangeInput.decrement();
+        await expectAsyncExpression("rangeInput.intValue", 25);
+        output += expect("rangeInput.intValue", "25");
 
-            rangeInput.decrement();
-            await expectAsyncExpression("rangeInput.intValue", 0);
+        rangeInput.decrement();
+        await expectAsyncExpression("rangeInput.intValue", 0);
+        output += expect("rangeInput.intValue", "0");
 
-            rangeInput.decrement();
-            await expectAsyncExpression("rangeInput.intValue", 0);
+        rangeInput.decrement();
+        await expectAsyncExpression("rangeInput.intValue", 0);
+        output += expect("rangeInput.intValue", "0");
 
-            finishJSTest();
-        }, 0);
-    }
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/removed-continuation-element-causes-crash-expected.txt
+++ b/LayoutTests/accessibility/removed-continuation-element-causes-crash-expected.txt
@@ -1,10 +1,7 @@
-  asdfasdf
 When you have elements that are continuations, and one of those elements is removed, the parent chain is not being updated accordingly. This can cause a crash.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+  asdfasdf

--- a/LayoutTests/accessibility/removed-continuation-element-causes-crash.html
+++ b/LayoutTests/accessibility/removed-continuation-element-causes-crash.html
@@ -1,6 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <script>
 
 function removeElement() {
@@ -8,7 +10,6 @@ function removeElement() {
 }
 
 </script>
-<script src="../resources/js-test-pre.js"></script>
 </head>
 <body>
 
@@ -18,28 +19,23 @@ function removeElement() {
 asdfasdf
 </a>
 
-
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
 
-    description("When you have elements that are continuations, and one of those elements is removed, the parent chain is not being updated accordingly. This can cause a crash.");
+var output = "When you have elements that are continuations, and one of those elements is removed, the parent chain is not being updated accordingly. This can cause a crash.\n\n";
 
-    if (window.accessibilityController) {
+if (window.accessibilityController) {
+    document.getElementById("link").focus();
+    var link = accessibilityController.focusedElement;
+    link.attributesOfChildren();
 
-        document.getElementById("link").focus();
-        var link = accessibilityController.focusedElement;
-        link.attributesOfChildren();
+    removeElement();
 
-        removeElement();
+    // should not cause a crash...
+    link.attributesOfChildren();
+}
 
-        // should not cause a crash...
-        link.attributesOfChildren();
-    }
+debug(output);
 
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/scroll-to-make-visible-div-overflow-expected.txt
+++ b/LayoutTests/accessibility/scroll-to-make-visible-div-overflow-expected.txt
@@ -1,16 +1,31 @@
-Tests that scrolling to make an element visible successfully scrolls an arbitrary HTML element that has CSS overflow set to 'scroll'.
+This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.
 
-PASS: container.scrollTop === 0
-PASS: container.scrollTop >= minYOffset === true
-PASS: container.scrollTop <= maxYOffset === true
-PASS: container.scrollTop >= minYOffset === true
-PASS: container.scrollTop <= maxYOffset === true
-PASS: container.scrollTop >= minYOffset === true
-PASS: container.scrollTop <= maxYOffset === true
+test 1: aria-labelledby description: hello link use world test1 test2 test3
+test 1: expected description: hello link use world test1 test2 test3
+
+test 2: aria-labelledby description: foo bar
+test 2: expected description: foo bar
+
+test 3: aria-labelledby description: foo bar
+test 3: expected description: foo bar
+
+test 4: aria-labelledby description: foo
+test 4: expected description: foo
+
+test 5: aria-labelledby description: Delete
+test 5: expected description: Delete
+
+test 6: aria-labelledby description: Delete product name
+test 6: expected description: Delete product name
+
+test 7: aria-labelledby description: foo bar baz bop bap boom
+test 7: expected description: foo bar baz bop bap boom
+
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Upper Target
-5000-pixel box
-Lower Target
+
+
+
+

--- a/LayoutTests/accessibility/scroll-to-make-visible-div-overflow.html
+++ b/LayoutTests/accessibility/scroll-to-make-visible-div-overflow.html
@@ -1,63 +1,58 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/accessibility-helper.js"></script>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
-<body>
+<body id="body">
 
-<div id="container" style="height: 100px; overflow: scroll">
-  <button id="upper_target">Upper Target</button>
-  <div style="border: 1px solid #000; height: 5000px;">5000-pixel box</div>
-  <button id="lower_target">Lower Target</button>
+<div id="content">
+
+<div class="ex" data-label="hello link use world test1 test2 test3" aria-labelledby="a1 b1" id="test1" role="group">group text</div>
+<div id="a1">hello <a href="#">link</a> <div role="group">skip</div> <div role="group" aria-label="use">skip</div> world</div>
+<!-- paragraph role is ambiguous so okay to leave next example as it -->
+<div id="b1"><button>test1</button><p tabindex=0>test2 <span aria-hidden="true">hidden</span> test3</p></div>
+
+<input type="checkbox" aria-labelledby="reverselabelfor" id="test2" class="ex" data-label="foo bar" data-note="labelled by label element">
+<label id="reverselabelfor">foo <span role="text" aria-label="bar">skip</span></label>
+<br>
+
+<input type="checkbox" aria-labelledby="reverselabelforwithdiv" id="test3" class="ex" data-label="foo bar" data-note="labelled by div element">
+<div id="reverselabelforwithdiv">foo <span role="text" aria-label="bar">skip</span></div>
+<br>
+
+<!-- would be "bar" natively, but label explicitly overridden to "foo" by labelledby -->
+<div id="overridesnativelabel">foo</div><label for="nativelabeloverridden">bar</label>
+<input class="ex" data-label="foo" id="test4" type="text" aria-labelledby="overridesnativelabel" data-note="overrides native label">
+
+<!-- self-referencing labelledby in combination with external reference -->
+<div id="productname1"><nav role="navigation"><!-- nav does not get nameFrom:contents -->product name</nav></div>
+<button class="ex" data-label="Delete" aria-label="Delete" aria-labelledby="test5 productname1" id="test5" data-note="self-referencial labelledby includes nav">x</button>
+
+<!-- self-referencing labelledby in combination with external reference -->
+<div id="productname2"><nav role="heading"><!-- nav does not get nameFrom:contents, but heading does. -->product name</nav></div>
+<button class="ex" data-label="Delete product name" aria-label="Delete" aria-labelledby="test6 productname2" id="test6" data-note="self-referencial labelledby includes heading">x</button>
+
+<div class="ex" data-label="foo bar baz bop bap boom" aria-labelledby="a3 b3" id="test7" role="group" data-note="includes form elements">foo</div>
+<button id="a3"> foo <img src="#" alt="bar"> baz</button>
+<div id="b3">bop <input value="bap"> <input type="range" aria-valuetext="boom"></div>
+
+
 </div>
 
 <script>
-var output = "Tests that scrolling to make an element visible successfully scrolls an arbitrary HTML element that has CSS overflow set to 'scroll'.\n\n";
-
-var upperTarget = document.getElementById("upper_target");
-var lowerTarget = document.getElementById("lower_target");
-window.container = document.getElementById("container");
-async function scrollToMakeVisibleAndCheck(axElement, domTarget) {
-    axElement.scrollToMakeVisible();
-    await waitFor(() => {
-        var top = domTarget.offsetTop - container.offsetTop;
-        window.minYOffset = top + domTarget.offsetHeight - container.offsetHeight;
-        window.maxYOffset = top;
-        return container.scrollTop >= minYOffset && container.scrollTop <= maxYOffset;
-    });
-
-    output += expect("container.scrollTop >= minYOffset", "true");
-    output += expect("container.scrollTop <= maxYOffset", "true");
-}
+var output = "This tests that if aria-labelledby is pointing to nodes with descendants, it returns all text.\n\n";
 
 if (window.accessibilityController) {
-    window.jsTestIsAsync = true;
-
-    var lowerTargetAccessibleObject;
-    var upperTargetAccessibleObject;
-    setTimeout(async function() {
-        lowerTargetAccessibleObject = await waitForFocus("lower_target");
-        upperTargetAccessibleObject = await waitForFocus("upper_target");
-
-        // Reset the initial scroll position (since calling focus() can scroll the page too).
-        container.scrollTop = 0;
-        output += expect("container.scrollTop", "0");
-
-        // Scroll to make lower target visible and check.
-        await scrollToMakeVisibleAndCheck(lowerTargetAccessibleObject, lowerTarget);
-
-        // Do it again. It shouldn't scroll.
-        await scrollToMakeVisibleAndCheck(lowerTargetAccessibleObject, lowerTarget);
-
-        // Now do the upper target.
-        await scrollToMakeVisibleAndCheck(upperTargetAccessibleObject, upperTarget);
-
-        debug(output);
-        finishJSTest();
-    }, 0);
+    for (var k = 1; k < 8; k++) {
+        var test = accessibilityController.accessibleElementById("test" + k);
+        output += "test " + k + ": aria-labelledby description: " + platformValueForW3CName(test) + "\n";
+        output += "test " + k + ": expected description: " + document.getElementById("test" + k).getAttribute("data-label") + "\n\n";
+    }
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
 }
 </script>
+
 </body>
 </html>
-

--- a/LayoutTests/accessibility/secure-textfield-title-ui-expected.txt
+++ b/LayoutTests/accessibility/secure-textfield-title-ui-expected.txt
@@ -1,4 +1,9 @@
-Password
+This test makes sure that a secure text field has the correct title ui element
 
 Test passed
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Password
 

--- a/LayoutTests/accessibility/secure-textfield-title-ui.html
+++ b/LayoutTests/accessibility/secure-textfield-title-ui.html
@@ -1,8 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-    if (window.testRunner)
-        testRunner.dumpAsText();
-</script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <body id="body">
  
     <!-- This test makes sure that a secure text field has the correct title ui element -->
@@ -10,24 +11,28 @@
     <label for="accountpassword"><span class="dslabel">Password</span></label><br>
     <input size="30" maxlength="32" id="accountpassword" type="password" name="theAccountPW">
     
-    <div id="result"></div>
-
-     
     <script>
+        var output = "This test makes sure that a secure text field has the correct title ui element\n\n";
+        
         if (window.accessibilityController) {
-            var result = document.getElementById("result");
-
-            var pass = document.getElementById("accountpassword");
-            pass.focus();
-            var titleUIElement = accessibilityController.focusedElement.titleUIElement();
-            // On the Mac, element text is exposed in StaticText children; in ATSPI, in the element itself.
-            var titleText = titleUIElement.childrenCount ? titleUIElement.childAtIndex(0) : titleUIElement;
-            if (titleText.stringValue == "AXValue: Password") {
-                result.innerText += "Test passed\n";
-            }
-            else {
-                 result.innerText += "Test failed\n";
-            }
+            window.jsTestIsAsync = true;
+            
+            setTimeout(function() {
+                var pass = document.getElementById("accountpassword");
+                pass.focus();
+                var titleUIElement = accessibilityController.focusedElement.titleUIElement();
+                // On the Mac, element text is exposed in StaticText children; in ATSPI, in the element itself.
+                var titleText = titleUIElement.childrenCount ? titleUIElement.childAtIndex(0) : titleUIElement;
+                
+                if (titleText.stringValue == "AXValue: Password") {
+                    output += "Test passed\n";
+                } else {
+                    output += "Test failed\n";
+                }
+                
+                debug(output);
+                finishJSTest();
+            }, 0);
         }
     </script>
 </body>

--- a/LayoutTests/accessibility/selected-text-range-aria-elements-expected.txt
+++ b/LayoutTests/accessibility/selected-text-range-aria-elements-expected.txt
@@ -1,8 +1,4 @@
-
 This test makes sure that a native text control with a text-like ARIA value returns selectedTextRange
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 Text range: {4, 2}
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/selected-text-range-aria-elements.html
+++ b/LayoutTests/accessibility/selected-text-range-aria-elements.html
@@ -1,29 +1,27 @@
 <html>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
     <input id="combo" type="text" role="combobox" value="Hello World"> 
     
-    <p id="description"></p>
-    <div id="console"></div>
-     
     <script>
- 
+        var output = "This test makes sure that a native text control with a text-like ARIA value returns selectedTextRange\n\n";
+
         var node = document.getElementById("combo");
         node.focus();
         node.setSelectionRange(4, 6); 
 
         if (window.accessibilityController) {
-            description("This test makes sure that a native text control with a text-like ARIA value returns selectedTextRange");
-
             var element = accessibilityController.accessibleElementById("combo");
-            debug("Text range: " + element.selectedTextRange);
+            output += "Text range: " + element.selectedTextRange;
+            
+            debug(output);
         }
     </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/selection-states-expected.txt
+++ b/LayoutTests/accessibility/selection-states-expected.txt
@@ -1,14 +1,15 @@
-
 This tests that we report the correct selection-related states.
 
-PASS accessibilityController.accessibleElementById("selectElement").isMultiSelectable is true
-PASS accessibilityController.accessibleElementById("selectElement").childAtIndex(0).isSelectable is true
-PASS accessibilityController.accessibleElementById("selectElement").childAtIndex(0).isSelected is true
-PASS accessibilityController.accessibleElementById("selectElement").childAtIndex(1).isSelectable is true
-PASS accessibilityController.accessibleElementById("selectElement").childAtIndex(1).isSelected is false
-PASS accessibilityController.accessibleElementById("selectElement").childAtIndex(2).isSelectable is false
-PASS accessibilityController.accessibleElementById("selectElement").childAtIndex(2).isSelected is false
+PASS: accessibilityController.accessibleElementById('selectElement').isMultiSelectable === true
+PASS: accessibilityController.accessibleElementById('selectElement').childAtIndex(0).isSelectable === true
+PASS: accessibilityController.accessibleElementById('selectElement').childAtIndex(0).isSelected === true
+PASS: accessibilityController.accessibleElementById('selectElement').childAtIndex(1).isSelectable === true
+PASS: accessibilityController.accessibleElementById('selectElement').childAtIndex(1).isSelected === false
+PASS: accessibilityController.accessibleElementById('selectElement').childAtIndex(2).isSelectable === false
+PASS: accessibilityController.accessibleElementById('selectElement').childAtIndex(2).isSelected === false
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
 
+This tests that we report the correct selection-related states.

--- a/LayoutTests/accessibility/selection-states.html
+++ b/LayoutTests/accessibility/selection-states.html
@@ -1,6 +1,7 @@
 <html>
 <head>
     <script src="../resources/js-test.js"></script>
+    <script src="../resources/accessibility-helper.js"></script>
 </head>
 
 <body id="body">
@@ -13,17 +14,19 @@
 
 <p>This tests that we report the correct selection-related states.</p>
 
-<p id="console"></p>
-
 <script>
-    if (window.testRunner && window.accessibilityController) {
-        shouldBeTrue('accessibilityController.accessibleElementById("selectElement").isMultiSelectable');
-        shouldBeTrue('accessibilityController.accessibleElementById("selectElement").childAtIndex(0).isSelectable');
-        shouldBeTrue('accessibilityController.accessibleElementById("selectElement").childAtIndex(0).isSelected');
-        shouldBeTrue('accessibilityController.accessibleElementById("selectElement").childAtIndex(1).isSelectable');
-        shouldBeFalse('accessibilityController.accessibleElementById("selectElement").childAtIndex(1).isSelected');
-        shouldBeFalse('accessibilityController.accessibleElementById("selectElement").childAtIndex(2).isSelectable');
-        shouldBeFalse('accessibilityController.accessibleElementById("selectElement").childAtIndex(2).isSelected');
+    var output = "This tests that we report the correct selection-related states.\n\n";
+
+    if (window.accessibilityController) {
+        output += expect("accessibilityController.accessibleElementById('selectElement').isMultiSelectable", "true");
+        output += expect("accessibilityController.accessibleElementById('selectElement').childAtIndex(0).isSelectable", "true");
+        output += expect("accessibilityController.accessibleElementById('selectElement').childAtIndex(0).isSelected", "true");
+        output += expect("accessibilityController.accessibleElementById('selectElement').childAtIndex(1).isSelectable", "true");
+        output += expect("accessibilityController.accessibleElementById('selectElement').childAtIndex(1).isSelected", "false");
+        output += expect("accessibilityController.accessibleElementById('selectElement').childAtIndex(2).isSelectable", "false");
+        output += expect("accessibilityController.accessibleElementById('selectElement').childAtIndex(2).isSelected", "false");
+        
+        debug(output);
     }
 </script>
 </body>

--- a/LayoutTests/accessibility/set-selected-text-range-after-newline.html
+++ b/LayoutTests/accessibility/set-selected-text-range-after-newline.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/accessibility-helper.js"></script>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -14,7 +14,7 @@ var output = "This test exercises a combination of selectedTextRange, stringForR
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
-    var newlineRegex = new RegExp('(?:\\r\\n|\\r|\\n)', 'g');
+    var newlineRegex = new RegExp('(?:\\r\\n|\\n)', 'g');
     var contenteditable;
     setTimeout(async function() {
         contenteditable = await waitForFocus("contenteditable");
@@ -42,4 +42,3 @@ if (window.accessibilityController) {
 </script>
 </body>
 </html>
-

--- a/LayoutTests/accessibility/svg-element-press-expected.txt
+++ b/LayoutTests/accessibility/svg-element-press-expected.txt
@@ -1,8 +1,5 @@
 This tests that AXPress works on SVG elements
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 SVG element WAS clicked with accessibility
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/svg-element-press.html
+++ b/LayoutTests/accessibility/svg-element-press.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
@@ -13,17 +14,14 @@
     </svg>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+    var output = "This tests that AXPress works on SVG elements\n\n";
 
     window.jsTestIsAsync = true;
 
-    description("This tests that AXPress works on SVG elements");
-
     function svgClicked() {
-        debug("SVG element WAS clicked with accessibility");
+        output += "SVG element WAS clicked with accessibility";
+        debug(output);
         finishJSTest();
     }
 
@@ -31,9 +29,7 @@
         var svg = accessibilityController.accessibleElementById("svg");
         svg.press();
     }
-
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/svg-text-expected.txt
+++ b/LayoutTests/accessibility/svg-text-expected.txt
@@ -1,14 +1,12 @@
-Hello World!
 This tests SVGText elements and their content are properly handled as static text.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: text1.role === 'AXRole: AXGroup'
+PASS: text1.childrenCount === 1
+PASS: staticText.role === 'AXRole: AXStaticText'
+PASS: staticText.stringValue === 'AXValue: Hello World!'
 
-
-PASS text1.role is 'AXRole: AXGroup'
-PASS text1.childrenCount is 1
-PASS staticText.role is 'AXRole: AXStaticText'
-PASS staticText.stringValue is 'AXValue: Hello World!'
 PASS successfullyParsed is true
 
 TEST COMPLETE
+Hello World!
 

--- a/LayoutTests/accessibility/svg-text.html
+++ b/LayoutTests/accessibility/svg-text.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
@@ -10,20 +10,19 @@
     <text id="text1">Hello World!</text>
 </svg>
 
-<div id="console"></div>
-
 <script>
-    description("This tests SVGText elements and their content are properly handled as static text.");
+var output = "This tests SVGText elements and their content are properly handled as static text.\n\n";
 
-    if (window.accessibilityController) {
-        text1 = accessibilityController.accessibleElementById("text1");
-        shouldBe("text1.role", "'AXRole: AXGroup'");
-        shouldBe("text1.childrenCount", "1");
-        staticText = text1.childAtIndex(0);
-        shouldBe("staticText.role", "'AXRole: AXStaticText'");
-        shouldBe("staticText.stringValue", "'AXValue: Hello World!'");
-    }
+if (window.accessibilityController) {
+    text1 = accessibilityController.accessibleElementById("text1");
+    output += expect("text1.role", "'AXRole: AXGroup'");
+    output += expect("text1.childrenCount", "1");
+    staticText = text1.childAtIndex(0);
+    output += expect("staticText.role", "'AXRole: AXStaticText'");
+    output += expect("staticText.stringValue", "'AXValue: Hello World!'");
+    
+    debug(output);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/table-cell-display-block-expected.txt
+++ b/LayoutTests/accessibility/table-cell-display-block-expected.txt
@@ -1,13 +1,11 @@
 This tests that if a table cell uses display:block, the table cell will still be accessible
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: cell1a.isEqual(cell1b) === true
+PASS: cell1a.role === 'AXRole: AXCell'
+PASS: domCell1.style.display === 'block'
+PASS: table2.role === 'AXRole: AXGroup'
+PASS: cell2.role == 'AXRole: AXCell' === false
 
-
-PASS cell1a.isEqual(cell1b) is true
-PASS cell1a.role is 'AXRole: AXCell'
-PASS domCell1.style.display is 'block'
-PASS table2.role is 'AXRole: AXGroup'
-PASS cell2.role == 'AXRole: AXCell' is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/table-cell-display-block.html
+++ b/LayoutTests/accessibility/table-cell-display-block.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -18,36 +19,34 @@
 </table>
 
 </div>
-<p id="description"></p>
-<div id="console"></div>
 <script>
 
-    description("This tests that if a table cell uses display:block, the table cell will still be accessible");
+var output = "This tests that if a table cell uses display:block, the table cell will still be accessible\n\n";
 
-    if (window.accessibilityController) {
-        var table = accessibilityController.accessibleElementById("table1");
-        var cell1a = table.cellForColumnAndRow(0, 0);
-        var cell1b = table.childAtIndex(0).childAtIndex(0);
+if (window.accessibilityController) {
+    var table = accessibilityController.accessibleElementById("table1");
+    var cell1a = table.cellForColumnAndRow(0, 0);
+    var cell1b = table.childAtIndex(0).childAtIndex(0);
 
-        shouldBeTrue("cell1a.isEqual(cell1b)");
-        shouldBe("cell1a.role", "'AXRole: AXCell'");
-        
-        var domCell1 = document.getElementById("cell1");
-        shouldBe("domCell1.style.display", "'block'");
+    output += expect("cell1a.isEqual(cell1b)", "true");
+    output += expect("cell1a.role", "'AXRole: AXCell'");
+    
+    var domCell1 = document.getElementById("cell1");
+    output += expect("domCell1.style.display", "'block'");
 
-        // Now check a table that uses a different role to make sure we don't have any cell roles.
-        var table2 = accessibilityController.accessibleElementById("table2");
-        shouldBe("table2.role", "'AXRole: AXGroup'");
-        var cell2 = table2.childAtIndex(0);
-        if (accessibilityController.platformName === "atspi")
-            cell2 = table2.childAtIndex(0).childAtIndex(0);
-        shouldBeFalse("cell2.role == 'AXRole: AXCell'");
+    // Now check a table that uses a different role to make sure we don't have any cell roles.
+    var table2 = accessibilityController.accessibleElementById("table2");
+    output += expect("table2.role", "'AXRole: AXGroup'");
+    var cell2 = table2.childAtIndex(0);
+    if (accessibilityController.platformName === "atspi")
+        cell2 = table2.childAtIndex(0).childAtIndex(0);
+    output += expect("cell2.role == 'AXRole: AXCell'", "false");
 
-        document.getElementById("content").style.visibility = "hidden";
-    }
+    document.getElementById("content").style.visibility = "hidden";
+    
+    debug(output);
+}
 
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/table-cell-spans-expected.txt
+++ b/LayoutTests/accessibility/table-cell-spans-expected.txt
@@ -1,47 +1,39 @@
-Cell A
-COLSPAN="2"
-ROWSPAN="2"	Cell B
-COLSPAN="2"
-2,3	2,4
-Cell C
-ROWSPAN="2"	3,2	3,3	3,4
-4,2	4,3	4,4
 ----------------------
 { 0, 0 }
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 3>
-AXChildrenInNavigationOrder: <array of size 3>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {239, 78}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 30}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -53,37 +45,37 @@ AXRequired: 0
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 3>
-AXChildrenInNavigationOrder: <array of size 3>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {239, 78}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 30}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -95,37 +87,37 @@ AXRequired: 0
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 2>
-AXChildrenInNavigationOrder: <array of size 2>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {120, 60}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 18}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 2}
 AXColumnIndexRange: NSRange: {0, 1}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -137,37 +129,37 @@ AXRequired: 0
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 2>
-AXChildrenInNavigationOrder: <array of size 2>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {120, 60}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 18}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 2}
 AXColumnIndexRange: NSRange: {0, 1}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -179,37 +171,37 @@ AXRequired: 0
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {120, 30}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 3}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {3, 1}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -222,3 +214,14 @@ AXRequired: 0
 {0, 0}, {0, 0}
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Cell A
+COLSPAN="2"
+ROWSPAN="2"	Cell B
+COLSPAN="2"
+2,3	2,4
+Cell C
+ROWSPAN="2"	3,2	3,3	3,4
+4,2	4,3	4,4

--- a/LayoutTests/accessibility/table-cell-spans.html
+++ b/LayoutTests/accessibility/table-cell-spans.html
@@ -1,8 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-    if (window.testRunner)
-        testRunner.dumpAsText();
-</script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <body id="body">
     
     <!-- Test image map -->
@@ -31,54 +32,58 @@
             <td class="center">4,4</td>
             </tr>
     </table>
-
-    <div id="result"></div>
-    
     
     <script>
+        var output = "";
+
         if (window.accessibilityController) {
-            var result = document.getElementById("result");
+            window.jsTestIsAsync = true;
 
-            var body = document.getElementById("body");
-            body.focus();
-            var table = accessibilityController.focusedElement.childAtIndex(0);
+            setTimeout(function() {
+                var body = document.getElementById("body");
+                body.focus();
+                var table = accessibilityController.focusedElement.childAtIndex(0);
 
-            var cell = table.cellForColumnAndRow(0,0); 
-            result.innerText += "----------------------\n";
-            result.innerText += "{ 0, 0 }\n";
-            result.innerText += cell.allAttributes() + "\n";
-            result.innerText += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
+                var cell = table.cellForColumnAndRow(0,0); 
+                output += "----------------------\n";
+                output += "{ 0, 0 }\n";
+                output += cell.allAttributes() + "\n";
+                output += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
 
-            var cell = table.cellForColumnAndRow(1,1); 
-            result.innerText += "----------------------\n";
-            result.innerText += "{ 1, 1 }\n";
-            result.innerText += cell.allAttributes() + "\n";
-            result.innerText += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
+                cell = table.cellForColumnAndRow(1,1); 
+                output += "----------------------\n";
+                output += "{ 1, 1 }\n";
+                output += cell.allAttributes() + "\n";
+                output += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
 
-            var cell = table.cellForColumnAndRow(0,3); 
-            result.innerText += "----------------------\n";
-            result.innerText += "{ 3, 0 }\n";
-            result.innerText += cell.allAttributes() + "\n";
-            result.innerText += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
+                cell = table.cellForColumnAndRow(0,3); 
+                output += "----------------------\n";
+                output += "{ 3, 0 }\n";
+                output += cell.allAttributes() + "\n";
+                output += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
 
-            cell = table.cellForColumnAndRow(0,2); 
-            result.innerText += "----------------------\n";
-            result.innerText += "{ 2, 0 }\n";
-            result.innerText += cell.allAttributes() + "\n";
-            result.innerText += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
+                cell = table.cellForColumnAndRow(0,2); 
+                output += "----------------------\n";
+                output += "{ 2, 0 }\n";
+                output += cell.allAttributes() + "\n";
+                output += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
 
-            cell = table.cellForColumnAndRow(3,2); 
-            result.innerText += "----------------------\n";
-            result.innerText += "{ 2, 3 }\n";
-            result.innerText += cell.allAttributes() + "\n";
-            result.innerText += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
+                cell = table.cellForColumnAndRow(3,2); 
+                output += "----------------------\n";
+                output += "{ 2, 3 }\n";
+                output += cell.allAttributes() + "\n";
+                output += cell.rowIndexRange() + ", " + cell.columnIndexRange()  + "\n\n"; 
 
-            cell = table.cellForColumnAndRow(10,10); 
-            result.innerText += "----------------------\n";
-            result.innerText += "{ 10, 10 }\n";
-            result.innerText += (cell != null ? cell.allAttributes() : "") + "\n";
-            result.innerText += cell != null ? cell.rowIndexRange() : "{0, 0}";
-            result.innerText += ", " + (cell != null ? cell.columnIndexRange() : "{0, 0}") + "\n\n";
+                cell = table.cellForColumnAndRow(10,10); 
+                output += "----------------------\n";
+                output += "{ 10, 10 }\n";
+                output += (cell != null ? cell.allAttributes() : "") + "\n";
+                output += cell != null ? cell.rowIndexRange() : "{0, 0}";
+                output += ", " + (cell != null ? cell.columnIndexRange() : "{0, 0}") + "\n\n";
+
+                debug(output);
+                finishJSTest();
+            }, 0);
         }
     </script>
 </body>

--- a/LayoutTests/accessibility/table-cells-expected.txt
+++ b/LayoutTests/accessibility/table-cells-expected.txt
@@ -1,49 +1,39 @@
-Example #1: Nested Stubs
-Ruritanian
-Population
-Survey	All
-Genders	By Gender
-Males	Females
-All Regions	North	3333	1111	2222
-South	3333	1111	2222
-South	3333	1111	2222
-South	3333	1111	2222
 ------------------------
 [0,0]
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 3>
-AXChildrenInNavigationOrder: <array of size 3>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {145, 66}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -54,37 +44,37 @@ AXSortDirection: AXUnknownSortDirection
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {54, 36}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 5}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {1, 1}
 AXColumnIndexRange: NSRange: {3, 1}
-AXColumnHeaderUIElements: <array of size 1>
-AXRowHeaderUIElements: <array of size 1>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -94,37 +84,37 @@ AXRequired: 0
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 3>
-AXChildrenInNavigationOrder: <array of size 3>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {145, 66}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 1>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 28}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {0, 2}
 AXColumnIndexRange: NSRange: {0, 2}
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -135,37 +125,37 @@ AXSortDirection: AXUnknownSortDirection
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {71, 30}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {2, 1}
 AXColumnIndexRange: NSRange: {2, 1}
-AXColumnHeaderUIElements: <array of size 1>
-AXRowHeaderUIElements: <array of size 1>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -175,37 +165,37 @@ AXRequired: 0
 AXRole: AXCell
 AXSubrole: (null)
 AXRoleDescription: cell
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXCell>
+AXParent:
 AXSize: NSSize: {54, 30}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXCell>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXCell>
-AXEndTextMarker: <AXCell>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXCell>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXCell>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXVisibleCharacterRange: NSRange: {0, 4}
 AXElementBusy: 0
 AXRowIndexRange: NSRange: {5, 1}
 AXColumnIndexRange: NSRange: {3, 1}
-AXColumnHeaderUIElements: <array of size 1>
-AXRowHeaderUIElements: <array of size 1>
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
 AXARIAColumnIndex: -1
 AXARIARowIndex: -1
 AXRequired: 0
@@ -217,3 +207,16 @@ AXRequired: 0
 [0,100]
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Example #1: Nested Stubs
+Ruritanian
+Population
+Survey	All
+Genders	By Gender
+Males	Females
+All Regions	North	3333	1111	2222
+South	3333	1111	2222
+South	3333	1111	2222
+South	3333	1111	2222

--- a/LayoutTests/accessibility/table-cells.html
+++ b/LayoutTests/accessibility/table-cells.html
@@ -1,8 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-    if (window.testRunner)
-        testRunner.dumpAsText();
-</script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <body id="body">
     
     
@@ -48,36 +49,39 @@
             </tr>
     </table>
     
-    <div id="result"></div>
-    
     <script>
-        if (window.accessibilityController) {
-            var result = document.getElementById("result");
+        var output = "";
+        
+        if (window.testRunner)
+            testRunner.dumpAsText();
 
+        if (window.accessibilityController) {
             var body = document.getElementById("body");
             body.focus();
             var table = accessibilityController.focusedElement.childAtIndex(0);
             
-            result.innerText += "------------------------\n"; 
-            result.innerText += "[0,0]\n" + table.cellForColumnAndRow(0,0).allAttributes() + "\n";
-            result.innerText += "------------------------\n"; 
-            result.innerText += "[3,1]\n" + table.cellForColumnAndRow(3,1).allAttributes() + "\n"; 
-            result.innerText += "------------------------\n"; 
-            result.innerText += "[1,1]\n" + table.cellForColumnAndRow(1,1).allAttributes() + "\n"; 
-            result.innerText += "------------------------\n"; 
-            result.innerText += "[2,2]\n" + table.cellForColumnAndRow(2,2).allAttributes() + "\n"; 
-            result.innerText += "------------------------\n"; 
-            result.innerText += "[3,5]\n" + table.cellForColumnAndRow(3,5).allAttributes() + "\n"; 
-            result.innerText += "------------------------\n"; 
-            result.innerText += "[100,0]\n";
+            output += "------------------------\n"; 
+            output += "[0,0]\n" + table.cellForColumnAndRow(0,0).allAttributes() + "\n";
+            output += "------------------------\n"; 
+            output += "[3,1]\n" + table.cellForColumnAndRow(3,1).allAttributes() + "\n"; 
+            output += "------------------------\n"; 
+            output += "[1,1]\n" + table.cellForColumnAndRow(1,1).allAttributes() + "\n"; 
+            output += "------------------------\n"; 
+            output += "[2,2]\n" + table.cellForColumnAndRow(2,2).allAttributes() + "\n"; 
+            output += "------------------------\n"; 
+            output += "[3,5]\n" + table.cellForColumnAndRow(3,5).allAttributes() + "\n"; 
+            output += "------------------------\n"; 
+            output += "[100,0]\n";
             outOfRangeCell = table.cellForColumnAndRow(100,0);
-            result.innerText += outOfRangeCell != null ? outOfRangeCell.allAttributes() : "";
-            result.innerText += "\n";
-            result.innerText += "------------------------\n";
+            output += outOfRangeCell != null ? outOfRangeCell.allAttributes() : "";
+            output += "\n";
+            output += "------------------------\n";
             outOfRangeCell = table.cellForColumnAndRow(0,100);
-            result.innerText += "[0,100]\n";
-            result.innerText += outOfRangeCell != null ? outOfRangeCell.allAttributes() : "";
-            result.innerText += "\n";
+            output += "[0,100]\n";
+            output += outOfRangeCell != null ? outOfRangeCell.allAttributes() : "";
+            output += "\n";
+            
+            debug(output);
         }
     </script>
 </body>

--- a/LayoutTests/accessibility/table-headers-expected.txt
+++ b/LayoutTests/accessibility/table-headers-expected.txt
@@ -1,9 +1,3 @@
-No	Country	Capital
-1.	Poland	Warsaw
-2.	Russia	Moscow
-3.	Ukraine	Kiev
-
-
 This tests that the columnHeaders() and rowHeaders() functions return the correct headers for a table cell.
 
 The table cell at (0,3) should have exactly one column header, currently it has 1 column header(s).
@@ -12,4 +6,10 @@ The table cell at (0,3) should have exactly 0 row headers, currently it has 0 ro
 The table cell at (1,2) should have exactly one column header, currently it has 1 column header(s).
 The table cell at (1,2) should have exactly one row header, currently it has 1 row header(s).
 
+PASS successfullyParsed is true
 
+TEST COMPLETE
+No	Country	Capital
+1.	Poland	Warsaw
+2.	Russia	Moscow
+3.	Ukraine	Kiev

--- a/LayoutTests/accessibility/table-headers.html
+++ b/LayoutTests/accessibility/table-headers.html
@@ -1,11 +1,9 @@
-<!-- This test was made after noticing that all th elements in the table were included in the columnHeaders,
-     and the only criterion for including a cell to rowHeaders was only scope attribute (but not th).
--->
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-  if (window.testRunner)
-    testRunner.dumpAsText();
-</script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <body>
 
 <table id="table1">
@@ -35,26 +33,25 @@
   </tbody>
 </table>
 
-<br>
-<br>
-<p>This tests that the columnHeaders() and rowHeaders() functions return the correct headers for a table cell.</p>
-<div id="result"></div>
-
 <script>
-  if (window.accessibilityController) {
-      var table = accessibilityController.accessibleElementById("table1");
-      var cell1 = table.cellForColumnAndRow(0, 3);
-      var colHeaders1 = cell1.columnHeaders();
-      var rowHeaders1 = cell1.rowHeaders();
-      var cell2 = table.cellForColumnAndRow(1, 2);
-      var colHeaders2 = cell2.columnHeaders();
-      var rowHeaders2 = cell2.rowHeaders();
+var output = "This tests that the columnHeaders() and rowHeaders() functions return the correct headers for a table cell.\n\n";
 
-      result.innerText += "The table cell at (0,3) should have exactly one column header, currently it has " + colHeaders1.length + " column header(s).\n";
-      result.innerText += "The table cell at (0,3) should have exactly 0 row headers, currently it has " + rowHeaders1.length + " row header(s).\n\n";
-      result.innerText += "The table cell at (1,2) should have exactly one column header, currently it has " + colHeaders2.length + " column header(s).\n";
-      result.innerText += "The table cell at (1,2) should have exactly one row header, currently it has " + rowHeaders2.length + " row header(s).\n\n";
-    }
+if (window.accessibilityController) {
+    var table = accessibilityController.accessibleElementById("table1");
+    var cell1 = table.cellForColumnAndRow(0, 3);
+    var colHeaders1 = cell1.columnHeaders();
+    var rowHeaders1 = cell1.rowHeaders();
+    var cell2 = table.cellForColumnAndRow(1, 2);
+    var colHeaders2 = cell2.columnHeaders();
+    var rowHeaders2 = cell2.rowHeaders();
+
+    output += "The table cell at (0,3) should have exactly one column header, currently it has " + colHeaders1.length + " column header(s).\n";
+    output += "The table cell at (0,3) should have exactly 0 row headers, currently it has " + rowHeaders1.length + " row header(s).\n\n";
+    output += "The table cell at (1,2) should have exactly one column header, currently it has " + colHeaders2.length + " column header(s).\n";
+    output += "The table cell at (1,2) should have exactly one row header, currently it has " + rowHeaders2.length + " row header(s).\n";
+    
+    debug(output);
+}
 </script>
 
 </body>

--- a/LayoutTests/accessibility/table-hierarchy.html
+++ b/LayoutTests/accessibility/table-hierarchy.html
@@ -1,18 +1,19 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <script>
-    function dumpAccessibilityChildren(element, level) {
+    function dumpAccessibilityChildren(element, level, output) {
         if (element.stringValue.indexOf('End of test') >= 0)
             return false;
 
         var indent = "";
         for (var k = 0; k < level; k++) { indent += "  "; }
-        debug(indent + element.role + " " + element.stringValue);
+        output.push(indent + element.role + " " + element.stringValue);
         var childrenCount = element.childrenCount;
         for (var k = 0; k < childrenCount; k++) {
-            if (!dumpAccessibilityChildren(element.childAtIndex(k), level+1))
+            if (!dumpAccessibilityChildren(element.childAtIndex(k), level+1, output))
                 return false;
         }
         return true;
@@ -39,15 +40,22 @@
 <tr><td><p>3</p></td><td><p>4</p></td></tr>
 </table>
 <div>End of test</div>
-<p id="description"></p>
-<div id="console"></div>
 <script>
-    description("This tests the accessible hierarchy for an HTML table.");
-    if (window.accessibilityController) {
-      document.getElementById("body").focus();
-      dumpAccessibilityChildren(accessibilityController.focusedElement, 0);
-    }
+var output = "This tests the accessible hierarchy for an HTML table.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    
+    setTimeout(function() {
+        document.getElementById("body").focus();
+        var outputLines = [];
+        dumpAccessibilityChildren(accessibilityController.focusedElement, 0, outputLines);
+        output += outputLines.join("\n");
+        
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/table-roles-hierarchy.html
+++ b/LayoutTests/accessibility/table-roles-hierarchy.html
@@ -1,7 +1,10 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
   <script src="../resources/js-test.js"></script>
+  <script src="../resources/accessibility-helper.js"></script>
   <script>
+    var output = "This shows the hierarchy of table roles.\n\n";
     var tableAXObject;
     var indentLevel = 0;
 
@@ -11,8 +14,9 @@
     }
 
     function dumpObject(axObject) {
-      debug(indent(indentLevel) + "role: " + axObject.role);
-      if (axObject.subrole && axObject.subrole != 'AXSubrole: ') debug(indent(indentLevel) + "subrole: " + axObject.subrole);
+      output += indent(indentLevel) + "role: " + axObject.role + "\n";
+      if (axObject.subrole && axObject.subrole != 'AXSubrole: ')
+        output += indent(indentLevel) + "subrole: " + axObject.subrole + "\n";
     }
 
     function dumpChildren(axObject) {
@@ -32,14 +36,14 @@
       }
       indentLevel -= 4;
     }
-    function dumpTableAX()
-    {
-      if (!window.accessibilityController)
-        return;
-      var table = accessibilityController.accessibleElementById("table1");
-
-      dumpObject(table);
-      dumpChildren(table);
+    
+    function dumpTableAX() {
+      if (window.accessibilityController) {
+        var table = accessibilityController.accessibleElementById("table1");
+        dumpObject(table);
+        dumpChildren(table);
+        debug(output);
+      }
     }
   </script>
 </head>
@@ -84,8 +88,6 @@
 <br>
 
 <p>This shows the hierarchy of table roles.</p>
-
-<div id=console></div>
 
 </body>
 </html>

--- a/LayoutTests/accessibility/table-with-footer-section-above-body-expected.txt
+++ b/LayoutTests/accessibility/table-with-footer-section-above-body-expected.txt
@@ -1,16 +1,17 @@
 This tests that the row span information for the cells in the body is not offset by the footer section, even though the footer section is above the body in the DOM. This tests tables that have a role=grid and without.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 Table1 cell content at {0, 1}: AXValue: a
 Table1 cell range at {0, 1}: {1, 1}
+
 Table1 cell content at {0, 2}: AXValue: Name
 Table1 cell range at {0, 2}: {2, 1}
+
 Table2 cell content at {0, 1}: AXValue: a
 Table2 cell range at {0, 1}: {1, 1}
+
 Table2 cell content at {0, 2}: AXValue: Name
 Table2 cell range at {0, 2}: {2, 1}
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/table-with-footer-section-above-body.html
+++ b/LayoutTests/accessibility/table-with-footer-section-above-body.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -36,50 +37,45 @@
 
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that the row span information for the cells in the body is not offset by the footer section, even though the footer section is above the body in the DOM. This tests tables that have a role=grid and without.\n\n";
 
-    description("This tests that the row span information for the cells in the body is not offset by the footer section, even though the footer section is above the body in the DOM. This tests tables that have a role=grid and without.");
+if (window.accessibilityController) {
+    var table = accessibilityController.accessibleElementById("table1");
+    var testCell = table.cellForColumnAndRow(0, 1);
+    if (accessibilityController.platformName != "atspi")
+        output += "Table1 cell content at {0, 1}: " + testCell.childAtIndex(0).stringValue + "\n";
+    else
+        output += "Table1 cell content at {0, 1}: " + testCell.stringValue + "\n";
+    output += "Table1 cell range at {0, 1}: " + testCell.rowIndexRange() + "\n\n";
 
-    if (window.accessibilityController) {
-     
-        var table = accessibilityController.accessibleElementById("table1");
-        var testCell = table.cellForColumnAndRow(0, 1);
-        if (accessibilityController.platformName != "atspi")
-            debug("Table1 cell content at {0, 1}: " + testCell.childAtIndex(0).stringValue);
-        else
-            debug("Table1 cell content at {0, 1}: " + testCell.stringValue);
-        debug("Table1 cell range at {0, 1}: " + testCell.rowIndexRange());
+    testCell = table.cellForColumnAndRow(0, 2);
+    if (accessibilityController.platformName != "atspi")
+        output += "Table1 cell content at {0, 2}: " + testCell.childAtIndex(0).stringValue + "\n";
+    else
+        output += "Table1 cell content at {0, 2}: " + testCell.stringValue + "\n";
+    output += "Table1 cell range at {0, 2}: " + testCell.rowIndexRange() + "\n\n";
 
-        testCell = table.cellForColumnAndRow(0, 2);
-        if (accessibilityController.platformName != "atspi")
-            debug("Table1 cell content at {0, 2}: " + testCell.childAtIndex(0).stringValue);
-        else
-            debug("Table1 cell content at {0, 2}: " + testCell.stringValue);
-        debug("Table1 cell range at {0, 2}: " + testCell.rowIndexRange());
+    table = accessibilityController.accessibleElementById("table2");
+    testCell = table.cellForColumnAndRow(0, 1);
+    if (accessibilityController.platformName != "atspi")
+        output += "Table2 cell content at {0, 1}: " + testCell.childAtIndex(0).stringValue + "\n";
+    else
+        output += "Table2 cell content at {0, 1}: " + testCell.stringValue + "\n";
+    output += "Table2 cell range at {0, 1}: " + testCell.rowIndexRange() + "\n\n";
 
-        table = accessibilityController.accessibleElementById("table2");
-        testCell = table.cellForColumnAndRow(0, 1);
-        if (accessibilityController.platformName != "atspi")
-            debug("Table2 cell content at {0, 1}: " + testCell.childAtIndex(0).stringValue);
-        else
-            debug("Table2 cell content at {0, 1}: " + testCell.stringValue);
-        debug("Table2 cell range at {0, 1}: " + testCell.rowIndexRange());
+    testCell = table.cellForColumnAndRow(0, 2);
+    if (accessibilityController.platformName != "atspi")
+        output += "Table2 cell content at {0, 2}: " + testCell.childAtIndex(0).stringValue + "\n";
+    else
+        output += "Table2 cell content at {0, 2}: " + testCell.stringValue + "\n";
+    output += "Table2 cell range at {0, 2}: " + testCell.rowIndexRange() + "\n";
 
-        testCell = table.cellForColumnAndRow(0, 2);
-        if (accessibilityController.platformName != "atspi")
-            debug("Table2 cell content at {0, 2}: " + testCell.childAtIndex(0).stringValue);
-        else
-            debug("Table2 cell content at {0, 2}: " + testCell.stringValue);
-        debug("Table2 cell range at {0, 2}: " + testCell.rowIndexRange());
-
-        document.getElementById("content").style.visibility = "hidden";
-    }
-
+    document.getElementById("content").style.visibility = "hidden";
+    
+    debug(output);
+}
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/table-with-rules-expected.txt
+++ b/LayoutTests/accessibility/table-with-rules-expected.txt
@@ -1,52 +1,45 @@
-asdf	asdf
-asdf	asdf
-asdf	asdf
-asdf	asdf
-asdf	asdf
-
-------------------------------------
 AXRole: AXTable
 AXSubrole: (null)
 AXRoleDescription: table
-AXChildren: <array of size 4>
-AXChildrenInNavigationOrder: <array of size 4>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXTable>
+AXParent:
 AXSize: NSSize: {58, 20}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXTable>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXTable>
-AXEndTextMarker: <AXTable>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXTable>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier: testTable2
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXTable>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXElementBusy: 0
-AXRows: <array of size 1>
-AXVisibleRows: <array of size 1>
-AXColumns: <array of size 2>
-AXVisibleColumns: <array of size 2>
-AXVisibleCells: <array of size 2>
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
-AXHeader: <AXTable>
+AXRows:
+AXVisibleRows:
+AXColumns:
+AXVisibleColumns:
+AXVisibleCells:
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
+AXHeader:
 AXColumnCount: 2
 AXRowCount: 1
 AXARIAColumnCount: 0
 AXARIARowCount: 0
-AXSelectedCells: <array of size 0>
+AXSelectedCells:
 AXSelectedChildren: (null)
 AXTableLevel: 1
 
@@ -54,45 +47,45 @@ AXTableLevel: 1
 AXRole: AXTable
 AXSubrole: (null)
 AXRoleDescription: table
-AXChildren: <array of size 4>
-AXChildrenInNavigationOrder: <array of size 4>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXTable>
+AXParent:
 AXSize: NSSize: {63, 24}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXTable>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXTable>
-AXEndTextMarker: <AXTable>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXTable>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier: testTable3
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXTable>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXElementBusy: 0
-AXRows: <array of size 1>
-AXVisibleRows: <array of size 1>
-AXColumns: <array of size 2>
-AXVisibleColumns: <array of size 2>
-AXVisibleCells: <array of size 2>
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
-AXHeader: <AXTable>
+AXRows:
+AXVisibleRows:
+AXColumns:
+AXVisibleColumns:
+AXVisibleCells:
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
+AXHeader:
 AXColumnCount: 2
 AXRowCount: 1
 AXARIAColumnCount: 0
 AXARIARowCount: 0
-AXSelectedCells: <array of size 0>
+AXSelectedCells:
 AXSelectedChildren: (null)
 AXTableLevel: 1
 
@@ -100,45 +93,45 @@ AXTableLevel: 1
 AXRole: AXTable
 AXSubrole: (null)
 AXRoleDescription: table
-AXChildren: <array of size 4>
-AXChildrenInNavigationOrder: <array of size 4>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXTable>
+AXParent:
 AXSize: NSSize: {57, 20}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXTable>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXTable>
-AXEndTextMarker: <AXTable>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXTable>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier: testTable4
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXTable>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXElementBusy: 0
-AXRows: <array of size 1>
-AXVisibleRows: <array of size 1>
-AXColumns: <array of size 2>
-AXVisibleColumns: <array of size 2>
-AXVisibleCells: <array of size 2>
-AXColumnHeaderUIElements: <array of size 0>
-AXRowHeaderUIElements: <array of size 0>
-AXHeader: <AXTable>
+AXRows:
+AXVisibleRows:
+AXColumns:
+AXVisibleColumns:
+AXVisibleCells:
+AXColumnHeaderUIElements:
+AXRowHeaderUIElements:
+AXHeader:
 AXColumnCount: 2
 AXRowCount: 1
 AXARIAColumnCount: 0
 AXARIARowCount: 0
-AXSelectedCells: <array of size 0>
+AXSelectedCells:
 AXSelectedChildren: (null)
 AXTableLevel: 1
 
@@ -146,29 +139,29 @@ AXTableLevel: 1
 AXRole: AXGroup
 AXSubrole: (null)
 AXRoleDescription: group
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXGroup>
+AXParent:
 AXSize: NSSize: {29, 20}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXGroup>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXGroup>
-AXEndTextMarker: <AXGroup>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXGroup>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXGroup>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXElementBusy: 0
@@ -178,29 +171,29 @@ AXInlineText: 0
 AXRole: AXGroup
 AXSubrole: (null)
 AXRoleDescription: group
-AXChildren: <array of size 1>
-AXChildrenInNavigationOrder: <array of size 1>
+AXChildren:
+AXChildrenInNavigationOrder:
 AXHelp:
-AXParent: <AXGroup>
+AXParent:
 AXSize: NSSize: {30, 20}
 AXTitle:
 AXDescription:
 AXValue:
 AXFocused: 0
 AXEnabled: 1
-AXWindow: <AXGroup>
+AXWindow:
 AXSelectedTextMarkerRange: (null)
-AXStartTextMarker: <AXGroup>
-AXEndTextMarker: <AXGroup>
+AXStartTextMarker:
+AXEndTextMarker:
 AXVisited: 0
-AXLinkedUIElements: <array of size 0>
+AXLinkedUIElements:
 AXSelected: 0
 AXBlockQuoteLevel: 0
-AXTopLevelUIElement: <AXGroup>
+AXTopLevelUIElement:
 AXLanguage:
 AXDOMIdentifier:
-AXDOMClassList: <array of size 0>
-AXFocusableAncestor: <AXGroup>
+AXDOMClassList:
+AXFocusableAncestor:
 AXEditableAncestor: (null)
 AXHighestEditableAncestor: (null)
 AXElementBusy: 0
@@ -208,3 +201,11 @@ AXInlineText: 0
 
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
+asdf	asdf
+asdf	asdf
+asdf	asdf
+asdf	asdf
+asdf	asdf

--- a/LayoutTests/accessibility/table-with-rules.html
+++ b/LayoutTests/accessibility/table-with-rules.html
@@ -1,8 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script>
-    if (window.testRunner)
-        testRunner.dumpAsText();
-</script>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
 <body id="body">
         
     <table id="testTable1" rules="rows"><tr><td>asdf</td><td>asdf</td></tr></table>
@@ -11,22 +12,26 @@
     <table id="testTable4" rules="groups"><tr><td>asdf</td><td>asdf</td></tr></table>
     <table id="testTable5"><tr><td>asdf</td><td>asdf</td></tr></table>
     
-    <BR>------------------------------------<BR>
-    
-    <div id="result"></div>
- 
     <script>
+        var output = "";
+        
         if (window.accessibilityController) {
-            var result = document.getElementById("result");
-            var body = document.getElementById("body");
-            body.focus();
+            window.jsTestIsAsync = true;
             
-            // these should be the tables. in this order
-            // the last two tables should not show up as tables
-            for (var k = 1; k < 6; k++) {
-                var table = accessibilityController.focusedElement.childAtIndex(k);
-                result.innerText += table.allAttributes() + "\n\n"; 
-            }
+            setTimeout(function() {
+                var body = document.getElementById("body");
+                body.focus();
+                
+                // these should be the tables. in this order
+                // the last two tables should not show up as tables
+                for (var k = 1; k < 6; k++) {
+                    var table = accessibilityController.focusedElement.childAtIndex(k);
+                    output += table.allAttributes() + "\n\n"; 
+                }
+                
+                debug(output);
+                finishJSTest();
+            }, 0);
         }
     </script>
 </body>

--- a/LayoutTests/accessibility/text-element-path-expected.txt
+++ b/LayoutTests/accessibility/text-element-path-expected.txt
@@ -1,11 +1,4 @@
-Add or delete a table in Numbers on iPhone
-
-When you add a table, you choose from a number of predesigned styles that match your template. After you add a table, you can customize it however you like. You can add as many tables as you want to a sheet.
-
 This tests that text elements properly support paths.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 AXRole: AXStaticText
 AXValue: Add or delete a table in Numbers on iPhone
@@ -61,7 +54,10 @@ AXValue: template
 
 Start Path
 
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
+Add or delete a table in Numbers on iPhone
 
+When you add a table, you choose from a number of predesigned styles that match your template. After you add a table, you can customize it however you like. You can add as many tables as you want to a sheet.

--- a/LayoutTests/accessibility/text-element-path.html
+++ b/LayoutTests/accessibility/text-element-path.html
@@ -1,33 +1,34 @@
 <!DOCTYPE HTML>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
 <h1 id="h1">Add or delete a table in Numbers on iPhone</h1>
 <p id="p1">When you add a table, you choose from a number of predesigned styles that match your <a href="#" id="link1">template</a>. After you add a table, you can customize it however you like. You can add as many tables as you want to a <a href="#" id="link2">sheet</a>.</p>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This tests that text elements properly support paths.");
+var output = "This tests that text elements properly support paths.\n\n";
 
-    function logChildrenPath(accessibleElement) {
-        for (i = 0; i < accessibleElement.childrenCount; ++i) {
-            child = accessibleElement.childAtIndex(i);
-            debug(child.role);
-            debug(child.stringValue);
-            debug(child.pathDescription);
-        }
+function logChildrenPath(accessibleElement) {
+    for (i = 0; i < accessibleElement.childrenCount; ++i) {
+        child = accessibleElement.childAtIndex(i);
+        output += child.role + "\n";
+        output += child.stringValue + "\n";
+        output += child.pathDescription + "\n";
     }
+}
 
-    if (window.accessibilityController) {
-        logChildrenPath(accessibilityController.accessibleElementById("h1"));
-        logChildrenPath(accessibilityController.accessibleElementById("p1"));
-        logChildrenPath(accessibilityController.accessibleElementById("link1"));
-    }
+if (window.accessibilityController) {
+    window.jsTestIsAsync = false;
+    
+    logChildrenPath(accessibilityController.accessibleElementById("h1"));
+    logChildrenPath(accessibilityController.accessibleElementById("p1"));
+    logChildrenPath(accessibilityController.accessibleElementById("link1"));
+    
+    debug(output);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/textarea-selected-text-range-expected.txt
+++ b/LayoutTests/accessibility/textarea-selected-text-range-expected.txt
@@ -1,6 +1,7 @@
 PASS: textArea.selectedTextRange is {4, 0}
 PASS: textArea.selectedTextRange is {8, 2}
 PASS: textArea.selectedTextRange is {25, 0}
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/textarea-selected-text-range.html
+++ b/LayoutTests/accessibility/textarea-selected-text-range.html
@@ -1,6 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
+<head>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
-<script src="../resources/js-test-pre.js"></script>
+</head>
 <body>
     
     <div id="result"></div>
@@ -12,6 +15,8 @@ line 3
     </textarea>
 
 <script>
+    var output = "";
+    
     if (window.accessibilityController) {
         window.jsTestIsAsync = true;
         var area1 = document.getElementById("area1");
@@ -27,24 +32,24 @@ line 3
             await waitFor(() => {
                 return textArea.selectedTextRange == "{4, 0}";
             });
-            debug("PASS: textArea.selectedTextRange is {4, 0}");
+            output += "PASS: textArea.selectedTextRange is {4, 0}\n";
 
             textArea.setSelectedTextRange(8, 2);
             await waitFor(() => {
                 return textArea.selectedTextRange == "{8, 2}";
             });
-            debug("PASS: textArea.selectedTextRange is {8, 2}");
+            output += "PASS: textArea.selectedTextRange is {8, 2}\n";
 
             textArea.setSelectedTextRange(100, 0);
             await waitFor(() => {
                 return textArea.selectedTextRange == "{25, 0}";
             });
-            debug("PASS: textArea.selectedTextRange is {25, 0}");
+            output += "PASS: textArea.selectedTextRange is {25, 0}\n";
 
+            debug(output);
             finishJSTest();
         }, 0);
     }
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/transformed-bounds-expected.txt
+++ b/LayoutTests/accessibility/transformed-bounds-expected.txt
@@ -1,12 +1,9 @@
-Test
 This tests that if a view is in a transformed layer, the bounds will not be offset by the origin of the transformed layer.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: tab.width < 40 === true
+PASS: tab.height < 30 === true
 
-
-PASS tab.width < 40 is true
-PASS tab.height < 30 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+Test

--- a/LayoutTests/accessibility/transformed-bounds.html
+++ b/LayoutTests/accessibility/transformed-bounds.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 
     <style>
         
@@ -70,23 +71,17 @@
   </div>
 </div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that if a view is in a transformed layer, the bounds will not be offset by the origin of the transformed layer.\n\n";
 
-    description("This tests that if a view is in a transformed layer, the bounds will not be offset by the origin of the transformed layer.");
-
-    if (window.accessibilityController) {
-        var tab = accessibilityController.accessibleElementById("tab");
-        shouldBeTrue("tab.width < 40");
-        shouldBeTrue("tab.height < 30");
-    }
-
+if (window.accessibilityController) {
+    var tab = accessibilityController.accessibleElementById("tab");
+    output += expect("tab.width < 40", "true");
+    output += expect("tab.height < 30", "true");
+    
+    debug(output);
+}
 </script>
 
-<script src="../resources/js-test-post.js"></script>
-
-</div>
 </body>
 </html>

--- a/LayoutTests/accessibility/unknown-roles-not-exposed-expected.txt
+++ b/LayoutTests/accessibility/unknown-roles-not-exposed-expected.txt
@@ -1,10 +1,7 @@
-
 This tests accessibility objects with role 'unknown' are not being exposed.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: unknownChild == null === true
 
-
-PASS findUnknownChild(accessibilityController.focusedElement) == null is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/unknown-roles-not-exposed.html
+++ b/LayoutTests/accessibility/unknown-roles-not-exposed.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 <script>
 function findUnknownChild(accessibilityObject) {
     if (accessibilityObject.role == "AXRole: AXUnknown")
@@ -20,20 +21,22 @@ function findUnknownChild(accessibilityObject) {
 function runTest()
 {
   if (window.accessibilityController) {
+    var output = "This tests accessibility objects with role 'unknown' are not being exposed.\n\n";
     document.body.focus();
-    shouldBeTrue("findUnknownChild(accessibilityController.focusedElement) == null");
+    unknownChild = findUnknownChild(accessibilityController.focusedElement);
+    output += expect("unknownChild == null", "true");
+    debug(output);
+    finishJSTest();
   }
 }
 </script>
 </head>
 <body id="body" onload="runTest()">
 <iframe src="data:text/html,<body><button>Click me</button></body>"></iframe>
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-description("This tests accessibility objects with role 'unknown' are not being exposed.");
-
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/mac/accessibility/aria-labelledby-overrides-aria-label-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/aria-labelledby-overrides-aria-label-expected.txt
@@ -1,12 +1,18 @@
 This tests that if aria-labelledby is used, then aria-label attributes are not used.
 
-Alpha Beta Delta Eta Epsilon Theta
 usingNone.title: [AXTitle: Alpha]
-usingNone.description: [AXDescription: ]
-usingLabel.title: [AXTitle: Gamma]
-usingLabel.description: [AXDescription: Gamma]
-usingLabelledby.title: [AXTitle: Epsilon]
-usingLabelledby.description: [AXDescription: Epsilon]
-usingLabeledby.title: [AXTitle: Theta]
-usingLabeledby.description: [AXDescription: Theta]
+usingNone.description:  [AXDescription: ]
 
+usingLabel.title: [AXTitle: Gamma]
+usingLabel.description:  [AXDescription: Gamma]
+
+usingLabelledby.title: [AXTitle: Epsilon]
+usingLabelledby.description:  [AXDescription: Epsilon]
+
+usingLabeledby.title: [AXTitle: Theta]
+usingLabeledby.description:  [AXDescription: Theta]
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Alpha Beta Delta Eta Epsilon Theta

--- a/LayoutTests/platform/mac/accessibility/aria-mappings-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/aria-mappings-expected.txt
@@ -1,3 +1,37 @@
+This tests that each of these ARIA roles have appropriate mappings.
+
+Role for 'body' is: AXRole: AXWebArea
+
+role="alert" should give a message with important, and usually time-sensitive, information.
+Role for 'alert' div is: AXRole: AXGroup
+
+role="alertdialog" is a dialog which contains an alert message.
+Role for 'alertdialog' div is: AXRole: AXGroup
+
+role="article" is a  section of a page that consists of a composition that forms an independent part of a document, page, or site
+Role for 'article' div is: AXRole: AXGroup
+
+role="dialog" is an application window that is designed to interrupt the current processing of an application in order to prompt the user to enter information or require a response.
+Role for 'dialog' div is: AXRole: AXGroup
+
+role="document" is a region containing related information that is declared as document content, as opposed to a web application.
+Role for 'document' div is: AXRole: AXGroup
+
+role="status" is a container whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.
+Role for 'status' div is: AXRole: AXGroup
+
+role="tooltip" is a contextual popup that displays a description for an element.
+Role for 'tooltip' div is: AXRole: AXGroup
+
+role="tree" is a type of list that may contain sub-level nested groups that can be collapsed and expanded.
+Role for 'tree' div is: AXRole: AXOutline
+
+role="treeitem" is an option item of a tree.
+Role for 'treeitem' div is: AXRole: AXRow
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
 alert role
 alertdialog role
 article role
@@ -8,49 +42,4 @@ tooltip role
 tree role
 treeitem role
 
-This tests that each of these ARIA roles have appropriate mappings.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-Role for 'body' is: AXRole: AXWebArea
-
-
-role="alert" should give a message with important, and usually time-sensitive, information.
-Role for 'alert' div is: AXRole: AXGroup
-
-
-role="alertdialog" is a dialog which contains an alert message.
-Role for 'alertdialog' div is: AXRole: AXGroup
-
-
-role="article" is a  section of a page that consists of a composition that forms an independent part of a document, page, or site
-Role for 'article' div is: AXRole: AXGroup
-
-
-role="dialog" is an application window that is designed to interrupt the current processing of an application in order to prompt the user to enter information or require a response.
-Role for 'dialog' div is: AXRole: AXGroup
-
-
-role="document" is a region containing related information that is declared as document content, as opposed to a web application.
-Role for 'document' div is: AXRole: AXGroup
-
-
-role="status" is a container whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.
-Role for 'status' div is: AXRole: AXGroup
-
-
-role="tooltip" is a contextual popup that displays a description for an element.
-Role for 'tooltip' div is: AXRole: AXGroup
-
-
-role="tree" is a type of list that may contain sub-level nested groups that can be collapsed and expanded.
-Role for 'tree' div is: AXRole: AXOutline
-
-
-role="treeitem" is an option item of a tree.
-Role for 'treeitem' div is: AXRole: AXRow
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/platform/mac/accessibility/aria-selected-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/aria-selected-expected.txt
@@ -1,8 +1,5 @@
 This tests that items with aria-selected are reported as selected children of the parent container.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 AXRole: AXTabGroup has 1 selected child(ren)
 	second (AXRole: AXRadioButton) isSelectable: true isSelected: true
 AXRole: AXTabGroup has 1 selected child(ren)
@@ -15,6 +12,7 @@ AXRole: AXTable has 1 selected child(ren)
 AXRole: AXTable has 2 selected child(ren)
 	first - level 2 (AXRole: AXRow) isSelectable: true isSelected: true
 	third - level 2 (AXRole: AXRow) isSelectable: true isSelected: true
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac/accessibility/aria-switch-text-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/aria-switch-text-expected.txt
@@ -1,21 +1,20 @@
-One
-Two
-Three
 This tests that ARIA switches use accessible name computation and have no child text.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 widget.title is AXTitle: One
 widget.description is AXDescription:
 widget.childrenCount is 0
+
 widget.title is AXTitle: Two
 widget.description is AXDescription:
 widget.childrenCount is 0
+
 widget.title is AXTitle: foo
 widget.description is AXDescription: foo
 widget.childrenCount is 0
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+One
+Two
+Three

--- a/LayoutTests/platform/mac/accessibility/box-styled-lists-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/box-styled-lists-expected.txt
@@ -1,13 +1,12 @@
-test 1
-test 2
-test a
-test b
-
-
-
-
 il in ol role: AXRole: AXGroup
 
 il in ul role: AXRole: AXGroup
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
+test 1
+test 2
+test a
+test b

--- a/LayoutTests/platform/mac/accessibility/css-content-attribute-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/css-content-attribute-expected.txt
@@ -1,10 +1,4 @@
-SAMPLE
-
-End of test
 This tests that when the content attribute in CSS is used, the correct values are returned.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 AXRole: AXWebArea AXValue:
   AXRole: AXHeading AXValue: 1
@@ -15,4 +9,6 @@ AXRole: AXWebArea AXValue:
 PASS successfullyParsed is true
 
 TEST COMPLETE
+SAMPLE
 
+End of test

--- a/LayoutTests/platform/mac/accessibility/div-within-anchors-causes-crash-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/div-within-anchors-causes-crash-expected.txt
@@ -1,3 +1,9 @@
+This can cause a crash.
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
 End of test
 Before:
 AXRole: AXWebArea AXValue:
@@ -5,13 +11,6 @@ AXRole: AXWebArea AXValue:
     AXRole: AXGroup AXValue:
 After:
 AXRole: AXWebArea AXValue:
+    AXRole: AXLink AXValue:
     AXRole: AXGroup AXValue:
-This can cause a crash.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/platform/mac/accessibility/math-foreign-content-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/math-foreign-content-expected.txt
@@ -1,15 +1,13 @@
 This verifies the expected roles and values are exposed for foreign content in MathML.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
+PASS successfullyParsed is true
 
+TEST COMPLETE
 AXRole: AXGroup AXSubrole: AXDocumentMath AXValue:
     AXRole: AXGroup AXSubrole: AXMathRow AXValue:
         AXRole: AXGroup AXSubrole:  AXValue:
             AXRole: AXStaticText AXSubrole:  AXValue: SVG
     AXRole: AXGroup AXSubrole: AXMathText AXValue:
         AXRole: AXStaticText AXSubrole:  AXValue: HTML
-PASS successfullyParsed is true
-
-TEST COMPLETE
 

--- a/LayoutTests/platform/mac/accessibility/meter-element-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/meter-element-expected.txt
@@ -1,15 +1,11 @@
 This tests that the meter element is accessible.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 Meter1
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription: 6 blocks used (out of 8 total)
 AXValueSettable: false
-
 
 Meter2
 AXRole: AXLevelIndicator
@@ -18,14 +14,12 @@ AXDescription:
 AXValueDescription: 75%
 AXValueSettable: false
 
-
 Meter3
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription:
 AXValueSettable: false
-
 
 Meter4
 AXRole: AXLevelIndicator
@@ -34,14 +28,12 @@ AXDescription:
 AXValueDescription: 12cm
 AXValueSettable: false
 
-
 Meter5
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription: 2cm
 AXValueSettable: false
-
 
 Meter6
 AXRole: AXLevelIndicator
@@ -50,14 +42,12 @@ AXDescription:
 AXValueDescription: 12cm
 AXValueSettable: false
 
-
 Meter7
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription: 2cm
 AXValueSettable: false
-
 
 Meter8
 AXRole: AXLevelIndicator
@@ -66,14 +56,12 @@ AXDescription:
 AXValueDescription: 75 out of 100
 AXValueSettable: false
 
-
 Meter9
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription: 75 percent
 AXValueSettable: false
-
 
 Meter10
 AXRole: AXLevelIndicator
@@ -82,14 +70,12 @@ AXDescription:
 AXValueDescription: 75 percent
 AXValueSettable: false
 
-
 Meter11
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription: 75 (100 total)
 AXValueSettable: false
-
 
 Meter12
 AXRole: AXLevelIndicator
@@ -98,14 +84,12 @@ AXDescription:
 AXValueDescription: 75 (out of 100 total)
 AXValueSettable: false
 
-
 Meter13
 AXRole: AXLevelIndicator
 AXTitle:
 AXDescription:
 AXValueDescription: 75 (out of 100 total)
 AXValueSettable: false
-
 
 Meter14
 AXRole: AXLevelIndicator

--- a/LayoutTests/platform/mac/accessibility/table-hierarchy-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/table-hierarchy-expected.txt
@@ -1,22 +1,4 @@
-foo	bar
-Odd	Even
-1	2
-3	4
-hello	world
-Odd	Even
-1
-
-2
-
-3
-
-4
-
-End of test
 This tests the accessible hierarchy for an HTML table.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
 
 AXRole: AXWebArea AXValue:
   AXRole: AXGroup AXValue:
@@ -109,4 +91,18 @@ AXRole: AXWebArea AXValue:
 PASS successfullyParsed is true
 
 TEST COMPLETE
+foo	bar
+Odd	Even
+1	2
+3	4
+hello	world
+Odd	Even
+1
 
+2
+
+3
+
+4
+
+End of test

--- a/LayoutTests/platform/mac/accessibility/table-roles-hierarchy-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/table-roles-hierarchy-expected.txt
@@ -1,11 +1,3 @@
-No	Country	Capital
-1.	Poland	Warsaw
-2.	Russia	Moscow
-3.	Ukraine	Kiev
-All	3 countries	3 capitals
-
-
-
 This shows the hierarchy of table roles.
 
 role: AXRole: AXTable
@@ -84,7 +76,16 @@ role: AXRole: AXTable
             role: AXRole: AXStaticText
         role: AXRole: AXCell
             role: AXRole: AXStaticText
+
 PASS successfullyParsed is true
 
 TEST COMPLETE
+No	Country	Capital
+1.	Poland	Warsaw
+2.	Russia	Moscow
+3.	Ukraine	Kiev
+All	3 countries	3 capitals
 
+
+
+This shows the hierarchy of table roles.


### PR DESCRIPTION
#### 283ede6fbad90eb86d609bd1a45e1375cefcc9c1
<pre>
AX: finish modernizing accessibility layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=296600">https://bugs.webkit.org/show_bug.cgi?id=296600</a>
<a href="https://rdar.apple.com/156959823">rdar://156959823</a>

Reviewed by NOBODY (OOPS!).

Written with the help of AI

* LayoutTests/accessibility/accessibility-crash-setattribute-expected.txt:
* LayoutTests/accessibility/accessibility-crash-setattribute.html:
* LayoutTests/accessibility/add-children-pseudo-element-expected.txt:
* LayoutTests/accessibility/anonymous-render-block-in-continuation-causes-crash-expected.txt:
* LayoutTests/accessibility/anonymous-render-block-in-continuation-causes-crash.html:
* LayoutTests/accessibility/aria-cellspans-with-native-cellspans-expected.txt:
* LayoutTests/accessibility/aria-cellspans-with-native-cellspans.html:
* LayoutTests/accessibility/aria-expanded-supported-roles.html:
* LayoutTests/accessibility/aria-grid-column-span-expected.txt:
* LayoutTests/accessibility/aria-grid-column-span.html:
* LayoutTests/accessibility/aria-labelledby-overrides-aria-label.html:
* LayoutTests/accessibility/aria-labelledby-stay-within-expected.txt:
* LayoutTests/accessibility/aria-labelledby-stay-within.html:
* LayoutTests/accessibility/aria-labelledby-with-descendants-expected.txt:
* LayoutTests/accessibility/aria-labelledby-with-descendants.html:
* LayoutTests/accessibility/aria-link-supports-press-expected.txt:
* LayoutTests/accessibility/aria-link-supports-press.html:
* LayoutTests/accessibility/aria-mappings.html:
* LayoutTests/accessibility/aria-presentational-role-expected.txt:
* LayoutTests/accessibility/aria-presentational-role.html:
* LayoutTests/accessibility/aria-selected.html:
* LayoutTests/accessibility/aria-switch-sends-notification.html:
* LayoutTests/accessibility/aria-switch-text.html:
* LayoutTests/accessibility/box-styled-lists.html:
* LayoutTests/accessibility/canvas-accessibilitynodeobject-expected.txt:
* LayoutTests/accessibility/canvas-accessibilitynodeobject.html:
* LayoutTests/accessibility/content-editable-set-inner-text-generates-axvalue-notification-expected.txt:
* LayoutTests/accessibility/content-editable-set-inner-text-generates-axvalue-notification.html:
* LayoutTests/accessibility/contenteditable-table-check-causes-crash-expected.txt:
* LayoutTests/accessibility/contenteditable-table-check-causes-crash.html:
* LayoutTests/accessibility/crashing-a-tag-in-map-expected.txt:
* LayoutTests/accessibility/crashing-a-tag-in-map.html:
* LayoutTests/accessibility/css-content-attribute.html:
* LayoutTests/accessibility/css-table-ignored-expected.txt:
* LayoutTests/accessibility/css-table-ignored.html:
* LayoutTests/accessibility/dimensions-include-descendants-expected.txt:
* LayoutTests/accessibility/dimensions-include-descendants.html:
* LayoutTests/accessibility/display-contents/descendant-menu-item-expected.txt:
* LayoutTests/accessibility/display-contents/descendant-menu-item.html:
* LayoutTests/accessibility/div-within-anchors-causes-crash.html:
* LayoutTests/accessibility/double-nested-inline-element-missing-from-tree-expected.txt:
* LayoutTests/accessibility/double-nested-inline-element-missing-from-tree.html:
* LayoutTests/accessibility/duplicate-axrenderobject-crash-expected.txt:
* LayoutTests/accessibility/duplicate-axrenderobject-crash.html:
* LayoutTests/accessibility/dynamically-ignored-canvas-expected.txt:
* LayoutTests/accessibility/element-reflection-ariaactivedescendant-expected.txt:
* LayoutTests/accessibility/ellipsis-text-expected.txt:
* LayoutTests/accessibility/ellipsis-text.html:
* LayoutTests/accessibility/embedded-image-description-expected.txt:
* LayoutTests/accessibility/embedded-image-description.html:
* LayoutTests/accessibility/fieldset-element-expected.txt:
* LayoutTests/accessibility/fieldset-element.html:
* LayoutTests/accessibility/focusable-inside-hidden-expected.txt:
* LayoutTests/accessibility/focusable-inside-hidden.html:
* LayoutTests/accessibility/frame-disconnect-textmarker-cache-crash-expected.txt:
* LayoutTests/accessibility/frame-disconnect-textmarker-cache-crash.html:
* LayoutTests/accessibility/heading-title-includes-links-expected.txt:
* LayoutTests/accessibility/heading-title-includes-links.html:
* LayoutTests/accessibility/hidden-slot-expected.txt:
* LayoutTests/accessibility/hidden-slot.html:
* LayoutTests/accessibility/hidden-th-still-column-header-expected.txt:
* LayoutTests/accessibility/hidden-th-still-column-header.html:
* LayoutTests/accessibility/iframe-within-cell-expected.txt:
* LayoutTests/accessibility/iframe-within-cell.html:
* LayoutTests/accessibility/image-link-expected.txt:
* LayoutTests/accessibility/image-link-inline-cont-expected.txt:
* LayoutTests/accessibility/image-link-inline-cont.html:
* LayoutTests/accessibility/image-link.html:
* LayoutTests/accessibility/image-map1-expected.txt:
* LayoutTests/accessibility/image-map1.html:
* LayoutTests/accessibility/image-role-is-synonomous-with-img-role-expected.txt:
* LayoutTests/accessibility/image-role-is-synonomous-with-img-role.html:
* LayoutTests/accessibility/insert-children-assert-expected.txt:
* LayoutTests/accessibility/insert-children-assert.html:
* LayoutTests/accessibility/insert-text-into-password-field.html:
* LayoutTests/accessibility/keyevents-for-actions-mimic-real-key-events-expected.txt:
* LayoutTests/accessibility/keyevents-for-increment-actions-with-node-removal-expected.txt:
* LayoutTests/accessibility/keyevents-for-increment-actions-with-node-removal.html:
* LayoutTests/accessibility/keyevents-posted-for-dismiss-action-expected.txt:
* LayoutTests/accessibility/keyevents-posted-for-dismiss-action.html:
* LayoutTests/accessibility/keyevents-posted-for-increment-actions-expected.txt:
* LayoutTests/accessibility/keyevents-posted-for-increment-actions.html:
* LayoutTests/accessibility/label-element-press-expected.txt:
* LayoutTests/accessibility/label-element-press.html:
* LayoutTests/accessibility/listbox-clear-selection.html:
* LayoutTests/accessibility/mac/attributed-string-for-text-marker-range-using-webarea-expected.txt:
* LayoutTests/accessibility/mac/attributed-string-includes-misspelled-with-selection-expected.txt:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable-expected.txt:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range-expected.txt:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-for-range-with-options-expected.txt:
* LayoutTests/accessibility/mac/attributed-string/attributed-string-has-completion-annotation-expected.txt:
* LayoutTests/accessibility/mac/character-offset-from-upstream-position-expected.txt:
* LayoutTests/accessibility/mac/document-attributes-expected.txt:
* LayoutTests/accessibility/mac/focus-setting-selection-syncronizing-not-clearing-expected.txt:
* LayoutTests/accessibility/mac/frame-with-title-expected.txt:
* LayoutTests/accessibility/mac/misspelled-attributed-string-expected.txt:
* LayoutTests/accessibility/mac/pseudo-element-text-markers-expected.txt:
* LayoutTests/accessibility/mac/ruby-hierarchy-roles-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-from-ignored-element-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-immediate-descendants-only-expected.txt:
* LayoutTests/accessibility/mac/search-predicate-visible-button-expected.txt:
* LayoutTests/accessibility/mac/search-when-element-starts-in-table-expected.txt:
* LayoutTests/accessibility/mac/selected-visible-position-range-expected.txt:
* LayoutTests/accessibility/mac/set-value-editable-types-expected.txt:
* LayoutTests/accessibility/mac/setting-attributes-is-asynchronous-expected.txt:
* LayoutTests/accessibility/mac/text-marker-for-index-2-expected.txt:
* LayoutTests/accessibility/mac/text-marker-for-index-expected.txt:
* LayoutTests/accessibility/mac/text-marker-p-tags-expected.txt:
* LayoutTests/accessibility/mac/text-marker-string-for-document-end-replaced-node-expected.txt:
* LayoutTests/accessibility/mac/text-marker-word-nav-collapsed-whitespace-expected.txt:
* LayoutTests/accessibility/mac/text-marker-word-nav-expected.txt:
* LayoutTests/accessibility/mac/text-markers-for-input-with-placeholder-expected.txt:
* LayoutTests/accessibility/mac/text-operation/text-operation-replace-across-multiple-fields-expected.txt:
* LayoutTests/accessibility/mac/textmarker-range-for-range-expected.txt:
* LayoutTests/accessibility/math-foreign-content.html:
* LayoutTests/accessibility/menu-item-crash-expected.txt:
* LayoutTests/accessibility/menu-item-crash.html:
* LayoutTests/accessibility/menuitem-is-selected-expected.txt:
* LayoutTests/accessibility/meter-element.html:
* LayoutTests/accessibility/minimal-table-with-aria-is-data-table-expected.txt:
* LayoutTests/accessibility/minimal-table-with-aria-is-data-table.html:
* LayoutTests/accessibility/node-only-object-element-rect.html:
* LayoutTests/accessibility/out-of-bounds-rowspan-aria-hidden.html:
* LayoutTests/accessibility/poorly-formed-aria-table-expected.txt:
* LayoutTests/accessibility/poorly-formed-aria-table.html:
* LayoutTests/accessibility/presentation-role-iframe-expected.txt:
* LayoutTests/accessibility/range-alter-by-percent-expected.txt:
* LayoutTests/accessibility/range-alter-by-percent.html:
* LayoutTests/accessibility/range-alter-by-step-expected.txt:
* LayoutTests/accessibility/range-alter-by-step.html:
* LayoutTests/accessibility/removed-continuation-element-causes-crash-expected.txt:
* LayoutTests/accessibility/removed-continuation-element-causes-crash.html:
* LayoutTests/accessibility/scroll-to-make-visible-div-overflow-expected.txt:
* LayoutTests/accessibility/scroll-to-make-visible-div-overflow.html:
* LayoutTests/accessibility/search-misspellings-expected.txt:
* LayoutTests/accessibility/secure-textfield-title-ui-expected.txt:
* LayoutTests/accessibility/secure-textfield-title-ui.html:
* LayoutTests/accessibility/selected-text-range-aria-elements-expected.txt:
* LayoutTests/accessibility/selected-text-range-aria-elements.html:
* LayoutTests/accessibility/selection-states-expected.txt:
* LayoutTests/accessibility/selection-states.html:
* LayoutTests/accessibility/set-selected-text-range-after-newline.html:
* LayoutTests/accessibility/svg-element-press-expected.txt:
* LayoutTests/accessibility/svg-element-press.html:
* LayoutTests/accessibility/svg-text-expected.txt:
* LayoutTests/accessibility/svg-text.html:
* LayoutTests/accessibility/table-cell-display-block-expected.txt:
* LayoutTests/accessibility/table-cell-display-block.html:
* LayoutTests/accessibility/table-cell-spans-expected.txt:
* LayoutTests/accessibility/table-cell-spans.html:
* LayoutTests/accessibility/table-cells-expected.txt:
* LayoutTests/accessibility/table-cells.html:
* LayoutTests/accessibility/table-detection-expected.txt:
* LayoutTests/accessibility/table-headers-expected.txt:
* LayoutTests/accessibility/table-headers.html:
* LayoutTests/accessibility/table-hierarchy.html:
* LayoutTests/accessibility/table-roles-hierarchy.html:
* LayoutTests/accessibility/table-with-footer-section-above-body-expected.txt:
* LayoutTests/accessibility/table-with-footer-section-above-body.html:
* LayoutTests/accessibility/table-with-rules-expected.txt:
* LayoutTests/accessibility/table-with-rules.html:
* LayoutTests/accessibility/text-element-path-expected.txt:
* LayoutTests/accessibility/text-element-path.html:
* LayoutTests/accessibility/text-marker/text-marker-bidi-element-arabic-expected.txt:
* LayoutTests/accessibility/text-marker/text-marker-bidi-element-hebrew-expected.txt:
* LayoutTests/accessibility/textarea-insertion-point-line-number-expected.txt:
* LayoutTests/accessibility/textarea-selected-text-range-expected.txt:
* LayoutTests/accessibility/textarea-selected-text-range.html:
* LayoutTests/accessibility/transformed-bounds-expected.txt:
* LayoutTests/accessibility/transformed-bounds.html:
* LayoutTests/accessibility/unknown-roles-not-exposed-expected.txt:
* LayoutTests/accessibility/unknown-roles-not-exposed.html:
* LayoutTests/platform/mac/accessibility/aria-labelledby-overrides-aria-label-expected.txt:
* LayoutTests/platform/mac/accessibility/aria-mappings-expected.txt:
* LayoutTests/platform/mac/accessibility/aria-selected-expected.txt:
* LayoutTests/platform/mac/accessibility/aria-switch-text-expected.txt:
* LayoutTests/platform/mac/accessibility/box-styled-lists-expected.txt:
* LayoutTests/platform/mac/accessibility/content-editable-as-textarea-expected.txt:
* LayoutTests/platform/mac/accessibility/css-content-attribute-expected.txt:
* LayoutTests/platform/mac/accessibility/div-within-anchors-causes-crash-expected.txt:
* LayoutTests/platform/mac/accessibility/mac/spellcheck-with-voiceover-expected.txt:
* LayoutTests/platform/mac/accessibility/math-foreign-content-expected.txt:
* LayoutTests/platform/mac/accessibility/meter-element-expected.txt:
* LayoutTests/platform/mac/accessibility/native-text-control-attributed-string-expected.txt:
* LayoutTests/platform/mac/accessibility/table-hierarchy-expected.txt:
* LayoutTests/platform/mac/accessibility/table-roles-hierarchy-expected.txt:
* LayoutTests/platform/mac/accessibility/text-marker/text-marker-previous-next-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283ede6fbad90eb86d609bd1a45e1375cefcc9c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34000 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/41959 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86436 "Found 24 new test failures: accessibility/aria-labelledby-overrides-aria-label.html accessibility/aria-mappings.html accessibility/aria-selected.html accessibility/aria-switch-sends-notification.html accessibility/aria-switch-text.html accessibility/box-styled-lists.html accessibility/css-content-attribute.html accessibility/dimensions-include-descendants.html accessibility/display-contents/descendant-menu-item.html accessibility/div-within-anchors-causes-crash.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41551 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102142 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66791 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26360 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20266 "Found 3 new test failures: accessibility/div-within-anchors-causes-crash.html accessibility/image-link.html accessibility/keyevents-posted-for-increment-actions.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96503 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20369 "Found 4 new test failures: accessibility/display-contents/descendant-menu-item.html accessibility/div-within-anchors-causes-crash.html accessibility/image-link.html accessibility/keyevents-posted-for-increment-actions.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40688 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30358 "Found 4 new test failures: accessibility/display-contents/descendant-menu-item.html accessibility/div-within-anchors-causes-crash.html accessibility/image-link.html accessibility/keyevents-posted-for-increment-actions.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95284 "Found 24 new test failures: accessibility/aria-labelledby-overrides-aria-label.html accessibility/aria-mappings.html accessibility/aria-selected.html accessibility/aria-switch-sends-notification.html accessibility/aria-switch-text.html accessibility/box-styled-lists.html accessibility/css-content-attribute.html accessibility/dimensions-include-descendants.html accessibility/display-contents/descendant-menu-item.html accessibility/div-within-anchors-causes-crash.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41079 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98357 "Exiting early after 10 failures. 35 tests run. 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40175 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17980 "Found 4 new test failures: accessibility/display-contents/descendant-menu-item.html accessibility/div-within-anchors-causes-crash.html accessibility/image-link.html accessibility/keyevents-posted-for-increment-actions.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36899 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40570 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/41985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->