### PR TITLE
Track and log reasons for ServiceWorkers spinning in a tight loop

### DIFF
--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -29,6 +29,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 namespace WTF {
@@ -201,6 +202,41 @@ void RunLoop::threadWillExit()
         Locker locker { m_nextIterationLock };
         m_nextIteration.clear();
     }
+}
+
+void RunLoop::registerTimer(TimerBase& timer)
+{
+    Locker locker { m_registeredTimerLock };
+    m_registeredTimers.add(&timer);
+}
+
+void RunLoop::unregisterTimer(TimerBase& timer)
+{
+    Locker locker { m_registeredTimerLock };
+    m_registeredTimers.remove(&timer);
+}
+
+String RunLoop::listActiveTimersForLogging() const
+{
+    Vector<ASCIILiteral> timers;
+    {
+        Locker locker { m_registeredTimerLock };
+        for (auto* timer : m_registeredTimers)
+            timers.append(timer->description());
+    }
+
+    if (timers.isEmpty())
+        return "{ }"_s;
+
+    StringBuilder builder;
+    builder.append("{ "_s);
+    for (size_t i = 0; i < timers.size() - 1; ++i) {
+        builder.append(timers[i]);
+        builder.append(", "_s);
+    }
+    builder.append(timers.last());
+    builder.append(" }"_s);
+    return builder.toString();
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -245,6 +245,8 @@ public:
 
     WTF_EXPORT_PRIVATE Ref<RunLoop::DispatchTimer> dispatchAfter(Seconds, Function<void()>&&);
 
+    WTF_EXPORT_PRIVATE String listActiveTimersForLogging() const;
+
 private:
     class Holder;
     static ThreadSpecific<Holder>& runLoopHolder();
@@ -252,6 +254,12 @@ private:
     RunLoop();
 
     void performWork();
+
+    void registerTimer(TimerBase&);
+    void unregisterTimer(TimerBase&);
+
+    mutable Lock m_registeredTimerLock;
+    HashSet<TimerBase *> m_registeredTimers;
 
     Deque<Function<void()>> m_currentIteration;
 

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -105,11 +105,13 @@ RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop, ASCIILiteral description)
     : m_runLoop(WTFMove(runLoop))
     , m_description(description)
 {
+    m_runLoop->registerTimer(*this);
 }
 
 RunLoop::TimerBase::~TimerBase()
 {
     stop();
+    m_runLoop->unregisterTimer(*this);
 }
 
 void RunLoop::TimerBase::start(Seconds interval, bool repeat)

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -34,7 +34,10 @@
 
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
+#include "Logging.h"
+#include "SWServer.h"
 #include "ScriptExecutionContext.h"
+#include "ServiceWorkerGlobalScope.h"
 #include "SharedTimer.h"
 #include "ThreadGlobalData.h"
 #include "ThreadTimers.h"
@@ -47,6 +50,10 @@
 #include <JavaScriptCore/JSRunLoopTimer.h>
 #include <wtf/AutodrainedPool.h>
 #include <wtf/TZoneMallocInlines.h>
+
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
 
 #if USE(GLIB)
 #include <glib.h>
