### PR TITLE
[Liquid Glass] iPad: Glass elements over web views don't get the right appearance after rdar://155261419

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1286,6 +1286,10 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (_UIScrollPocket *)_pocketForEdge:(UIRectEdge)edge makeIfNeeded:(BOOL)makeIfNeeded;
 @end
 
+@interface UIScrollView (Staging_155261419)
+- (void)_setPrefersSolidColorHardPocket:(BOOL)prefersSolidColorHardPocket forEdge:(UIRectEdge)edge;
+@end
+
 #endif // HAVE(LIQUID_GLASS)
 
 WTF_EXTERN_C_BEGIN

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -544,6 +544,7 @@ struct PerWebProcessState {
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 - (void)_updateFixedColorExtensionViews;
 - (void)_updateFixedColorExtensionViewFrames;
+- (void)_updatePrefersSolidColorHardPocket;
 - (BOOL)_hasVisibleColorExtensionView:(WebCore::BoxSide)side;
 - (void)_addReasonToHideTopScrollPocket:(WebKit::HideScrollPocketReason)reason;
 - (void)_removeReasonToHideTopScrollPocket:(WebKit::HideScrollPocketReason)reason;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2495,7 +2495,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         if ([_scrollView _wk_isScrolledBeyondTopExtent])
             return NO;
 
-        if ([_scrollView _wk_usesHardTopScrollEdgeEffect])
+        if ([_scrollView _usesHardTopScrollEdgeEffect])
             return NO;
 
         return [_scrollView contentOffset].y < 0;
@@ -2516,6 +2516,9 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         return YES;
 
     if (_needsTopScrollPocketDueToVisibleContentInset)
+        return NO;
+
+    if ([_scrollView _usesHardTopScrollEdgeEffect])
         return NO;
 
     return [self _hasVisibleColorExtensionView:WebCore::BoxSide::Top];

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -45,9 +45,6 @@ enum class BoxSide : uint8_t;
 @property (readonly, nonatomic) CGFloat _wk_contentHeightIncludingInsets;
 @property (readonly, nonatomic) BOOL _wk_isScrollAnimating;
 @property (readonly, nonatomic) BOOL _wk_isZoomAnimating;
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-@property (readonly, nonatomic) BOOL _wk_usesHardTopScrollEdgeEffect;
-#endif
 - (void)_wk_setContentOffsetAndShowScrollIndicators:(CGPoint)offset animated:(BOOL)animated;
 - (void)_wk_setTransfersHorizontalScrollingToParent:(BOOL)value;
 - (void)_wk_setTransfersVerticalScrollingToParent:(BOOL)value;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -224,17 +224,6 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
     [self _flashScrollIndicatorsForAxes:axes persistingPreviousFlashes:YES];
 }
 
