### PR TITLE
Relanding Web Extensions: Add delegate functions for bookmarks.getTree()

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2074,6 +2074,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionBookmark {
+    header "_WKWebExtensionBookmarks.h"
+    export *
+  }
+
   explicit module WKWebExtensionCommandPrivate {
     header "WKWebExtensionCommandPrivate.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2980,6 +2980,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionBookmark {
+    header "_WKWebExtensionBookmarks.h"
+    export *
+  }
+  
   explicit module WKWebExtensionCommandPrivate {
     header "WKWebExtensionCommandPrivate.h"
     export *

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -26,6 +26,9 @@
 #import <WebKit/WKWebExtensionControllerDelegate.h>
 
 @class _WKWebExtensionSidebar;
+@class _WKWebExtensionBookmark;
+@protocol _WKWebExtensionBookmark;
+
 
 WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
@@ -111,6 +114,33 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller didUpdateSidebar:(_WKWebExtensionSidebar * _Nonnull)sidebar forExtensionContext:(WKWebExtensionContext * _Nonnull)context;
 
+/*!
+ @abstract Called when the root-level bookmarks are needed to begin building the bookmark tree.
+ @param controller The web extension controller initiating the request.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes an array of objects conforming to
+ the `_WKWebExtensionBookmark` protocol and an optional error argument.
+ @discussion This method is the entry point for the `bookmarks.getTree` API. The delegate is responsible for
+ translating its native bookmark objects into objects that conform to the `_WKWebExtensionBookmark` protocol and
+ represent the top-level nodes of the bookmark hierarchy.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller bookmarksForExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> * _Nullable, NSError * _Nullable))completionHandler;
+
+/*!
+ @abstract Called when a new bookmark or folder is requested to be created.
+ @param controller The web extension controller initiating the request.
+ @param parentId The string identifier of the parent folder. Can be nil or "0" for a top-level item.
+ @param index The desired index for the new bookmark within its parent. Can be nil.
+ @param url The URL for the new bookmark. Should be nil if creating a folder.
+ @param title The title for the new bookmark or folder.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes the newly created bookmark node
+ (as an object conforming to the `id <_WKWebExtensionBookmark>` protocol) and an optional error argument.
+ @discussion This method is the entry point for the `bookmarks.create` API. The delegate is responsible for
+ taking the 4 parameters, creating the bookmark in its data store, and returning a new object that
+ represents the created item.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller createBookmarkWithParentIdentifier:(nullable NSString *)parentId index:(nullable NSNumber *)index url:(nullable NSString *)url title:(NSString * _Nonnull)title forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> * _Nullable, NSError * _Nullable))completionHandler;
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
@@ -1,0 +1,80 @@
+// Copyright © 2025  All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WKFoundation.h>
+
+
+@class WKWebExtensionContext;
+@protocol _WKWebExtensionBookmark;
+
+WK_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+/*!
+ @abstract Constants used by ``_WKWebExtensionBookmark`` to indicate the type of a bookmark node.
+ @constant _WKWebExtensionBookmarkTypeBookmark  Indicates the node is a bookmark with a URL.
+ @constant _WKWebExtensionBookmarkTypeFolder  Indicates the node is a folder that can contain other bookmarks or folders.
+ @constant _WKWebExtensionBookmarkTypeSeparator  Indicates the node is a separator.
+ */
+typedef NS_ENUM(NSInteger, _WKWebExtensionBookmarkType) {
+    _WKWebExtensionBookmarkTypeBookmark,
+    _WKWebExtensionBookmarkTypeFolder,
+} NS_SWIFT_NAME(_WKWebExtension.BookmarkType) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/*! @abstract A class conforming to the ``_WKWebExtensionBookmark`` protocol represents a single bookmark node (a bookmark or folder) to web extensions. */
+WK_SWIFT_UI_ACTOR
+@protocol _WKWebExtensionBookmark <NSObject>
+@optional
+
+/*!
+ @abstract Called when the unique identifier for the bookmark node is needed.
+ @param context The context in which the web extension is running.
+ @return A string uniquely identifying this bookmark node.
+ */
+- (NSString *)identifierForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(identifier(for:));
+
+/*!
+ @abstract Called when the identifier of the parent folder is needed.
+ @param context The context in which the web extension is running.
+ @return The unique identifier of the parent folder, or `nil` if the node is at the root level.
+ */
+- (nullable NSString *)parentIdentifierForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(parentIdentifier(for:));
+
+/*!
+ @abstract Called when the title of the bookmark node is needed.
+ @param context The context in which the web extension is running.
+ @return The user-visible title of the bookmark or folder.
+ */
+- (nullable NSString *)titleForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(title(for:));
+
+/*!
+ @abstract Called when the URL of the bookmark is needed.
+ @param context The context in which the web extension is running.
+ @return The URL the bookmark points to. This should be `nil` for folders.
+ */
+- (nullable NSString *)urlStringForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(url(for:));
+
+/*!
+ @abstract Called when the type of the bookmark node is needed.
+ @param context The context in which the web extension is running.
+ @return The type of the bookmark node.
+ */
+- (_WKWebExtensionBookmarkType)bookmarkTypeForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(bookmarkType(for:));
+
+/*!
+ @abstract Called when the children of a folder are needed.
+ @param context The context in which the web extension is running.
+ @return An array of bookmark nodes contained within this folder. Should be `nil` if the node is not a folder.
+ */
+- (nullable NSArray<id<_WKWebExtensionBookmark>> *)childrenForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(children(for:));
+
+/*!
+ @abstract Called when the zero-based index of this node within its parent folder is needed.
+ @param context The context in which the web extension is running.
+ @return The index of the bookmark node.
+ */
+- (NSInteger)indexForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(index(for:));
+
+@end
+
+WK_HEADER_AUDIT_END(nullability, sendability)
+

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
@@ -6,6 +6,10 @@
 #import "config.h"
 #import "WebExtensionContext.h"
 
+#include "WebExtensionBookmarksParameters.h"
+#include "WebExtensionController.h"
+#include "_WKWebExtensionBookmarks.h"
+
 #include <wtf/Vector.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
@@ -20,13 +24,125 @@ bool WebExtensionContext::isBookmarksMessageAllowed(IPC::Decoder& message)
     return false;
 }
 
