### PR TITLE
HDR 2D canvas -- exploring, DO NOT PUBLISH

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2104,6 +2104,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/AlphaPremultiplication.h
     platform/graphics/AnimationFrameRate.h
+    platform/graphics/ArrayPixelBuffer.h
     platform/graphics/AudioTrackPrivate.h
     platform/graphics/AudioTrackPrivateClient.h
     platform/graphics/CopyImageOptions.h

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -101,6 +101,7 @@ platform/graphics/ImageBufferContextSwitcher.h
 platform/graphics/StringTruncator.cpp
 platform/graphics/angle/ANGLEUtilities.cpp
 platform/graphics/angle/GraphicsContextGLANGLE.cpp
+platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
 platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2436,6 +2436,7 @@ platform/gamepad/GamepadConstants.cpp
 platform/gamepad/GamepadProvider.cpp
 platform/graphics/AV1Utilities.cpp
 platform/graphics/AlphaPremultiplication.cpp
+platform/graphics/ArrayPixelBuffer.cpp
 platform/graphics/AnimationFrameRate.cpp
 platform/graphics/BifurcatedGraphicsContext.cpp
 platform/graphics/BitmapImage.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2914,6 +2914,7 @@
 		72FD88D1295E3C40006FACDC /* MenuListPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FD88D0295D56E2006FACDC /* MenuListPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7410760E2D6BDCA9000EC9C0 /* PlatformDynamicRangeLimitCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 7410760D2D6BDB77000EC9C0 /* PlatformDynamicRangeLimitCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		74C2F53E29AC9B0B006C5F97 /* ApplePayDeferredPaymentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C2F53D29AC9B0A006C5F97 /* ApplePayDeferredPaymentRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		74FDCF282E4212BD00F31834 /* ArrayPixelBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 74FDCF252E4212BD00F31834 /* ArrayPixelBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7553CFE8108F473F00EA281E /* TimelineRecordFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7553CFE6108F473F00EA281E /* TimelineRecordFactory.h */; };
 		75793E840D0CE0B3007FC0AC /* MessageEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 75793E810D0CE0B3007FC0AC /* MessageEvent.h */; };
 		75793EC90D0CE72D007FC0AC /* JSMessageEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 75793EC70D0CE72D007FC0AC /* JSMessageEvent.h */; };
@@ -13792,6 +13793,8 @@
 		74C2F53D29AC9B0A006C5F97 /* ApplePayDeferredPaymentRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePayDeferredPaymentRequest.h; sourceTree = "<group>"; };
 		74C2F53F29AC9B1C006C5F97 /* ApplePayDeferredPaymentRequest.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ApplePayDeferredPaymentRequest.idl; sourceTree = "<group>"; };
 		74CE9900299503A200096552 /* attachmentElementShadow.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = attachmentElementShadow.css; sourceTree = "<group>"; };
+		74FDCF252E4212BD00F31834 /* ArrayPixelBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArrayPixelBuffer.h; sourceTree = "<group>"; };
+		74FDCF262E4212BD00F31834 /* ArrayPixelBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ArrayPixelBuffer.cpp; sourceTree = "<group>"; };
 		7553CFE6108F473F00EA281E /* TimelineRecordFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimelineRecordFactory.h; sourceTree = "<group>"; };
 		7553CFE7108F473F00EA281E /* TimelineRecordFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TimelineRecordFactory.cpp; sourceTree = "<group>"; };
 		75793E800D0CE0B3007FC0AC /* MessageEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = MessageEvent.cpp; sourceTree = "<group>"; };
@@ -34358,6 +34361,8 @@
 				7299BC6423D686A600CC6883 /* AlphaPremultiplication.h */,
 				0F7E475125EEB79A0013F909 /* AnimationFrameRate.cpp */,
 				722A815C238FD50500C00583 /* AnimationFrameRate.h */,
+				74FDCF262E4212BD00F31834 /* ArrayPixelBuffer.cpp */,
+				74FDCF252E4212BD00F31834 /* ArrayPixelBuffer.h */,
 				BEF29EE91715DD0900C4B4C9 /* AudioTrackPrivate.h */,
 				CD1F9B152702360E00617EB6 /* AudioTrackPrivateClient.h */,
 				CD1A22572B0759AC0038923E /* AV1Utilities.cpp */,
@@ -40921,6 +40926,7 @@
 				512DD8FC0D91E6AF000F89EE /* ArchiveResource.h in Headers */,
 				512DD8F80D91E6AF000F89EE /* ArchiveResourceCollection.h in Headers */,
 				716C4C3627EB60C900531467 /* ARKitBadgeSystemImage.h in Headers */,
+				74FDCF282E4212BD00F31834 /* ArrayPixelBuffer.h in Headers */,
 				FD5686CA13AC180200B69C68 /* AsyncAudioDecoder.h in Headers */,
 				E1CDE9221501916900862CC5 /* AsyncFileStream.h in Headers */,
 				01D22A1F2CFD826C002DC857 /* AsyncNodeDeletionQueue.h in Headers */,

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -57,7 +57,8 @@ static ImageDataStorageFormat computeStorageFormat(std::optional<ImageDataSettin
 Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
 {
     auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
-    return adoptRef(*new ImageData(pixelBuffer->size(), pixelBuffer->takeData(), *colorSpace, overridingStorageFormat));
+    auto size = pixelBuffer->size();
+    return adoptRef(*new ImageData(size, WTFMove(pixelBuffer.get()).takeData(), *colorSpace, overridingStorageFormat));
 }
 
 RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -61,11 +61,27 @@ Ref<ImageData> ImageData::create(Ref<ByteArrayPixelBuffer>&& pixelBuffer, std::o
     return adoptRef(*new ImageData(size, WTFMove(pixelBuffer.get()).takeData(), *colorSpace, overridingStorageFormat));
 }
 
+Ref<ImageData> ImageData::create(Ref<Float16ArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
+{
+    auto colorSpace = toPredefinedColorSpace(pixelBuffer->format().colorSpace);
+    auto size = pixelBuffer->size();
+    return adoptRef(*new ImageData(size, WTFMove(pixelBuffer.get()).takeData(), *colorSpace, overridingStorageFormat));
+}
+
 RefPtr<ImageData> ImageData::create(RefPtr<ByteArrayPixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
 {
     if (!pixelBuffer)
         return nullptr;
     return create(pixelBuffer.releaseNonNull(), overridingStorageFormat);
+}
+
+RefPtr<ImageData> ImageData::create(Ref<PixelBuffer>&& pixelBuffer, std::optional<ImageDataStorageFormat> overridingStorageFormat)
+{
+    if (is<ByteArrayPixelBuffer>(pixelBuffer))
+        return create(uncheckedDowncast<ByteArrayPixelBuffer>(WTFMove(pixelBuffer)), overridingStorageFormat);
+    if (is<Float16ArrayPixelBuffer>(pixelBuffer))
+        return create(uncheckedDowncast<Float16ArrayPixelBuffer>(WTFMove(pixelBuffer)), overridingStorageFormat);
+    return nullptr;
 }
 
 RefPtr<ImageData> ImageData::create(const IntSize& size, PredefinedColorSpace colorSpace, ImageDataStorageFormat imageDataStorageFormat)
@@ -161,6 +177,24 @@ Ref<ByteArrayPixelBuffer> ImageData::byteArrayPixelBuffer() const
     Ref uint8Data = m_data.asUint8ClampedArray();
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(m_colorSpace) };
     return ByteArrayPixelBuffer::create(format, m_size, uint8Data.get());
+}
+
+Ref<Float16ArrayPixelBuffer> ImageData::float16ArrayPixelBuffer() const
+{
+    Ref float16Data = m_data.asFloat16Array();
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA16F, toDestinationColorSpace(m_colorSpace) };
+    return Float16ArrayPixelBuffer::create(format, m_size, float16Data.get());
+}
+
+Ref<PixelBuffer> ImageData::pixelBuffer() const
+{
+    switch (m_data.storageFormat()) {
+    case ImageDataStorageFormat::Uint8:
+        return byteArrayPixelBuffer();
+    case ImageDataStorageFormat::Float16:
+        return float16ArrayPixelBuffer();
+    }
+    RELEASE_ASSERT_NOT_REACHED("Unexpected ImageDataStorageFormat value");
 }
 
 TextStream& operator<<(TextStream& ts, const ImageData& imageData)

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include "ImageDataArray.h"
 #include "ImageDataSettings.h"
 #include "IntSize.h"