-#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
-- (BOOL)_wk_usesHardTopScrollEdgeEffect
-{
-    // Calling this getter may trigger unintended behaviors, since calling -[UIScrollEdgeEffect style]
-    // may cause UIKit to layout subviews during the next update cycle.
-    return [self.topEdgeEffect.style isEqual:UIScrollEdgeEffectStyle.hardStyle];
-}
-
-#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-
 @end
 
 @implementation UIView (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -74,6 +74,7 @@
 #import "WKPreviewActionItemInternal.h"
 #import "WKPreviewElementInfoInternal.h"
 #import "WKQuickboardViewControllerDelegate.h"
+#import "WKScrollView.h"
 #import "WKSelectMenuListViewController.h"
 #import "WKSyntheticFlagsChangedWebEvent.h"
 #import "WKTapHighlightView.h"
@@ -8466,7 +8467,7 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         [self becomeFirstResponder];
 
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
-    if (_focusedElementInformation.shouldHideSoftTopScrollEdgeEffect && ![[_webView scrollView] _wk_usesHardTopScrollEdgeEffect])
+    if (_focusedElementInformation.shouldHideSoftTopScrollEdgeEffect && ![[_webView _wkScrollView] _usesHardTopScrollEdgeEffect])
         [_webView _addReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::SiteSpecificQuirk];
     else
         [_webView _removeReasonToHideTopScrollPocket:WebKit::HideScrollPocketReason::SiteSpecificQuirk];

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -55,11 +55,13 @@
 #endif
 
 #if HAVE(LIQUID_GLASS)
+@property (nonatomic, readonly) BOOL _usesHardTopScrollEdgeEffect;
+- (void)_setInternalTopPocketColor:(UIColor *)color;
 - (WKUIScrollEdgeEffect *)_wk_topEdgeEffect;
 - (WKUIScrollEdgeEffect *)_wk_leftEdgeEffect;
 - (WKUIScrollEdgeEffect *)_wk_rightEdgeEffect;
 - (WKUIScrollEdgeEffect *)_wk_bottomEdgeEffect;
-#endif
+#endif // HAVE(LIQUID_GLASS)
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -157,6 +157,8 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
 #endif
 #if HAVE(LIQUID_GLASS)
     WebCore::RectEdges<RetainPtr<WKUIScrollEdgeEffect>> _edgeEffectWrappers;
+    RetainPtr<UIColor> _topPocketColorSetInternally;
+    RetainPtr<UIColor> _topPocketColorSetByClient;
 #endif
 }
 
@@ -658,6 +660,36 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Bottom, wrapper);
     }
     return wrapper.get();
+}
+
+- (void)_setInternalTopPocketColor:(UIColor *)color
+{
+    _topPocketColorSetInternally = color;
+
+    [self _updateTopPocketColor];
+}
+
+- (void)_setPocketColor:(UIColor *)color forEdge:(UIRectEdge)edge
+{
+    if (edge != UIRectEdgeTop) {
+        [super _setPocketColor:color forEdge:edge];
+        return;
+    }
+
+    _topPocketColorSetByClient = color;
+
+    [self _updateTopPocketColor];
+}
+
+- (void)_updateTopPocketColor
+{
+    RetainPtr colorToSet = _topPocketColorSetByClient ?: _topPocketColorSetInternally;
+    [super _setPocketColor:colorToSet.get() forEdge:UIRectEdgeTop];
+}
+
+- (BOOL)_usesHardTopScrollEdgeEffect
+{
+    return [[self _wk_topEdgeEffect] usesHardStyle];
 }
 
 #endif // HAVE(LIQUID_GLASS)

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
@@ -37,6 +37,7 @@
 - (instancetype)initWithScrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)side;
 
 @property (nonatomic, getter=isInternallyHidden) BOOL internallyHidden;
+@property (nonatomic) BOOL usesHardStyle;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
@@ -44,6 +44,7 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
     __weak UIScrollEdgeEffect *_effect;
     OptionSet<WebKit::HiddenScrollEdgeEffectSource> _hiddenSources;
     WebCore::BoxSide _boxSide;
+    BOOL _usesHardStyle;
 }
 
 - (instancetype)initWithScrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)boxSide
@@ -100,6 +101,13 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
         return;
 
     _effect.hidden = !newVisible;
+}
+
+- (void)setStyle:(UIScrollEdgeEffectStyle *)style
+{
+    _usesHardStyle = [style isEqual:UIScrollEdgeEffectStyle.hardStyle];
+
+    _effect.style = style;
 }
 
 - (NSString *)description


### PR DESCRIPTION
#### 3c544bf0f87b3e0dda5c56562cf95b5968f233fe
<pre>
[Liquid Glass] iPad: Glass elements over web views don&apos;t get the right appearance after <a href="https://rdar.apple.com/155261419">rdar://155261419</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296633">https://bugs.webkit.org/show_bug.cgi?id=296633</a>
<a href="https://rdar.apple.com/157030903">rdar://157030903</a>

