### PR TITLE
[JSC] Implement `Set.prototype.union` in C++

### DIFF
--- a/JSTests/microbenchmarks/set-prototype-union-large-other.js
+++ b/JSTests/microbenchmarks/set-prototype-union-large-other.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function createSequentialSet(size, start = 0) {
+    let set = new Set();
+    for (let i = start; i < start + size; i++) {
+        set.add(i);
+    }
+    return set;
+}
+
+let smallSet = createSequentialSet(100, 0);
+let largeSet = createSequentialSet(10000, 50);
+
+for (let i = 0; i < 100; ++i) {
+    let result = smallSet.union(largeSet);
+    
+    // Verify result size is correct
+    shouldBe(result.size <= smallSet.size + largeSet.size, true);
+    
+    // Verify all elements from both sets are in result
+    for (let value of smallSet) {
+        shouldBe(result.has(value), true);
+    }
+    
+    for (let value of largeSet) {
+        shouldBe(result.has(value), true);
+    }
+}

--- a/JSTests/microbenchmarks/set-prototype-union-large-this.js
+++ b/JSTests/microbenchmarks/set-prototype-union-large-this.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function createSequentialSet(size, start = 0) {
+    let set = new Set();
+    for (let i = start; i < start + size; i++) {
+        set.add(i);
+    }
+    return set;
+}
+
+let largeSet = createSequentialSet(10000, 0);
+let smallSet = createSequentialSet(100, 5000);
+
+for (let i = 0; i < 100; ++i) {
+    let result = largeSet.union(smallSet);
+    
+    // Verify result size is correct
+    shouldBe(result.size <= largeSet.size + smallSet.size, true);
+    
+    // Verify all elements from both sets are in result
+    for (let value of largeSet) {
+        shouldBe(result.has(value), true);
+    }
+    
+    for (let value of smallSet) {
+        shouldBe(result.has(value), true);
+    }
+}

--- a/JSTests/microbenchmarks/set-prototype-union.js
+++ b/JSTests/microbenchmarks/set-prototype-union.js
@@ -1,0 +1,32 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function createRandomSet(size) {
+    let set = new Set();
+    for (let i = 0; i < size; i++) {
+        set.add(Math.random() * 1000000 | 0);
+    }
+    return set;
+}
+
+let set1 = createRandomSet(1000);
+let set2 = createRandomSet(1000);
+
+for (let i = 0; i < 1000; ++i) {
+    let result = set1.union(set2);
+    
+    // Verify result size is correct (should be <= sum of both sets)
+    shouldBe(result.size <= set1.size + set2.size, true);
+    
+    // Verify all elements from set1 are in result
+    for (let value of set1) {
+        shouldBe(result.has(value), true);
+    }
+    
+    // Verify all elements from set2 are in result
+    for (let value of set2) {
+        shouldBe(result.has(value), true);
+    }
+}

--- a/JSTests/stress/array-prototype-slice-to-number-error.js
+++ b/JSTests/stress/array-prototype-slice-to-number-error.js
@@ -1,0 +1,6 @@
+const array = [1, 2, 3];
+
+try {
+    array.slice(3.4);
+} catch {}
+

--- a/JSTests/stress/set-prototype-union-empty-sets.js
+++ b/JSTests/stress/set-prototype-union-empty-sets.js
@@ -1,0 +1,42 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+// Test with empty sets
+let emptySet1 = new Set();
+let emptySet2 = new Set();
+let result = emptySet1.union(emptySet2);
+shouldBe(result.size, 0);
+
+// Test with one empty set
+let set1 = new Set([1, 2, 3]);
+let empty = new Set();
+result = set1.union(empty);
+shouldBe(result.size, 3);
+shouldBe(result.has(1), true);
+shouldBe(result.has(2), true);
+shouldBe(result.has(3), true);
+
+result = empty.union(set1);
+shouldBe(result.size, 3);
+shouldBe(result.has(1), true);
+shouldBe(result.has(2), true);
+shouldBe(result.has(3), true);
+
+// Test with overlapping sets
+let set2 = new Set([2, 3, 4]);
+result = set1.union(set2);
+shouldBe(result.size, 4);
+shouldBe(result.has(1), true);
+shouldBe(result.has(2), true);
+shouldBe(result.has(3), true);
+shouldBe(result.has(4), true);
+
+// Test with identical sets
+let set3 = new Set([1, 2, 3]);
+result = set1.union(set3);
+shouldBe(result.size, 3);
+shouldBe(result.has(1), true);
+shouldBe(result.has(2), true);
+shouldBe(result.has(3), true);

