### PR TITLE
[MacOS] Have scrollbar testing match system width

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -621,6 +621,7 @@ platform/mac/ScrollViewMac.mm
 platform/mac/ScrollbarMac.mm @no-unify
 platform/mac/ScrollbarsControllerMac.mm @no-unify
 platform/mac/ScrollbarThemeMac.mm @no-unify
+platform/mac/ScrollbarThemeMockMac.mm @no-unify
 platform/mac/ScrollingEffectsController.mm
 platform/mac/ScrollingMomentumCalculatorMac.mm
 platform/mac/SerializedPlatformDataCueMac.mm

--- a/Source/WebCore/platform/ScrollbarTheme.cpp
+++ b/Source/WebCore/platform/ScrollbarTheme.cpp
@@ -32,6 +32,10 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if PLATFORM(MAC)
+#include "ScrollbarThemeMockMac.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollbarTheme);
@@ -39,8 +43,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollbarTheme);
 ScrollbarTheme& ScrollbarTheme::theme()
 {
     if (DeprecatedGlobalSettings::mockScrollbarsEnabled()) {
+#if PLATFORM(MAC)
+        static NeverDestroyed<ScrollbarThemeMockMac> mockTheme;
+        return mockTheme;
+# else
         static NeverDestroyed<ScrollbarThemeMock> mockTheme;
         return mockTheme;
+# endif
     }
     return nativeTheme();
 }

--- a/Source/WebCore/platform/mac/ScrollbarThemeMockMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMockMac.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2008 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "ScrollbarThemeMock.h"
+
+#if PLATFORM(MAC)
+
+OBJC_CLASS CALayer;
+
+namespace WebCore {
+
+class ScrollbarThemeMockMac : public ScrollbarThemeMock {
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) final;
+
+};
+
+}
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ScrollbarThemeMockMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMockMac.mm
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2008-2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#import "config.h"
+#import "ScrollbarThemeMockMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ScrollTypesMac.h"
+
+#import <pal/spi/mac/NSScrollerImpSPI.h>
+#import <wtf/BlockObjCExceptions.h>
+
+namespace WebCore {
+
+int ScrollbarThemeMockMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState, OverlayScrollbarSizeRelevancy overlayRelevancy)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if (scrollbarWidth == ScrollbarWidth::None || (usesOverlayScrollbars() && overlayRelevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize))
+        return 0;
+    NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:NSScrollerStyleOverlay controlSize:nsControlSizeFromScrollbarWidth(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
+    [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];
+    return [scrollerImp trackBoxWidth];
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Tools/DumpRenderTree/mac/Info.plist
+++ b/Tools/DumpRenderTree/mac/Info.plist
@@ -8,7 +8,5 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
-	<key>UIDesignRequiresCompatibility</key>
-        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### e5270b90db441a49ef2154c6799555e2a73fdee6
<pre>
[MacOS] Have scrollbar testing match system width
<a href="https://bugs.webkit.org/show_bug.cgi?id=296602">https://bugs.webkit.org/show_bug.cgi?id=296602</a>
<a href="https://rdar.apple.com/156966150">rdar://156966150</a>

Reviewed by NOBODY (OOPS!).

Have scrollbarThickness use system scrollbar width on wk1 and wk2.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ScrollbarTheme.cpp:
(WebCore::ScrollbarTheme::theme):
* Source/WebCore/platform/mac/ScrollbarThemeMockMac.h: Copied from Source/WebCore/platform/ScrollbarTheme.cpp.
* Source/WebCore/platform/mac/ScrollbarThemeMockMac.mm: Copied from Source/WebCore/platform/ScrollbarTheme.cpp.
(WebCore::ScrollbarThemeMockMac::scrollbarThickness):
* Tools/DumpRenderTree/mac/Info.plist:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5270b90db441a49ef2154c6799555e2a73fdee6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86570 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41758 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26485 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20430 "Found 60 new test failures: accessibility/password-notifications-timing.html compositing/clipping/border-radius-async-overflow-clipping-layer.html compositing/geometry/limit-layer-bounds-clipping-ancestor.html compositing/layers-inside-overflow-scroll.html compositing/overflow/clipping-ancestor-with-accelerated-scrolling-ancestor.html compositing/overflow/content-gains-scrollbars.html compositing/overflow/nested-scrolling.html compositing/overflow/overflow-clip-with-accelerated-scrolling-ancestor.html compositing/overflow/overflow-scroll.html compositing/overflow/overflow-scrollbar-layer-positions.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96652 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20546 "Found 60 new test failures: compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/backing-store-attachment-outside-viewport.html compositing/backing/backing-store-attachment-scroll.html compositing/backing/child-layer-no-backing.html compositing/backing/layer-outside-tiled-parent.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123298 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40946 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30485 "Found 60 new test failures: compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/backing-store-attachment-outside-viewport.html compositing/backing/backing-store-attachment-scroll.html compositing/backing/child-layer-no-backing.html compositing/backing/layer-outside-tiled-parent.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95401 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98512 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95174 "Found 102 new API test failures: /TestWebKit:WebKit.EvaluateJavaScriptThatCreatesBlob, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editor-state/typing-attributes, /TestWebKit:WebKit.FirstMeaningfulPaint, /TestWebKit:WebKit.FrameMIMETypeHTML, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40314 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18121 "Found 60 new test failures: compositing/absolute-inside-out-of-view-fixed.html compositing/accelerated-layers-after-back.html compositing/backing-store-attachment-1.html compositing/backing/animate-into-view-with-descendant.html compositing/backing/animate-into-view.html compositing/backing/backing-store-attachment-animating-outside-viewport.html compositing/backing/backing-store-attachment-outside-viewport.html compositing/backing/backing-store-attachment-scroll.html compositing/backing/child-layer-no-backing.html compositing/backing/layer-outside-tiled-parent.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46325 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->