### PR TITLE
[Style] Generalize Style::LengthWrapperBase - Part 1: Replace WebCore::Length with Style::LengthWrapperBaseData

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2834,6 +2834,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/position/StyleInset.h
 
     style/values/primitives/StyleLengthWrapper.h
+    style/values/primitives/StyleLengthWrapperData.h
     style/values/primitives/StylePosition.h
     style/values/primitives/StylePrimitiveNumeric+Forward.h
     style/values/primitives/StylePrimitiveNumeric.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -979,6 +979,7 @@ style/Styleable.cpp
 style/Styleable.h
 style/TransformOperationsBuilder.cpp
 style/UserAgentStyle.cpp
+style/values/primitives/StyleLengthWrapperData.cpp
 style/values/transforms/StyleRotate.cpp
 style/values/transforms/StyleScale.cpp
 style/values/transforms/StyleTranslate.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3202,6 +3202,7 @@ style/values/overflow/StyleBlockEllipsis.cpp
 style/values/overflow/StyleScrollBehavior.cpp
 style/values/overflow/StyleScrollbarGutter.cpp
 style/values/primitives/StyleLengthResolution.cpp
+style/values/primitives/StyleLengthWrapperData.cpp
 style/values/primitives/StylePosition.cpp
 style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
 style/values/primitives/StyleRatio.cpp

--- a/Source/WebCore/platform/Length.h
+++ b/Source/WebCore/platform/Length.h
@@ -155,6 +155,8 @@ public:
     std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { value() }) : std::nullopt; }
 
     LengthType type() const;
+    bool isFloat() const;
+
     WEBCORE_EXPORT IPCData ipcData() const;
 
     bool isFixed() const;
@@ -420,6 +422,11 @@ inline float Length::percent() const
 inline LengthType Length::type() const
 {
     return static_cast<LengthType>(m_type);
+}
+
+inline bool Length::isFloat() const
+{
+    return m_isFloat;
 }
 
 inline bool Length::hasQuirk() const

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -111,13 +111,13 @@ float FixedTableLayout::calcWidthArray()
             if (currentEffectiveColumn >= nEffCols) {
                 m_table->appendColumn(span);
                 nEffCols++;
-                m_width.append(Length());
+                m_width.append(CSS::Keyword::Auto { });
                 spanInCurrentEffectiveColumn = span;
             } else {
                 if (span < m_table->spanOfEffCol(currentEffectiveColumn)) {
                     m_table->splitColumn(currentEffectiveColumn, span);
                     nEffCols++;
-                    m_width.append(Length());
+                    m_width.append(CSS::Keyword::Auto { });
                 }
                 spanInCurrentEffectiveColumn = m_table->spanOfEffCol(currentEffectiveColumn);
             }

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -87,21 +87,21 @@ void RenderScrollbarPart::layoutVerticalPart()
 static int calcScrollbarThicknessUsing(const Style::PreferredSize& preferredSize)
 {
     if (!preferredSize.isPercentOrCalculated() && !preferredSize.isIntrinsicOrLegacyIntrinsicOrAuto())
-        return Style::evaluateMinimum(preferredSize, { });
+        return Style::evaluateMinimum(preferredSize, 0_lu);
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MinimumSize& minimumSize)
 {
     if ((!minimumSize.isPercentOrCalculated() && !minimumSize.isIntrinsicOrLegacyIntrinsicOrAuto()) || minimumSize.isAuto())
-        return Style::evaluateMinimum(minimumSize, { });
+        return Style::evaluateMinimum(minimumSize, 0_lu);
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 
 static int calcScrollbarThicknessUsing(const Style::MaximumSize& maximumSize)
 {
     if (!maximumSize.isPercentOrCalculated() && !maximumSize.isIntrinsic() && !maximumSize.isLegacyIntrinsic())
-        return Style::evaluateMinimum(maximumSize, { });
+        return Style::evaluateMinimum(maximumSize, 0_lu);
     return ScrollbarTheme::theme().scrollbarThickness();
 }
 

--- a/Source/WebCore/rendering/style/StyleBoxData.cpp
+++ b/Source/WebCore/rendering/style/StyleBoxData.cpp
@@ -26,6 +26,7 @@
 #include "RenderStyleConstants.h"
 #include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/style/StyleTransformData.cpp
+++ b/Source/WebCore/rendering/style/StyleTransformData.cpp
@@ -24,6 +24,7 @@
 
 #include "RenderStyleInlines.h"
 #include "RenderStyleDifference.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
@@ -34,7 +34,7 @@ std::optional<PreferredSize> FlexBasis::tryPreferredSize() const
 {
     if (isContent())
         return { };
-    return PreferredSize { WebCore::Length { m_value } };
+    return PreferredSize { m_value };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -43,24 +43,28 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
                 : state.cssToLengthConversionData();
 
             if (primitiveValue.isLength()) {
-                return T { WebCore::Length {
-                    CSS::clampToRange<T::Fixed::range, float>(primitiveValue.resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
-                    LengthType::Fixed,
+                return T {
+                    typename T::Fixed {
+                        CSS::clampToRange<T::Fixed::range, float>(primitiveValue.resolveAsLength(conversionData), minValueForCssLength, maxValueForCssLength),
+                    },
                     primitiveValue.primitiveType() == CSSUnitType::CSS_QUIRKY_EM
-                } };
+                };
             }
 
             if (primitiveValue.isPercentage()) {
-                return T { WebCore::Length {
-                    CSS::clampToRange<T::Percentage::range, float>(primitiveValue.resolveAsPercentage(conversionData)),
-                    LengthType::Percent
-                } };
+                return T {
+                    typename T::Percentage {
+                        CSS::clampToRange<T::Percentage::range, float>(primitiveValue.resolveAsPercentage(conversionData)),
+                    }
+                };
             }
 
             if (primitiveValue.isCalculatedPercentageWithLength()) {
-                return T { WebCore::Length {
-                    primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })
-                } };
+                return T {
+                    typename T::Calc {
+                        primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })
+                    }
+                };
             }
 
             ASSERT_NOT_REACHED();
@@ -76,55 +80,55 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
                 return convertLengthPercentage();
             case CSSValueIntrinsic:
                 if constexpr (T::SupportsIntrinsic)
-                    return T { WebCore::Length(LengthType::Intrinsic) };
+                    return CSS::Keyword::Intrinsic { };
                 else
                     break;
             case CSSValueMinIntrinsic:
                 if constexpr (T::SupportsMinIntrinsic)
-                    return T { WebCore::Length(LengthType::MinIntrinsic) };
+                    return CSS::Keyword::MinIntrinsic { };
                 else
                     break;
             case CSSValueMinContent:
             case CSSValueWebkitMinContent:
                 if constexpr (T::SupportsMinContent)
-                    return T { WebCore::Length(LengthType::MinContent) };
+                    return CSS::Keyword::MinContent { };
                 else
                     break;
             case CSSValueMaxContent:
             case CSSValueWebkitMaxContent:
                 if constexpr (T::SupportsMaxContent)
-                    return T { WebCore::Length(LengthType::MaxContent) };
+                    return CSS::Keyword::MaxContent { };
                 else
                     break;
             case CSSValueWebkitFillAvailable:
                 if constexpr (T::SupportsWebkitFillAvailable)
-                    return T { WebCore::Length(LengthType::FillAvailable) };
+                    return CSS::Keyword::WebkitFillAvailable { };
                 else
                     break;
             case CSSValueFitContent:
             case CSSValueWebkitFitContent:
                 if constexpr (T::SupportsFitContent)
-                    return T { WebCore::Length(LengthType::FitContent) };
+                    return CSS::Keyword::FitContent { };
                 else
                     break;
             case CSSValueAuto:
                 if constexpr (T::SupportsAuto)
-                    return T { WebCore::Length(LengthType::Auto) };
+                    return CSS::Keyword::Auto { };
                 else
                     break;
             case CSSValueContent:
                 if constexpr (T::SupportsContent)
-                    return T { WebCore::Length(LengthType::Content) };
+                    return CSS::Keyword::Content { };
                 else
                     break;
             case CSSValueNormal:
                 if constexpr (T::SupportsNormal)
-                    return T { WebCore::Length(LengthType::Normal) };
+                    return CSS::Keyword::Normal { };
                 else
                     break;
             case CSSValueNone:
                 if constexpr (T::SupportsNone)
-                    return T { WebCore::Length(LengthType::Undefined) };
+                    return CSS::Keyword::None { };
                 else
                     break;
             default:

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -25,19 +25,18 @@
 #pragma once
 
 #include "CSSPrimitiveKeywordList.h"
-#include "Length.h"
-#include "LengthFunctions.h"
+#include "StyleLengthWrapperData.h"
 #include "StylePrimitiveNumericTypes+Platform.h"
 #include "StylePrimitiveNumericTypes.h"
-#include "StyleValueTypes.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
-template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase;
+template<typename, CSS::PrimitiveKeyword...> struct LengthWrapperBase;
+template<typename> struct MinimumEvaluation;
 