@@ -43,6 +44,8 @@ template<typename> class ExceptionOr;
 class ImageData : public RefCounted<ImageData> {
 public:
     WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<Float16ArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+    WEBCORE_EXPORT static RefPtr<ImageData> create(Ref<PixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataStorageFormat = ImageDataStorageFormat::Uint8);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
@@ -64,6 +67,8 @@ public:
     ImageDataStorageFormat storageFormat() const { return m_data.storageFormat(); }
 
     Ref<ByteArrayPixelBuffer> byteArrayPixelBuffer() const;
+    Ref<Float16ArrayPixelBuffer> float16ArrayPixelBuffer() const;
+    Ref<PixelBuffer> pixelBuffer() const;
 
 private:
     explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -29,18 +29,9 @@
 #include "config.h"
 #include "ImageDataArray.h"
 
-#include <JavaScriptCore/Float16Array.h>
+#include "ArrayPixelBuffer.h"
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
-#include <JavaScriptCore/Uint8ClampedArray.h>
 #include <wtf/StdLibExtras.h>
-
-// Needed for `downcast` below.
-SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Uint8ClampedArray)
-    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeUint8Clamped; }
-SPECIALIZE_TYPE_TRAITS_END()
-SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Float16Array)
-    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeFloat16; }
-SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {
 

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -43,6 +43,7 @@ public:
 
     ImageDataArray(Ref<JSC::Uint8ClampedArray>&&);
     ImageDataArray(Ref<JSC::Float16Array>&&);
+    ImageDataArray(Ref<JSC::ArrayBufferView>&&);
     ImageDataArray(ImageDataArray&& original, std::optional<ImageDataStorageFormat> overridingStorageFormat);
 
     static std::optional<ImageDataArray> tryCreate(size_t, ImageDataStorageFormat, std::span<const uint8_t> = { });
@@ -62,8 +63,6 @@ public:
     Ref<JSON::Value> copyToJSONArray() const;
 
 private:
-    ImageDataArray(Ref<JSC::ArrayBufferView>&&);
-
     Ref<ArrayBufferView> extractBufferViewWithStorageFormat(std::optional<ImageDataStorageFormat>) &&;
 
     // Needed by `toJS<IDLUnion<IDLUint8ClampedArray, ...>, const ImageDataArray&>()`

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2495,13 +2495,13 @@ void CanvasRenderingContext2DBase::evictCachedImageData()
     m_cachedContents.emplace<CachedContentsUnknown>();
 }
 
-CanvasRenderingContext2DBase::CachedContentsImageData::CachedContentsImageData(CanvasRenderingContext2DBase& context, Ref<ByteArrayPixelBuffer> imageData)
+CanvasRenderingContext2DBase::CachedContentsImageData::CachedContentsImageData(CanvasRenderingContext2DBase& context, Ref<ArrayPixelBuffer> imageData)
     : imageData(WTFMove(imageData))
     , evictionTimer(context, &CanvasRenderingContext2DBase::evictCachedImageData, 5_s)
 {
 }
 
