### PR TITLE
[Style] Convert column-count and column-width properties to strong style types

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -220,6 +220,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/lists"
     "${WEBCORE_DIR}/style/values/masking"
     "${WEBCORE_DIR}/style/values/motion"
+    "${WEBCORE_DIR}/style/values/multicol"
     "${WEBCORE_DIR}/style/values/non-standard"
     "${WEBCORE_DIR}/style/values/overflow"
     "${WEBCORE_DIR}/style/values/position"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2820,6 +2820,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/motion/StyleOffsetRotate.h
     style/values/motion/StyleRayFunction.h
 
+    style/values/multicol/StyleColumnCount.h
+    style/values/multicol/StyleColumnWidth.h
+
     style/values/non-standard/StyleWebKitBorderSpacing.h
     style/values/non-standard/StyleWebKitOverflowScrolling.h
     style/values/non-standard/StyleWebKitTextStrokeWidth.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3196,6 +3196,8 @@ style/values/motion/StyleOffsetPath.cpp
 style/values/motion/StyleOffsetPosition.cpp
 style/values/motion/StyleOffsetRotate.cpp
 style/values/motion/StyleRayFunction.cpp
+style/values/multicol/StyleColumnCount.cpp
+style/values/multicol/StyleColumnWidth.cpp
 style/values/non-standard/StyleWebKitOverflowScrolling.cpp
 style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
 style/values/non-standard/StyleWebKitTouchCallout.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4888,6 +4888,8 @@
 		BC22AABA2E371A4C009AC0C3 /* StyleWebKitBorderSpacing.h in Headers */ = {isa = PBXBuildFile; fileRef = BC22AAB92E371A4C009AC0C3 /* StyleWebKitBorderSpacing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC22AAE42E37F534009AC0C3 /* StylePrimitiveNumericTypes+Evaluation.h in Headers */ = {isa = PBXBuildFile; fileRef = BCB271F42CC018F100265123 /* StylePrimitiveNumericTypes+Evaluation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC22AAE52E37F567009AC0C3 /* StylePrimitiveNumericTypes+Calculation.h in Headers */ = {isa = PBXBuildFile; fileRef = BC05ACC82CEE5C9600750CB1 /* StylePrimitiveNumericTypes+Calculation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC22AB142E3944B4009AC0C3 /* StyleColumnWidth.h in Headers */ = {isa = PBXBuildFile; fileRef = BC22AB132E394476009AC0C3 /* StyleColumnWidth.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC22AB172E39485C009AC0C3 /* StyleColumnCount.h in Headers */ = {isa = PBXBuildFile; fileRef = BC22AB162E39485C009AC0C3 /* StyleColumnCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC22AB362E3ABBDC009AC0C3 /* StyleOpacity.h in Headers */ = {isa = PBXBuildFile; fileRef = BC22AB332E3A9B8E009AC0C3 /* StyleOpacity.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC23875B2D84982100698102 /* CSSRatio.h in Headers */ = {isa = PBXBuildFile; fileRef = BC23875A2D84982100698102 /* CSSRatio.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC2387602D84A59400698102 /* StyleRatio.h in Headers */ = {isa = PBXBuildFile; fileRef = BC23875F2D84A59400698102 /* StyleRatio.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -18110,6 +18112,10 @@
 		BC22AA9D2E36A2BD009AC0C3 /* StyleImageWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleImageWrapper.h; sourceTree = "<group>"; };
 		BC22AA9F2E36A554009AC0C3 /* StyleImageWrapper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleImageWrapper.cpp; sourceTree = "<group>"; };
 		BC22AAB92E371A4C009AC0C3 /* StyleWebKitBorderSpacing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleWebKitBorderSpacing.h; sourceTree = "<group>"; };
+		BC22AB122E394476009AC0C3 /* StyleColumnWidth.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleColumnWidth.cpp; sourceTree = "<group>"; };
+		BC22AB132E394476009AC0C3 /* StyleColumnWidth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleColumnWidth.h; sourceTree = "<group>"; };
+		BC22AB152E39485C009AC0C3 /* StyleColumnCount.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleColumnCount.cpp; sourceTree = "<group>"; };
+		BC22AB162E39485C009AC0C3 /* StyleColumnCount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleColumnCount.h; sourceTree = "<group>"; };
 		BC22AB332E3A9B8E009AC0C3 /* StyleOpacity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleOpacity.h; sourceTree = "<group>"; };
 		BC22AB342E3A9BA3009AC0C3 /* StyleOpacity.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleOpacity.cpp; sourceTree = "<group>"; };
 		BC2387582D84867A00698102 /* CSSPropertyParserConsumer+UnicodeRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+UnicodeRange.h"; sourceTree = "<group>"; };
@@ -35119,6 +35125,17 @@
 			path = js;
 			sourceTree = "<group>";
 		};
+		BC22AB112E394447009AC0C3 /* multicol */ = {
+			isa = PBXGroup;
+			children = (
+				BC22AB152E39485C009AC0C3 /* StyleColumnCount.cpp */,
+				BC22AB162E39485C009AC0C3 /* StyleColumnCount.h */,
+				BC22AB122E394476009AC0C3 /* StyleColumnWidth.cpp */,
+				BC22AB132E394476009AC0C3 /* StyleColumnWidth.h */,
+			);
+			path = multicol;
+			sourceTree = "<group>";
+		};
 		BC2387AA2D8742AB00698102 /* inline */ = {
 			isa = PBXGroup;
 			children = (
@@ -35768,6 +35785,7 @@
 				BC966B3F2E275AB10028A7AF /* lists */,
 				BCCE4F722DF9DDB7005554EA /* masking */,
 				BCEA07322CC5EBBA000AC148 /* motion */,
+				BC22AB112E394447009AC0C3 /* multicol */,
 				BC0929AE2E2AA595002ACB2C /* non-standard */,
 				BC966B362E274F530028A7AF /* overflow */,
 				BC9ABA182DECC6AE00F7E52D /* position */,
@@ -45370,6 +45388,8 @@
 				BCB660952BEEF46200528480 /* StyleColor.h in Headers */,
 				BC4AF4192CF96B930037C65C /* StyleColorOptions.h in Headers */,
 				BCEA078D2CCC719D000AC148 /* StyleColorScheme.h in Headers */,
+				BC22AB172E39485C009AC0C3 /* StyleColumnCount.h in Headers */,
+				BC22AB142E3944B4009AC0C3 /* StyleColumnWidth.h in Headers */,
 				BC2A0EF22E120B93003CBA0E /* StyleContainerName.h in Headers */,
 				BCD9EFE92E18E58000D1C3DF /* StyleContainIntrinsicSize.h in Headers */,
 				BC5EB9810E82072500B25965 /* StyleContent.h in Headers */,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9098,9 +9098,8 @@
                 "aliases": [
                     "-webkit-column-count"
                 ],
-                "animation-wrapper": "AutoWrapper<unsigned short>",
-                "animation-wrapper-requires-additional-parameters": ["&RenderStyle::hasAutoColumnCount", "&RenderStyle::setHasAutoColumnCount", "1U"],
-                "auto-functions": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<ColumnCount>",
                 "parser-grammar": "auto | <integer [1,inf]>",
                 "parser-exported": true
             },
@@ -9309,10 +9308,8 @@
                 "aliases": [
                     "-webkit-column-width"
                 ],
-                "animation-wrapper": "AutoWrapper<float>",
-                "animation-wrapper-requires-additional-parameters": ["&RenderStyle::hasAutoColumnWidth", "&RenderStyle::setHasAutoColumnWidth", "0.0f"],
-                "style-converter": "ComputedLength<float>",
-                "auto-functions": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<ColumnWidth>",
                 "parser-grammar": "auto | <length [0,inf]>",
                 "parser-exported": true
             },

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -114,12 +114,94 @@ template<Range range, std::floating_point T> constexpr T clampToRange(T value, T
     );
 }
 
+// Clamps a signed integral value to within `range`.
+template<Range range, std::signed_integral T> constexpr T clampToRange(T value)
+{
+    if constexpr (range.min == -Range::infinity && range.max == Range::infinity) {
+        return clampTo<T>(
+            value,
+            std::numeric_limits<T>::min(),
+            std::numeric_limits<T>::max()
+        );
+    } else if constexpr (range.min == -Range::infinity) {
+        return clampTo<T>(
+            value,
+            std::numeric_limits<T>::min(),
+            std::min<T>(range.max, std::numeric_limits<T>::max())
+        );
+    } else if constexpr (range.max == Range::infinity) {
+        return clampTo<T>(
+            value,
+            std::max<T>(range.min, std::numeric_limits<T>::min()),
+            std::numeric_limits<T>::max()
+        );
+    } else {
+        return clampTo<T>(
+            value,
+            std::max<T>(range.min, std::numeric_limits<T>::min()),
+            std::min<T>(range.max, std::numeric_limits<T>::max())
+        );
+    }
+}
+
+// Clamps an unsigned integral value to within `range`.
+template<Range range, std::unsigned_integral T> constexpr T clampToRange(T value)
+{
+    static_assert(range.min >= 0);
+
+    if constexpr (range.max == Range::infinity) {
+        return clampTo<T>(
+            value,
+            std::max<T>(range.min, std::numeric_limits<T>::min()),
+            std::numeric_limits<T>::max()
+        );
+    } else {
+        return clampTo<T>(
+            value,
+            std::max<T>(range.min, std::numeric_limits<T>::min()),
+            std::min<T>(range.max, std::numeric_limits<T>::max())
+        );
+    }
+}
+
 // Checks if a floating point value is within `range`.
 template<Range range, std::floating_point T> constexpr bool isWithinRange(T value)
 {
     return !std::isnan(value)
         && value >= std::max<T>(range.min, -std::numeric_limits<T>::max())
         && value <= std::min<T>(range.max,  std::numeric_limits<T>::max());
+}
+
+// Checks if a signed integral value is within `range`.
+template<Range range, std::signed_integral T> constexpr bool isWithinRange(T value)
+{
+    if constexpr (range.min == -Range::infinity && range.max == Range::infinity) {
+        return value >= std::numeric_limits<T>::min()
+            && value <= std::numeric_limits<T>::max();
+    } else if constexpr (range.min == -Range::infinity) {
+        return value >= std::numeric_limits<T>::min()
+            && value <= std::min<T>(range.max, std::numeric_limits<T>::max());
+    } else if constexpr (range.max == Range::infinity) {
+        return value >= std::max<T>(range.min, std::numeric_limits<T>::min())
+            && value <= std::numeric_limits<T>::max();
+    } else {
+        return value >= std::max<T>(range.min, std::numeric_limits<T>::min())
+            && value <= std::min<T>(range.max, std::numeric_limits<T>::max());
+    }
+}
+
+// Checks if an unsigned integral value is within `range`.
+template<Range range, std::unsigned_integral T> constexpr bool isWithinRange(T value)
+{
+    static_assert(range.min >= 0);
+
+    if constexpr (range.max == Range::infinity) {
+        return value >= std::max<T>(range.min, std::numeric_limits<T>::min())
+            && value <= std::numeric_limits<T>::max();
+    } else {
+        return value >= std::max<T>(range.min, std::numeric_limits<T>::min())
+            && value <= std::min<T>(range.max, std::numeric_limits<T>::max());
+    }
 }
 
 } // namespace CSS

--- a/Source/WebCore/platform/animation/AnimationUtilities.h
+++ b/Source/WebCore/platform/animation/AnimationUtilities.h
@@ -96,6 +96,19 @@ inline unsigned blend(unsigned from, unsigned to, const BlendingContext& context
     return static_cast<unsigned>(lround(from + from + (static_cast<double>(to) - from) * context.progress));
 }
 
+inline unsigned short blend(unsigned short from, unsigned short to, const BlendingContext& context)
+{
+    if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
+        auto iterationIncrement = static_cast<unsigned short>(context.currentIteration * static_cast<double>(to));
+        from += iterationIncrement;
+        to += iterationIncrement;
+    }
+
+    if (context.compositeOperation == CompositeOperation::Replace)
+        return static_cast<unsigned short>(lround(from + (static_cast<double>(to) - from) * context.progress));
+    return static_cast<unsigned short>(lround(from + from + (static_cast<double>(to) - from) * context.progress));
+}
+
 inline double blend(double from, double to, const BlendingContext& context)
 {  
     if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -274,6 +274,8 @@ struct Clip;
 struct ClipPath;
 struct Color;
 struct ColorScheme;
+struct ColumnCount;
+struct ColumnWidth;
 struct ContainIntrinsicSize;
 struct ContainerNames;
 struct Content;
@@ -967,10 +969,8 @@ public:
     inline ColumnAxis columnAxis() const;
     inline bool hasInlineColumnAxis() const;
     inline ColumnProgression columnProgression() const;
-    inline float columnWidth() const;
-    inline bool hasAutoColumnWidth() const;
-    inline unsigned short columnCount() const;
-    inline bool hasAutoColumnCount() const;
+    inline Style::ColumnWidth columnWidth() const;
+    inline Style::ColumnCount columnCount() const;
     inline bool specifiesColumns() const;
     inline ColumnFill columnFill() const;
     inline BorderStyle columnRuleStyle() const;
@@ -1578,10 +1578,8 @@ public:
     inline void setResize(Resize);
     inline void setColumnAxis(ColumnAxis);
     inline void setColumnProgression(ColumnProgression);
-    inline void setColumnWidth(float);
-    inline void setHasAutoColumnWidth();
-    inline void setColumnCount(unsigned short);
-    inline void setHasAutoColumnCount();
+    inline void setColumnWidth(Style::ColumnWidth);
+    inline void setColumnCount(Style::ColumnCount);
     inline void setColumnFill(ColumnFill);
     inline void setColumnGap(Style::GapGutter&&);
     inline void setRowGap(Style::GapGutter&&);
@@ -2089,10 +2087,11 @@ public:
 
     static constexpr Order initialRTLOrdering();
     static constexpr Style::WebkitTextStrokeWidth initialTextStrokeWidth();
-    static unsigned short initialColumnCount() { return 1; }
+    static constexpr Style::ColumnCount initialColumnCount();
     static constexpr ColumnFill initialColumnFill();
     static constexpr ColumnSpan initialColumnSpan();
     static inline Style::GapGutter initialColumnGap();
+    static constexpr Style::ColumnWidth initialColumnWidth();
     static inline Style::GapGutter initialRowGap();
     static inline TransformOperations initialTransform();
     static inline Style::TransformOrigin initialTransformOrigin();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -174,7 +174,7 @@ inline const Style::Clip& RenderStyle::clip() const { return m_nonInheritedData-
 inline const Style::ClipPath& RenderStyle::clipPath() const { return m_nonInheritedData->rareData->clipPath; }
 inline bool RenderStyle::collapseWhiteSpace() const { return collapseWhiteSpace(whiteSpaceCollapse()); }
 inline ColumnAxis RenderStyle::columnAxis() const { return static_cast<ColumnAxis>(m_nonInheritedData->miscData->multiCol->axis); }
-inline unsigned short RenderStyle::columnCount() const { return m_nonInheritedData->miscData->multiCol->count; }
+inline Style::ColumnCount RenderStyle::columnCount() const { return m_nonInheritedData->miscData->multiCol->count; }
 inline ColumnFill RenderStyle::columnFill() const { return static_cast<ColumnFill>(m_nonInheritedData->miscData->multiCol->fill); }
 inline const Style::GapGutter& RenderStyle::columnGap() const { return m_nonInheritedData->rareData->columnGap; }
 inline ColumnProgression RenderStyle::columnProgression() const { return static_cast<ColumnProgression>(m_nonInheritedData->miscData->multiCol->progression); }
@@ -183,7 +183,7 @@ inline bool RenderStyle::columnRuleIsTransparent() const { return m_nonInherited
 inline BorderStyle RenderStyle::columnRuleStyle() const { return m_nonInheritedData->miscData->multiCol->rule.style(); }
 inline Style::LineWidth RenderStyle::columnRuleWidth() const { return m_nonInheritedData->miscData->multiCol->ruleWidth(); }
 inline ColumnSpan RenderStyle::columnSpan() const { return static_cast<ColumnSpan>(m_nonInheritedData->miscData->multiCol->columnSpan); }
-inline float RenderStyle::columnWidth() const { return m_nonInheritedData->miscData->multiCol->width; }
+inline Style::ColumnWidth RenderStyle::columnWidth() const { return m_nonInheritedData->miscData->multiCol->width; }
 inline const AtomString& RenderStyle::computedLocale() const { return fontDescription().computedLocale(); }
 inline OptionSet<Containment> RenderStyle::contain() const { return m_nonInheritedData->rareData->contain; }
 inline const Style::ContainIntrinsicSize& RenderStyle::containIntrinsicLogicalHeight() const { return writingMode().isHorizontal() ? containIntrinsicHeight() : containIntrinsicWidth(); }
@@ -262,8 +262,6 @@ inline bool RenderStyle::hasAspectRatio() const { return aspectRatio().hasRatio(
 inline bool RenderStyle::hasAttrContent() const { return m_nonInheritedData->miscData->hasAttrContent; }
 inline bool RenderStyle::hasAutoAccentColor() const { return m_rareInheritedData->hasAutoAccentColor; }
 inline bool RenderStyle::hasAutoCaretColor() const { return m_rareInheritedData->hasAutoCaretColor; }
-inline bool RenderStyle::hasAutoColumnCount() const { return m_nonInheritedData->miscData->multiCol->autoCount; }
-inline bool RenderStyle::hasAutoColumnWidth() const { return m_nonInheritedData->miscData->multiCol->autoWidth; }
 inline bool RenderStyle::hasAutoLeftAndRight() const { return left().isAuto() && right().isAuto(); }
 inline bool RenderStyle::hasAutoLengthContainIntrinsicSize() const { return containIntrinsicWidth().hasAuto() || containIntrinsicHeight().hasAuto(); }
 inline bool RenderStyle::hasAutoOrphans() const { return m_rareInheritedData->hasAutoOrphans; }
@@ -372,11 +370,13 @@ inline Style::Clip RenderStyle::initialClip() { return CSS::Keyword::Auto { }; }
 inline Style::ClipPath RenderStyle::initialClipPath() { return CSS::Keyword::None { }; }
 inline Color RenderStyle::initialColor() { return Color::black; }
 constexpr ColumnAxis RenderStyle::initialColumnAxis() { return ColumnAxis::Auto; }
+constexpr Style::ColumnCount RenderStyle::initialColumnCount() { return CSS::Keyword::Auto { }; }
 constexpr ColumnFill RenderStyle::initialColumnFill() { return ColumnFill::Balance; }
 inline Style::GapGutter RenderStyle::initialColumnGap() { return CSS::Keyword::Normal { }; }
 constexpr ColumnProgression RenderStyle::initialColumnProgression() { return ColumnProgression::Normal; }
 constexpr Style::LineWidth RenderStyle::initialColumnRuleWidth() { return CSS::Keyword::Medium { }; }
 constexpr ColumnSpan RenderStyle::initialColumnSpan() { return ColumnSpan::None; }
+constexpr Style::ColumnWidth RenderStyle::initialColumnWidth() { return CSS::Keyword::Auto { }; }
 inline Style::ContainIntrinsicSize RenderStyle::initialContainIntrinsicHeight() { return CSS::Keyword::None { }; }
 inline Style::ContainIntrinsicSize RenderStyle::initialContainIntrinsicWidth() { return CSS::Keyword::None { }; }
 inline Style::ContainerNames RenderStyle::initialContainerNames() { return CSS::Keyword::None { }; }
@@ -732,7 +732,7 @@ inline bool RenderStyle::isSkippedRootOrSkippedContent() const { return usedCont
 inline OptionSet<SpeakAs> RenderStyle::speakAs() const { return OptionSet<SpeakAs>::fromRaw(m_rareInheritedData->speakAs); }
 inline const AtomString& RenderStyle::specifiedLocale() const { return fontDescription().specifiedLocale(); }
 inline int RenderStyle::specifiedZIndex() const { return m_nonInheritedData->boxData->specifiedZIndex(); }
-inline bool RenderStyle::specifiesColumns() const { return !hasAutoColumnCount() || !hasAutoColumnWidth() || !hasInlineColumnAxis(); }
+inline bool RenderStyle::specifiesColumns() const { return !columnCount().isAuto() || !columnWidth().isAuto() || !hasInlineColumnAxis(); }
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
 inline const Style::Color& RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline float RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -133,6 +133,7 @@ inline void RenderStyle::setCapStyle(LineCap style) { SET(m_rareInheritedData, c
 inline void RenderStyle::setCaretColor(Style::Color&& color) { SET_PAIR(m_rareInheritedData, caretColor, WTFMove(color), hasAutoCaretColor, false); }
 inline void RenderStyle::setClip(Style::Clip&& clip) { SET_NESTED(m_nonInheritedData, rareData, clip, WTFMove(clip)); }
 inline void RenderStyle::setColumnAxis(ColumnAxis axis) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, axis, static_cast<unsigned>(axis)); }
+inline void RenderStyle::setColumnCount(Style::ColumnCount count) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, count, count); }
 inline void RenderStyle::setColumnFill(ColumnFill fill) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, fill, static_cast<unsigned>(fill)); }
 inline void RenderStyle::setColumnGap(Style::GapGutter&& gap) { SET_NESTED(m_nonInheritedData, rareData, columnGap, WTFMove(gap)); }
 inline void RenderStyle::setColumnProgression(ColumnProgression progression) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, progression, static_cast<unsigned>(progression)); }
@@ -140,7 +141,7 @@ inline void RenderStyle::setColumnRuleColor(Style::Color&& c) { SET_DOUBLY_NESTE
 inline void RenderStyle::setColumnRuleStyle(BorderStyle b) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_style, static_cast<unsigned>(b)); }
 inline void RenderStyle::setColumnRuleWidth(Style::LineWidth width) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, rule.m_width, width); }
 inline void RenderStyle::setColumnSpan(ColumnSpan span) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, columnSpan, static_cast<unsigned>(span)); }