-// Transitionary type acting as a `Style::PrimitiveNumericOrKeyword<...>` but implemented by wrapping a `WebCore::Length`.
+// Transitionary type acting as a `Style::PrimitiveNumericOrKeyword<...>` but implemented by wrapping a `LengthWrapperData`.
 template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase {
     using Base = LengthWrapperBase<Numeric, Ks...>;
     using Keywords = CSS::PrimitiveKeywordList<Ks...>;
@@ -58,52 +57,57 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     static constexpr bool SupportsContent = Keywords::isValidKeyword(CSS::Keyword::Content { });
     static constexpr bool SupportsNone = Keywords::isValidKeyword(CSS::Keyword::None { });
 
-    LengthWrapperBase(CSS::Keyword::Auto) requires (SupportsAuto) : m_value(WebCore::LengthType::Auto) { }
-    LengthWrapperBase(CSS::Keyword::Normal) requires (SupportsNormal) : m_value(WebCore::LengthType::Normal) { }
-    LengthWrapperBase(CSS::Keyword::Intrinsic) requires (SupportsIntrinsic) : m_value(WebCore::LengthType::Intrinsic) { }
-    LengthWrapperBase(CSS::Keyword::MinIntrinsic) requires (SupportsMinIntrinsic) : m_value(WebCore::LengthType::MinIntrinsic) { }
-    LengthWrapperBase(CSS::Keyword::MinContent) requires (SupportsMinContent) : m_value(WebCore::LengthType::MinContent) { }
-    LengthWrapperBase(CSS::Keyword::MaxContent) requires (SupportsMaxContent) : m_value(WebCore::LengthType::MaxContent) { }
-    LengthWrapperBase(CSS::Keyword::WebkitFillAvailable) requires (SupportsWebkitFillAvailable) : m_value(WebCore::LengthType::FillAvailable) { }
-    LengthWrapperBase(CSS::Keyword::FitContent) requires (SupportsFitContent) : m_value(WebCore::LengthType::FitContent) { }
-    LengthWrapperBase(CSS::Keyword::Content) requires (SupportsContent) : m_value(WebCore::LengthType::Content) { }
-    LengthWrapperBase(CSS::Keyword::None) requires (SupportsNone) : m_value(WebCore::LengthType::Undefined) { }
+    LengthWrapperBase(CSS::Keyword::Auto) requires (SupportsAuto) : m_value(LengthWrapperDataType::Auto) { }
+    LengthWrapperBase(CSS::Keyword::Normal) requires (SupportsNormal) : m_value(LengthWrapperDataType::Normal) { }
+    LengthWrapperBase(CSS::Keyword::Intrinsic) requires (SupportsIntrinsic) : m_value(LengthWrapperDataType::Intrinsic) { }
+    LengthWrapperBase(CSS::Keyword::MinIntrinsic) requires (SupportsMinIntrinsic) : m_value(LengthWrapperDataType::MinIntrinsic) { }
+    LengthWrapperBase(CSS::Keyword::MinContent) requires (SupportsMinContent) : m_value(LengthWrapperDataType::MinContent) { }
+    LengthWrapperBase(CSS::Keyword::MaxContent) requires (SupportsMaxContent) : m_value(LengthWrapperDataType::MaxContent) { }
+    LengthWrapperBase(CSS::Keyword::WebkitFillAvailable) requires (SupportsWebkitFillAvailable) : m_value(LengthWrapperDataType::FillAvailable) { }
+    LengthWrapperBase(CSS::Keyword::FitContent) requires (SupportsFitContent) : m_value(LengthWrapperDataType::FitContent) { }
+    LengthWrapperBase(CSS::Keyword::Content) requires (SupportsContent) : m_value(LengthWrapperDataType::Content) { }
+    LengthWrapperBase(CSS::Keyword::None) requires (SupportsNone) : m_value(LengthWrapperDataType::Undefined) { }
 
-    LengthWrapperBase(Fixed fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    LengthWrapperBase(Percentage percent) : m_value(percent.value, WebCore::LengthType::Percent) { }
-    LengthWrapperBase(Specified&& specified) : m_value(toPlatform(WTFMove(specified))) { }
-    LengthWrapperBase(const Specified& specified) : m_value(toPlatform(specified)) { }
+    LengthWrapperBase(Fixed fixed) : m_value(fixed.value, LengthWrapperDataType::Fixed) { }
+    LengthWrapperBase(Fixed fixed, bool hasQuirk) : m_value(fixed.value, LengthWrapperDataType::Fixed, hasQuirk) { }
+    LengthWrapperBase(Percentage percent) : m_value(percent.value, LengthWrapperDataType::Percent) { }
+    LengthWrapperBase(Calc&& calc) : m_value(calc.protectedCalculation()) { }
+    LengthWrapperBase(Specified&& specified) : m_value(toData(specified)) { }
+    LengthWrapperBase(const Specified& specified) : m_value(toData(specified)) { }
 
-    LengthWrapperBase(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-    LengthWrapperBase(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Percent) { }
+    LengthWrapperBase(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), LengthWrapperDataType::Fixed) { }
+    LengthWrapperBase(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), LengthWrapperDataType::Percent) { }
 
     explicit LengthWrapperBase(WebCore::Length&& other) : m_value(WTFMove(other)) { validate(m_value); }
     explicit LengthWrapperBase(const WebCore::Length& other) : m_value(other) { validate(m_value); }
 
+    explicit LengthWrapperBase(LengthWrapperData&& other) : m_value(WTFMove(other)) { validate(m_value); }
+    explicit LengthWrapperBase(const LengthWrapperData& other) : m_value(other) { validate(m_value); }
+
     explicit LengthWrapperBase(WTF::HashTableEmptyValueType token) : m_value(token) { }
 
     // IPC Support
-    explicit LengthWrapperBase(WebCore::Length::IPCData&& data) : m_value { WTFMove(data) } { validate(m_value); }
-    WebCore::Length::IPCData ipcData() const { return m_value.ipcData(); }
+    explicit LengthWrapperBase(LengthWrapperData::IPCData&& data) : m_value { WTFMove(data) } { validate(m_value); }
+    LengthWrapperData::IPCData ipcData() const { return m_value.ipcData(); }
 
-    ALWAYS_INLINE bool isFixed() const { return m_value.type() == WebCore::LengthType::Fixed; }
-    ALWAYS_INLINE bool isPercent() const { return m_value.type() == WebCore::LengthType::Percent; }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.type() == WebCore::LengthType::Calculated; }
+    ALWAYS_INLINE bool isFixed() const { return m_value.type() == LengthWrapperDataType::Fixed; }
+    ALWAYS_INLINE bool isPercent() const { return m_value.type() == LengthWrapperDataType::Percent; }
+    ALWAYS_INLINE bool isCalculated() const { return m_value.type() == LengthWrapperDataType::Calculated; }
     ALWAYS_INLINE bool isPercentOrCalculated() const { return isPercent() || isCalculated(); }
     ALWAYS_INLINE bool isSpecified() const { return isFixed() || isPercent() || isCalculated(); }
 
-    ALWAYS_INLINE bool isAuto() const requires (SupportsAuto) { return m_value.type() == WebCore::LengthType::Auto; }
-    ALWAYS_INLINE bool isNormal() const requires (SupportsNormal) { return m_value.type() == WebCore::LengthType::Normal; }
-    ALWAYS_INLINE bool isIntrinsicKeyword() const requires (SupportsIntrinsic) { return m_value.type() == WebCore::LengthType::Intrinsic; }
-    ALWAYS_INLINE bool isMinIntrinsic() const requires (SupportsMinIntrinsic) { return m_value.type() == WebCore::LengthType::MinIntrinsic; }
-    ALWAYS_INLINE bool isMinContent() const requires (SupportsMinContent) { return m_value.type() == WebCore::LengthType::MinContent; }
-    ALWAYS_INLINE bool isMaxContent() const requires (SupportsMaxContent) { return m_value.type() == WebCore::LengthType::MaxContent; }
-    ALWAYS_INLINE bool isFillAvailable() const requires (SupportsWebkitFillAvailable) { return m_value.type() == WebCore::LengthType::FillAvailable; }
-    ALWAYS_INLINE bool isFitContent() const requires (SupportsFitContent) { return m_value.type() == WebCore::LengthType::FitContent; }
-    ALWAYS_INLINE bool isContent() const requires (SupportsContent) { return m_value.type() == WebCore::LengthType::Content; }
-    ALWAYS_INLINE bool isNone() const requires (SupportsNone) { return m_value.type() == WebCore::LengthType::Undefined; }
+    ALWAYS_INLINE bool isAuto() const requires (SupportsAuto) { return m_value.type() == LengthWrapperDataType::Auto; }
+    ALWAYS_INLINE bool isNormal() const requires (SupportsNormal) { return m_value.type() == LengthWrapperDataType::Normal; }
+    ALWAYS_INLINE bool isIntrinsicKeyword() const requires (SupportsIntrinsic) { return m_value.type() == LengthWrapperDataType::Intrinsic; }
+    ALWAYS_INLINE bool isMinIntrinsic() const requires (SupportsMinIntrinsic) { return m_value.type() == LengthWrapperDataType::MinIntrinsic; }
+    ALWAYS_INLINE bool isMinContent() const requires (SupportsMinContent) { return m_value.type() == LengthWrapperDataType::MinContent; }
+    ALWAYS_INLINE bool isMaxContent() const requires (SupportsMaxContent) { return m_value.type() == LengthWrapperDataType::MaxContent; }
+    ALWAYS_INLINE bool isFillAvailable() const requires (SupportsWebkitFillAvailable) { return m_value.type() == LengthWrapperDataType::FillAvailable; }
+    ALWAYS_INLINE bool isFitContent() const requires (SupportsFitContent) { return m_value.type() == LengthWrapperDataType::FitContent; }
+    ALWAYS_INLINE bool isContent() const requires (SupportsContent) { return m_value.type() == LengthWrapperDataType::Content; }
+    ALWAYS_INLINE bool isNone() const requires (SupportsNone) { return m_value.type() == LengthWrapperDataType::Undefined; }
 
-    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthType::Intrinsic` but instead it checks `type = LengthType::MinContent || type == LengthType::MaxContent || type == LengthType::FillAvailable || type == LengthType::FitContent`.
+    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthWrapperDataType::Intrinsic` but instead it checks `type = LengthWrapperDataType::MinContent || type == LengthWrapperDataType::MaxContent || type == LengthWrapperDataType::FillAvailable || type == LengthWrapperDataType::FitContent`.
 
     static constexpr bool SupportsIsIntrinsic = SupportsMinContent || SupportsMaxContent || SupportsWebkitFillAvailable || SupportsFitContent;
     static constexpr bool SupportsIsLegacyIntrinsic = SupportsIntrinsic || SupportsMinIntrinsic;