Reviewed by Abrar Rahman Protyasha.

After the UIKit changes in <a href="https://rdar.apple.com/155261419">rdar://155261419</a>, glass effects that overlay the inset area in web views
no longer adapt to fixed color extensions, resulting in an over- or under-saturated glass background
color when switching tabs. This is because we currently hide the scroll pocket when showing fixed
color extensions, but UIKit now requires the scroll pocket to be shown in order to correctly adapt
the appearance of floating glass effects.

To fix this, we adopt `-_setPocketColor:forEdge:` and `-_setPrefersSolidColorHardPocket:forEdge:` to
keep the scroll pocket shown when there are fixed color extensions, but with a solid (opaque)
capture color that elides any color sampling or variable blur overhead. This effectively makes the
magic pocket a solid color which we (or Safari) specifies, while allowing glass effect views on top
of the pocket to continue adapting.

This strategy closely mirrors the strategy used on macOS (`NSScrollPocket`). See comments below for
more detail.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateTopScrollPocketCaptureColor]):
(-[WKWebView _updatePrefersSolidColorHardPocket]):

Add an idempotent helper method to update the state of `-_setPrefersSolidColorHardPocket:` on the
top scroll edge effect (i.e. only if there&apos;s a top fixed color extension and the scroll edge effect
style is `.hard`). This is now cross-platform (closely mirroring the same logic for macOS on
`WebViewImpl`), and simply calls through to `WebViewImpl` on macOS.

(-[WKWebView colorExtensionViewWillDisappear:]):
(-[WKWebView colorExtensionViewDidAppear:]):

Make this macOS-specific logic run on iOS as well, by calling into the above helper (now that solid
color hard pockets exist on iPad).

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateNeedsTopScrollPocketDueToVisibleContentInset]):
(-[WKWebView _shouldHideTopScrollPocket]):

Avoid hiding the top scroll pocket, in the case where we&apos;re using a hard pocket and therefore prefer
to force a solid color instead of hiding.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_usesHardTopScrollEdgeEffect]): Deleted.

Remove this `-_wk_usesHardTopScrollEdgeEffect` helper; see below.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _continueElementDidFocus:requiresStrongPasswordAssistance:focusedElementInfo:activityStateChanges:restoreValues:]):
* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _setInternalTopPocketColor:]):
(-[WKScrollView _setPocketColor:forEdge:]):
(-[WKScrollView _updateTopPocketColor]):

Make it possible for clients (e.g. Safari) to safely override the hard pocket color. Since we _and_
Safari now both attempt to set the top pocket color, we would (naively) stomp over each other&apos;s
specified colors. This ensures a deterministic (null_resettable-like) behavior, by allowing Safari
to override the top pocket color, but fall back on WebKit&apos;s default pocket color by setting the
color to `nil`.

(-[WKScrollView _usesHardTopScrollEdgeEffect]):

Change the way we ask the scroll view whether it&apos;s using hard or soft pocket; from 297197@main, we
know that simply consulting `-[UIScrollEdgeEffect style]` can trigger unintended side effects and
break layout. Now that we override the edge effect object entirely, we can instead detect when the
scroll edge effect style is set, and cache state on the scroll edge effect itself that represents
whether or not we&apos;re using a hard pocket.

This allows us to ask if `WKScrollView` is using a hard top pocket at any time without triggering
other bugs due to the scroll pocket being backed by `@Observable` state.

* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h:
* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm:
(-[WKUIScrollEdgeEffect setStyle:]):

Canonical link: <a href="https://commits.webkit.org/298002@main">https://commits.webkit.org/298002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9bad32a50915309da1bfeaf26beec15f094a872

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120029 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5e798df-6157-4297-8196-187096e2a2f8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86544 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a12513ab-4521-4d25-84be-1c9d435ad677) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66917 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26456 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123263 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30456 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98489 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24268 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40288 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18099 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40781 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/46292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43722 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/42181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->