-RefPtr<ByteArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(const ImageData& imageData, const IntRect& sourceRect, const IntPoint& destinationPosition)
+RefPtr<ArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(const ImageData& imageData, const IntRect& sourceRect, const IntPoint& destinationPosition)
 {
     if (!destinationPosition.isZero() || !sourceRect.location().isZero() || sourceRect.size() != imageData.size() || sourceRect.size() != canvasBase().size())
         return nullptr;
@@ -2562,16 +2562,17 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
     if (colorSpace != m_settings.colorSpace)
         return nullptr;
 
+    auto format = pixelBuffer->format();
     auto size = pixelBuffer->size();
-    auto data = pixelBuffer->takeData();
+    auto data = WTFMove(pixelBuffer.get()).takeData();
     unsigned bytesPerRow = static_cast<unsigned>(size.width()) * 4u;
     ConstPixelBufferConversionView source {
-        .format = pixelBuffer->format(),
+        .format = format,
         .bytesPerRow = bytesPerRow,
         .rows = data->span(),
     };
     PixelBufferConversionView destination {
-        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, pixelBuffer->format().colorSpace },
+        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, format.colorSpace },
         .bytesPerRow = bytesPerRow,
         .rows = data->mutableSpan(),
     };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2501,7 +2501,17 @@ CanvasRenderingContext2DBase::CachedContentsImageData::CachedContentsImageData(C
 {
 }
 
-RefPtr<ArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(const ImageData& imageData, const IntRect& sourceRect, const IntPoint& destinationPosition)
+static constexpr PixelFormat toPixelFormat(CanvasRenderingContext2DSettings::PixelFormat canvasPixelFormat)
+{
+    switch (canvasPixelFormat) {
+    case CanvasRenderingContext2DSettings::PixelFormat::Uint8:
+        return PixelFormat::RGBA8;
+    case CanvasRenderingContext2DSettings::PixelFormat::Float16:
+        return PixelFormat::RGBA16F;
+    }
+}
+
+RefPtr<PixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(const ImageData& imageData, const IntRect& sourceRect, const IntPoint& destinationPosition)
 {
     if (!destinationPosition.isZero() || !sourceRect.location().isZero() || sourceRect.size() != imageData.size() || sourceRect.size() != canvasBase().size())
         return nullptr;
@@ -2522,30 +2532,45 @@ RefPtr<ArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossible(
     // We're not doing RGBA -> BGRA swizzle here, as that is not needed for cache retrieval and
     // the swizzle copy can be made at the putImageData copy site.
     auto colorSpace = toDestinationColorSpace(imageData.colorSpace());
-    unsigned bytesPerRow = static_cast<unsigned>(size.width()) * 4u;
-    PixelBufferFormat cachedFormat { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, colorSpace };
-    auto cachedBuffer = ByteArrayPixelBuffer::tryCreate(cachedFormat, size);
-    if (!cachedBuffer)
-        return nullptr;
+
+    auto imagePixelFormat = toPixelFormat(imageData.storageFormat());
+    unsigned imageBytesPerRow = static_cast<unsigned>(size.width()) * bytesPerPixel(imagePixelFormat);
     ConstPixelBufferConversionView source {
-        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace },
-        .bytesPerRow = bytesPerRow,
-        .rows = imageData.data().asUint8ClampedArray()->span(),
+        .format = { AlphaPremultiplication::Unpremultiplied, imagePixelFormat, colorSpace },
+        .bytesPerRow = imageBytesPerRow,
+        .rows = imageData.data().span(),
     };
+
+    auto cachePixelFormat = toPixelFormat(m_settings.pixelFormat);
+    unsigned cacheBytesPerRow = static_cast<unsigned>(size.width()) * bytesPerPixel(cachePixelFormat);
+    PixelBufferFormat cacheFormat { AlphaPremultiplication::Premultiplied, cachePixelFormat, colorSpace };
+    RefPtr cacheBuffer = ArrayPixelBuffer::tryCreate(cacheFormat, size);
+    if (!cacheBuffer)
+        return nullptr;
     PixelBufferConversionView destination {
-        .format = cachedFormat,
-        .bytesPerRow = bytesPerRow,
-        .rows = cachedBuffer->data().mutableSpan(),
+        .format = cacheFormat,
+        .bytesPerRow = cacheBytesPerRow,
+        .rows = cacheBuffer->bytes(),
     };
     convertImagePixels(source, destination, size);
-    m_cachedContents.emplace<CachedContentsImageData>(*this, *cachedBuffer);
-    return cachedBuffer;
+    m_cachedContents.emplace<CachedContentsImageData>(*this, *cacheBuffer);
+    return cacheBuffer;
 }
 
-RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(const IntRect& sourceRect, PredefinedColorSpace colorSpace) const
+static constexpr ImageDataStorageFormat toImageDataStorageFormat(CanvasRenderingContext2DSettings::PixelFormat canvasPixelFormat)
+{
+    switch (canvasPixelFormat) {
+    case CanvasRenderingContext2DSettings::PixelFormat::Uint8:
+        return ImageDataStorageFormat::Uint8;
+    case CanvasRenderingContext2DSettings::PixelFormat::Float16:
+        return ImageDataStorageFormat::Float16;
+    }
+}
+
+RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(const IntRect& sourceRect, PredefinedColorSpace colorSpace, ImageDataStorageFormat storageFormat) const
 {
     if (std::holds_alternative<CachedContentsTransparent>(m_cachedContents))
-        return ImageData::create(sourceRect.size(), colorSpace);
+        return ImageData::create(sourceRect.size(), colorSpace, toImageDataStorageFormat(m_settings.pixelFormat));
     if (std::holds_alternative<CachedContentsUnknown>(m_cachedContents))
         return nullptr;
     static_assert(WTF::VariantSizeV<decltype(m_cachedContents)> == 3); // Written this way to avoid dangling references during visit.
@@ -2562,17 +2587,20 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
     if (colorSpace != m_settings.colorSpace)
         return nullptr;
 
+    if (pixelBuffer->format().pixelFormat != toPixelFormat(m_settings.pixelFormat) || storageFormat != toImageDataStorageFormat(m_settings.pixelFormat))
+        return nullptr;
+
     auto format = pixelBuffer->format();
     auto size = pixelBuffer->size();
     auto data = WTFMove(pixelBuffer.get()).takeData();
-    unsigned bytesPerRow = static_cast<unsigned>(size.width()) * 4u;
+    unsigned bytesPerRow = static_cast<unsigned>(size.width()) * bytesPerPixel(format.pixelFormat);
     ConstPixelBufferConversionView source {
         .format = format,
         .bytesPerRow = bytesPerRow,
         .rows = data->span(),
     };
     PixelBufferConversionView destination {
-        .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, format.colorSpace },
+        .format = { AlphaPremultiplication::Unpremultiplied, format.pixelFormat, format.colorSpace },
         .bytesPerRow = bytesPerRow,
         .rows = data->mutableSpan(),
     };
@@ -2595,41 +2623,40 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     if (sw < 0) {
         sx += sw;
         sw = -sw;
-    }    
+    }
     if (sh < 0) {
         sy += sh;
         sh = -sh;
     }
 
     IntRect imageDataRect { sx, sy, sw, sh };
-    auto overridingStorageFormat = settings ? std::optional(settings->storageFormat) : std::optional<ImageDataStorageFormat>();
+    auto outputStorageFormat = settings ? settings->storageFormat : ImageDataStorageFormat::Uint8;
+    auto outputPixelFormat = toPixelFormat(outputStorageFormat);
 
     if (scriptContext && scriptContext->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::Canvas)) {
         RefPtr buffer = canvasBase().createImageForNoiseInjection();
         if (!buffer)
             return Exception { ExceptionCode::InvalidStateError };
 
-        auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, buffer->colorSpace() };
+        auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, buffer->colorSpace() };
         RefPtr pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
         if (!pixelBuffer)
             return Exception { ExceptionCode::InvalidStateError };
 
-        return { { ImageData::create(pixelBuffer.releaseNonNull(), overridingStorageFormat) } };
+        return { { ImageData::create(pixelBuffer.releaseNonNull(), outputStorageFormat) } };
     }
 
     auto computedColorSpace = ImageData::computeColorSpace(settings, m_settings.colorSpace);
 
-    if (!overridingStorageFormat || *overridingStorageFormat == ImageDataStorageFormat::Uint8) {
-        if (auto imageData = makeImageDataIfContentsCached(imageDataRect, computedColorSpace))
-            return imageData.releaseNonNull();
-    }
+    if (auto imageData = makeImageDataIfContentsCached(imageDataRect, computedColorSpace, outputStorageFormat))
+        return imageData.releaseNonNull();
 
     RefPtr<ImageBuffer> buffer = canvasBase().makeRenderingResultsAvailable();
     if (!buffer)
         return ImageData::create(imageDataRect.width(), imageDataRect.height(), m_settings.colorSpace, settings);
 
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, toDestinationColorSpace(computedColorSpace) };
-    RefPtr pixelBuffer = dynamicDowncast<ByteArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, toDestinationColorSpace(computedColorSpace) };
+    RefPtr pixelBuffer = buffer->getPixelBuffer(format, imageDataRect);
     if (!pixelBuffer) {
         scriptContext->addConsoleMessage(MessageSource::Rendering, MessageLevel::Error,
             makeString("Unable to get image data from canvas. Requested size was "_s, imageDataRect.width(), " x "_s, imageDataRect.height()));
@@ -2638,7 +2665,10 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
 
     ASSERT(pixelBuffer->format().colorSpace == toDestinationColorSpace(computedColorSpace));
 
-    return { { ImageData::create(pixelBuffer.releaseNonNull(), overridingStorageFormat) } };
+    if (RefPtr imageData = ImageData::create(pixelBuffer.releaseNonNull(), outputStorageFormat))
+        return { { imageData.releaseNonNull() } };
+
+    return Exception { ExceptionCode::InvalidStateError };
 }
 
 void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy)
@@ -2675,7 +2705,7 @@ void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy,
         if (pixelBuffer)
             options.add(DidDrawOption::PreserveCachedContents);
         else
-            pixelBuffer = data.byteArrayPixelBuffer();
+            pixelBuffer = data.pixelBuffer();
         buffer->putPixelBuffer(*pixelBuffer, sourceRect, destOffset);
     }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-class ByteArrayPixelBuffer;
