### PR TITLE
[WPE] mouse drag support for the legacy API

### DIFF
--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -54,6 +54,17 @@ static OptionSet<WebEventModifier> modifiersForEventModifiers(unsigned eventModi
     return modifiers;
 }
 
+static WebMouseEventButton mouseButtonForEventModifiers(unsigned eventModifiers)
+{
+    if (eventModifiers & wpe_input_pointer_modifier_button1)
+        return WebMouseEventButton::Left;
+    if (eventModifiers & wpe_input_pointer_modifier_button2)
+        return WebMouseEventButton::Middle;
+    if (eventModifiers & wpe_input_pointer_modifier_button3)
+        return WebMouseEventButton::Right;
+    return WebMouseEventButton::None;
+}
+
 static OptionSet<WebEventModifier> modifiersForKeyboardEvent(struct wpe_input_keyboard_event* event)
 {
     OptionSet<WebEventModifier> modifiers = modifiersForEventModifiers(event->modifiers);
@@ -175,6 +186,8 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(struct wpe_input_pointer_even
     WebMouseEventButton button = WebMouseEventButton::None;
     switch (event->type) {
     case wpe_input_pointer_event_type_motion:
+        button = mouseButtonForEventModifiers(event->modifiers);
+        break;
     case wpe_input_pointer_event_type_button:
         if (event->button == 1)
             button = WebMouseEventButton::Left;


### PR DESCRIPTION
#### 3ae038d0d22efd4b11b301c4903be897a73e9f98
<pre>
[WPE] mouse drag support for the legacy API
<a href="https://bugs.webkit.org/show_bug.cgi?id=296612">https://bugs.webkit.org/show_bug.cgi?id=296612</a>

Reviewed by Carlos Garcia Campos.

&lt;<a href="https://commits.webkit.org/297961@main">https://commits.webkit.org/297961@main</a>&gt; added mouse drag support only
for the modern API. After the change, some layout tests were failing
only for the legacy API. Added the implementation for the legacy.

* Source/WebKit/Shared/libwpe/WebEventFactory.cpp:
(WebKit::mouseButtonForEventModifiers):
(WebKit::WebEventFactory::createWebMouseEvent):

Canonical link: <a href="https://commits.webkit.org/297973@main">https://commits.webkit.org/297973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b0fbba602f846c620837f674c7d2492999ba227

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119932 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86467 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102194 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66830 "Found 142 new API test failures: /WPE/TestWebKitWebView:/webkit/WebKitWebView/page-visibility, /WPE/TestAuthentication:/webkit/Authentication/authentication-no-credential, /WPE/TestWebKitWebContext:/webkit/WebKitSecurityManager/file-xhr, /WPE/TestUIClient:/webkit/WebKitWebView/usermedia-permission-requests, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestWebKitWebView:/webkit/WebKitWebView/enable-html5-database, /WPE/TestBackForwardList:/webkit/BackForwardList/navigation, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-disallowed, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-request, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received ... (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26398 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63656 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123169 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/30386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95078 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18026 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/36972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40648 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/46157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/40288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/43586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/42064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->