@@ -111,27 +115,27 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     ALWAYS_INLINE bool isIntrinsic() const
         requires (SupportsIsIntrinsic)
     {
-        return (SupportsMinContent && m_value.type() == WebCore::LengthType::MinContent)
-            || (SupportsMaxContent && m_value.type() == WebCore::LengthType::MaxContent)
-            || (SupportsWebkitFillAvailable && m_value.type() == WebCore::LengthType::FillAvailable)
-            || (SupportsFitContent && m_value.type() == WebCore::LengthType::FitContent);
+        return (SupportsMinContent && m_value.type() == LengthWrapperDataType::MinContent)
+            || (SupportsMaxContent && m_value.type() == LengthWrapperDataType::MaxContent)
+            || (SupportsWebkitFillAvailable && m_value.type() == LengthWrapperDataType::FillAvailable)
+            || (SupportsFitContent && m_value.type() == LengthWrapperDataType::FitContent);
     }
     ALWAYS_INLINE bool isLegacyIntrinsic() const
         requires (SupportsIsLegacyIntrinsic)
     {
-        return (SupportsIntrinsic && m_value.type() == WebCore::LengthType::Intrinsic)
-            || (SupportsMinIntrinsic && m_value.type() == WebCore::LengthType::MinIntrinsic);
+        return (SupportsIntrinsic && m_value.type() == LengthWrapperDataType::Intrinsic)
+            || (SupportsMinIntrinsic && m_value.type() == LengthWrapperDataType::MinIntrinsic);
     }
     ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
         requires (SupportsIsIntrinsic || SupportsIsLegacyIntrinsic || SupportsAuto)
     {
-        return (SupportsMinContent && m_value.type() == WebCore::LengthType::MinContent)
-            || (SupportsMinContent && m_value.type() == WebCore::LengthType::MaxContent)
-            || (SupportsWebkitFillAvailable && m_value.type() == WebCore::LengthType::FillAvailable)
-            || (SupportsFitContent && m_value.type() == WebCore::LengthType::FitContent)
-            || (SupportsIntrinsic && m_value.type() == WebCore::LengthType::Intrinsic)
-            || (SupportsMinIntrinsic && m_value.type() == WebCore::LengthType::MinIntrinsic)
-            || (SupportsAuto && m_value.type() == WebCore::LengthType::Auto);
+        return (SupportsMinContent && m_value.type() == LengthWrapperDataType::MinContent)
+            || (SupportsMinContent && m_value.type() == LengthWrapperDataType::MaxContent)
+            || (SupportsWebkitFillAvailable && m_value.type() == LengthWrapperDataType::FillAvailable)
+            || (SupportsFitContent && m_value.type() == LengthWrapperDataType::FitContent)
+            || (SupportsIntrinsic && m_value.type() == LengthWrapperDataType::Intrinsic)
+            || (SupportsMinIntrinsic && m_value.type() == LengthWrapperDataType::MinIntrinsic)
+            || (SupportsAuto && m_value.type() == LengthWrapperDataType::Auto);
     }
 
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
@@ -164,20 +168,20 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
         switch (m_value.type()) {
-        case WebCore::LengthType::Fixed:            return visitor(Fixed { m_value.value() });
-        case WebCore::LengthType::Percent:          return visitor(Percentage { m_value.value() });
-        case WebCore::LengthType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case WebCore::LengthType::Auto:             if constexpr (SupportsAuto) { return visitor(CSS::Keyword::Auto { }); } else { break; }
-        case WebCore::LengthType::Intrinsic:        if constexpr (SupportsIntrinsic) { return visitor(CSS::Keyword::Intrinsic { }); } else { break; }
-        case WebCore::LengthType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return visitor(CSS::Keyword::MinIntrinsic { }); } else { break; }
-        case WebCore::LengthType::MinContent:       if constexpr (SupportsMinContent) { return visitor(CSS::Keyword::MinContent { }); } else { break; }
-        case WebCore::LengthType::MaxContent:       if constexpr (SupportsMaxContent) { return visitor(CSS::Keyword::MaxContent { }); } else { break; }
-        case WebCore::LengthType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return visitor(CSS::Keyword::WebkitFillAvailable { }); } else { break; }
-        case WebCore::LengthType::FitContent:       if constexpr (SupportsFitContent) { return visitor(CSS::Keyword::FitContent { }); } else { break; }
-        case WebCore::LengthType::Content:          if constexpr (SupportsContent) { return visitor(CSS::Keyword::Content { }); } else { break; }
-        case WebCore::LengthType::Normal:           if constexpr (SupportsNormal) { return visitor(CSS::Keyword::Normal { }); } else { break; }
-        case WebCore::LengthType::Undefined:        if constexpr (SupportsNone) { return visitor(CSS::Keyword::None { }); } else { break; }
-        case WebCore::LengthType::Relative:
+        case LengthWrapperDataType::Fixed:            return visitor(Fixed { m_value.value() });
+        case LengthWrapperDataType::Percent:          return visitor(Percentage { m_value.value() });
+        case LengthWrapperDataType::Calculated:       return visitor(Calc { m_value.calculationValue() });
+        case LengthWrapperDataType::Auto:             if constexpr (SupportsAuto) { return visitor(CSS::Keyword::Auto { }); } else { break; }
+        case LengthWrapperDataType::Intrinsic:        if constexpr (SupportsIntrinsic) { return visitor(CSS::Keyword::Intrinsic { }); } else { break; }
+        case LengthWrapperDataType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return visitor(CSS::Keyword::MinIntrinsic { }); } else { break; }
+        case LengthWrapperDataType::MinContent:       if constexpr (SupportsMinContent) { return visitor(CSS::Keyword::MinContent { }); } else { break; }
+        case LengthWrapperDataType::MaxContent:       if constexpr (SupportsMaxContent) { return visitor(CSS::Keyword::MaxContent { }); } else { break; }
+        case LengthWrapperDataType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return visitor(CSS::Keyword::WebkitFillAvailable { }); } else { break; }
+        case LengthWrapperDataType::FitContent:       if constexpr (SupportsFitContent) { return visitor(CSS::Keyword::FitContent { }); } else { break; }
+        case LengthWrapperDataType::Content:          if constexpr (SupportsContent) { return visitor(CSS::Keyword::Content { }); } else { break; }
+        case LengthWrapperDataType::Normal:           if constexpr (SupportsNormal) { return visitor(CSS::Keyword::Normal { }); } else { break; }
+        case LengthWrapperDataType::Undefined:        if constexpr (SupportsNone) { return visitor(CSS::Keyword::None { }); } else { break; }
+        case LengthWrapperDataType::Relative:
             break;
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -189,30 +193,48 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
 
 protected:
     template<typename> friend struct ToPlatform;
+    template<typename> friend struct Evaluation;
+    template<typename> friend struct MinimumEvaluation;
+    template<typename> friend struct Blending;
 