+class ArrayPixelBuffer;
 class CachedImage;
 class CanvasLayerContextSwitcher;
 class CanvasGradient;
@@ -400,9 +400,9 @@ private:
     struct CachedContentsUnknown {
     };
     struct CachedContentsImageData {
-        CachedContentsImageData(CanvasRenderingContext2DBase&, Ref<ByteArrayPixelBuffer>);
+        CachedContentsImageData(CanvasRenderingContext2DBase&, Ref<ArrayPixelBuffer>);
 
-        Ref<ByteArrayPixelBuffer> imageData;
+        Ref<ArrayPixelBuffer> imageData;
         DeferrableOneShotTimer evictionTimer;
     };
 
@@ -489,7 +489,7 @@ private:
 
     FloatPoint textOffset(float width, TextDirection);
 
-    RefPtr<ByteArrayPixelBuffer> cacheImageDataIfPossible(const ImageData&, const IntRect& sourceRect, const IntPoint& destinationPosition);
+    RefPtr<ArrayPixelBuffer> cacheImageDataIfPossible(const ImageData&, const IntRect& sourceRect, const IntPoint& destinationPosition);
     RefPtr<ImageData> makeImageDataIfContentsCached(const IntRect& sourceRect, PredefinedColorSpace) const;
     void evictCachedImageData();
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -489,8 +489,8 @@ private:
 
     FloatPoint textOffset(float width, TextDirection);
 
-    RefPtr<ArrayPixelBuffer> cacheImageDataIfPossible(const ImageData&, const IntRect& sourceRect, const IntPoint& destinationPosition);
-    RefPtr<ImageData> makeImageDataIfContentsCached(const IntRect& sourceRect, PredefinedColorSpace) const;
+    RefPtr<PixelBuffer> cacheImageDataIfPossible(const ImageData&, const IntRect& sourceRect, const IntPoint& destinationPosition);
+    RefPtr<ImageData> makeImageDataIfContentsCached(const IntRect& sourceRect, PredefinedColorSpace, ImageDataStorageFormat) const;
     void evictCachedImageData();
 
     static constexpr unsigned MaxSaveCount = 1024 * 16;

--- a/Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ArrayPixelBuffer.h"
+
+namespace WebCore {
+
+ArrayPixelBuffer::ArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::ArrayBufferView>&& data)
+    : PixelBuffer(format, size, data->mutableSpan())
+    , m_data(WTFMove(data))
+{
+    ASSERT(m_data->getType() == JSC::TypeUint8Clamped || m_data->getType() == JSC::TypeFloat16);
+}
+
+ArrayPixelBuffer::~ArrayPixelBuffer() = default;
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp
@@ -26,7 +26,28 @@
 #include "config.h"
 #include "ArrayPixelBuffer.h"
 
+#include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
+
 namespace WebCore {
+
+RefPtr<ArrayPixelBuffer> ArrayPixelBuffer::tryCreate(const PixelBufferFormat& pixelBufferFormat, const IntSize& size)
+{
+    switch (pixelBufferFormat.pixelFormat) {
+    case PixelFormat::RGBA8:
+    case PixelFormat::BGRA8:
+        ASSERT(supportedPixelFormat(pixelBufferFormat.pixelFormat));
+        return ByteArrayPixelBuffer::tryCreate(pixelBufferFormat, size);
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case PixelFormat::RGBA16F:
+        ASSERT(supportedPixelFormat(pixelBufferFormat.pixelFormat));
+        return Float16ArrayPixelBuffer::tryCreate(pixelBufferFormat, size);
+#endif
+    default:
+        ASSERT(!supportedPixelFormat(pixelBufferFormat.pixelFormat));
+        return nullptr;
+    }
+}
 
 ArrayPixelBuffer::ArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::ArrayBufferView>&& data)
     : PixelBuffer(format, size, data->mutableSpan())

--- a/Source/WebCore/platform/graphics/ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ArrayPixelBuffer.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PixelBuffer.h"
+#include <JavaScriptCore/ArrayBufferView.h>
+#include <JavaScriptCore/TypedArrayAdaptersForwardDeclarations.h>
+
+namespace WebCore {
+
+class ArrayPixelBuffer : public PixelBuffer {
+public:
+    WEBCORE_EXPORT virtual ~ArrayPixelBuffer();
+
+    JSC::ArrayBufferView& data() const LIFETIME_BOUND { return m_data.get(); }
+    Ref<JSC::ArrayBufferView> protectedData() const { return m_data; }
+    Ref<JSC::ArrayBufferView>&& takeData() && { return WTFMove(m_data); }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_data->span(); }
+
+protected:
+    ArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBufferView>&&);
+
+private:
+    Ref<JSC::ArrayBufferView> m_data;
+};
+
+} // namespace WebCore
+
+// Needed to safely downcast from JSC::ArrayBufferView to the concrete types used in WebCore.
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Uint8ClampedArray)
+    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeUint8Clamped; }
+SPECIALIZE_TYPE_TRAITS_END()
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Float16Array)
+    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeFloat16; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ArrayPixelBuffer.h
@@ -33,6 +33,8 @@ namespace WebCore {
 
 class ArrayPixelBuffer : public PixelBuffer {
 public:
+    static RefPtr<ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&);
+
     WEBCORE_EXPORT virtual ~ArrayPixelBuffer();
 
     JSC::ArrayBufferView& data() const LIFETIME_BOUND { return m_data.get(); }

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -108,7 +108,7 @@ ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, cons
 
 RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
-    return ByteArrayPixelBuffer::tryCreate(m_format, size);
+    return ByteArrayPixelBuffer::tryCreate(format(), size);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -103,21 +103,12 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
 }
 
 ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::Uint8ClampedArray>&& data)
-    : PixelBuffer(format, size, data->mutableSpan())
-    , m_data(WTFMove(data))
-{
-}
+    : ArrayPixelBuffer(format, size, WTFMove(data))
+{ }
 
 RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
     return ByteArrayPixelBuffer::tryCreate(m_format, size);
-}
-
-std::span<const uint8_t> ByteArrayPixelBuffer::span() const
-{
-    Ref data = m_data;
-    ASSERT(data->byteLength() == (m_size.area() * 4));
-    return data->span();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -45,6 +45,8 @@ public:
     Type type() const override { return Type::ByteArray; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 
+    static constexpr unsigned bytesPerPixel = 4;
+
 private:
     ByteArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::Uint8ClampedArray>&&);
 };
@@ -53,4 +55,5 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ByteArrayPixelBuffer)
     static bool isType(const WebCore::PixelBuffer& pixelBuffer) { return pixelBuffer.type() == WebCore::PixelBuffer::Type::ByteArray; }