+static Vector<WebExtensionBookmarksParameters> createParametersFromProtocolObjects(NSArray<id<_WKWebExtensionBookmark>> *, WKWebExtensionContext *);
+
+static std::optional<WebExtensionBookmarksParameters> createParametersFromProtocolObject(id<_WKWebExtensionBookmark> bookmark, WKWebExtensionContext *context)
+{
+    if (!bookmark)
+        return std::nullopt;
+
+    WebExtensionBookmarksParameters parameters;
+
+    NSString *nodeId = [bookmark identifierForWebExtensionContext:context];
+    if (!nodeId)
+        return std::nullopt;
+    parameters.nodeId = nodeId;
+
+    parameters.parentId = [bookmark parentIdentifierForWebExtensionContext:context];
+    parameters.index = [bookmark indexForWebExtensionContext:context];
+    parameters.title = [bookmark titleForWebExtensionContext:context];
+    parameters.url = [bookmark urlStringForWebExtensionContext:context];
+
+    if (NSArray *children = [bookmark childrenForWebExtensionContext:context])
+        parameters.children = createParametersFromProtocolObjects(children, context);
+
+    return parameters;
+}
+
+static Vector<WebExtensionBookmarksParameters> createParametersFromProtocolObjects(NSArray<id<_WKWebExtensionBookmark>> *bookmarkNodes, WKWebExtensionContext *context)
+{
+    if (!bookmarkNodes.count)
+        return { };
+
+    Vector<WebExtensionBookmarksParameters> parameters;
+    parameters.reserveInitialCapacity(bookmarkNodes.count);
+
+    for (id<_WKWebExtensionBookmark> bookmark in bookmarkNodes) {
+        auto parametersOptional = createParametersFromProtocolObject(bookmark, context);
+        if (parametersOptional)
+            parameters.append(WTFMove(*parametersOptional));
+    }
+
+    return parameters;
+}
+
 void WebExtensionContext::bookmarksCreate(const std::optional<String>& parentId, const std::optional<uint64_t>& index, const std::optional<String>& url, const std::optional<String>& title, CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"bookmarks.create()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:createBookmarkWithParentIdentifier:index:url:title:forExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    NSString *parentIdString = parentId ? parentId->createNSString().get() : nil;
+    NSNumber *indexNumber = index ? @(index.value()) : nil;
+    NSString *urlString = url ? url->createNSString().get() : nil;
+    NSString *titleString = title ? title->createNSString().get() : @"";
+
+    [controllerDelegate _webExtensionController:controllerWrapper createBookmarkWithParentIdentifier:parentIdString index:indexNumber url:urlString title:titleString forExtensionContext:contextWrapper completionHandler:^(NSObject<_WKWebExtensionBookmark> *newBookmark, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"error was reported"));
+            return;
+        }
+        auto parametersOptional = createParametersFromProtocolObject(newBookmark, contextWrapper);
+        if (!parametersOptional.has_value()) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"bookmark was null or invalid"));
+            return;
+        }
+
+        completionHandler(Expected<WebExtensionBookmarksParameters, WebExtensionError> { WTFMove(parametersOptional.value()) });
+    }];
 }
 void WebExtensionContext::bookmarksGetTree(CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString * const apiName = @"bookmarks.getTree()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:bookmarksForExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    [controllerDelegate _webExtensionController:controllerWrapper bookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *bookmarkNodes, NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            return;
+        }
+
+        if (!bookmarkNodes) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"returned array of bookmarks was invalid"));
+            return;
+        }
+        Vector<WebExtensionBookmarksParameters> topLevelNodes = createParametersFromProtocolObjects(bookmarkNodes, contextWrapper);
+        WebExtensionBookmarksParameters rootNode;
+
+        // FIXME: @"testBookmarksRoot" will be removed or changed when we aren't mocking bookmarks anymore.
+        rootNode.nodeId = @"testBookmarksRoot";
+        rootNode.children = WTFMove(topLevelNodes);
+        completionHandler(Expected<WebExtensionBookmarksParameters, WebExtensionError> { WTFMove(rootNode) });
+    }];
 }
 void WebExtensionContext::bookmarksGetSubTree(const String& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&& completionHandler)
 {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1853,6 +1853,7 @@
 		9565083A26D87A2B00E15CB7 /* AppleMediaServicesUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 9565083826D87A2B00E15CB7 /* AppleMediaServicesUISPI.h */; };
 		9593675F252E5E3100D3F0A0 /* WKStylusDeviceObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */; };
 		95C943912523C0D00054F3D5 /* BaseBoardSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C943902523C0D00054F3D5 /* BaseBoardSPI.h */; };