@@ -161,17 +168,88 @@ void WorkerDedicatedRunLoop::run(WorkerOrWorkletGlobalScope* context)
 {
     RunLoopSetup setup(*this, RunLoopSetup::IsForDebugging::No);
     ModePredicate modePredicate(defaultMode(), false);
-    MessageQueueWaitResult result;
+
+    // <rdar://155433911> - ServiceWorkers sometimes end up spinning their worker runloop endlessly,
+    // repeatedly timing out getting a task from the message queue, not firing the web shared timer,
+    // then firing their CFRunLoopTimers which do very little (or nothing).
+    // This spinning is wasteful and - we suspect - unproductive.
+    // For ServiceWorkers only, we will log this scenario to learn more.
+    // The requirements are:
+    // 1 - The RunLoop must spin repeatedly, never handling a message or firing the web shared timer
+    // 2 - It must do so spanning at least "defaultTerminationDelay" seconds
+    // 3 - It must do so at a frequency we expect to be bad. (I'm arbitrarily choosing 10hz)
+    struct RunLoopStatus {
+        enum class ShouldLogExcessiveRunLoopSpinning : bool { No, Yes };
+        ShouldLogExcessiveRunLoopSpinning addRunLoopSpin()
+        {
+            numberOfRunLoopSpinsInARow++;
+            auto now = MonotonicTime::now();
+
+            if (timeOfFirstRunLoopOnlySpin == MonotonicTime::infinity()) {
+                timeOfFirstRunLoopOnlySpin = now;
+                return ShouldLogExcessiveRunLoopSpinning::No;
+            }
+
+            static constexpr Seconds lengthOfAllowableSpinning = SWServer::defaultTerminationDelay;
+
+            auto timeSpinning = now - timeOfFirstRunLoopOnlySpin;
+            if (timeSpinning < lengthOfAllowableSpinning)
+                return ShouldLogExcessiveRunLoopSpinning::No;
+
+            static const double frequencyLimit = 10.0;
+            if (numberOfRunLoopSpinsInARow / timeSpinning.seconds() < frequencyLimit)
+                return ShouldLogExcessiveRunLoopSpinning::No;
+
+            return ShouldLogExcessiveRunLoopSpinning::Yes;
+        }
+
+        double secondsSpentSpinning()
+        {
+            return std::max(0.0, (MonotonicTime::now() - timeOfFirstRunLoopOnlySpin).seconds());
+        }
+
+    private:
+        MonotonicTime timeOfFirstRunLoopOnlySpin { MonotonicTime::infinity() };
+        size_t numberOfRunLoopSpinsInARow { 0 };
+    };
+    RunLoopStatus currentRunLoopStatus;
+    RunInModeResult result;
+
     do {
         result = runInMode(context, modePredicate);
-    } while (result != MessageQueueTerminated);
+
+        // Only do further RunLoop status tracking for ServiceWorker contexts.
+        if (!is<ServiceWorkerGlobalScope>(context))
+            continue;
+
+        // We consider the message queue handling a message or this thread's shared timer firing to signify
+        // web content "making progress", so either are an acceptable result;
+        if (result.messageQueueResult != MessageQueueTimeout || result.firedSharedTimer) {
+            currentRunLoopStatus = { };
+            continue;
+        }
+
+        if (currentRunLoopStatus.addRunLoopSpin() == RunLoopStatus::ShouldLogExcessiveRunLoopSpinning::No)
+            continue;
+
+        auto reason = makeString("ServiceWorker message queue spun excessively without making web content progress for "_s, currentRunLoopStatus.secondsSpentSpinning(), " seconds. Shared timer firing in "_s, m_sharedTimer->fireTimeDelay().seconds(), " seconds. RunLoop rimers before: "_s, result.activeRunLoopTimersBeforeFiring, ". RunLoop timers after: "_s, result.activeRunLoopTimersAfterFiring);
+        RELEASE_LOG(ServiceWorker, "%s", reason.utf8().data());
+
+#if PLATFORM(COCOA)
+        if (WTF::CocoaApplication::isAppleApplication())
+            os_fault_with_payload(OS_REASON_WEBKIT, 0, nullptr, 0, reason.utf8().data(), 0);
+#endif
+
+        // Reset status to start tracking a new sequence of spinning.
+        currentRunLoopStatus = { };
+    } while (result.messageQueueResult != MessageQueueTerminated);
     runCleanupTasks(context);
 }
 
 MessageQueueWaitResult WorkerDedicatedRunLoop::runInDebuggerMode(WorkerOrWorkletGlobalScope& context)
 {
     RunLoopSetup setup(*this, RunLoopSetup::IsForDebugging::Yes);
-    return runInMode(&context, ModePredicate { debuggerMode(), false });
+    return runInMode(&context, ModePredicate { debuggerMode(), false }).messageQueueResult;
 }
 
 bool WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalScope* context, const String& mode, bool allowEventLoopTasks)
@@ -179,10 +257,10 @@ bool WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalScope* context, cons
     ASSERT(mode != debuggerMode());
     RunLoopSetup setup(*this, RunLoopSetup::IsForDebugging::No);
     ModePredicate modePredicate(String { mode }, allowEventLoopTasks);
-    return runInMode(context, modePredicate) != MessageQueueWaitResult::MessageQueueTerminated;
+    return runInMode(context, modePredicate).messageQueueResult != MessageQueueWaitResult::MessageQueueTerminated;
 }
 
-MessageQueueWaitResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalScope* context, const ModePredicate& predicate)
+WorkerDedicatedRunLoop::RunInModeResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalScope* context, const ModePredicate& predicate)
 {
     ASSERT(context);
     ASSERT(context->workerOrWorkletThread()->thread() == &Thread::currentSingleton());
@@ -233,8 +311,11 @@ MessageQueueWaitResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalSc
         script->removeTimerSetNotification(timerAddedTask);
     }
 