+    static bool isType(const WebCore::ArrayPixelBuffer& pixelBuffer) { return pixelBuffer.type() == WebCore::PixelBuffer::Type::ByteArray; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include "PixelBuffer.h"
+#include "ArrayPixelBuffer.h"
 #include <JavaScriptCore/Uint8ClampedArray.h>
 
 namespace WebCore {
 
-class ByteArrayPixelBuffer : public PixelBuffer {
+class ByteArrayPixelBuffer final : public ArrayPixelBuffer {
 public:
     WEBCORE_EXPORT static Ref<ByteArrayPixelBuffer> create(const PixelBufferFormat&, const IntSize&, JSC::Uint8ClampedArray&);
     WEBCORE_EXPORT static std::optional<Ref<ByteArrayPixelBuffer>> create(const PixelBufferFormat&, const IntSize&, std::span<const uint8_t> data);
@@ -38,18 +38,15 @@ public:
     WEBCORE_EXPORT static RefPtr<ByteArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&);
     WEBCORE_EXPORT static RefPtr<ByteArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);
 
-    JSC::Uint8ClampedArray& data() const LIFETIME_BOUND { return m_data.get(); }
-    Ref<JSC::Uint8ClampedArray> protectedData() const { return m_data; }
-    Ref<JSC::Uint8ClampedArray>&& takeData() { return WTFMove(m_data); }
-    WEBCORE_EXPORT std::span<const uint8_t> span() const LIFETIME_BOUND;
+    JSC::Uint8ClampedArray& data() const LIFETIME_BOUND { return uncheckedDowncast<JSC::Uint8ClampedArray>(ArrayPixelBuffer::data()); }
+    Ref<JSC::Uint8ClampedArray> protectedData() const { return data(); }
+    Ref<JSC::Uint8ClampedArray> takeData() && { return adoptRef(uncheckedDowncast<JSC::Uint8ClampedArray>(WTFMove(*this).ArrayPixelBuffer::takeData().leakRef())); }
 
     Type type() const override { return Type::ByteArray; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 
 private:
     ByteArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::Uint8ClampedArray>&&);
-
-    Ref<JSC::Uint8ClampedArray> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
@@ -105,21 +105,12 @@ RefPtr<Float16ArrayPixelBuffer> Float16ArrayPixelBuffer::tryCreate(const PixelBu
 }
 
 Float16ArrayPixelBuffer::Float16ArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::Float16Array>&& data)
-    : PixelBuffer(format, size, data->mutableSpan())
-    , m_data(WTFMove(data))
-{
-}
+    : ArrayPixelBuffer(format, size, WTFMove(data))
+{ }
 
 RefPtr<PixelBuffer> Float16ArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
     return Float16ArrayPixelBuffer::tryCreate(m_format, size);
-}
-
-std::span<const uint8_t> Float16ArrayPixelBuffer::span() const
-{
-    Ref data = m_data;
-    ASSERT(data->byteLength() == (m_size.area() * 4 * sizeof(Float16)));
-    return data->span();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp
@@ -110,7 +110,7 @@ Float16ArrayPixelBuffer::Float16ArrayPixelBuffer(const PixelBufferFormat& format
 
 RefPtr<PixelBuffer> Float16ArrayPixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
-    return Float16ArrayPixelBuffer::tryCreate(m_format, size);
+    return Float16ArrayPixelBuffer::tryCreate(format(), size);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
@@ -27,12 +27,12 @@
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
 
-#include "PixelBuffer.h"
+#include "ArrayPixelBuffer.h"
 #include <JavaScriptCore/Float16Array.h>
 
 namespace WebCore {
 
-class Float16ArrayPixelBuffer : public PixelBuffer {
+class Float16ArrayPixelBuffer final: public ArrayPixelBuffer {
 public:
     WEBCORE_EXPORT static Ref<Float16ArrayPixelBuffer> create(const PixelBufferFormat&, const IntSize&, JSC::Float16Array&);
     WEBCORE_EXPORT static std::optional<Ref<Float16ArrayPixelBuffer>> create(const PixelBufferFormat&, const IntSize&, std::span<const Float16> data);
@@ -40,17 +40,15 @@ public:
     WEBCORE_EXPORT static RefPtr<Float16ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&);
     WEBCORE_EXPORT static RefPtr<Float16ArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);
 
-    JSC::Float16Array& data() const LIFETIME_BOUND { return m_data.get(); }
-    Ref<JSC::Float16Array>&& takeData() { return WTFMove(m_data); }
-    WEBCORE_EXPORT std::span<const uint8_t> span() const LIFETIME_BOUND;
+    JSC::Float16Array& data() const LIFETIME_BOUND { return uncheckedDowncast<JSC::Float16Array>(ArrayPixelBuffer::data()); }
+    Ref<JSC::Float16Array> protectedData() const { return data(); }
+    Ref<JSC::Float16Array> takeData() && { return adoptRef(uncheckedDowncast<JSC::Float16Array>(WTFMove(*this).ArrayPixelBuffer::takeData().leakRef())); }
 
     Type type() const override { return Type::Float16Array; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 
 private:
     Float16ArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::Float16Array>&&);
-
-    Ref<JSC::Float16Array> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class Float16ArrayPixelBuffer final: public ArrayPixelBuffer {
+class Float16ArrayPixelBuffer final : public ArrayPixelBuffer {
 public:
     WEBCORE_EXPORT static Ref<Float16ArrayPixelBuffer> create(const PixelBufferFormat&, const IntSize&, JSC::Float16Array&);
     WEBCORE_EXPORT static std::optional<Ref<Float16ArrayPixelBuffer>> create(const PixelBufferFormat&, const IntSize&, std::span<const Float16> data);
@@ -47,6 +47,8 @@ public:
     Type type() const override { return Type::Float16Array; }
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 
+    static constexpr unsigned bytesPerPixel = 8;
+
 private:
     Float16ArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSC::Float16Array>&&);
 };
@@ -55,6 +57,7 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Float16ArrayPixelBuffer)
     static bool isType(const WebCore::PixelBuffer& pixelBuffer) { return pixelBuffer.type() == WebCore::PixelBuffer::Type::Float16Array; }
+    static bool isType(const WebCore::ArrayPixelBuffer& pixelBuffer) { return pixelBuffer.type() == WebCore::PixelBuffer::Type::Float16Array; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(PIXEL_FORMAT_RGBA16F)

--- a/Source/WebCore/platform/graphics/ImageBufferAllocator.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferAllocator.cpp
@@ -27,6 +27,7 @@
 #include "ImageBufferAllocator.h"
 
 #include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include "ImageBuffer.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -44,6 +45,8 @@ RefPtr<ImageBuffer> ImageBufferAllocator::createImageBuffer(const FloatSize& siz
 
 RefPtr<PixelBuffer> ImageBufferAllocator::createPixelBuffer(const PixelBufferFormat& format, const IntSize& size) const
 {
+    if (format.pixelFormat == PixelFormat::RGBA16F)
+        return Float16ArrayPixelBuffer::tryCreate(format, size);
     return ByteArrayPixelBuffer::tryCreate(format, size);
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -118,7 +118,8 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, std::span<con
         sourceBytesPerRow,
         sourceData.subspan(sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4)
     };
-    unsigned destinationBytesPerRow = static_cast<unsigned>(4u * sourceRect.width());
+    unsigned bytesPerPixel = (destinationPixelBuffer.format().pixelFormat == PixelFormat::RGBA16F) ? 8u : 4u;
+    unsigned destinationBytesPerRow = static_cast<unsigned>(bytesPerPixel * sourceRect.width());
     size_t offset = destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4;
     if (offset > destinationPixelBuffer.bytes().size())
         return;
@@ -148,7 +149,8 @@ void ImageBufferBackend::putPixelBuffer(const PixelBufferSourceView& sourcePixel
     destinationRect.intersect(backendRect);
     sourceRectClipped.setSize(destinationRect.size());
 
-    unsigned sourceBytesPerRow = static_cast<unsigned>(4u * sourcePixelBuffer.size().width());
+    unsigned bytesPerPixel = (sourcePixelBuffer.format().pixelFormat == PixelFormat::RGBA16F) ? 8u : 4u;
+    unsigned sourceBytesPerRow = static_cast<unsigned>(bytesPerPixel * sourcePixelBuffer.size().width());
     ConstPixelBufferConversionView source {
         sourcePixelBuffer.format(),
         sourceBytesPerRow,

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "PixelBuffer.h"
 
+#include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -62,7 +62,7 @@ public:
 #endif
         Other
     };
-    virtual Type type() const { return Type::Other; }
+    virtual Type type() const = 0;
     virtual RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const = 0;
 
     bool setRange(std::span<const uint8_t> data, size_t byteOffset);
@@ -74,7 +74,7 @@ public:
 
 protected:
     WEBCORE_EXPORT PixelBuffer(const PixelBufferFormat&, const IntSize&, std::span<uint8_t> bytes);
-    
+
     PixelBufferFormat m_format;
     IntSize m_size;
 

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -75,6 +75,7 @@ public:
 protected:
     WEBCORE_EXPORT PixelBuffer(const PixelBufferFormat&, const IntSize&, std::span<uint8_t> bytes);
 
+private:
     PixelBufferFormat m_format;
     IntSize m_size;
 

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -29,9 +29,11 @@
 #include "AlphaPremultiplication.h"
 #include "DestinationColorSpace.h"
 #include "IntSize.h"
+#include "Logging.h"
 #include "PixelFormat.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/TextStream.h>
 
 #if USE(ACCELERATE) && USE(CG)
 #include <Accelerate/Accelerate.h>
@@ -316,8 +318,184 @@ static void copyImagePixels(const ConstPixelBufferConversionView& source, const 
 }
 #endif
 
+static Float16 readFloat16(const std::span<const uint8_t>& span8, size_t offset)
+{
+    union {
+        Float16 float16 { };
+        uint8_t bytes[sizeof(Float16)];
+    } magicBox;
+    for (size_t i = 0; i < sizeof(Float16); ++i) {
+        auto u8 = span8[offset + i];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        magicBox.bytes[i] = u8;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    }
+    return magicBox.float16;
+}
+
+static void writeFloat16(Float16 f16, const std::span<uint8_t>& spanFloat16, size_t offset)
+{
+    union MagicBox {
+        Float16 float16;
+        uint8_t bytes[sizeof(Float16)];
+        MagicBox(Float16 f16) : float16(f16) { }
+    } magicBox(f16);
+    for (size_t i = 0; i < sizeof(Float16); ++i) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        auto u8 = magicBox.bytes[i];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        spanFloat16[offset + i] = u8;
+    }
+}
+
+static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    if (source.format.colorSpace != destination.format.colorSpace)
+        return;
+
+    ASSERT(source.format.pixelFormat == PixelFormat::RGBA16F);
+    ASSERT(destination.format.pixelFormat == PixelFormat::RGBA16F);
+
+    auto sourceBytes = source.rows.size_bytes();
+    auto sourcePixelComponents = sourceBytes / 2;
+    auto sourcePixels = sourcePixelComponents / 4;
+    auto sourceHeight = sourceBytes / source.bytesPerRow;
+    auto sourceWidth = sourcePixels / sourceHeight;
+
+    auto destinationBytes = destination.rows.size_bytes();
+    auto destinationPixelComponents = destinationBytes / 2;
+    auto destinationPixels = destinationPixelComponents / 4;
+    auto destinationHeight = destinationBytes / destination.bytesPerRow;
+    auto destinationWidth = destinationPixels / destinationHeight;
+
+    if (destinationSize.height() >= 0 && size_t(destinationSize.height()) < destinationHeight)
+        destinationHeight = size_t(destinationSize.height());
+    if (destinationSize.width() >= 0 && size_t(destinationSize.width()) < destinationWidth)
+        destinationWidth = size_t(destinationSize.width());
+
+    auto sourceRowStartOffset = 0;
+    auto destinationRowStartOffset = 0;
+    for (size_t y = 0; y < sourceHeight && y < destinationHeight; ++y) {
+        size_t offset = 0;
+        for (size_t x = 0; x < sourceWidth && x < destinationWidth; ++x) {
+            struct Pixel16 { Float16 r = { }, g = { }, b = { }, a = { }; };
+            static_assert(sizeof(Float16) == 2);
+            static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
+            union MagicBox {
+                Pixel16 pixel16;
+                uint8_t bytes[sizeof(Pixel16)];
+                MagicBox() : pixel16() { }
+            } magicBox;
+            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte) {
+                auto value = source.rows[sourceRowStartOffset + offset + byte];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+                magicBox.bytes[byte] = value;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            }
+            if (source.format.alphaFormat != destination.format.alphaFormat) {
+                if (source.format.alphaFormat == AlphaPremultiplication::Unpremultiplied && destination.format.alphaFormat == AlphaPremultiplication::Premultiplied) {
+                    auto fa = float(magicBox.pixel16.a);
+                    magicBox.pixel16.r = Float16(float(magicBox.pixel16.r) * fa);
+                    magicBox.pixel16.g = Float16(float(magicBox.pixel16.g) * fa);
+                    magicBox.pixel16.b = Float16(float(magicBox.pixel16.b) * fa);
+                } else if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied && destination.format.alphaFormat == AlphaPremultiplication::Unpremultiplied) {
+                    auto fa = float(magicBox.pixel16.a);
+                    if (fa) {
+                        magicBox.pixel16.r = Float16(float(magicBox.pixel16.r) / fa);
+                        magicBox.pixel16.g = Float16(float(magicBox.pixel16.g) / fa);
+                        magicBox.pixel16.b = Float16(float(magicBox.pixel16.b) / fa);
+                    }
+                } else {
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+            }
+            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+                auto value = magicBox.bytes[byte];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+                destination.rows[destinationRowStartOffset + offset + byte] = value;
+            }
+            offset += sizeof(Pixel16);
+        }
+        sourceRowStartOffset += source.bytesPerRow;
+        destinationRowStartOffset += destination.bytesPerRow;
+    }
+}
+
+static void convertImagePixelsFromFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    ASSERT(source.format.pixelFormat == PixelFormat::RGBA16F);
+    ASSERT(destination.format.pixelFormat != PixelFormat::RGBA16F);
+
+    auto pixelComponents = source.rows.size_bytes() / sizeof(Float16);
+
+    Vector<uint8_t> rgba8;
+    rgba8.reserveInitialCapacity(pixelComponents);
+
+    for (size_t i = 0; i < pixelComponents; ++i) {
+        auto f16 = readFloat16(source.rows, i * sizeof(Float16));
+        float f = float(f16);
+        auto u8 = (f <= 0.f) ? uint8(0) : ((f >= 1.f) ? uint8(255) : uint8(f * 255.f));
+        rgba8.append(u8);
+    }
+
+    ConstPixelBufferConversionView rgba8ConversionView {
+        .format = PixelBufferFormat {
+            .alphaFormat = source.format.alphaFormat,
+            .pixelFormat = PixelFormat::RGBA8,
+            .colorSpace = source.format.colorSpace
+        },
+        .bytesPerRow = source.bytesPerRow / unsigned(sizeof(Float16)),
+        .rows = rgba8.span()
+    };
+
+    convertImagePixels(rgba8ConversionView, destination, destinationSize);
+}
+
+// [[noreturn]]
+static void convertImagePixelsToFloat16(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    ASSERT(source.format.pixelFormat != PixelFormat::RGBA16F);
+    ASSERT(destination.format.pixelFormat == PixelFormat::RGBA16F);
+
+    auto pixelComponents = destination.rows.size_bytes() / sizeof(Float16);
+
+    Vector<uint8_t> rgba8;
+    rgba8.reserveInitialCapacity(pixelComponents);
+    rgba8.fill(uint8_t(0), pixelComponents);
+
+    PixelBufferConversionView rgba8ConversionView {
+        .format = PixelBufferFormat {
+            .alphaFormat = destination.format.alphaFormat,
+            .pixelFormat = PixelFormat::RGBA8,
+            .colorSpace = destination.format.colorSpace
+        },
+        .bytesPerRow = destination.bytesPerRow / unsigned(sizeof(Float16)),
+        .rows = rgba8.mutableSpan()
+    };
+
+    convertImagePixels(source, rgba8ConversionView, destinationSize);
+
+    for (size_t i = 0; i < pixelComponents; ++i) {
+        auto u8 = rgba8[i];
+        float f = float(u8) / 255.f;
+        Float16 f16 = f;
+        writeFloat16(f16, destination.rows, i * 2);
+    }
+
+}
+
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
+    auto isSourceFloat = source.format.pixelFormat == PixelFormat::RGBA16F;
+    auto isDestinationFloat = destination.format.pixelFormat == PixelFormat::RGBA16F;
+    if (isSourceFloat && isDestinationFloat)
+        return convertImagePixelsFromFloat16ToFloat16(source, destination, destinationSize);
+    if (isSourceFloat)
+        return convertImagePixelsFromFloat16(source, destination, destinationSize);
+    if (isDestinationFloat)
+        return convertImagePixelsToFloat16(source, destination, destinationSize);
+
     // We currently only support converting between RGBA8, BGRA8, and BGRX8.
     ASSERT(source.format.pixelFormat == PixelFormat::RGBA8 || source.format.pixelFormat == PixelFormat::BGRA8 || source.format.pixelFormat == PixelFormat::BGRX8);
     ASSERT(destination.format.pixelFormat == PixelFormat::RGBA8 || destination.format.pixelFormat == PixelFormat::BGRA8 || destination.format.pixelFormat == PixelFormat::BGRX8);

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -46,6 +46,29 @@ enum class PixelFormat : uint8_t {
 
 enum class UseLosslessCompression : bool { No, Yes };
 
+inline constexpr unsigned bytesPerPixel(PixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case PixelFormat::RGBA8:
+        return 4;
+    case PixelFormat::BGRX8:
+        return 3;
+    case PixelFormat::BGRA8:
+        return 4;
+#if ENABLE(PIXEL_FORMAT_RGB10)
+    case PixelFormat::RGB10:
+        return 4;
+#endif
+#if ENABLE(PIXEL_FORMAT_RGB10A8)
+    case PixelFormat::RGB10A8
+#endif
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case PixelFormat::RGBA16F:
+        return 8;
+#endif
+    }
+}
+
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, PixelFormat);
 
 }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -60,9 +60,13 @@ ImageBufferCGBackend::ImageBufferCGBackend(const Parameters& parameters, std::un
 
 ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
-unsigned ImageBufferCGBackend::calculateBytesPerRow(const IntSize& backendSize)
+unsigned ImageBufferCGBackend::calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat imageBufferPixelFormat)
 {
     ASSERT(!backendSize.isEmpty());
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (imageBufferPixelFormat == ImageBufferPixelFormat::RGBA16F)
+        return CheckedUint32(backendSize.width()) * 8;
+#endif
     return CheckedUint32(backendSize.width()) * 4;
 }
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class WEBCORE_EXPORT ImageBufferCGBackend : public ImageBufferBackend {
 public:
     ~ImageBufferCGBackend() override;
-    static unsigned calculateBytesPerRow(const IntSize& backendSize);
+    static unsigned calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat);
 
 protected:
     ImageBufferCGBackend(const Parameters&, std::unique_ptr<GraphicsContextCG>&& = nullptr);

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ImageBufferCGBitmapBackend);
 
 size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
 }
 
 std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