--- a/JSTests/stress/set-prototype-union-generic-object.js
+++ b/JSTests/stress/set-prototype-union-generic-object.js
@@ -1,0 +1,77 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+        shouldBe(e instanceof errorType, true);
+    }
+    shouldBe(threw, true);
+}
+
+// Test with generic set-like object
+let set1 = new Set([1, 2, 3]);
+let setLikeObject = {
+    size: 2,
+    has: function(key) {
+        return key === 4 || key === 5;
+    },
+    keys: function() {
+        let values = [4, 5];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+let result = set1.union(setLikeObject);
+shouldBe(result.size, 5);
+shouldBe(result.has(1), true);
+shouldBe(result.has(2), true);
+shouldBe(result.has(3), true);
+shouldBe(result.has(4), true);
+shouldBe(result.has(5), true);
+
+// Test error cases
+shouldThrow(() => {
+    set1.union({
+        size: 1,
+        has: "not a function",
+        keys: function() { return {}; }
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.union({
+        size: 1,
+        has: function() { return true; },
+        keys: "not a function"
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.union({
+        size: NaN,
+        has: function() { return true; },
+        keys: function() { return {}; }
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.union({
+        size: -1,
+        has: function() { return true; },
+        keys: function() { return {}; }
+    });
+}, RangeError);

--- a/JSTests/stress/set-prototype-union-iterator-effects.js
+++ b/JSTests/stress/set-prototype-union-iterator-effects.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+// Test with modification during iteration
+function main() {
+    let set1 = new Set([1, 2, 3, 4, 5]);
+    let iterationCount = 0;
+    
+    let otherObject = {
+        size: 3,
+        has: function(key) {
+            return true;
+        },
+        keys: function() {
+            return {
+                next: function() {
+                    iterationCount++;
+                    if (iterationCount === 1) {
+                        // Modify set1 during iteration
+                        set1.delete(1);
+                        set1.delete(2);
+                        return { value: 6, done: false };
+                    } else if (iterationCount === 2) {
+                        return { value: 7, done: false };
+                    } else if (iterationCount === 3) {
+                        return { value: 8, done: false };
+                    } else {
+                        return { done: true };
+                    }
+                }
+            };
+        }
+    };
+    
+    let result = set1.union(otherObject);
+    
+    // Result should contain remaining elements from set1 plus new elements
+    shouldBe(result.has(3), true);
+    shouldBe(result.has(4), true);
+    shouldBe(result.has(5), true);
+    shouldBe(result.has(6), true);
+    shouldBe(result.has(7), true);
+    shouldBe(result.has(8), true);
+    
+    // Elements deleted during iteration should still be in result
+    // because they were copied before the modification
+    shouldBe(result.has(1), true);
+    shouldBe(result.has(2), true);
+}
+
+main();

--- a/JSTests/stress/set-union-cursor-reference.js
+++ b/JSTests/stress/set-union-cursor-reference.js
@@ -1,0 +1,65 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected: ' + expected);
+}
+
+function main() {
+    let capturedKey = null;
+
+    try {
+        const set = new Set([1, 2, 3, 4, 5]);
+
+        let iterationCount = 0;
+        const result = set.union({
+            size: 3,
+            has: key => true,
+            keys: function() {
+                return {
+                    next: function() {
+                        iterationCount++;
+                        
+                        if (iterationCount === 1) {
+                            // Modify the set during the generic path iteration
+                            // This tests that our cursor handling is correct
+                            set.delete(1);
+                            set.delete(2);
+                            set.delete(3);
+                            set.delete(4);
+                            return { value: 6, done: false };
+                        } else if (iterationCount === 2) {
+                            // Capture what remains in the original set
+                            capturedKey = [...set][0]; // Should be 5
+                            return { value: 7, done: false };
+                        } else if (iterationCount === 3) {
+                            return { value: 8, done: false };
+                        } else {
+                            return { done: true };
+                        }
+                    }
+                };
+            }
+        });
+
+        // Verify the result contains the original elements (due to efficient cloning)
+        // plus the new elements from the iterator
+        shouldBe(result.has(1), true); // From original set (cloned before modification)
+        shouldBe(result.has(2), true); // From original set (cloned before modification)
+        shouldBe(result.has(3), true); // From original set (cloned before modification)
+        shouldBe(result.has(4), true); // From original set (cloned before modification)
+        shouldBe(result.has(5), true); // From original set (cloned before modification)
+        shouldBe(result.has(6), true); // From iterator
+        shouldBe(result.has(7), true); // From iterator
+        shouldBe(result.has(8), true); // From iterator
+        shouldBe(result.size, 8);
+
+        // The original set should be modified
+        shouldBe(capturedKey, 5);
+        shouldBe(set.size, 1);
+        shouldBe(set.has(5), true);
+
+    } catch (e) {
+        throw new Error('Unexpected error: ' + e);
+    }
+}
+
+main();

--- a/JSTests/stress/set-union-iteration-reference.js
+++ b/JSTests/stress/set-union-iteration-reference.js
@@ -1,0 +1,53 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let emptyValue = null;
+
+    try {
+        const set = new Set([1, 2, 3, 4, 5]);
+
+        let cnt = 0;
+        set.union({
+            size: 10,
+            has: key => {
+                return true;
+            },
+            keys: function() {
+                let values = [6, 7, 8, 9, 10];
+                let index = 0;
+                return {
+                    next: function() {
+                        cnt++;
+                        
+                        if (cnt === 1) {
+                            // Modify the original set during iteration
+                            set.delete(1);
+                            set.delete(2);
+                            set.delete(3);
+                            set.delete(4);
+                        } else if (cnt === 2) {
+                            emptyValue = set.size; // Should still see the original elements in result
+                            throw 1; // Break out of iteration
+                        }
+                        
+                        if (index < values.length) {
+                            return { value: values[index++], done: false };
+                        }
+                        return { done: true };
+                    }
+                };
+            }
+        });
+    } catch {
+        // Expected to throw
+    }
+
+    // The result should contain the elements that were in the set at the time
+    // the clone was made, not the current state of the set
+    shouldBe(emptyValue, 1); // Only element 5 should remain in the original set
+}
+
+main();

--- a/JSTests/stress/set-union-reference.js
+++ b/JSTests/stress/set-union-reference.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let emptyValue = null;
+
+    try {
+        const set = new Set([1, 2, 3, 4, 5]);
+
+        let cnt = 0;
+        set.union({
+            size: 10,
+            has: key => {
+                return true; // Not used in union, but required
+            },
+
+            keys() {
+                return {
+                    next() {
+                        cnt++;
+
+                        if (cnt === 1) {
+                            set.delete(1);
+                            set.delete(2);
+                            set.delete(3);
+                            set.delete(4);
+                            return { value: 6, done: false };
+                        } else {
+                            emptyValue = 6; // The value we should have processed
+                            throw 1;
+                        }
+                    }
+                };
+            }
+        });
+    } catch {
+        // Expected to throw
+    }
+
+    shouldBe(emptyValue, 6);
+}
+
+main();

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -67,39 +67,6 @@ function getSetSizeAsInt(other)
     return sizeInt;
 }
 
-function union(other)
-{
-    "use strict";
-
-    if (!@isSet(this))
-        @throwTypeError("Set operation called on non-Set object");
-
-    // Get Set Record
-    var size = @getSetSizeAsInt(other); // unused but @getSetSizeAsInt call is observable
-
-    var has = other.has;
-    if (!@isCallable(has))
-        @throwTypeError("Set.prototype.union expects other.has to be callable");
-
-    var keys = other.keys;
-    if (!@isCallable(keys))
-        @throwTypeError("Set.prototype.union expects other.keys to be callable");
-
-    var iterator = keys.@call(other);
-    var iteratorNextMethod = iterator.next;
-    var wrapper = {
-        @@iterator: function () {
-           return { next: function () { return iteratorNextMethod.@call(iterator); } };
-        }
-    };
-
-    var result = @setClone(this);
-    for (var key of wrapper)
-        result.@add(key);
-
-    return result;
-}
-
 function difference(other)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -48,6 +48,7 @@ static JSC_DECLARE_HOST_FUNCTION(setProtoFuncHas);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncValues);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncEntries);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIntersection);
+static JSC_DECLARE_HOST_FUNCTION(setProtoFuncUnion);
 
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncSize);
 