-    static void validate(const WebCore::Length& length)
+    static void validate(const LengthWrapperData& length)
     {
         switch (length.type()) {
-        case WebCore::LengthType::Fixed:            RELEASE_ASSERT(CSS::isWithinRange<Fixed::range>(length.value())); return;
-        case WebCore::LengthType::Percent:          RELEASE_ASSERT(CSS::isWithinRange<Percentage::range>(length.value())); return;
-        case WebCore::LengthType::Calculated:       return;
-        case WebCore::LengthType::Auto:             if constexpr (SupportsAuto) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::Intrinsic:        if constexpr (SupportsIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::MinContent:       if constexpr (SupportsMinContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::MaxContent:       if constexpr (SupportsMaxContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::FitContent:       if constexpr (SupportsFitContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::Content:          if constexpr (SupportsContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::Normal:           if constexpr (SupportsNormal) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::Undefined:        if constexpr (SupportsNone) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case WebCore::LengthType::Relative:
+        case LengthWrapperDataType::Fixed:            RELEASE_ASSERT(CSS::isWithinRange<Fixed::range>(length.value())); return;
+        case LengthWrapperDataType::Percent:          RELEASE_ASSERT(CSS::isWithinRange<Percentage::range>(length.value())); return;
+        case LengthWrapperDataType::Calculated:       return;
+        case LengthWrapperDataType::Auto:             if constexpr (SupportsAuto) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::Intrinsic:        if constexpr (SupportsIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::MinContent:       if constexpr (SupportsMinContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::MaxContent:       if constexpr (SupportsMaxContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::FitContent:       if constexpr (SupportsFitContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::Content:          if constexpr (SupportsContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::Normal:           if constexpr (SupportsNormal) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::Undefined:        if constexpr (SupportsNone) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
+        case LengthWrapperDataType::Relative:
             break;
         }
         RELEASE_ASSERT_NOT_REACHED();
     }
 
-    WebCore::Length m_value;
+    static LengthWrapperData toData(const Specified& specified)
+    {
+        return WTF::switchOn(specified,
+            [](const Fixed& fixed) {
+                return LengthWrapperData { fixed.value, LengthWrapperDataType::Fixed };
+            },
+            [](const Percentage& percentage) {
+                return LengthWrapperData { percentage.value, LengthWrapperDataType::Percent };
+            },
+            [](const Calc& calc) {
+                return LengthWrapperData { calc.protectedCalculation() };
+            }
+        );
+    }
+
+    LengthWrapperData m_value;
 };
 
 // MARK: - Concepts
@@ -224,7 +246,7 @@ template<typename T> concept LengthWrapperBaseDerived = WTF::IsBaseOfTemplate<Le
 template<LengthWrapperBaseDerived T> struct ToPlatform<T> {
     auto operator()(const T& value) -> WebCore::Length
     {
-        return value.m_value;
+        return value.m_value.toPlatform();
     }
 };
 
@@ -233,51 +255,58 @@ template<LengthWrapperBaseDerived T> struct ToPlatform<T> {
 template<LengthWrapperBaseDerived T> struct Evaluation<T> {
     auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor) -> LayoutUnit
     {
-        return valueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(toPlatform(value), lazyMaximumValueFunctor);
+        return valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, lazyMaximumValueFunctor);
     }
     auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor) -> float
     {
-        return valueForLengthWithLazyMaximum<float, float>(toPlatform(value), lazyMaximumValueFunctor);
+        return valueForLengthWrapperDataWithLazyMaximum<float, float>(value.m_value, lazyMaximumValueFunctor);
     }
-    auto operator()(const T& value, LayoutUnit referenceLength) -> LayoutUnit
+    auto operator()(const T& value, LayoutUnit maximumValue) -> LayoutUnit
     {
-        return valueForLength(toPlatform(value), referenceLength);
+        return valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
     }
-    auto operator()(const T& value, float referenceLength) -> float
+    auto operator()(const T& value, float maximumValue) -> float
     {
-        return floatValueForLength(toPlatform(value), referenceLength);
+        return valueForLengthWrapperDataWithLazyMaximum<float, float>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
     }
 };
 
-template<LengthWrapperBaseDerived T> inline LayoutUnit evaluateMinimum(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor)
+template<typename StyleType, typename Reference> decltype(auto) evaluateMinimum(const StyleType& value, NOESCAPE Reference&& reference)
 {
-    return minimumValueForLengthWithLazyMaximum<LayoutUnit, LayoutUnit>(toPlatform(value), lazyMaximumValueFunctor);
+    return MinimumEvaluation<StyleType>{}(value, std::forward<Reference>(reference));
 }
 
-template<LengthWrapperBaseDerived T> inline LayoutUnit evaluateMinimum(const T& value, LayoutUnit maximumValue)
-{
-    return minimumValueForLength(toPlatform(value), maximumValue);
-}
-
-template<LengthWrapperBaseDerived T> inline float evaluateMinimum(const T& value, float maximumValue)
-{
-    return minimumValueForLength(toPlatform(value), maximumValue);
-}
+template<LengthWrapperBaseDerived T> struct MinimumEvaluation<T> {
+    auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor) -> LayoutUnit
+    {
+        return minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, lazyMaximumValueFunctor);
+    }
+    auto operator()(const T& value, LayoutUnit maximumValue) -> LayoutUnit
+    {
+        return minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+    }
+    auto operator()(const T& value, float maximumValue) -> float
+    {
+        return minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); });
+    }
+};
 
 // MARK: - Blending
 
 template<LengthWrapperBaseDerived T> struct Blending<T> {
     auto canBlend(const T& a, const T& b) -> bool
     {
-        return WebCore::canInterpolateLengths(toPlatform(a), toPlatform(b), true);
+        if (a.hasSameType(b))
+            return true;
+        return a.isSpecified() && b.isSpecified();
     }
     auto requiresInterpolationForAccumulativeIteration(const T& a, const T& b) -> bool
     {
-        return WebCore::lengthsRequireInterpolationForAccumulativeIteration(toPlatform(a), toPlatform(b));
+        return a.isCalculated() || b.isCalculated() || !a.hasSameType(b);
     }
     auto blend(const T& a, const T& b, const BlendingContext& context) -> T
     {
-        return T { WebCore::blend(toPlatform(a), toPlatform(b), context, T::Fixed::range == CSS::Nonnegative ? ValueRange::NonNegative : ValueRange::All) };
+        return T { blendLengthWrapperData(a.m_value, b.m_value, context, T::Fixed::range == CSS::Nonnegative ? ValueRange::NonNegative : ValueRange::All) };
     }
 };
 
@@ -285,7 +314,8 @@ template<LengthWrapperBaseDerived T> struct Blending<T> {
 
 template<LengthWrapperBaseDerived T> WTF::TextStream& operator<<(WTF::TextStream& ts, const T& value)
 {
-    return ts << toPlatform(value);
+    WTF::switchOn(value, [&](const auto& alternative) { ts << alternative; });
+    return ts;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleLengthWrapperData.h"
+
+#include "AnimationUtilities.h"
+#include "CalculationCategory.h"
+#include "CalculationTree.h"
+#include "CalculationValue.h"
+#include "CalculationValueMap.h"
+#include <wtf/ASCIICType.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/StringView.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+namespace Style {
+
+LengthWrapperData::LengthWrapperData(Ref<CalculationValue>&& value)
+    : m_type(LengthWrapperDataType::Calculated)
+{
+    m_calculationValueHandle = CalculationValueMap::calculationValues().insert(WTFMove(value));
+}
+
+CalculationValue& LengthWrapperData::calculationValue() const
+{
+    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    return CalculationValueMap::calculationValues().get(m_calculationValueHandle);
+}
+
+Ref<CalculationValue> LengthWrapperData::protectedCalculationValue() const
+{
+    return calculationValue();
+}
+
+void LengthWrapperData::ref() const
+{
+    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    CalculationValueMap::calculationValues().ref(m_calculationValueHandle);
+}
+
+void LengthWrapperData::deref() const
+{
+    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    CalculationValueMap::calculationValues().deref(m_calculationValueHandle);
+}
+
+LengthWrapperData::LengthWrapperData(const WebCore::Length& length)
+{
+    switch (length.type()) {
+    case WebCore::LengthType::Fixed:
+        m_type = LengthWrapperDataType::Fixed;
+        m_isFloat = length.isFloat();
+        if (m_isFloat)
+            m_floatValue = length.value();
+        else
+            m_intValue = length.intValue();
+        return;
+    case WebCore::LengthType::Percent:
+        m_type = LengthWrapperDataType::Percent;
+        m_isFloat = length.isFloat();
+        if (m_isFloat)
+            m_floatValue = length.value();
+        else
+            m_intValue = length.intValue();
+        return;
+    case WebCore::LengthType::Relative:
+        m_type = LengthWrapperDataType::Relative;
+        m_isFloat = length.isFloat();
+        if (m_isFloat)
+            m_floatValue = length.value();
+        else
+            m_intValue = length.intValue();
+        return;
+    case WebCore::LengthType::Calculated:
+        m_type = LengthWrapperDataType::Calculated;
+        m_calculationValueHandle = CalculationValueMap::calculationValues().insert(length.protectedCalculationValue());
+        return;
+    case WebCore::LengthType::Auto:
+        m_type = LengthWrapperDataType::Auto;
+        return;
+    case WebCore::LengthType::Content:
+        m_type = LengthWrapperDataType::Content;
+        return;
+    case WebCore::LengthType::FillAvailable:
+        m_type = LengthWrapperDataType::FillAvailable;
+        return;
+    case WebCore::LengthType::FitContent:
+        m_type = LengthWrapperDataType::FitContent;
+        return;
+    case WebCore::LengthType::Intrinsic:
+        m_type = LengthWrapperDataType::Intrinsic;
+        return;
+    case WebCore::LengthType::MinIntrinsic:
+        m_type = LengthWrapperDataType::MinIntrinsic;
+        return;
+    case WebCore::LengthType::MinContent:
+        m_type = LengthWrapperDataType::MinContent;
+        return;
+    case WebCore::LengthType::MaxContent:
+        m_type = LengthWrapperDataType::MaxContent;
+        return;
+    case WebCore::LengthType::Normal:
+        m_type = LengthWrapperDataType::Normal;
+        return;
+    case WebCore::LengthType::Undefined:
+        m_type = LengthWrapperDataType::Undefined;
+        return;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+LengthWrapperData::LengthWrapperData(WebCore::Length&& length)
+{
+    switch (length.type()) {
+    case WebCore::LengthType::Fixed:
+        m_type = LengthWrapperDataType::Fixed;
+        m_isFloat = length.isFloat();
+        if (m_isFloat)
+            m_floatValue = length.value();
+        else
+            m_intValue = length.intValue();
+        return;
+    case WebCore::LengthType::Percent:
+        m_type = LengthWrapperDataType::Percent;
+        m_isFloat = length.isFloat();
+        if (m_isFloat)
+            m_floatValue = length.value();
+        else
+            m_intValue = length.intValue();
+        return;
+    case WebCore::LengthType::Relative:
+        m_type = LengthWrapperDataType::Relative;
+        m_isFloat = length.isFloat();
+        if (m_isFloat)
+            m_floatValue = length.value();
+        else
+            m_intValue = length.intValue();
+        return;
+    case WebCore::LengthType::Calculated:
+        m_type = LengthWrapperDataType::Calculated;
+        m_calculationValueHandle = CalculationValueMap::calculationValues().insert(length.protectedCalculationValue());
+        return;
+    case WebCore::LengthType::Auto:
+        m_type = LengthWrapperDataType::Auto;
+        return;
+    case WebCore::LengthType::Content:
+        m_type = LengthWrapperDataType::Content;
+        return;
+    case WebCore::LengthType::FillAvailable:
+        m_type = LengthWrapperDataType::FillAvailable;
+        return;
+    case WebCore::LengthType::FitContent:
+        m_type = LengthWrapperDataType::FitContent;
+        return;
+    case WebCore::LengthType::Intrinsic:
+        m_type = LengthWrapperDataType::Intrinsic;
+        return;
+    case WebCore::LengthType::MinIntrinsic:
+        m_type = LengthWrapperDataType::MinIntrinsic;
+        return;
+    case WebCore::LengthType::MinContent:
+        m_type = LengthWrapperDataType::MinContent;
+        return;
+    case WebCore::LengthType::MaxContent:
+        m_type = LengthWrapperDataType::MaxContent;
+        return;
+    case WebCore::LengthType::Normal:
+        m_type = LengthWrapperDataType::Normal;
+        return;
+    case WebCore::LengthType::Undefined:
+        m_type = LengthWrapperDataType::Undefined;
+        return;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+WebCore::Length LengthWrapperData::toPlatform() const
+{
+    switch (type()) {
+    case LengthWrapperDataType::Fixed:
+        return m_isFloat
+            ? WebCore::Length(m_floatValue, WebCore::LengthType::Fixed, m_hasQuirk)
+            : WebCore::Length(m_intValue, WebCore::LengthType::Fixed, m_hasQuirk);
+    case LengthWrapperDataType::Percent:
+        return m_isFloat
+            ? WebCore::Length(m_floatValue, WebCore::LengthType::Percent)
+            : WebCore::Length(m_intValue, WebCore::LengthType::Percent);
+    case LengthWrapperDataType::Relative:
+        return m_isFloat
+            ? WebCore::Length(m_floatValue, WebCore::LengthType::Relative)
+            : WebCore::Length(m_intValue, WebCore::LengthType::Relative);
+    case LengthWrapperDataType::Calculated:
+        return WebCore::Length(protectedCalculationValue());
+    case LengthWrapperDataType::FillAvailable:
+        return WebCore::Length(WebCore::LengthType::FillAvailable);
+    case LengthWrapperDataType::Auto:
+        return WebCore::Length(WebCore::LengthType::Auto);
+    case LengthWrapperDataType::Normal:
+        return WebCore::Length(WebCore::LengthType::Normal);
+    case LengthWrapperDataType::Content:
+        return WebCore::Length(WebCore::LengthType::Content);
+    case LengthWrapperDataType::Intrinsic:
+        return WebCore::Length(WebCore::LengthType::Intrinsic);
+    case LengthWrapperDataType::MinIntrinsic:
+        return WebCore::Length(WebCore::LengthType::MinIntrinsic);
+    case LengthWrapperDataType::MinContent:
+        return WebCore::Length(WebCore::LengthType::MinContent);
+    case LengthWrapperDataType::MaxContent:
+        return WebCore::Length(WebCore::LengthType::MaxContent);
+    case LengthWrapperDataType::FitContent:
+        return WebCore::Length(WebCore::LengthType::FitContent);
+    case LengthWrapperDataType::Undefined:
+        return WebCore::Length(WebCore::LengthType::Undefined);
+    }
+    ASSERT_NOT_REACHED();
+    return WebCore::Length();
+}
+
+LengthWrapperDataType LengthWrapperData::typeFromIndex(const IPCData& data)
+{
+    static_assert(WTF::VariantSizeV<IPCData> == 13);
+    switch (data.index()) {
+    case WTF::alternativeIndexV<AutoData, IPCData>:
+        return LengthWrapperDataType::Auto;
+    case WTF::alternativeIndexV<NormalData, IPCData>:
+        return LengthWrapperDataType::Normal;
+    case WTF::alternativeIndexV<RelativeData, IPCData>:
+        return LengthWrapperDataType::Relative;
+    case WTF::alternativeIndexV<PercentData, IPCData>:
+        return LengthWrapperDataType::Percent;
+    case WTF::alternativeIndexV<FixedData, IPCData>:
+        return LengthWrapperDataType::Fixed;
+    case WTF::alternativeIndexV<IntrinsicData, IPCData>:
+        return LengthWrapperDataType::Intrinsic;
+    case WTF::alternativeIndexV<MinIntrinsicData, IPCData>:
+        return LengthWrapperDataType::MinIntrinsic;
+    case WTF::alternativeIndexV<MinContentData, IPCData>:
+        return LengthWrapperDataType::MinContent;
+    case WTF::alternativeIndexV<MaxContentData, IPCData>:
+        return LengthWrapperDataType::MaxContent;
+    case WTF::alternativeIndexV<FillAvailableData, IPCData>:
+        return LengthWrapperDataType::FillAvailable;
+    case WTF::alternativeIndexV<FitContentData, IPCData>:
+        return LengthWrapperDataType::FitContent;
+    case WTF::alternativeIndexV<ContentData, IPCData>:
+        return LengthWrapperDataType::Content;
+    case WTF::alternativeIndexV<UndefinedData, IPCData>:
+        return LengthWrapperDataType::Undefined;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+LengthWrapperData::LengthWrapperData(IPCData&& data)
+    : m_type(typeFromIndex(data))
+{
+    WTF::switchOn(data,
+        [&](const FixedData& data) {
+            WTF::switchOn(data.value,
+                [&](float value) {
+                    m_isFloat = true;
+                    m_floatValue = value;
+                },
+                [&](int value) {
+                    m_isFloat = false;
+                    m_intValue = value;
+                }
+            );
+            m_hasQuirk = data.hasQuirk;
+        },
+        [&](const RelativeData& data) {
+            WTF::switchOn(data.value,
+                [&](float value) {
+                    m_isFloat = true;
+                    m_floatValue = value;
+                },
+                [&](int value) {
+                    m_isFloat = false;
+                    m_intValue = value;
+                }
+            );
+        },
+        [&](const PercentData& data) {
+            WTF::switchOn(data.value,
+                [&](float value) {
+                    m_isFloat = true;
+                    m_floatValue = value;
+                },
+                [&](int value) {
+                    m_isFloat = false;
+                    m_intValue = value;
+                }
+            );
+        },
+        []<typename EmptyData>(EmptyData) requires std::is_empty_v<EmptyData> { }
+    );
+}
+
+auto LengthWrapperData::ipcData() const -> IPCData
+{
+    switch (m_type) {
+    case LengthWrapperDataType::Auto:
+        return AutoData { };
+    case LengthWrapperDataType::Normal:
+        return NormalData { };
+    case LengthWrapperDataType::Relative:
+        return RelativeData { floatOrInt() };
+    case LengthWrapperDataType::Percent:
+        return PercentData { floatOrInt() };
+    case LengthWrapperDataType::Fixed:
+        return FixedData { floatOrInt(), m_hasQuirk };
+    case LengthWrapperDataType::Intrinsic:
+        return IntrinsicData { };
+    case LengthWrapperDataType::MinIntrinsic:
+        return MinIntrinsicData { };
+    case LengthWrapperDataType::MinContent:
+        return MinContentData { };
+    case LengthWrapperDataType::MaxContent:
+        return MaxContentData { };
+    case LengthWrapperDataType::FillAvailable:
+        return FillAvailableData { };
+    case LengthWrapperDataType::FitContent:
+        return FitContentData { };
+    case LengthWrapperDataType::Content:
+        return ContentData { };
+    case LengthWrapperDataType::Undefined:
+        return UndefinedData { };
+    case LengthWrapperDataType::Calculated:
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+auto LengthWrapperData::floatOrInt() const -> FloatOrInt
+{
+    ASSERT(m_type != LengthWrapperDataType::Calculated);
+    if (m_isFloat)
+        return m_floatValue;
+    return m_intValue;
+}
+
+float LengthWrapperData::nonNanCalculatedValue(float maxValue) const
+{
+    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    float result = protectedCalculationValue()->evaluate(maxValue);
+    if (std::isnan(result))
+        return 0;
+    return result;
+}
+
+bool LengthWrapperData::isCalculatedEqual(const LengthWrapperData& other) const
+{
+    return calculationValue() == other.calculationValue();
+}
+
+static Calculation::Child lengthCalculation(const LengthWrapperData& length)
+{
+    if (length.type() == LengthWrapperDataType::Percent)
+        return Calculation::percentage(length.value());
+
+    if (length.type() == LengthWrapperDataType::Calculated)
+        return length.calculationValue().copyRoot();
+
+    ASSERT(length.type() == LengthWrapperDataType::Fixed);
+    return Calculation::dimension(length.value());
+}
+
+static LengthWrapperData makeLengthWrapperData(Calculation::Child&& root)
+{
+    // FIXME: Value range should be passed in.
+
+    // NOTE: category is always `LengthPercentage` as late resolved `LengthWrapperData` values defined by percentages is the only reason calculation value is needed by `LengthWrapperData`.
+    return LengthWrapperData(CalculationValue::create(Calculation::Category::LengthPercentage, Calculation::All, Calculation::Tree { WTFMove(root) }));
+}
+
+static LengthWrapperData blendLengthWrapperDataMixedTypes(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext& context)
+{
+    if (context.compositeOperation != CompositeOperation::Replace)
+        return makeLengthWrapperData(Calculation::add(lengthCalculation(from), lengthCalculation(to)));
+
+    if ((from.type() != LengthWrapperDataType::Fixed
+                && from.type() != LengthWrapperDataType::Percent
+                && from.type() != LengthWrapperDataType::Calculated
+                && from.type() != LengthWrapperDataType::Relative)
+        || (to.type() != LengthWrapperDataType::Fixed
+                && to.type() != LengthWrapperDataType::Percent
+                && to.type() != LengthWrapperDataType::Calculated
+                && to.type() != LengthWrapperDataType::Relative)) {
+        ASSERT(context.isDiscrete);
+        ASSERT(!context.progress || context.progress == 1);
+        return context.progress ? to : from;
+    }
+
+    if (from.type() == LengthWrapperDataType::Relative || to.type() == LengthWrapperDataType::Relative)
+        return { 0, LengthWrapperDataType::Fixed };
+
+    if (to.type() != LengthWrapperDataType::Calculated && from.type() != LengthWrapperDataType::Percent && (context.progress == 1 || from.isZero()))
+        return blendLengthWrapperData(LengthWrapperData(0, to.type()), to, context);
+
+    if (from.type() != LengthWrapperDataType::Calculated && to.type() != LengthWrapperDataType::Percent && (!context.progress || to.isZero()))
+        return blendLengthWrapperData(from, LengthWrapperData(0, from.type()), context);
+
+    return makeLengthWrapperData(Calculation::blend(lengthCalculation(from), lengthCalculation(to), context.progress));
+}
+
+LengthWrapperData blendLengthWrapperData(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext& context)
+{
+    if (from.type() == LengthWrapperDataType::Auto || to.type() == LengthWrapperDataType::Auto || from.type() == LengthWrapperDataType::Undefined || to.type() == LengthWrapperDataType::Undefined || from.type() == LengthWrapperDataType::Normal || to.type() == LengthWrapperDataType::Normal)
+        return context.progress < 0.5 ? from : to;
+
+    if (from.type() == LengthWrapperDataType::Calculated || to.type() == LengthWrapperDataType::Calculated || (from.type() != to.type()))
+        return blendLengthWrapperDataMixedTypes(from, to, context);
+
+    if (!context.progress && context.isReplace())
+        return from;
+
+    if (context.progress == 1 && context.isReplace())
+        return to;
+
+    auto resultType = to.type();
+    if (to.isZero())
+        resultType = from.type();
+
+    if (resultType == LengthWrapperDataType::Percent) {
+        float fromPercent = from.isZero() ? 0 : from.value();
+        float toPercent = to.isZero() ? 0 : to.value();
+        return LengthWrapperData(WebCore::blend(fromPercent, toPercent, context), LengthWrapperDataType::Percent);
+    }
+
+    float fromValue = from.isZero() ? 0 : from.value();
+    float toValue = to.isZero() ? 0 : to.value();
+    return LengthWrapperData(WebCore::blend(fromValue, toValue, context), resultType);
+}
+
+LengthWrapperData blendLengthWrapperData(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext& context, ValueRange valueRange)
+{
+    auto blended = blendLengthWrapperData(from, to, context);
+    if (valueRange == ValueRange::NonNegative && blended.isNegative()) {
+        auto type = from.isZero() ? to.type() : from.type();
+        if (type != LengthWrapperDataType::Calculated)
+            return { 0, type };
+        return { 0, LengthWrapperDataType::Fixed };
+    }
+    return blended;
+}
+
+static TextStream& operator<<(TextStream& ts, LengthWrapperDataType type)
+{
+    switch (type) {
+    case LengthWrapperDataType::Auto: ts << "auto"_s; break;
+    case LengthWrapperDataType::Calculated: ts << "calc"_s; break;
+    case LengthWrapperDataType::Content: ts << "content"_s; break;
+    case LengthWrapperDataType::FillAvailable: ts << "fill-available"_s; break;
+    case LengthWrapperDataType::FitContent: ts << "fit-content"_s; break;
+    case LengthWrapperDataType::Fixed: ts << "fixed"_s; break;
+    case LengthWrapperDataType::Intrinsic: ts << "intrinsic"_s; break;
+    case LengthWrapperDataType::MinIntrinsic: ts << "min-intrinsic"_s; break;
+    case LengthWrapperDataType::MinContent: ts << "min-content"_s; break;
+    case LengthWrapperDataType::MaxContent: ts << "max-content"_s; break;
+    case LengthWrapperDataType::Normal: ts << "normal"_s; break;
+    case LengthWrapperDataType::Percent: ts << "percent"_s; break;
+    case LengthWrapperDataType::Relative: ts << "relative"_s; break;
+    case LengthWrapperDataType::Undefined: ts << "undefined"_s; break;
+    }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const LengthWrapperData& length)
+{
+    switch (length.type()) {
+    case LengthWrapperDataType::Auto:
+    case LengthWrapperDataType::Content:
+    case LengthWrapperDataType::Normal:
+    case LengthWrapperDataType::Undefined:
+        ts << length.type();
+        break;
+    case LengthWrapperDataType::Fixed:
+        ts << TextStream::FormatNumberRespectingIntegers(length.value()) << "px"_s;
+        break;
+    case LengthWrapperDataType::Relative:
+    case LengthWrapperDataType::Intrinsic:
+    case LengthWrapperDataType::MinIntrinsic:
+    case LengthWrapperDataType::MinContent:
+    case LengthWrapperDataType::MaxContent:
+    case LengthWrapperDataType::FillAvailable:
+    case LengthWrapperDataType::FitContent:
+        ts << length.type() << ' ' << TextStream::FormatNumberRespectingIntegers(length.value());
+        break;
+    case LengthWrapperDataType::Percent:
+        ts << TextStream::FormatNumberRespectingIntegers(length.value()) << '%';
+        break;
+    case LengthWrapperDataType::Calculated:
+        ts << length.protectedCalculationValue();
+        break;
+    }
+
+    if (length.hasQuirk())
+        ts << " has-quirk"_s;
+
+    return ts;
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -1,0 +1,449 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Length.h"
+
+namespace WebCore {
+namespace Style {
+
+// Currently this is a copy of `WebCore::Length`. It is in the process of being refactored to be more general.
+
+enum class LengthWrapperDataType : uint8_t {
+    Auto,
+    Normal,
+    Relative,
+    Percent,
+    Fixed,
+    Intrinsic,
+    MinIntrinsic,
+    MinContent,
+    MaxContent,
+    FillAvailable,
+    FitContent,
+    Calculated,
+    Content,
+    Undefined
+};
+
+struct LengthWrapperData {
+    LengthWrapperData(LengthWrapperDataType = LengthWrapperDataType::Auto);
+
+    using FloatOrInt = Variant<float, int>;
+    struct AutoData { };
+    struct NormalData { };
+    struct FixedData {
+        FloatOrInt value;
+        bool hasQuirk;
+    };
+    struct RelativeData {
+        FloatOrInt value;
+    };
+    struct PercentData {
+        FloatOrInt value;
+    };
+    struct IntrinsicData { };
+    struct MinIntrinsicData { };
+    struct MinContentData { };
+    struct MaxContentData { };
+    struct FillAvailableData { };
+    struct FitContentData { };
+    struct ContentData { };
+    struct UndefinedData { };
+    using IPCData = Variant<
+        AutoData,
+        NormalData,
+        RelativeData,
+        PercentData,
+        FixedData,
+        IntrinsicData,
+        MinIntrinsicData,
+        MinContentData,
+        MaxContentData,
+        FillAvailableData,
+        FitContentData,
+        ContentData,
+        UndefinedData
+        // LengthWrapperDataType::Calculated is intentionally not serialized.
+    >;
+
+    WEBCORE_EXPORT LengthWrapperData(IPCData&&);
+    LengthWrapperData(int value, LengthWrapperDataType, bool hasQuirk = false);
+    LengthWrapperData(LayoutUnit value, LengthWrapperDataType, bool hasQuirk = false);
+    LengthWrapperData(float value, LengthWrapperDataType, bool hasQuirk = false);
+    LengthWrapperData(double value, LengthWrapperDataType, bool hasQuirk = false);
+    WEBCORE_EXPORT explicit LengthWrapperData(Ref<CalculationValue>&&);
+    explicit LengthWrapperData(WTF::HashTableEmptyValueType);
+
+    LengthWrapperData(const LengthWrapperData&);
+    LengthWrapperData(LengthWrapperData&&);
+    LengthWrapperData& operator=(const LengthWrapperData&);
+    LengthWrapperData& operator=(LengthWrapperData&&);
+
+    ~LengthWrapperData();
+
+    bool operator==(const LengthWrapperData&) const;
+
+    LengthWrapperDataType type() const;
+
+    float value() const;
+    int intValue() const;
+    CalculationValue& calculationValue() const;
+    Ref<CalculationValue> protectedCalculationValue() const;
+
+    struct Fixed { float value; };
+    std::optional<Fixed> tryFixed() const { return m_type == LengthWrapperDataType::Fixed ? std::make_optional(Fixed { value() }) : std::nullopt; }
+
+    struct Percentage { float value; };
+    std::optional<Percentage> tryPercentage() const { return m_type == LengthWrapperDataType::Percent ? std::make_optional(Percentage { value() }) : std::nullopt; }
+
+    explicit LengthWrapperData(const WebCore::Length&);
+    explicit LengthWrapperData(WebCore::Length&&);
+    WebCore::Length toPlatform() const;
+
+    WEBCORE_EXPORT IPCData ipcData() const;
+
+    bool isEmptyValue() const { return m_isEmptyValue; }
+
+    bool hasQuirk() const;
+
+    bool isZero() const;
+    bool isPositive() const;
+    bool isNegative() const;
+
+    WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
+
+private:
+    static LengthWrapperData createEmptyValue()
+    {
+        auto result = LengthWrapperData(LengthWrapperDataType::Undefined);
+        result.m_isEmptyValue = true;
+        return result;
+    }
+
+    bool isCalculatedEqual(const LengthWrapperData&) const;
+
+    void initialize(const LengthWrapperData&);
+    void initialize(LengthWrapperData&&);
+
+    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void deref() const;
+    FloatOrInt floatOrInt() const;
+    static LengthWrapperDataType typeFromIndex(const IPCData&);
+
+    union {
+        int m_intValue { 0 };
+        float m_floatValue;
+        unsigned m_calculationValueHandle;
+    };
+    LengthWrapperDataType m_type;
+    bool m_hasQuirk { false };
+    bool m_isFloat { false };
+    bool m_isEmptyValue { false };
+};
+
+inline LengthWrapperData::LengthWrapperData(LengthWrapperDataType type)
+    : m_type(type)
+{
+    ASSERT(type != LengthWrapperDataType::Calculated);
+}
+
+inline LengthWrapperData::LengthWrapperData(int value, LengthWrapperDataType type, bool hasQuirk)
+    : m_intValue(value)
+    , m_type(type)
+    , m_hasQuirk(hasQuirk)
+{
+    ASSERT(type != LengthWrapperDataType::Calculated);
+}
+
+inline LengthWrapperData::LengthWrapperData(LayoutUnit value, LengthWrapperDataType type, bool hasQuirk)
+    : m_floatValue(value.toFloat())
+    , m_type(type)
+    , m_hasQuirk(hasQuirk)
+    , m_isFloat(true)
+{
+    ASSERT(type != LengthWrapperDataType::Calculated);
+}
+
+inline LengthWrapperData::LengthWrapperData(float value, LengthWrapperDataType type, bool hasQuirk)
+    : m_floatValue(value)
+    , m_type(type)
+    , m_hasQuirk(hasQuirk)
+    , m_isFloat(true)
+{
+    ASSERT(type != LengthWrapperDataType::Calculated);
+}
+
+inline LengthWrapperData::LengthWrapperData(double value, LengthWrapperDataType type, bool hasQuirk)
+    : m_floatValue(static_cast<float>(value))
+    , m_type(type)
+    , m_hasQuirk(hasQuirk)
+    , m_isFloat(true)
+{
+    ASSERT(type != LengthWrapperDataType::Calculated);
+}
+
+inline LengthWrapperData::LengthWrapperData(WTF::HashTableEmptyValueType)
+    : m_type(LengthWrapperDataType::Undefined)
+    , m_isEmptyValue(true)
+{
+}
+
+inline LengthWrapperData::LengthWrapperData(const LengthWrapperData& other)
+{
+    initialize(other);
+}
+
+inline LengthWrapperData::LengthWrapperData(LengthWrapperData&& other)
+{
+    initialize(WTFMove(other));
+}
+
+inline LengthWrapperData& LengthWrapperData::operator=(const LengthWrapperData& other)
+{
+    if (this == &other)
+        return *this;
+
+    if (m_type == LengthWrapperDataType::Calculated)
+        deref();
+
+    initialize(other);
+    return *this;
+}
+
+inline LengthWrapperData& LengthWrapperData::operator=(LengthWrapperData&& other)
+{
+    if (this == &other)
+        return *this;
+
+    if (m_type == LengthWrapperDataType::Calculated)
+        deref();
+
+    initialize(WTFMove(other));
+    return *this;
+}
+
+inline void LengthWrapperData::initialize(const LengthWrapperData& other)
+{
+    m_type = other.m_type;
+    m_hasQuirk = other.m_hasQuirk;
+    m_isEmptyValue = other.m_isEmptyValue;
+
+    switch (m_type) {
+    case LengthWrapperDataType::Auto:
+    case LengthWrapperDataType::Normal:
+    case LengthWrapperDataType::Content:
+    case LengthWrapperDataType::Undefined:
+        m_intValue = 0;
+        break;
+    case LengthWrapperDataType::Fixed:
+    case LengthWrapperDataType::Relative:
+    case LengthWrapperDataType::Intrinsic:
+    case LengthWrapperDataType::MinIntrinsic:
+    case LengthWrapperDataType::MinContent:
+    case LengthWrapperDataType::MaxContent:
+    case LengthWrapperDataType::FillAvailable:
+    case LengthWrapperDataType::FitContent:
+    case LengthWrapperDataType::Percent:
+        m_isFloat = other.m_isFloat;
+        if (m_isFloat)
+            m_floatValue = other.m_floatValue;
+        else
+            m_intValue = other.m_intValue;
+        break;
+    case LengthWrapperDataType::Calculated:
+        m_calculationValueHandle = other.m_calculationValueHandle;
+        ref();
+        break;
+    }
+}
+
+inline void LengthWrapperData::initialize(LengthWrapperData&& other)
+{
+    m_type = other.m_type;
+    m_hasQuirk = other.m_hasQuirk;
+    m_isEmptyValue = other.m_isEmptyValue;
+
+    switch (m_type) {
+    case LengthWrapperDataType::Auto:
+    case LengthWrapperDataType::Normal:
+    case LengthWrapperDataType::Content:
+    case LengthWrapperDataType::Undefined:
+        m_intValue = 0;
+        break;
+    case LengthWrapperDataType::Fixed:
+    case LengthWrapperDataType::Relative:
+    case LengthWrapperDataType::Intrinsic:
+    case LengthWrapperDataType::MinIntrinsic:
+    case LengthWrapperDataType::MinContent:
+    case LengthWrapperDataType::MaxContent:
+    case LengthWrapperDataType::FillAvailable:
+    case LengthWrapperDataType::FitContent:
+    case LengthWrapperDataType::Percent:
+        m_isFloat = other.m_isFloat;
+        if (m_isFloat)
+            m_floatValue = other.m_floatValue;
+        else
+            m_intValue = other.m_intValue;
+        break;
+    case LengthWrapperDataType::Calculated:
+        m_calculationValueHandle = std::exchange(other.m_calculationValueHandle, 0);
+        break;
+    }
+
+    other.m_type = LengthWrapperDataType::Auto;
+}
+
+inline LengthWrapperData::~LengthWrapperData()
+{
+    if (m_type == LengthWrapperDataType::Calculated)
+        deref();
+}
+
+inline bool LengthWrapperData::operator==(const LengthWrapperData& other) const
+{
+    // FIXME: This might be too long to be inline.
+    if (type() != other.type() || hasQuirk() != other.hasQuirk())
+        return false;
+    if (isEmptyValue() || other.isEmptyValue())
+        return isEmptyValue() && other.isEmptyValue();
+    if (m_type == LengthWrapperDataType::Undefined)
+        return true;
+    if (m_type == LengthWrapperDataType::Calculated)
+        return isCalculatedEqual(other);
+    return value() == other.value();
+}
+
+inline float LengthWrapperData::value() const
+{
+    ASSERT(!isEmptyValue());
+    return m_isFloat ? m_floatValue : m_intValue;
+}
+
+inline int LengthWrapperData::intValue() const
+{
+    // FIXME: Makes no sense to return 0 here but not in the value() function above.
+    if (m_type == LengthWrapperDataType::Calculated)
+        return 0;
+    return m_isFloat ? static_cast<int>(m_floatValue) : m_intValue;
+}
+
+inline LengthWrapperDataType LengthWrapperData::type() const
+{
+    return static_cast<LengthWrapperDataType>(m_type);
+}
+
+inline bool LengthWrapperData::hasQuirk() const
+{
+    return m_hasQuirk;
+}
+
+inline bool LengthWrapperData::isPositive() const
+{
+    ASSERT(!isEmptyValue());
+    if (m_type == LengthWrapperDataType::Calculated)
+        return true;
+    return m_isFloat ? (m_floatValue > 0) : (m_intValue > 0);
+}
+
+inline bool LengthWrapperData::isNegative() const
+{
+    ASSERT(!isEmptyValue());
+    if (m_type == LengthWrapperDataType::Calculated)
+        return false;
+    return m_isFloat ? (m_floatValue < 0) : (m_intValue < 0);
+}
+
+inline bool LengthWrapperData::isZero() const
+{
+    ASSERT(!isEmptyValue());
+    if (m_type == LengthWrapperDataType::Calculated)
+        return false;
+    return m_isFloat ? !m_floatValue : !m_intValue;
+}
+
+LengthWrapperData blendLengthWrapperData(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext&);
+LengthWrapperData blendLengthWrapperData(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext&, ValueRange);
+
+WTF::TextStream& operator<<(WTF::TextStream&, const LengthWrapperData&);
+
+template<typename ReturnType, typename MaximumType>
+ReturnType minimumValueForLengthWrapperDataWithLazyMaximum(const LengthWrapperData& length, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor)
+{
+    switch (length.type()) {
+    case LengthWrapperDataType::Fixed:
+        return ReturnType(length.value());
+    case LengthWrapperDataType::Percent:
+        return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * length.value() / 100.0f));
+    case LengthWrapperDataType::Calculated:
+        return ReturnType(length.nonNanCalculatedValue(lazyMaximumValueFunctor()));
+    case LengthWrapperDataType::FillAvailable:
+    case LengthWrapperDataType::Auto:
+    case LengthWrapperDataType::Normal:
+    case LengthWrapperDataType::Content:
+        return ReturnType(0);
+    case LengthWrapperDataType::Relative:
+    case LengthWrapperDataType::Intrinsic:
+    case LengthWrapperDataType::MinIntrinsic:
+    case LengthWrapperDataType::MinContent:
+    case LengthWrapperDataType::MaxContent:
+    case LengthWrapperDataType::FitContent:
+    case LengthWrapperDataType::Undefined:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return ReturnType(0);
+}
+
+template<typename ReturnType, typename MaximumType>
+ReturnType valueForLengthWrapperDataWithLazyMaximum(const LengthWrapperData& length, NOESCAPE const Invocable<MaximumType()> auto& lazyMaximumValueFunctor)
+{
+    switch (length.type()) {
+    case LengthWrapperDataType::Fixed:
+        return ReturnType(length.value());
+    case LengthWrapperDataType::Percent:
+        return ReturnType(static_cast<float>(lazyMaximumValueFunctor() * length.value() / 100.0f));
+    case LengthWrapperDataType::Calculated:
+        return ReturnType(length.nonNanCalculatedValue(lazyMaximumValueFunctor()));
+    case LengthWrapperDataType::FillAvailable:
+    case LengthWrapperDataType::Auto:
+    case LengthWrapperDataType::Normal:
+        return ReturnType(lazyMaximumValueFunctor());
+    case LengthWrapperDataType::Content:
+    case LengthWrapperDataType::Relative:
+    case LengthWrapperDataType::Intrinsic:
+    case LengthWrapperDataType::MinIntrinsic:
+    case LengthWrapperDataType::MinContent:
+    case LengthWrapperDataType::MaxContent:
+    case LengthWrapperDataType::FitContent:
+    case LengthWrapperDataType::Undefined:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return ReturnType(0);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp
@@ -26,75 +26,26 @@
 #include "StyleScrollMargin.h"
 
 #include "LayoutRect.h"
-#include "StyleBuilderConverter.h"
 #include "StyleBuilderState.h"
-#include "StyleExtractorConverter.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
 
-LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit referenceLength)
+LayoutUnit Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, LayoutUnit)
 {
-    switch (edge.m_value.type()) {
-    case LengthType::Fixed:
-        return LayoutUnit(edge.m_value.value());
-
-    case LengthType::Percent:
-        return LayoutUnit(static_cast<float>(referenceLength * edge.m_value.percent() / 100.0f));
-
-    case LengthType::Calculated:
-        return LayoutUnit(edge.m_value.nonNanCalculatedValue(referenceLength));
-
-    case LengthType::FillAvailable:
-    case LengthType::Auto:
-    case LengthType::Normal:
-    case LengthType::Content:
-    case LengthType::Relative:
-    case LengthType::Intrinsic:
-    case LengthType::MinIntrinsic:
-    case LengthType::MinContent:
-    case LengthType::MaxContent:
-    case LengthType::FitContent:
-    case LengthType::Undefined:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return 0_lu;
+    return LayoutUnit(edge.m_value.value);
 }
 
-float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float referenceLength)
+float Evaluation<ScrollMarginEdge>::operator()(const ScrollMarginEdge& edge, float)
 {
-    switch (edge.m_value.type()) {
-    case LengthType::Fixed:
-        return edge.m_value.value();
-
-    case LengthType::Percent:
-        return referenceLength * edge.m_value.percent() / 100.0f;
-
-    case LengthType::Calculated:
-        return edge.m_value.nonNanCalculatedValue(referenceLength);
-
-    case LengthType::FillAvailable:
-    case LengthType::Auto:
-    case LengthType::Normal:
-    case LengthType::Content:
-    case LengthType::Relative:
-    case LengthType::Intrinsic:
-    case LengthType::MinIntrinsic:
-    case LengthType::MinContent:
-    case LengthType::MaxContent:
-    case LengthType::FitContent:
-    case LengthType::Undefined:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return 0.0f;
+    return edge.m_value.value;
 }
 
 auto CSSValueConversion<ScrollMarginEdge>::operator()(BuilderState& state, const CSSValue& value) -> ScrollMarginEdge
 {
-    return ScrollMarginEdge { BuilderConverter::convertLength(state, value) };
+    return ScrollMarginEdge { toStyleFromCSSValue<Length<>>(state, value) };
 }
 
 LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& rect)
@@ -105,11 +56,6 @@ LayoutBoxExtent extentForRect(const ScrollMarginBox& margin, const LayoutRect& r
         Style::evaluate(margin.bottom(), rect.height()),
         Style::evaluate(margin.left(), rect.width()),
     };
-}
-
-WTF::TextStream& operator<<(WTF::TextStream& ts, const ScrollMarginEdge& value)
-{
-    return ts << value.m_value;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h
@@ -25,34 +25,25 @@
 #pragma once
 
 #include "BoxExtents.h"
-#include "Length.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StyleValueTypes.h"
 
 namespace WebCore {
 
-class CSSValue;
 class LayoutRect;
 class LayoutUnit;
-class RenderStyle;
 
 namespace Style {
-
-class BuilderState;
-struct ExtractorState;
 
 // <'scroll-margin-*'> = <length>
 // https://drafts.csswg.org/css-scroll-snap-1/#margin-longhands-physical
 struct ScrollMarginEdge {
     using Fixed = Length<>;
 
-    ScrollMarginEdge(Fixed&& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
-    ScrollMarginEdge(const Fixed& fixed) : m_value(fixed.value, WebCore::LengthType::Fixed) { }
+    ScrollMarginEdge(Fixed&& fixed) : m_value(fixed) { }
+    ScrollMarginEdge(const Fixed& fixed) : m_value(fixed) { }
 
-    ScrollMarginEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), WebCore::LengthType::Fixed) { }
-
-    explicit ScrollMarginEdge(WebCore::Length&& other) : m_value(WTFMove(other)) { RELEASE_ASSERT(isValid(m_value)); }
-    explicit ScrollMarginEdge(const WebCore::Length& other) : m_value(other) { RELEASE_ASSERT(isValid(m_value)); }
+    ScrollMarginEdge(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(literal) { }
 
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
@@ -62,39 +53,15 @@ struct ScrollMarginEdge {
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
-        return visitor(Fixed { m_value.value() });
+        return visitor(m_value);
     }
 
     bool operator==(const ScrollMarginEdge&) const = default;
 
 private:
     friend struct Evaluation<ScrollMarginEdge>;
-    friend WTF::TextStream& operator<<(WTF::TextStream&, const ScrollMarginEdge&);
 
-    static bool isValid(const WebCore::Length& length)
-    {
-        switch (length.type()) {
-        case WebCore::LengthType::Fixed:
-            return CSS::isWithinRange<Fixed::range>(length.value());
-        case WebCore::LengthType::Percent:
-        case WebCore::LengthType::Calculated:
-        case WebCore::LengthType::Auto:
-        case WebCore::LengthType::Intrinsic:
-        case WebCore::LengthType::MinIntrinsic:
-        case WebCore::LengthType::MinContent:
-        case WebCore::LengthType::MaxContent:
-        case WebCore::LengthType::FillAvailable:
-        case WebCore::LengthType::FitContent:
-        case WebCore::LengthType::Content:
-        case WebCore::LengthType::Normal:
-        case WebCore::LengthType::Relative:
-        case WebCore::LengthType::Undefined:
-            break;
-        }
-        return false;
-    }
-
-    WebCore::Length m_value;
+    Length<> m_value;
 };
 
 // <'scroll-margin'> = <length>{1,4}
@@ -115,10 +82,6 @@ template<> struct Evaluation<ScrollMarginEdge> {
 // MARK: - Extent
 
 LayoutBoxExtent extentForRect(const ScrollMarginBox&, const LayoutRect&);
-
-// MARK: - Logging
-
-WTF::TextStream& operator<<(WTF::TextStream&, const ScrollMarginEdge&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp
@@ -26,70 +26,45 @@
 #include "StyleScrollPadding.h"
 
 #include "LayoutRect.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 
 namespace WebCore {
 namespace Style {
 
 LayoutUnit Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, LayoutUnit referenceLength)
 {
-    switch (edge.m_value.type()) {
-    case LengthType::Fixed:
-        return LayoutUnit(edge.m_value.value());
-
-    case LengthType::Percent:
-        return LayoutUnit(static_cast<float>(referenceLength * edge.m_value.percent() / 100.0f));
-
-    case LengthType::Calculated:
-        return LayoutUnit(edge.m_value.nonNanCalculatedValue(referenceLength));
-
-    case LengthType::Auto:
+    return WTF::switchOn(edge,
+        [&](const ScrollPaddingEdge::Fixed& fixed) {
+            return LayoutUnit(fixed.value);
+        },
+        [&](const ScrollPaddingEdge::Percentage& percentage) {
+            return Style::evaluate(percentage, referenceLength);
+        },
+        [&](const ScrollPaddingEdge::Calc& calculated) {
+            return Style::evaluate(calculated, referenceLength);
+        },
+        [&](const CSS::Keyword::Auto&) {
             return 0_lu;
-
-    case LengthType::FillAvailable:
-    case LengthType::Normal:
-    case LengthType::Content:
-    case LengthType::Relative:
-    case LengthType::Intrinsic:
-    case LengthType::MinIntrinsic:
-    case LengthType::MinContent:
-    case LengthType::MaxContent:
-    case LengthType::FitContent:
-    case LengthType::Undefined:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return 0_lu;
+        }
+    );
 }
 
 float Evaluation<ScrollPaddingEdge>::operator()(const ScrollPaddingEdge& edge, float referenceLength)
 {
-    switch (edge.m_value.type()) {
-    case LengthType::Fixed:
-        return edge.m_value.value();
-
-    case LengthType::Percent:
-        return referenceLength * edge.m_value.percent() / 100.0f;
-
-    case LengthType::Calculated:
-        return edge.m_value.nonNanCalculatedValue(referenceLength);
-
-    case LengthType::Auto:
-            return 0;
-
-    case LengthType::FillAvailable:
-    case LengthType::Normal:
-    case LengthType::Content:
-    case LengthType::Relative:
-    case LengthType::Intrinsic:
-    case LengthType::MinIntrinsic:
-    case LengthType::MinContent:
-    case LengthType::MaxContent:
-    case LengthType::FitContent:
-    case LengthType::Undefined:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return 0;
+    return WTF::switchOn(edge,
+        [&](const ScrollPaddingEdge::Fixed& fixed) {
+            return fixed.value;
+        },
+        [&](const ScrollPaddingEdge::Percentage& percentage) {
+            return Style::evaluate(percentage, referenceLength);
+        },
+        [&](const ScrollPaddingEdge::Calc& calculated) {
+            return Style::evaluate(calculated, referenceLength);
+        },
+        [&](const CSS::Keyword::Auto&) {
+            return 0.0f;
+        }
+    );
 }
 
 LayoutBoxExtent extentForRect(const ScrollPaddingBox& padding, const LayoutRect& rect)

--- a/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
+++ b/Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h
@@ -37,9 +37,6 @@ namespace Style {
 // https://drafts.csswg.org/css-scroll-snap-1/#padding-longhands-physical
 struct ScrollPaddingEdge : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
     using Base::Base;
-
-private:
-    friend struct Evaluation<ScrollPaddingEdge>;
 };
 
 // <'scroll-padding'> = [ auto | <length-percentage [0,∞]> ]{1,4}

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3238,12 +3238,47 @@ using WebCore::Style::ShapeCommand = Variant<WebCore::Style::MoveCommand, WebCor
     Vector<WebCore::Style::ShapeCommand> value;
 };
 
+header: <WebCore/StyleLengthWrapperData.h>
+[CustomHeader] struct WebCore::Style::LengthWrapperData {
+    Variant<WebCore::Style::LengthWrapperData::AutoData, WebCore::Style::LengthWrapperData::NormalData, WebCore::Style::LengthWrapperData::RelativeData, WebCore::Style::LengthWrapperData::PercentData, WebCore::Style::LengthWrapperData::FixedData, WebCore::Style::LengthWrapperData::IntrinsicData, WebCore::Style::LengthWrapperData::MinIntrinsicData, WebCore::Style::LengthWrapperData::MinContentData, WebCore::Style::LengthWrapperData::MaxContentData, WebCore::Style::LengthWrapperData::FillAvailableData, WebCore::Style::LengthWrapperData::FitContentData, WebCore::Style::LengthWrapperData::ContentData, WebCore::Style::LengthWrapperData::UndefinedData> ipcData();
+}
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::AutoData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::NormalData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FixedData {
+    Variant<float, int> value
+    bool hasQuirk
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::RelativeData {
+    Variant<float, int> value
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::PercentData {
+    Variant<float, int> value
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::IntrinsicData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::MinIntrinsicData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::MinContentData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::MaxContentData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FillAvailableData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FitContentData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::ContentData {
+};
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::UndefinedData {
+};
+
 header: <WebCore/StylePosition.h>
 [CustomHeader, Nested] struct WebCore::Style::PositionX {
-    Variant<WebCore::Length::AutoData, WebCore::Length::NormalData, WebCore::Length::RelativeData, WebCore::Length::PercentData, WebCore::Length::FixedData, WebCore::Length::IntrinsicData, WebCore::Length::MinIntrinsicData, WebCore::Length::MinContentData, WebCore::Length::MaxContentData, WebCore::Length::FillAvailableData, WebCore::Length::FitContentData, WebCore::Length::ContentData, WebCore::Length::UndefinedData> ipcData();
+    Variant<WebCore::Style::LengthWrapperData::AutoData, WebCore::Style::LengthWrapperData::NormalData, WebCore::Style::LengthWrapperData::RelativeData, WebCore::Style::LengthWrapperData::PercentData, WebCore::Style::LengthWrapperData::FixedData, WebCore::Style::LengthWrapperData::IntrinsicData, WebCore::Style::LengthWrapperData::MinIntrinsicData, WebCore::Style::LengthWrapperData::MinContentData, WebCore::Style::LengthWrapperData::MaxContentData, WebCore::Style::LengthWrapperData::FillAvailableData, WebCore::Style::LengthWrapperData::FitContentData, WebCore::Style::LengthWrapperData::ContentData, WebCore::Style::LengthWrapperData::UndefinedData> ipcData();
 };
 [CustomHeader, Nested] struct WebCore::Style::PositionY {
-    Variant<WebCore::Length::AutoData, WebCore::Length::NormalData, WebCore::Length::RelativeData, WebCore::Length::PercentData, WebCore::Length::FixedData, WebCore::Length::IntrinsicData, WebCore::Length::MinIntrinsicData, WebCore::Length::MinContentData, WebCore::Length::MaxContentData, WebCore::Length::FillAvailableData, WebCore::Length::FitContentData, WebCore::Length::ContentData, WebCore::Length::UndefinedData> ipcData();
+    Variant<WebCore::Style::LengthWrapperData::AutoData, WebCore::Style::LengthWrapperData::NormalData, WebCore::Style::LengthWrapperData::RelativeData, WebCore::Style::LengthWrapperData::PercentData, WebCore::Style::LengthWrapperData::FixedData, WebCore::Style::LengthWrapperData::IntrinsicData, WebCore::Style::LengthWrapperData::MinIntrinsicData, WebCore::Style::LengthWrapperData::MinContentData, WebCore::Style::LengthWrapperData::MaxContentData, WebCore::Style::LengthWrapperData::FillAvailableData, WebCore::Style::LengthWrapperData::FitContentData, WebCore::Style::LengthWrapperData::ContentData, WebCore::Style::LengthWrapperData::UndefinedData> ipcData();
 };
 [CustomHeader, Nested] struct WebCore::Style::Position {
     WebCore::Style::PositionX x;


### PR DESCRIPTION
#### c0b2282cf5ee913a2656fe2ceac0d0ea85cca0db
<pre>
[Style] Generalize Style::LengthWrapperBase - Part 1: Replace WebCore::Length with Style::LengthWrapperBaseData
<a href="https://bugs.webkit.org/show_bug.cgi?id=296632">https://bugs.webkit.org/show_bug.cgi?id=296632</a>

Reviewed by Antti Koivisto.

Copies the relevant code from `WebCore::Length` into a new type, `Style::LengthWrapperBaseData`,
and adopts it in `Style::LengthWrapperBase`. This will form the basis for further generalizations
without effecting other client of `WebCore::Length`.

To make this work, a few places that were depending on the `WebCore::Length` internals were
updated to use the `Style::LengthWrapperBase` functions instead (or, in the case of
`Style::ScrollMarginEdge`, moved off of `Style::LengthWrapperBase` entirely).

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
* Source/WebCore/rendering/style/StyleBoxData.cpp:
* Source/WebCore/rendering/style/StyleTransformData.cpp:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp: Added.
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h: Added.
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollMargin.h:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.cpp:
* Source/WebCore/style/values/scroll-snap/StyleScrollPadding.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/298190@main">https://commits.webkit.org/298190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7ae137c10c9e4d774556faf32d48d754e89bff9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114384 "44 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86927 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41842 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20854 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64237 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95750 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24376 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40687 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46786 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->