-    // If the context is closing, don't execute any further JavaScript tasks (per section 4.1.1 of the Web Workers spec).  However, there may be implementation cleanup tasks in the queue, so keep running through it.
+    RunInModeResult runInModeResult;
+    runInModeResult.messageQueueResult = result;
 
+    // If the context is closing, don't execute any further JavaScript tasks (per section 4.1.1 of the Web Workers spec).
+    // However, there may be implementation cleanup tasks in the queue, so keep running through it.
     switch (result) {
     case MessageQueueTerminated:
         break;
@@ -244,19 +325,26 @@ MessageQueueWaitResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalSc
         break;
 
     case MessageQueueTimeout:
-        if (!context->isClosing() && !isBeingDebugged())
+        if (!context->isClosing() && !isBeingDebugged()) {
+            runInModeResult.firedSharedTimer = true;
             m_sharedTimer->fire();
+        }
         break;
     }
 
 #if USE(CF)
     if (result != MessageQueueTerminated) {
-        if (nextCFRunLoopTimerFireDate <= CFAbsoluteTimeGetCurrent())
+        if (nextCFRunLoopTimerFireDate <= CFAbsoluteTimeGetCurrent()) {
+            runInModeResult.firedRunLoopTimer = true;
+
+            runInModeResult.activeRunLoopTimersBeforeFiring = RunLoop::currentSingleton().listActiveTimersForLogging();
             CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, /*returnAfterSourceHandled*/ false);
+            runInModeResult.activeRunLoopTimersAfterFiring = RunLoop::currentSingleton().listActiveTimersForLogging();
+        }
     }
 #endif
 
-    return result;
+    return runInModeResult;
 }
 
 void WorkerDedicatedRunLoop::runCleanupTasks(WorkerOrWorkletGlobalScope* context)

--- a/Source/WebCore/workers/WorkerRunLoop.h
+++ b/Source/WebCore/workers/WorkerRunLoop.h
@@ -115,7 +115,15 @@ public:
 
 private:
     friend class RunLoopSetup;
-    MessageQueueWaitResult runInMode(WorkerOrWorkletGlobalScope*, const ModePredicate&);
+
+    struct RunInModeResult {
+        MessageQueueWaitResult messageQueueResult;
+        bool firedSharedTimer { false };
+        bool firedRunLoopTimer { false };
+        String activeRunLoopTimersBeforeFiring;
+        String activeRunLoopTimersAfterFiring;
+    };
+    RunInModeResult runInMode(WorkerOrWorkletGlobalScope*, const ModePredicate&);
 
     // Runs any clean up tasks that are currently in the queue and returns.
     // This should only be called when the context is closed or loop has been terminated.


### PR DESCRIPTION
#### 509f9d38b696c0f867a987dbe8c00229ab13f2fd
<pre>
Track and log reasons for ServiceWorkers spinning in a tight loop
<a href="https://rdar.apple.com/156968388">rdar://156968388</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296605">https://bugs.webkit.org/show_bug.cgi?id=296605</a>

Reviewed by Basuke Suzuki.

We know that in some situations, ServiceWorkers are spinning their CFRunLoop excessively,
firing CFRunLoopTimers in a tight loop.

While doing so, they appear to not be making &quot;web progress&quot;, as defined by either handling
a message queue message or firing the shared timer.

This patch detects an arbitrary set of such spins in an attempt to learn more about them.

Have `RunLoop` keep track of its installed timers, and allow extracting those timer names
for logging purposes:
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::registerTimer):
(WTF::RunLoop::unregisterTimer):
(WTF::RunLoop::listActiveTimersForLogging const):
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::TimerBase::TimerBase):
(WTF::RunLoop::TimerBase::~TimerBase):

Teach WorkerRunLoop::run() to track the specific scenario of repeated spins based on
arbitrary metrics, and log if/when the fault condition occurs:
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::run):
(WebCore::WorkerDedicatedRunLoop::runInDebuggerMode):
(WebCore::WorkerDedicatedRunLoop::runInMode):
* Source/WebCore/workers/WorkerRunLoop.h:

Canonical link: <a href="https://commits.webkit.org/297968@main">https://commits.webkit.org/297968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef1622d1ab369d2191fed3a63b799aa9765e9f2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119874 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/41979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ✅ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66803 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20281 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63598 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106163 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123109 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112276 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/30364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95291 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95051 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24250 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40184 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/17993 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46096 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136483 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40226 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36575 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42002 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->