-inline void RenderStyle::setColumnWidth(float width) { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, miscData, multiCol, width, width, autoWidth, false); }
+inline void RenderStyle::setColumnWidth(Style::ColumnWidth width) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, width, width); }
 inline void RenderStyle::setContain(OptionSet<Containment> containment) { SET_NESTED(m_nonInheritedData, rareData, contain, containment); }
 inline void RenderStyle::setContainIntrinsicHeight(Style::ContainIntrinsicSize&& height) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicHeight, WTFMove(height)); }
 inline void RenderStyle::setContainIntrinsicWidth(Style::ContainIntrinsicSize&& width) { SET_NESTED(m_nonInheritedData, rareData, containIntrinsicWidth, WTFMove(width)); }
@@ -169,8 +170,6 @@ inline void RenderStyle::setHangingPunctuation(OptionSet<HangingPunctuation> pun
 inline void RenderStyle::setHasAttrContent() { SET_NESTED(m_nonInheritedData, miscData, hasAttrContent, true); }
 inline void RenderStyle::setHasAutoAccentColor() { SET_PAIR(m_rareInheritedData, hasAutoAccentColor, true, accentColor, Style::Color::currentColor()); }
 inline void RenderStyle::setHasAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasAutoCaretColor, true, caretColor, Style::Color::currentColor()); }