+		960C47F52E1CB1BB00B8D2D1 /* _WKWebExtensionBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 960C47F42E1C861C00B8D2D1 /* _WKWebExtensionBookmarks.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		961A72D02E17270900DD2AF9 /* WebExtensionBookmarksParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 96CC7DBF2E15EC2800233E69 /* WebExtensionBookmarksParameters.h */; };
 		96418A5E2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h in Headers */ = {isa = PBXBuildFile; fileRef = 96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */; };
 		96CC7DBE2E15DA4200233E69 /* WebExtensionContextAPIBookmarksCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 96CC7DBD2E15DA2900233E69 /* WebExtensionContextAPIBookmarksCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -7182,6 +7183,7 @@
 		9593675D252E5E3000D3F0A0 /* WKStylusDeviceObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKStylusDeviceObserver.h; path = ios/WKStylusDeviceObserver.h; sourceTree = "<group>"; };
 		9593675E252E5E3100D3F0A0 /* WKStylusDeviceObserver.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKStylusDeviceObserver.mm; path = ios/WKStylusDeviceObserver.mm; sourceTree = "<group>"; };
 		95C943902523C0D00054F3D5 /* BaseBoardSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseBoardSPI.h; sourceTree = "<group>"; };
+		960C47F42E1C861C00B8D2D1 /* _WKWebExtensionBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionBookmarks.h; sourceTree = "<group>"; };
 		96418A5D2DFA4B8100C19CDC /* JSWebExtensionAPIBookmarks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIBookmarks.h; sourceTree = "<group>"; };
 		96418A5F2DFA4BA900C19CDC /* JSWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
 		966F42B3BF3CA9AFEE64F9BF /* RemoteSerializedImageBufferIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteSerializedImageBufferIdentifier.h; sourceTree = "<group>"; };
@@ -12291,6 +12293,7 @@
 				574728D023456E98001700AF /* _WKWebAuthenticationPanel.mm */,
 				5790A6512565DE6A0077C5A7 /* _WKWebAuthenticationPanelForTesting.h */,
 				574728D3234570AE001700AF /* _WKWebAuthenticationPanelInternal.h */,
