### PR TITLE
Fix Mach port ownership issue in layer hosting

### DIFF
--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -186,7 +186,7 @@ WTF::MachSendRightAnnotated LayerHostingContext::sendRightAnnotated() const
     __block MachSendRight sendRight;
     __block RetainPtr<NSData> dataRepresentation;
     [[m_hostable handle] encodeWithBlock:^(mach_port_t copiedPort, NSData * _Nonnull data) {
-        sendRight = MachSendRight::create(copiedPort);
+        sendRight = MachSendRight::adopt(copiedPort);
         dataRepresentation = data;
     }];
     return { WTFMove(sendRight), FixedVector<uint8_t> { span(dataRepresentation.get()) } };
@@ -207,7 +207,7 @@ WTF::MachSendRightAnnotated LayerHostingContext::fence(BELayerHierarchyHostingTr
     __block MachSendRight sendRight;
     __block RetainPtr<NSData> dataRepresentation;
     [coordinator encodeWithBlock:^(mach_port_t copiedPort, NSData * _Nonnull data) {
-        sendRight = MachSendRight::create(copiedPort);
+        sendRight = MachSendRight::adopt(copiedPort);
         dataRepresentation = data;
     }];
     return { WTFMove(sendRight), FixedVector<uint8_t> { span(dataRepresentation.get()) } };


### PR DESCRIPTION
#### 1f1df62d223c106681af05fe65954f772734b08e
<pre>
Fix Mach port ownership issue in layer hosting
<a href="https://bugs.webkit.org/show_bug.cgi?id=296620">https://bugs.webkit.org/show_bug.cgi?id=296620</a>
<a href="https://rdar.apple.com/156078761">rdar://156078761</a>

Reviewed by Simon Fraser.

The documentation states that we should take ownership of the Mach port returned by encodeWithBlock.

* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::sendRightAnnotated const):
(WebKit::LayerHostingContext::fence):

Canonical link: <a href="https://commits.webkit.org/297987@main">https://commits.webkit.org/297987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/738b89a566c768f9bc72142cc8bdc8c2d192163f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/23980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/119959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86494 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41563 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26416 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63682 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123195 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95334 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95101 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/36998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18249 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->