-inline void RenderStyle::setHasAutoColumnCount() { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, miscData, multiCol, autoCount, true, count, initialColumnCount()); }
-inline void RenderStyle::setHasAutoColumnWidth() { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, miscData, multiCol, autoWidth, true, width, 0); }
 inline void RenderStyle::setHasAutoOrphans() { SET_PAIR(m_rareInheritedData, hasAutoOrphans, true, orphans, initialOrphans()); }
 inline void RenderStyle::setHasAutoSpecifiedZIndex() { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoSpecifiedZIndex, true, m_specifiedZIndex, 0); }
 inline void RenderStyle::setHasAutoUsedZIndex() { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoUsedZIndex, true, m_usedZIndex, 0); }
@@ -461,13 +460,6 @@ inline void RenderStyle::setClipPath(Style::ClipPath&& operation)
 {
     if (m_nonInheritedData->rareData->clipPath != operation)
         m_nonInheritedData.access().rareData.access().clipPath = WTFMove(operation);
-}
-
-inline void RenderStyle::setColumnCount(unsigned short count)
-{
-    unsigned short clampedCount = std::max<unsigned short>(count, 1);
-    SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, count, clampedCount);
-    SET_DOUBLY_NESTED(m_nonInheritedData, miscData, multiCol, autoCount, false);
 }
 
 inline void RenderStyle::setCursor(Style::Cursor&& cursor)