+				960C47F42E1C861C00B8D2D1 /* _WKWebExtensionBookmarks.h */,
 				028D30862C62FA8A004F4FC6 /* _WKWebExtensionSidebar.h */,
 				028D30892C63E14B004F4FC6 /* _WKWebExtensionSidebar.mm */,
 				028D308D2C63E3B3004F4FC6 /* _WKWebExtensionSidebarInternal.h */,
@@ -17032,6 +17035,7 @@
 				574728D4234570AE001700AF /* _WKWebAuthenticationPanelInternal.h in Headers */,
 				1CC5CA6D2C5ACB8500DF3B94 /* _WKWebExtension.h in Headers */,
 				1CC5CA722C5ACB8500DF3B94 /* _WKWebExtensionAction.h in Headers */,
+				960C47F52E1CB1BB00B8D2D1 /* _WKWebExtensionBookmarks.h in Headers */,
 				1CC5CA702C5ACB8500DF3B94 /* _WKWebExtensionCommand.h in Headers */,
 				1CC5CA922C5ACD5700DF3B94 /* _WKWebExtensionCommandPrivate.h in Headers */,
 				1CC5CA6E2C5ACB8500DF3B94 /* _WKWebExtensionContext.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm
@@ -31,7 +31,135 @@
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
 
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebExtensionControllerDelegatePrivate.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKWebExtensionBookmarks.h>
+
+
+@interface _MockBookmarkNode : NSObject <_WKWebExtensionBookmark>
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+@property (nonatomic, strong) NSMutableDictionary *dictionary;
+@end
+
+@implementation _MockBookmarkNode
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
+{
+    self = [super init];
+    if (self)
+        _dictionary = [dictionary mutableCopy];
+    return self;
+}
+
+- (NSString *)identifierForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    return _dictionary[@"id"];
+}
+
+- (NSString *)parentIdentifierForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    return _dictionary[@"parentId"];
+}
+
+- (NSString *)titleForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    return _dictionary[@"title"];
+}
+
+- (NSString *)urlStringForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    return _dictionary[@"url"];
+}
+
+- (NSInteger)indexForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    return [_dictionary[@"index"] integerValue];
+}
+
+- (NSArray<id<_WKWebExtensionBookmark>> *)childrenForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    NSArray *childDictionaries = _dictionary[@"children"];
+    if (!childDictionaries)
+        return nil;
+    NSMutableArray<id<_WKWebExtensionBookmark>> *children = [NSMutableArray array];
+    for (NSDictionary *childDict in childDictionaries)
+        [children addObject:[[_MockBookmarkNode alloc] initWithDictionary:childDict]];
+    return children;
+}
+
+@end
+
+
+@interface TestBookmarksDelegate : NSObject <WKWebExtensionControllerDelegatePrivate>
+@property (nonatomic, strong) NSMutableArray<NSMutableDictionary *> *mockBookmarks;
+@property (nonatomic) NSInteger nextMockBookmarkId;
+@end
+
+static NSMutableDictionary *findParentInMockTree(NSMutableArray<NSMutableDictionary *> *tree, NSString *parentId)
+{
+    for (NSMutableDictionary *node in tree) {
+        if ([node[@"id"] isEqualToString:parentId])
+            return node;
+        id children = node[@"children"];
+        if (children && [children isKindOfClass:[NSMutableArray class]]) {
+            NSMutableDictionary *found = findParentInMockTree(children, parentId);
+            if (found)
+                return found;
+        }
+    }
+    return nil;
+}
+
+
+@implementation TestBookmarksDelegate
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _mockBookmarks = [NSMutableArray array];
+        _nextMockBookmarkId = 100;
+    }
+    return self;
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller bookmarksForExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *))completionHandler
+{
+    NSMutableArray<NSObject<_WKWebExtensionBookmark> *> *results = [NSMutableArray array];
+    for (NSDictionary *bookmarkDict in self.mockBookmarks)
+        [results addObject:[[_MockBookmarkNode alloc] initWithDictionary:bookmarkDict]];
+    completionHandler(results, nil);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller createBookmarkWithParentIdentifier:(NSString *)parentId index:(NSNumber *)index url:(NSString *)url title:(NSString *)title forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler
+{
+    NSMutableDictionary *newBookmark = [NSMutableDictionary dictionary];
+    newBookmark[@"title"] = title;
+    if (url)
+        newBookmark[@"url"] = url;
+    NSString *newId = [NSString stringWithFormat:@"%ld", (long)self.nextMockBookmarkId];
+    _nextMockBookmarkId++;
+    newBookmark[@"id"] = newId;
+
+    if (parentId && ![parentId isEqualToString:@"0"]) {
+        NSMutableDictionary *parentDict = findParentInMockTree(self.mockBookmarks, parentId);
+        if (parentDict) {
+            NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+            newBookmark[@"parentId"] = parentId;
+            newBookmark[@"index"] = index ?: @(children.count);
+            [children addObject:newBookmark];
+            parentDict[@"children"] = children;
+
+            completionHandler([[_MockBookmarkNode alloc] initWithDictionary:newBookmark], nil);
+            return;
+        }
+    }
+
+    newBookmark[@"parentId"] = @"0";
+    newBookmark[@"index"] = index ?: @(self.mockBookmarks.count);
+    [self.mockBookmarks addObject:newBookmark];
+
+    completionHandler([[_MockBookmarkNode alloc] initWithDictionary:newBookmark], nil);
+}
+@end
 
 namespace TestWebKitAPI {
 
@@ -51,7 +179,7 @@ static constexpr auto *bookmarkOffManifest = @{
     },
 };
 
-static auto *bookmarkOnManifest = @{
+static constexpr auto *bookmarkOnManifest = @{
     @"manifest_version": @3,
     @"name": @"bookmarkpermission on Test",
     @"description": @"bookmarkpermission on Test",
@@ -84,6 +212,17 @@ protected:
                 [bookmarkConfig.webViewConfiguration.preferences _setEnabled:YES forFeature:feature];
         }
     }
+
+    RetainPtr<NSMutableArray> uiProcessMockBookmarks;
+    NSInteger nextMockBookmarkId;
+
+    void SetUp() override
+    {
+        testing::Test::SetUp();
+        uiProcessMockBookmarks = adoptNS([NSMutableArray new]);
+        nextMockBookmarkId = 100;
+    }
+
     RetainPtr<TestWebExtensionManager> getManagerFor(NSArray<NSString *> *script, NSDictionary<NSString *, id> *manifest)
     {
         return getManagerFor(@{ @"background.js" : Util::constructScript(script) }, manifest);
@@ -92,6 +231,47 @@ protected:
     RetainPtr<TestWebExtensionManager> getManagerFor(NSDictionary<NSString *, id> *resources, NSDictionary<NSString *, id> *manifest)
     {
         return Util::parseExtension(manifest, resources, bookmarkConfig);
+    }
+
+    void configureCreateBookmarkDelegate(TestWebExtensionManager *manager)
+    {
+        manager.internalDelegate.createBookmarkWithParentIdentifier = ^(NSString *parentId, NSNumber *index, NSString *url, NSString *title, void (^completionHandler)(NSObject<_WKWebExtensionBookmark>*, NSError*)) {
+            NSMutableDictionary *newBookmarkData = [NSMutableDictionary dictionary];
+            newBookmarkData[@"title"] = title;
+            if (url)
+                newBookmarkData[@"url"] = url;
+            NSString *newId = [NSString stringWithFormat:@"%ld", (long)this->nextMockBookmarkId];
+            this->nextMockBookmarkId++;
+            newBookmarkData[@"id"] = newId;
+
+            newBookmarkData[@"parentId"] = parentId;
+            if (parentId && ![parentId isEqualToString:@"0"]) {
+                NSMutableDictionary *parentDict = findParentInMockTree(this->uiProcessMockBookmarks.get(), parentId);
+                if (parentDict) {
+                    NSMutableArray *children = [parentDict[@"children"] mutableCopy] ?: [NSMutableArray array];
+                    newBookmarkData[@"parentId"] = parentId;
+                    newBookmarkData[@"index"] = index ?: @(children.count);
+                    [children addObject:newBookmarkData];
+                    parentDict[@"children"] = children;
+                    completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+                    return;
+                }
+            }
+
+            newBookmarkData[@"index"] = index ?: @(this->uiProcessMockBookmarks.get().count);
+            [this->uiProcessMockBookmarks addObject:newBookmarkData];
+            completionHandler(adoptNS([[_MockBookmarkNode alloc] initWithDictionary:newBookmarkData]).get(), nil);
+        };
+    }
+
+    void configureGetBookmarksDelegate(TestWebExtensionManager *manager)
+    {
+        manager.internalDelegate.bookmarksForExtensionContext = ^(void (^completionHandler)(NSArray<NSObject<_WKWebExtensionBookmark> *>*, NSError*)) {
+            NSMutableArray<NSObject<_WKWebExtensionBookmark>*> *results = [NSMutableArray array];
+            for (NSDictionary *dict in this->uiProcessMockBookmarks.get())
+                [results addObject:[[_MockBookmarkNode alloc] initWithDictionary:dict]];
+            completionHandler(results, nil);
+        };
     }
 
     WKWebExtensionControllerConfiguration *bookmarkConfig;
@@ -195,17 +375,23 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)
         @"browser.bookmarks.create({id: 'id_mid', title: 'Middle Bookmark', url: 'http://example.com/2', dateAdded: 2000})",
         @"let recent = await browser.bookmarks.getRecent(2)",
         @"browser.test.assertEq(2, recent.length, 'Should return exactly 2 bookmarks')",
-        @"browser.test.assertEq('id_new', recent[0].id, 'First result should be the newest bookmark')",
-        @"browser.test.assertEq('id_mid', recent[1].id, 'Second result should be the middle bookmark')",
+        @"browser.test.assertEq('Newest Bookmark', recent[0].title, 'First result should be the newest bookmark')",
+        @"browser.test.assertEq('Middle Bookmark', recent[1].title, 'Second result should be the middle bookmark')",
         @"let recent2 = await browser.bookmarks.getRecent(5)",
         @"browser.test.assertEq(3, recent2.length, 'Should adapt and return the max available which is 3')",
-        @"browser.test.assertEq('id_new', recent2[0].id, 'First result should be the newest bookmark')",
-        @"browser.test.assertEq('id_mid', recent2[1].id, 'Second result should be the middle bookmark')",
-        @"browser.test.assertEq('id_old', recent2[2].id, 'Second result should be the middle bookmark')",
+        @"browser.test.assertEq('Newest Bookmark', recent2[0].title, 'First result should be the newest bookmark')",
+        @"browser.test.assertEq('Middle Bookmark', recent2[1].title, 'Second result should be the middle bookmark')",
+        @"browser.test.assertEq('Oldest Bookmark', recent2[2].title, 'Second result should be the middle bookmark')",
         @"browser.test.notifyPass()",
     ];
 
-    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    configureCreateBookmarkDelegate(manager.get());
+
+    [manager loadAndRun];
 }
 
 TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)
@@ -218,11 +404,18 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)
         @"let createdNode2 = await browser.bookmarks.create({id: 'test2', title: 'My Test Folder', parentId: 'testFavorites'})",
         @"browser.test.assertEq('My Test Folder', createdNode2.title, 'Title should match');",
         @"browser.test.assertEq('folder', createdNode2.type, 'type should be folder because url is not specified');",
-        @"browser.test.assertEq('testfav', createdNode2.parentId, 'parentId should match');",
+        @"browser.test.assertEq('testFavorites', createdNode2.parentId, 'parentId should match');",
         @"browser.test.notifyPass()",
     ];
 
-    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    configureCreateBookmarkDelegate(manager.get());
+
+    [manager loadAndRun];
+
 }
 
 TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)
@@ -232,23 +425,18 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)
         @"let folder1 = await browser.bookmarks.create({id: 'folder1', type: 'folder', title: 'Top Folder 1'});",
         @"let bookmark2 = await browser.bookmarks.create({id: 'bookmark2', title: 'Child Bookmark 2', url: 'http://example.com/bm2', parentId: folder1.id});",
         @"let bookmark3 = await browser.bookmarks.create({id: 'bookmark3', title: 'Top Bookmark 3', url: 'http://example.com/bm3'});",
-        @"let tree = await browser.bookmarks.getTree();",
-        @"browser.test.assertEq(1, tree.length, 'Tree should have one root node');",
-        @"let root = tree[0];",
+        @"let root = await browser.bookmarks.getTree();",
         @"browser.test.assertEq('testBookmarksRoot', root.id, 'Root node ID should be root');",
-        @"browser.test.assertEq('folder', root.type, 'Root node type should be folder');",
         @"browser.test.assertTrue(root.children.length >= 1, 'Root should have at least one child (default folder)');",
-        @"let foundBookmark1 = root.children.find(n => n.id === bookmark1.id);",
+        @"let foundBookmark1 = root.children.find(n => n.title === bookmark1.title);",
         @"browser.test.assertEq('Top Bookmark 1', foundBookmark1.title, 'Bm1 title matches');",
         @"browser.test.assertEq('http://example.com/bm1', foundBookmark1.url, 'Bm1 URL matches');",
         @"browser.test.assertEq('bookmark', foundBookmark1.type, 'Bm1 type is bookmark');",
-        @"browser.test.assertEq(root.id, foundBookmark1.parentId, 'Bm1 parentId matches default folder');",
-        @"let foundFolder1 = root.children.find(n => n.id === folder1.id);",
+        @"let foundFolder1 = root.children.find(n => n.title === folder1.title);",
         @"browser.test.assertEq('Top Folder 1', foundFolder1.title, 'Folder1 title matches');",
         @"browser.test.assertEq('folder', foundFolder1.type, 'Folder1 type is folder');",
-        @"browser.test.assertEq(root.id, foundFolder1.parentId, 'Folder1 parentId matches default folder');",
-        @"browser.test.assertEq(bookmark2.id, foundFolder1.children[0].id, 'Folder1 should have children array');",
-        @"let foundBookmark2 = foundFolder1.children.find(n => n.id === bookmark2.id);",
+        @"browser.test.assertEq(bookmark2.title, foundFolder1.children[0].title, 'Folder1 should have children array');",
+        @"let foundBookmark2 = foundFolder1.children.find(n => n.title === bookmark2.title);",
         @"browser.test.assertEq('Child Bookmark 2', foundBookmark2.title, 'Bm2 title matches');",
         @"browser.test.assertEq('http://example.com/bm2', foundBookmark2.url, 'Bm2 URL matches');",
         @"browser.test.assertEq('bookmark', foundBookmark2.type, 'Bm2 type is bookmark');",
@@ -256,10 +444,50 @@ TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)
         @"browser.test.notifyPass()",
     ];
 
-    Util::loadAndRunExtension(bookmarkOnManifest, @{ @"background.js": Util::constructScript(script) }, bookmarkConfig);
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    configureCreateBookmarkDelegate(manager.get());
+    configureGetBookmarksDelegate(manager.get());
+    [manager loadAndRun];
+}
+
+TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)
+{
+    auto *script = @[
+        @"let folder = await browser.bookmarks.create({ id: 'testFolder', title: 'Test Folder' });",
+        @"browser.test.assertEq(folder.title, 'Test Folder', 'Folder title should be correct');",
+        @"browser.test.assertTrue(!!folder.id, 'Folder should have an ID');",
+        @"let bookmark = await browser.bookmarks.create({ id: 'testbookmark1', parentId: folder.id, title: 'WebKit.org', url: 'https://webkit.org/' });",
+        @"browser.test.assertEq(bookmark.title, 'WebKit.org', 'Bookmark title should be correct');",
+        @"browser.test.assertEq(bookmark.url, 'https://webkit.org/', 'Bookmark URL should be correct');",
+        @"let rootNode = await browser.bookmarks.getTree();",
+        @"browser.test.assertTrue(Array.isArray(rootNode.children), 'Root object should have a children array');",
+        @"browser.test.assertEq(rootNode.children.length, 1);",
+        @"browser.test.assertEq(rootNode.children[0].title, 'Test Folder');",
+        @"browser.test.assertTrue(Array.isArray(rootNode.children[0].children), 'Folder should have a children array');",
+        @"browser.test.assertEq(rootNode.children[0].children[0].title, 'WebKit.org', 'Child bookmark in tree should have correct title');",
+        @"browser.test.assertEq(rootNode.children[0].children[0].url, 'https://webkit.org/', 'Child bookmark in tree should have correct URL');",
+        @"let bookmark2 = await browser.bookmarks.create({ id: 'topLevelBookmark', title: 'Test Top Bookmark', url: 'https://coolbook.com/' });",
+        @"browser.test.assertEq(bookmark2.title, 'Test Top Bookmark', 'Bookmark title should be correct');",
+        @"browser.test.assertEq(bookmark2.url, 'https://coolbook.com/', 'Bookmark URL should be correct');",
+        @"let updatedRootNode = await browser.bookmarks.getTree();",
+        @"browser.test.assertEq(updatedRootNode.children.length, 2);",
+        @"browser.test.assertEq(updatedRootNode.children[0].title, 'Test Folder');",
+        @"browser.test.assertEq(updatedRootNode.children[1].title, 'Test Top Bookmark');",
+        @"browser.test.notifyPass();",
+    ];
+
+    auto *resources = @{ @"background.js": Util::constructScript(script) };
+
+    auto manager = getManagerFor(resources, bookmarkOnManifest);
+
+    configureCreateBookmarkDelegate(manager.get());
+    configureGetBookmarksDelegate(manager.get());
+    [manager loadAndRun];
 }
 
 }
-
 #endif
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -70,6 +70,9 @@
 
 @property (nonatomic, copy) void (^didUpdateSidebar)(_WKWebExtensionSidebar *);
 
+@property (nonatomic, copy) void (^createBookmarkWithParentIdentifier)(NSString *parentId, NSNumber *index, NSString *url, NSString *title, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
+@property (nonatomic, copy) void (^bookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *));
+
 @end
 
 #endif // __OBJC__

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -170,6 +170,23 @@
         _didUpdateSidebar(sidebar);
 }
 
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller createBookmarkWithParentIdentifier:(NSString *)parentId index:(NSNumber *)index url:(NSString *)url title:(NSString *)title forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler
+{
+    if (_createBookmarkWithParentIdentifier)
+        _createBookmarkWithParentIdentifier(parentId, index, url, title, completionHandler);
+    else if (completionHandler)
+        completionHandler(nil, nil);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller bookmarksForExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *))completionHandler
+{
+    if (_bookmarksForExtensionContext)
+        _bookmarksForExtensionContext(completionHandler);
+    else if (completionHandler)
+        completionHandler(@[], nil);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### ad84f1c662f2c7f28b94b2fdf51a13462a91ca44
<pre>
Relanding Web Extensions: Add delegate functions for bookmarks.getTree()
<a href="https://rdar.apple.com/155264420">rdar://155264420</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295551">https://bugs.webkit.org/show_bug.cgi?id=295551</a>

Reviewed by Brian Weinstein.

Implementation of getTree and mockNode for create bookmarks for testing. Created a delegate for getTree and create.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::createParametersFromProtocolObject):
(WebKit::createParametersFromProtocolObjects):
(WebKit::WebExtensionContext::bookmarksCreate):
(WebKit::WebExtensionContext::bookmarksGetTree):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::toAPI):
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getTree):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(-[_MockBookmarkNode initWithDictionary:]):
(-[_MockBookmarkNode identifierForWebExtensionContext:]):
(-[_MockBookmarkNode parentIdentifierForWebExtensionContext:]):
(-[_MockBookmarkNode titleForWebExtensionContext:]):
(-[_MockBookmarkNode urlStringForWebExtensionContext:]):
(-[_MockBookmarkNode indexForWebExtensionContext:]):
(-[_MockBookmarkNode childrenForWebExtensionContext:]):
(findParentInMockTree):
(-[TestBookmarksDelegate init]):
(-[TestBookmarksDelegate _webExtensionController:bookmarksForExtensionContext:completionHandler:]):
(-[TestBookmarksDelegate _webExtensionController:createBookmarkWithParentIdentifier:index:url:title:forExtensionContext:completionHandler:]):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureCreateBookmarkDelegate):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureGetBookmarksDelegate):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:createBookmarkWithParentIdentifier:index:url:title:forExtensionContext:completionHandler:]):
(-[TestWebExtensionsDelegate _webExtensionController:bookmarksForExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/298056@main">https://commits.webkit.org/298056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a76ab5ccc4f86d49b070c0342ce46c521f44c4c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86542 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20405 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95380 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98487 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95152 "Found 101 new API test failures: /TestWebKit:WebKit.EvaluateJavaScriptThatCreatesBlob, /TestWebKit:WebKit.DOMWindowExtensionCrashOnReload, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidBeginAndEndEditingEvents, /TestWebKit:WebKit2TextFieldBeginAndEditEditingTest.TextFieldDidEndShouldBeDispatchedForRemovedFocusField, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editor-state/typing-attributes, /TestWebKit:WebKit.FirstMeaningfulPaint, /TestWebKit:WebKit.FrameMIMETypeHTML, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio ... (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40291 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18097 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37051 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40779 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->