@@ -104,7 +104,7 @@ GraphicsContext& ImageBufferCGBitmapBackend::context()
 
 unsigned ImageBufferCGBitmapBackend::bytesPerRow() const
 {
-    return calculateBytesPerRow(m_parameters.backendSize);
+    return calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
 }
 
 bool ImageBufferCGBitmapBackend::canMapBackingStore() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
@@ -40,7 +40,7 @@ size_t ImageBufferCGPDFDocumentBackend::calculateMemoryCost(const Parameters& pa
 {
     // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
     // should really be based on the PDF document size.
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
 }
 
 std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -58,16 +58,16 @@ IntSize ImageBufferIOSurfaceBackend::calculateSafeBackendSize(const Parameters& 
     return backendSize;
 }
 
-unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backendSize)
+unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat imageBufferPixelFormat)
 {
-    unsigned bytesPerRow = ImageBufferCGBackend::calculateBytesPerRow(backendSize);
+    unsigned bytesPerRow = ImageBufferCGBackend::calculateBytesPerRow(backendSize, imageBufferPixelFormat);
     size_t alignmentMask = IOSurface::bytesPerRowAlignment() - 1;
     return (bytesPerRow + alignmentMask) & ~alignmentMask;
 }
 
 size_t ImageBufferIOSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
 }
 
 std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -40,7 +40,7 @@ class WEBCORE_EXPORT ImageBufferIOSurfaceBackend : public ImageBufferCGBackend {
     WTF_MAKE_NONCOPYABLE(ImageBufferIOSurfaceBackend);
 public:
     static IntSize calculateSafeBackendSize(const Parameters&);
-    static unsigned calculateBytesPerRow(const IntSize& backendSize);
+    static unsigned calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat);
     static size_t calculateMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferIOSurfaceBackend> create(const Parameters&, const ImageBufferCreationContext&);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5987,8 +5987,8 @@ static bool rendererHasHDRContent(const RenderElement& renderer)
                 return true;
         }
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    } else if (CheckedPtr canavsRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer)) {
-        if (auto* renderingContext = canavsRenderer->canvasElement().renderingContext()) {
+    } else if (CheckedPtr canvasRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer)) {
+        if (auto* renderingContext = canvasRenderer->canvasElement().renderingContext()) {
             if (renderingContext->isHDR())
                 return true;
         }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3931,8 +3931,10 @@ bool RenderLayerCompositor::requiresCompositingForCanvas(RenderLayerModelObject&
     bool isCanvasLargeEnoughToForceCompositing = true;
 #if !USE(COMPOSITING_FOR_SMALL_CANVASES)
     RefPtr canvas = downcast<HTMLCanvasElement>(renderer.element());
-    auto canvasArea = canvas->size().area<RecordOverflow>();
-    isCanvasLargeEnoughToForceCompositing = !canvasArea.hasOverflowed() && canvasArea >= canvasAreaThresholdRequiringCompositing;
+    if (RefPtr renderingContext = canvas->renderingContext(); !renderingContext->isHDR()) {
+        auto canvasArea = canvas->size().area<RecordOverflow>();
+        isCanvasLargeEnoughToForceCompositing = !canvasArea.hasOverflowed() && canvasArea >= canvasAreaThresholdRequiringCompositing;
+    }
 #endif
 
     CanvasCompositingStrategy compositingStrategy = canvasCompositingStrategy(renderer);

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
@@ -49,12 +49,12 @@ ShareablePixelBuffer::ShareablePixelBuffer(const PixelBufferFormat& format, cons
     : PixelBuffer(format, size, data->mutableSpan())
     , m_data(WTFMove(data))
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_size.area() * 4 <= bytes().size());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(size.area() * bytesPerPixel(format.pixelFormat) <= bytes().size());
 }
 
 RefPtr<PixelBuffer> ShareablePixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
-    return ShareablePixelBuffer::tryCreate(m_format, size);
+    return ShareablePixelBuffer::tryCreate(format(), size);
 }
 
 Ref<WebCore::SharedMemory> ShareablePixelBuffer::protectedData() const

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h
@@ -33,13 +33,14 @@ class SharedMemory;
 
 namespace WebKit {
 
-class ShareablePixelBuffer : public WebCore::PixelBuffer {
+class ShareablePixelBuffer final : public WebCore::PixelBuffer {
 public:
     static RefPtr<ShareablePixelBuffer> tryCreate(const WebCore::PixelBufferFormat&, const WebCore::IntSize&);
 
     WebCore::SharedMemory& data() const { return m_data.get(); }
     Ref<WebCore::SharedMemory> protectedData() const;
 
+    Type type() const override { return Type::Other; }
     RefPtr<WebCore::PixelBuffer> createScratchPixelBuffer(const WebCore::IntSize&) const override;
 
 private:

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -98,7 +98,7 @@ GraphicsContext& ImageBufferRemoteIOSurfaceBackend::context()
 
 unsigned ImageBufferRemoteIOSurfaceBackend::bytesPerRow() const
 {
-    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(m_parameters.backendSize);
+    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
 }
 
 RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage()


### PR DESCRIPTION
#### 20ae22aed3915c115cb17305eaefd99686dde640
<pre>
HDR 2D canvas -- exploring, DO NOT PUBLISH
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
(WebCore::ImageData::float16ArrayPixelBuffer const):
(WebCore::ImageData::pixelBuffer const):
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::toPixelFormat):
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::toImageDataStorageFormat):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp:
(WebCore::ArrayPixelBuffer::tryCreate):
* Source/WebCore/platform/graphics/ArrayPixelBuffer.h:
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::createScratchPixelBuffer const):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(isType):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp:
(WebCore::Float16ArrayPixelBuffer::createScratchPixelBuffer const):
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h:
(isType):
* Source/WebCore/platform/graphics/ImageBufferAllocator.cpp:
(WebCore::ImageBufferAllocator::createPixelBuffer const):
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::getPixelBuffer):
(WebCore::ImageBufferBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
* Source/WebCore/platform/graphics/PixelBuffer.h:
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::readFloat16):
(WebCore::writeFloat16):
(WebCore::convertImagePixelsFromFloat16ToFloat16):
(WebCore::convertImagePixelsFromFloat16):
(WebCore::convertImagePixelsToFloat16):
(WebCore::convertImagePixels):
* Source/WebCore/platform/graphics/PixelFormat.h:
(WebCore::bytesPerPixel):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::calculateBytesPerRow):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::calculateMemoryCost):
(WebCore::ImageBufferCGBitmapBackend::bytesPerRow const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp:
(WebCore::ImageBufferCGPDFDocumentBackend::calculateMemoryCost):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::calculateBytesPerRow):
(WebCore::ImageBufferIOSurfaceBackend::calculateMemoryCost):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForCanvas const):
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp:
(WebKit::ShareablePixelBuffer::ShareablePixelBuffer):
(WebKit::ShareablePixelBuffer::createScratchPixelBuffer const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::bytesPerRow const):
</pre>
----------------------------------------------------------------------
#### 87da1451bfb5ecf879bb34808819625013c8678f
<pre>
ArrayPixelBuffer and canvas cache
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Headers.cmake:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
* Source/WebCore/html/ImageDataArray.cpp:
(isType): Deleted.
* Source/WebCore/html/ImageDataArray.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::CachedContentsImageData::CachedContentsImageData):
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp: Added.
(WebCore::ArrayPixelBuffer::ArrayPixelBuffer):
* Source/WebCore/platform/graphics/ArrayPixelBuffer.h: Added.
(WebCore::ArrayPixelBuffer::protectedData const):
(WebCore::ArrayPixelBuffer::takeData):
(isType):
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::ByteArrayPixelBuffer):
(WebCore::ByteArrayPixelBuffer::span const): Deleted.
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(WebCore::ByteArrayPixelBuffer::protectedData const): Deleted.
(WebCore::ByteArrayPixelBuffer::takeData): Deleted.
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.cpp:
(WebCore::Float16ArrayPixelBuffer::Float16ArrayPixelBuffer):
(WebCore::Float16ArrayPixelBuffer::span const): Deleted.
* Source/WebCore/platform/graphics/Float16ArrayPixelBuffer.h:
(WebCore::Float16ArrayPixelBuffer::takeData): Deleted.
* Source/WebCore/platform/graphics/PixelBuffer.h:
(WebCore::PixelBuffer::type const): Deleted.
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h:
(WebKit::ShareablePixelBuffer::data const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20ae22aed3915c115cb17305eaefd99686dde640

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115300 "11 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34996 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25496 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121397 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65894 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b1285fa-181f-4c05-8cfe-be64485e56e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117189 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35653 "Hash 20ae22ae for PR 48642 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43566 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/121397 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/65894 "Hash 20ae22ae for PR 48642 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee5d0258-a53b-4b1e-b11c-146380b4d4a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118248 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/35653 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/25496 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/121397 "Hash 20ae22ae for PR 48642 does not build (failure)") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/35653 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/25496 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65054 "Hash 20ae22ae for PR 48642 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/35653 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/25496 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124567 "Hash 20ae22ae for PR 48642 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42245 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31625 "Found 45 new test failures: compositing/canvas/accelerated-canvas-compositing-size-limit.html compositing/clipping/border-radius-on-webgl.html compositing/webgl/update-composited-canvas-layer.html compositing/webgl/webgl-reflection.html css3/blending/blend-mode-clip-accelerated-blending-canvas.html css3/filters/canvas-with-filter-after-repaint.html css3/flexbox/z-index-with-normal-flow-only.html editing/undo/redo-reapply-edit-command-crash.html fast/block/child-not-removed-from-parent-lineboxes-crash.html fast/canvas/do-not-expose-non-default-focus-ring-color.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/124567 "Hash 20ae22ae for PR 48642 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42614 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/25496 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/124567 "Hash 20ae22ae for PR 48642 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/25496 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38185 "Hash 20ae22ae for PR 48642 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42125 "Hash 20ae22ae for PR 48642 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47678 "Found 2 new failures in platform/graphics/ArrayPixelBuffer.h, platform/graphics/ca/GraphicsLayerCA.cpp") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41639 "Hash 20ae22ae for PR 48642 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44964 "Hash 20ae22ae for PR 48642 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43365 "Hash 20ae22ae for PR 48642 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->