@@ -95,7 +96,7 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, values, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().unionPublicName(), setPrototypeUnionCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("union"_s, setProtoFuncUnion, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("intersection"_s, setProtoFuncIntersection, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().differencePublicName(), setPrototypeDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -344,6 +345,96 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIntersection, (JSGlobalObject* globalObject
             }
         });
     }
+
+    return JSValue::encode(result);
+}
+
+static EncodedJSValue fastSetUnion(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* result = thisSet->clone(globalObject, vm, globalObject->setStructure());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSCell* otherStorageCell = otherSet->storageOrSentinel(vm);
+    if (otherStorageCell != vm.orderedHashTableSentinel()) {
+        auto* otherStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+        JSSet::Helper::Entry entry = 0;
+
+        while (true) {
+            otherStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *otherStorage, entry);
+            if (otherStorageCell == vm.orderedHashTableSentinel())
+                break;
+
+            auto* currentStorage = jsCast<JSSet::Storage*>(otherStorageCell);
+            entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+            JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+            result->add(globalObject, entryKey);
+            RETURN_IF_EXCEPTION(scope, { });
+
+            otherStorage = currentStorage;
+        }
+    }
+
+    return JSValue::encode(result);
+}
+
+JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* thisSet = getSet(globalObject, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue otherValue = callFrame->argument(0);
+
+    if (otherValue.isCell()) [[likely]] {
+        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
+                scope.release();
+                return fastSetUnion(globalObject, thisSet, otherSet);
+            }
+        }
+    }
+
+    // unused but getSetSizeAsInt call is observable
+    getSetSizeAsInt(globalObject, otherValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ASSERT(otherValue.isObject());
+    JSObject* otherObject = asObject(otherValue);
+
+    JSValue has = otherObject->get(globalObject, vm.propertyNames->has);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!has.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.union expects other.has to be callable"_s);
+
+    JSValue keys = otherObject->get(globalObject, vm.propertyNames->keys);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!keys.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.union expects other.keys to be callable"_s);
+
+    CallData keysCallData = JSC::getCallData(keys);
+    MarkedArgumentBuffer args;
+    ASSERT(!args.hasOverflowed());
+    JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // unused but iterator.get call is observable
+    iterator.get(globalObject, vm.propertyNames->next);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSSet* result = thisSet->clone(globalObject, vm, globalObject->setStructure());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    scope.release();
+    forEachInIteratorProtocol(globalObject, iterator, [&](VM&, JSGlobalObject* globalObject, JSValue key) -> void {
+        result->add(globalObject, key);
+        RETURN_IF_EXCEPTION(scope, void());
+    });
 
     return JSValue::encode(result);
 }


