### PR TITLE
Store the opaque root in Node

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -325,7 +325,8 @@ public:
     inline void setParentNode(ContainerNode*);
     inline Node& rootNode() const;
     WEBCORE_EXPORT Node& traverseToRootNode() const;
-    Node& shadowIncludingRoot() const;
+    Node& shadowIncludingRoot() const { ASSERT(m_opaqueRoot == &traverseToShadowIncludingRoot()); return *m_opaqueRoot; }
+    Node& traverseToShadowIncludingRoot() const;
 
     struct GetRootNodeOptions {
         bool composed;
@@ -813,6 +814,7 @@ private:
     mutable OptionSet<StateFlag> m_stateFlags;
 
     CheckedPtr<ContainerNode> m_parentNode;
+    Node* m_opaqueRoot { this };
     TreeScope* m_treeScope { nullptr };
     Node* m_previousSibling { nullptr };
     CheckedPtr<Node> m_next;

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -40,12 +40,7 @@ inline RefPtr<ScriptExecutionContext> Node::protectedScriptExecutionContext() co
 
 inline WebCoreOpaqueRoot Node::opaqueRoot() const
 {
-    if (isConnected()) {
-        Locker locker { TreeScope::treeScopeMutationLock() };
-        return WebCoreOpaqueRoot { &treeScope().documentScope() };
-    }
-    // FIXME: Possible race?
-    return traverseToOpaqueRoot();
+    return WebCoreOpaqueRoot { m_opaqueRoot };
 }
 
 inline Document& Node::document() const
@@ -183,7 +178,8 @@ inline Node& Node::rootNode() const
 {
     if (isInTreeScope())
         return treeScope().rootNode();
-    return traverseToRootNode();
+    ASSERT(m_opaqueRoot == &traverseToRootNode());
+    return *m_opaqueRoot;
 }
 
 inline void Node::setParentNode(ContainerNode* parent)
@@ -247,7 +243,6 @@ inline ContainerNode* Node::parentNodeGuaranteedHostFree() const
 
 inline void Node::setTreeScope(TreeScope& scope)
 {
-    Locker locker { TreeScope::treeScopeMutationLock() };
     m_treeScope = &scope;
 }
 

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -158,9 +158,6 @@ public:
     void markPendingSVGResourcesForRemoval(const AtomString&);
     RefPtr<SVGElement> takeElementFromPendingSVGResourcesForRemovalMap(const AtomString&);
 
-    // FIXME: Add a ThreadSafetyAnalysis annotated Lock subclass that allows for asserted reads from the mutator
-    static ALWAYS_INLINE Lock& treeScopeMutationLock();
-
 protected:
     TreeScope(ShadowRoot&, Document&, RefPtr<CustomElementRegistry>&&);
     explicit TreeScope(Document&);

--- a/Source/WebCore/dom/TreeScopeInlines.h
+++ b/Source/WebCore/dom/TreeScopeInlines.h
@@ -66,14 +66,7 @@ inline bool TreeScope::containsMultipleElementsWithName(const AtomString& name) 
 
 inline void TreeScope::setDocumentScope(Document& document)
 {
-    Locker locker { treeScopeMutationLock() };
     m_documentScope = document;
-}
-
-ALWAYS_INLINE Lock& TreeScope::treeScopeMutationLock()
-{
-    static Lock s_treeScopeMutationLock;
-    return s_treeScopeMutationLock;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7f2645c0c68beda8acc152521a199eeeb9d97865
<pre>
Store the opaque root in Node
<a href="https://bugs.webkit.org/show_bug.cgi?id=296613">https://bugs.webkit.org/show_bug.cgi?id=296613</a>

Reviewed by Wenson Hsieh.

This PR reverts 296347@main in favor of storing the opaque root in Node instead.

The new approach is a more comprehensive solution to the problem and turns out
not to cause any memory usage regression based on our testing.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::traverseToShadowIncludingRoot const):
(WebCore::Node::insertedIntoAncestor):
(WebCore::Node::removedFromAncestor):
(WebCore::Node::shadowIncludingRoot const): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::Node::shadowIncludingRoot const):
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::opaqueRoot const):
(WebCore::Node::rootNode const):
(WebCore::Node::setTreeScope):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/dom/TreeScopeInlines.h:
(WebCore::TreeScope::setDocumentScope):
(WebCore::TreeScope::treeScopeMutationLock): Deleted.

Canonical link: <a href="https://commits.webkit.org/298015@main">https://commits.webkit.org/298015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/861f1f1058cbcdcbd7b063fec8f6d0bffe9a33b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119934 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86472 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41574 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20326 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123171 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95080 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36974 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46159 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->