### PR TITLE
Ensure new session restoration API uses no part of old SPI

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3526,7 +3526,7 @@ struct WKWebViewData {
 - (void)fetchDataOfTypes:(WKWebViewDataType)dataTypes completionHandler:(void (^)(NSData *, NSError *))completionHandler
 {
     Vector<WebKit::WebViewDataType> dataTypesToEncode;
-    if (dataTypes & _WKWebViewDataTypeSessionStorage)
+    if (dataTypes & WKWebViewDataTypeSessionStorage)
         dataTypesToEncode.append(WebKit::WebViewDataType::SessionStorage);
 
     auto data = Box<WKWebViewData>::create();
@@ -3557,7 +3557,7 @@ struct WKWebViewData {
         completionHandler(toNSData(encoder.span()).get(), nullptr);
     });
 
-    if (dataTypes & _WKWebViewDataTypeSessionStorage) {
+    if (dataTypes & WKWebViewDataTypeSessionStorage) {
         RefPtr page = [self _protectedPage];
         page->fetchSessionStorage([callbackAggregator, protectedPage = page, data](auto&& sessionStorage) {
             data->sessionStorage = WTFMove(sessionStorage);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm
@@ -69,7 +69,7 @@ static void testRestoreSessionStorage(RetainPtr<WKWebsiteDataStore> websiteDataS
 
     // Fetch the session storage data.
     __block RetainPtr<NSData> sessionStorageData;
-    [webView fetchDataOfTypes:_WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data, NSError *error) {
+    [webView fetchDataOfTypes:WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data, NSError *error) {
         EXPECT_NOT_NULL(data);
         EXPECT_NULL(error);
         sessionStorageData = data;
@@ -206,7 +206,7 @@ static void testRestoreSessionStorageThirdPartyIFrame(RetainPtr<WKWebsiteDataSto
 
     // Fetch the session storage data.
     __block RetainPtr<NSData> sessionStorageData;
-    [webView fetchDataOfTypes:_WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data, NSError *error) {
+    [webView fetchDataOfTypes:WKWebViewDataTypeSessionStorage completionHandler:^(NSData *data, NSError *error) {
         EXPECT_NOT_NULL(data);
         EXPECT_NULL(error);
         sessionStorageData = data;


### PR DESCRIPTION
#### dff84c2c1eaba074930667c1aa50b0529fe9afbc
<pre>
Ensure new session restoration API uses no part of old SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=296641">https://bugs.webkit.org/show_bug.cgi?id=296641</a>
<a href="https://rdar.apple.com/157037633">rdar://157037633</a>

Reviewed by Aditya Keerthi.

293571@main promoted the SPI to API but in the new API,
it forgot to use WKWebViewDataTypeSessionStorage instead
of _WKWebViewDataTypeSessionStorage.

We make that change here.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView fetchDataOfTypes:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreSessionStorage.mm:
(testRestoreSessionStorage):
(testRestoreSessionStorageThirdPartyIFrame):

Canonical link: <a href="https://commits.webkit.org/298020@main">https://commits.webkit.org/298020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cfec720ad46cf1b8570e1f2330c879b95145a65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86574 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123300 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95177 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37084 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18269 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46327 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->