### PR DESCRIPTION
#### 7a95fd2b53b6979312879679e3d164a3d3de20f4
<pre>
[JSC] Implement `Set.prototype.union` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=296630">https://bugs.webkit.org/show_bug.cgi?id=296630</a>

Reviewed by Yusuke Suzuki.

This patch implements `Set.prototype.union` in C++ using the same method
as <a href="https://commits.webkit.org/297882@main.">https://commits.webkit.org/297882@main.</a>

Baseline JIT:
                                         TipOfTree                  Patched

set-prototype-union-large-this        38.7738+-0.6428     ?     39.0824+-0.4664        ?
set-prototype-union-large-other       73.0084+-1.8569     ^     46.1917+-0.8838        ^ definitely 1.5806x faster
set-prototype-union                  101.5522+-1.6544     ^     79.3068+-6.7624        ^ definitely 1.2805x faster

DFG JIT:
                                         TipOfTree                  Patched

set-prototype-union-large-this        22.5983+-0.5920           22.2471+-0.8823          might be 1.0158x faster
set-prototype-union-large-other       42.3181+-0.7250     ^     29.8346+-0.7372        ^ definitely 1.4184x faster
set-prototype-union                   58.2014+-6.6992     ^     43.7404+-0.4108        ^ definitely 1.3306x faster

DFG/FTL JIT:
                                         TipOfTree                  Patched

set-prototype-union-large-this        18.2200+-0.3486           18.1483+-0.5727
set-prototype-union-large-other       30.3610+-0.7365     ^     23.4165+-0.7398        ^ definitely 1.2966x faster
set-prototype-union                   38.6149+-0.5740     ^     32.5765+-1.2320        ^ definitely 1.1854x faster

* JSTests/microbenchmarks/set-prototype-union-large-other.js: Added.
(shouldBe):
(set let):
* JSTests/microbenchmarks/set-prototype-union-large-this.js: Added.
(shouldBe):
(set let):
* JSTests/microbenchmarks/set-prototype-union.js: Added.
(shouldBe):
(set let):
* JSTests/stress/set-prototype-union-empty-sets.js: Added.
(shouldBe):
* JSTests/stress/set-prototype-union-generic-object.js: Added.
(shouldBe):
(let.setLikeObject.has):
(let.setLikeObject.return.next):
(let.setLikeObject.keys):
(shouldThrow.set1.union):
(shouldThrow):
* JSTests/stress/set-prototype-union-iterator-effects.js: Added.
(shouldBe):
(main.let.otherObject.has):
(main.let.otherObject.return.next):
(main.let.otherObject.keys):
* JSTests/stress/set-union-cursor-reference.js: Added.
(shouldBe):
(main.try.const.result.set union.):
(main.try.const.result.set union):
(main.set catch):
* JSTests/stress/set-union-iteration-reference.js: Added.
(shouldBe):
(main.try.set union.):
(main.try.set union):
(main.set catch):
* JSTests/stress/set-union-reference.js: Added.
(shouldBe):
(main.try.set union):
(main.set catch):
* Source/JavaScriptCore/builtins/SetPrototype.js:
(union.wrapper.return.next): Deleted.
(union.wrapper.iterator): Deleted.
(union): Deleted.
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):
(JSC::fastSetUnion):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/298316@main">https://commits.webkit.org/298316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be6b364650b96e660123f5f6c7de724bd949904

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65673 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67808 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21387 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64796 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107307 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124334 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113570 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96210 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95995 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41192 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38008 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41872 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47407 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137776 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41416 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36826 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->