--- a/Source/WebCore/rendering/style/StyleMultiColData.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiColData.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2004-2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -24,17 +25,17 @@
 
 #include "RenderStyleDifference.h"
 #include "RenderStyleInlines.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleMultiColData);
 
 StyleMultiColData::StyleMultiColData()
-    : count(RenderStyle::initialColumnCount())
-    , autoWidth(true)
-    , autoCount(true)
+    : width(RenderStyle::initialColumnWidth())
+    , count(RenderStyle::initialColumnCount())
     , fill(static_cast<unsigned>(RenderStyle::initialColumnFill()))
-    , columnSpan(false)
+    , columnSpan(static_cast<unsigned>(RenderStyle::initialColumnSpan()))
     , axis(static_cast<unsigned>(RenderStyle::initialColumnAxis()))
     , progression(static_cast<unsigned>(RenderStyle::initialColumnProgression()))
 {
@@ -46,8 +47,6 @@ inline StyleMultiColData::StyleMultiColData(const StyleMultiColData& other)
     , count(other.count)
     , rule(other.rule)
     , visitedLinkColumnRuleColor(other.visitedLinkColumnRuleColor)
-    , autoWidth(other.autoWidth)
-    , autoCount(other.autoCount)
     , fill(other.fill)
     , columnSpan(other.columnSpan)
     , axis(other.axis)
@@ -62,11 +61,14 @@ Ref<StyleMultiColData> StyleMultiColData::copy() const
 
 bool StyleMultiColData::operator==(const StyleMultiColData& other) const
 {
-    return width == other.width && count == other.count
-        && rule == other.rule && visitedLinkColumnRuleColor == other.visitedLinkColumnRuleColor
-        && autoWidth == other.autoWidth && autoCount == other.autoCount
-        && fill == other.fill && columnSpan == other.columnSpan
-        && axis == other.axis && progression == other.progression;
+    return width == other.width
+        && count == other.count
+        && rule == other.rule
+        && visitedLinkColumnRuleColor == other.visitedLinkColumnRuleColor
+        && fill == other.fill
+        && columnSpan == other.columnSpan
+        && axis == other.axis
+        && progression == other.progression;
 }
 
 #if !LOG_DISABLED
@@ -76,9 +78,6 @@ void StyleMultiColData::dumpDifferences(TextStream& ts, const StyleMultiColData&
     LOG_IF_DIFFERENT(count);
     LOG_IF_DIFFERENT(rule);
     LOG_IF_DIFFERENT(visitedLinkColumnRuleColor);
-
-    LOG_IF_DIFFERENT(autoWidth);
-    LOG_IF_DIFFERENT(autoCount);
 
     LOG_IF_DIFFERENT_WITH_CAST(ColumnFill, fill);
     LOG_IF_DIFFERENT_WITH_CAST(ColumnSpan, columnSpan);

--- a/Source/WebCore/rendering/style/StyleMultiColData.h
+++ b/Source/WebCore/rendering/style/StyleMultiColData.h
@@ -4,6 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  * Copyright (C) 2003-2017 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -26,6 +27,8 @@
 
 #include "BorderValue.h"
 #include "RenderStyleConstants.h"
+#include "StyleColumnCount.h"
+#include "StyleColumnWidth.h"
 #include <wtf/RefCounted.h>
 
 namespace WTF {
@@ -56,13 +59,11 @@ public:
         return rule.width();
     }
 
-    float width { 0 };
-    unsigned short count;
+    Style::ColumnWidth width { CSS::Keyword::Auto { } };
+    Style::ColumnCount count { CSS::Keyword::Auto { } };
     BorderValue rule;
     Style::Color visitedLinkColumnRuleColor;
 
-    bool autoWidth : 1;
-    bool autoCount : 1;
     PREFERRED_TYPE(ColumnFill) unsigned fill : 1;
     PREFERRED_TYPE(ColumnSpan) unsigned columnSpan : 1;
     PREFERRED_TYPE(ColumnAxis) unsigned axis : 2;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -148,7 +148,7 @@ RenderTreeBuilder::MultiColumn::MultiColumn(RenderTreeBuilder& builder)
 
 void RenderTreeBuilder::MultiColumn::updateAfterDescendants(RenderBlockFlow& flow)
 {
-    bool needsFragmentedFlow = flow.requiresColumns(flow.style().columnCount());
+    bool needsFragmentedFlow = flow.requiresColumns(flow.style().columnCount().tryValue().value_or(1).value);
     bool hasFragmentedFlow = flow.multiColumnFlow();
 
     if (!hasFragmentedFlow && needsFragmentedFlow) {

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -2343,32 +2343,23 @@ inline void ExtractorCustom::extractBorderRadiusShorthandSerialization(Extractor
 
 inline RefPtr<CSSValue> ExtractorCustom::extractColumnsShorthand(ExtractorState& state)
 {
-    if (state.style.hasAutoColumnCount())
-        return state.style.hasAutoColumnWidth() ? CSSPrimitiveValue::create(CSSValueAuto) : ExtractorConverter::convertNumberAsPixels(state, state.style.columnWidth());
-    if (state.style.hasAutoColumnWidth())
-        return state.style.hasAutoColumnCount() ? CSSPrimitiveValue::create(CSSValueAuto) : CSSPrimitiveValue::create(state.style.columnCount());
+    if (state.style.columnCount() == RenderStyle::initialColumnCount())
+        return createCSSValue(state.pool, state.style, state.style.columnWidth());
+    if (state.style.columnWidth() == RenderStyle::initialColumnWidth())
+        return createCSSValue(state.pool, state.style, state.style.columnCount());
     return extractStandardSpaceSeparatedShorthand(state, columnsShorthand());
 }
 
 inline void ExtractorCustom::extractColumnsShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
-    if (state.style.hasAutoColumnCount()) {
-        if (state.style.hasAutoColumnWidth()) {
-            CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });
-            return;
-        }
-        ExtractorSerializer::serializeNumberAsPixels(state, builder, context, state.style.columnWidth());
+    if (state.style.columnCount() == RenderStyle::initialColumnCount()) {
+        serializationForCSS(builder, context, state.style, state.style.columnWidth());
         return;
     }
-    if (state.style.hasAutoColumnWidth()) {
-        if (state.style.hasAutoColumnCount()) {
-            CSS::serializationForCSS(builder, context, CSS::Keyword::Auto { });
-            return;
-        }
-        ExtractorSerializer::serializeNumber(state, builder, context, state.style.columnCount());
+    if (state.style.columnWidth() == RenderStyle::initialColumnWidth()) {
+        serializationForCSS(builder, context, state.style, state.style.columnCount());
         return;
     }
-
     extractStandardSpaceSeparatedShorthandSerialization(state, builder, context, columnsShorthand());
 }
 

--- a/Source/WebCore/style/values/multicol/StyleColumnCount.cpp
+++ b/Source/WebCore/style/values/multicol/StyleColumnCount.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleColumnCount.h"
+
+#include "StylePrimitiveNumericTypes+Blending.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Blending
+
+auto Blending<ColumnCount>::canBlend(const ColumnCount& a, const ColumnCount& b) -> bool
+{
+    return !a.isAuto() && !b.isAuto();
+}
+
+auto Blending<ColumnCount>::blend(const ColumnCount& a, const ColumnCount& b, const BlendingContext& context) -> ColumnCount
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1);
+        return context.progress ? b : a;
+    }
+
+    ASSERT(!a.isAuto());
+    ASSERT(!b.isAuto());
+    return { WebCore::Style::blend(*a.tryValue(), *b.tryValue(), context) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/multicol/StyleColumnCount.h
+++ b/Source/WebCore/style/values/multicol/StyleColumnCount.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumericTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'column-width'> = auto | <integer [1,∞]>
+// https://www.w3.org/TR/css-multicol-1/#propdef-column-count
+struct ColumnCount : ValueOrKeyword<Integer<CSS::Range{1,CSS::Range::infinity}, unsigned short>, CSS::Keyword::Auto> {
+    using Base::Base;
+
+    bool isAuto() const { return isKeyword(); }
+};
+
+// MARK: - Blending
+
+template<> struct Blending<ColumnCount> {
+    auto canBlend(const ColumnCount&, const ColumnCount&) -> bool;
+    auto blend(const ColumnCount&, const ColumnCount&, const BlendingContext&) -> ColumnCount;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ColumnCount)

--- a/Source/WebCore/style/values/multicol/StyleColumnWidth.cpp
+++ b/Source/WebCore/style/values/multicol/StyleColumnWidth.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleColumnWidth.h"
+
+#include "StylePrimitiveNumericTypes+Blending.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Blending
+
+auto Blending<ColumnWidth>::canBlend(const ColumnWidth& a, const ColumnWidth& b) -> bool
+{
+    return !a.isAuto() && !b.isAuto();
+}
+
+auto Blending<ColumnWidth>::blend(const ColumnWidth& a, const ColumnWidth& b, const BlendingContext& context) -> ColumnWidth
+{
+    if (context.isDiscrete) {
+        ASSERT(!context.progress || context.progress == 1);
+        return context.progress ? b : a;
+    }
+
+    ASSERT(!a.isAuto());
+    ASSERT(!b.isAuto());
+    return { WebCore::Style::blend(*a.tryValue(), *b.tryValue(), context) };
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/multicol/StyleColumnWidth.h
+++ b/Source/WebCore/style/values/multicol/StyleColumnWidth.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumericTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'column-width'> = auto | <length [0,∞]>
+// https://www.w3.org/TR/css-multicol-1/#propdef-column-width
+struct ColumnWidth : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::Auto> {
+    using Base::Base;
+    using Length = typename Base::Value;
+
+    bool isAuto() const { return isKeyword(); }
+    bool isLength() const { return isValue(); }
+    std::optional<Length> tryLength() const { return tryValue(); }
+};
+
+// MARK: - Blending
+
+template<> struct Blending<ColumnWidth> {
+    auto canBlend(const ColumnWidth&, const ColumnWidth&) -> bool;
+    auto blend(const ColumnWidth&, const ColumnWidth&, const BlendingContext&) -> ColumnWidth;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::ColumnWidth)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -39,14 +39,14 @@ template<auto R, typename V> struct CSSValueConversion<Integer<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Integer<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Integer<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_integer;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -54,14 +54,14 @@ template<auto R, typename V> struct CSSValueConversion<Number<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Number<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Number<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_number;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -69,14 +69,14 @@ template<auto R, typename V> struct CSSValueConversion<Percentage<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Percentage<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Percentage<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_percentage;
-        return { protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -84,14 +84,14 @@ template<auto R, typename V> struct CSSValueConversion<Angle<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Angle<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Angle<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_deg;
-        return { protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -102,7 +102,7 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
         auto conversionData = builderState.useSVGZoomRulesForLength()
             ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
             : builderState.cssToLengthConversionData();
-        return { protectedValue->resolveAsLength<V>(conversionData) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Length<R, V>
     {
@@ -112,7 +112,7 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
         auto conversionData = builderState.useSVGZoomRulesForLength()
             ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
             : builderState.cssToLengthConversionData();
-        return { protectedValue->resolveAsLength<V>(conversionData) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
 };
 
@@ -120,14 +120,14 @@ template<auto R, typename V> struct CSSValueConversion<Time<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Time<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Time<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_s;
-        return { protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -135,14 +135,14 @@ template<auto R, typename V> struct CSSValueConversion<Resolution<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Resolution<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Resolution<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_dppx;
-        return { protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData())) };
     }
 };
 


### PR DESCRIPTION
#### 5e8445bb29295c284bd87a920fb46713d946d532
<pre>
[Style] Convert column-count and column-width properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296644">https://bugs.webkit.org/show_bug.cgi?id=296644</a>

Reviewed by NOBODY (OOPS!).

Converts the `column-count` and `column-width` properties to strong style types.

To make these work correctly, clamping of primitive values was pushed from
style setting (e.g. RenderStyle::setColumnCount) to style conversion, so that
the invariant that the numeric type never holds an illegal value can hold.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleMultiColData.cpp:
* Source/WebCore/rendering/style/StyleMultiColData.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/values/multicol/StyleColumnCount.cpp: Added.
* Source/WebCore/style/values/multicol/StyleColumnCount.h: Added.
* Source/WebCore/style/values/multicol/StyleColumnWidth.cpp: Added.
* Source/WebCore/style/values/multicol/StyleColumnWidth.h: Added.
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e8445bb29295c284bd87a920fb46713d946d532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114380 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86928 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41840 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67320 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26867 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/animation/column-count-interpolation.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20851 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/animation/column-count-interpolation.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64233 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97060 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20966 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/animation/column-count-interpolation.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123754 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41394 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30875 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/animation/column-count-interpolation.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95749 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/animation/column-count-interpolation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95533 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40686 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18522 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/animation/column-count-interpolation.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37435 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40866 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->