### PR TITLE
Defer setTimeout(0) until after DOMContentLoaded to fix test timeouts with async events

### DIFF
--- a/LayoutTests/http/wpt/dom/events-async-expected.txt
+++ b/LayoutTests/http/wpt/dom/events-async-expected.txt
@@ -1,0 +1,3 @@
+
+PASS microtask should run before window.onload when events are async
+

--- a/LayoutTests/http/wpt/dom/events-async.html
+++ b/LayoutTests/http/wpt/dom/events-async.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ AsyncDocumentLifecycleEventsEnabled=true ] -->
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script type="module">
+
+promise_test(async t => {
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+}, "microtask should run before window.onload when events are async");
+</script>

--- a/LayoutTests/http/wpt/dom/events-sync-expected.txt
+++ b/LayoutTests/http/wpt/dom/events-sync-expected.txt
@@ -1,0 +1,3 @@
+
+PASS in microtask execution in module, window.onload should be fired first for sync events
+

--- a/LayoutTests/http/wpt/dom/events-sync.html
+++ b/LayoutTests/http/wpt/dom/events-sync.html
@@ -1,0 +1,12 @@
+<!-- webkit-test-runner [ AsyncDocumentLifecycleEventsEnabled=false ] -->
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script type="module">
+
+promise_test(async t => {
+  assert_equals(document.readyState, 'complete', 'document.readyState should be complete');
+  t.done();
+}, "in microtask execution in module, window.onload should be fired first for sync events");
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -554,6 +554,20 @@ AsyncClipboardAPIEnabled:
     WebCore:
       default: false
 
+AsyncDocumentLifecycleEventsEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Async Document Lifecycle Events"
+  humanReadableDescription: "Fire DOMContentLoaded, load, and pageshow events asynchronously"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AsyncFrameScrollingEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1455,6 +1455,11 @@ public:
     bool isDelayingLoadEvent() const { return m_loadEventDelayCount; }
     WEBCORE_EXPORT void checkCompleted();
 
+    // Support for deferring setTimeout(0) until after DOMContentLoaded with async events
+    bool shouldDeferZeroDelayTimers() const;
+    void deferZeroDelayTimer(Function<void()>&&);
+    void flushDeferredZeroDelayTimers();
+
 #if ENABLE(IOS_TOUCH_EVENTS)
 #include <WebKitAdditions/DocumentIOS.h>
 #endif
@@ -2379,6 +2384,10 @@ private:
     Timer m_loadEventDelayTimer;
 
     CompletionHandler<void()> m_whenWindowLoadEventOrDestroyed;
+
+    // For deferring setTimeout(0) until after DOMContentLoaded with async events
+    Vector<Function<void()>> m_deferredZeroDelayTimers;
+    bool m_domContentLoadedEventWasDispatched { false };
 
     WeakHashMap<Node, std::unique_ptr<QuerySelectorAllResults>, WeakPtrImplWithEventTargetData> m_querySelectorAllResults;
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -84,7 +84,7 @@ const TestFeatures& TestOptions::defaults()
             { "AllowUniversalAccessFromFileURLs", true },
             { "AllowsInlineMediaPlayback", true },
             { "AppBadgeEnabled", true },
-            { "AsyncDocumentLifecycleEventsEnabled", false },
+            { "AsyncDocumentLifecycleEventsEnabled", true },
             { "AsyncFrameScrollingEnabled", false },
             { "AsyncOverflowScrollingEnabled", false },
             { "BuiltInNotificationsEnabled", false },

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -84,6 +84,7 @@ const TestFeatures& TestOptions::defaults()
             { "AllowUniversalAccessFromFileURLs", true },
             { "AllowsInlineMediaPlayback", true },
             { "AppBadgeEnabled", true },
+            { "AsyncDocumentLifecycleEventsEnabled", false },
             { "AsyncFrameScrollingEnabled", false },
             { "AsyncOverflowScrollingEnabled", false },
             { "BuiltInNotificationsEnabled", false },

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -213,12 +213,19 @@ static bool shouldEnableAsyncOverflowScrolling(const std::string& pathOrURL)
     return isWebPlatformTestURL({ { }, String::fromUTF8(pathOrURL.c_str()) });
 }
 
+static bool shouldEnableAsyncDocumentLifecycleEvents(const std::string& pathOrURL)
+{
+    return isWebPlatformTestURL({ { }, String::fromUTF8(pathOrURL.c_str()) });
+}
+
 TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCommand& command) const
 {
     TestFeatures features;
     features.boolTestRunnerFeatures.insert({ "useThreadedScrolling", true });
     if (shouldEnableAsyncOverflowScrolling(command.pathOrURL))
         features.boolWebPreferenceFeatures.insert({ "AsyncOverflowScrollingEnabled", true });
+    if (shouldEnableAsyncDocumentLifecycleEvents(command.pathOrURL))
+        features.boolWebPreferenceFeatures.insert({ "AsyncDocumentLifecycleEventsEnabled", true });
     return features;
 }
 


### PR DESCRIPTION
#### 65a7e91f24d7b6c19ceb6d6b3bc0264cb7d4d76e
<pre>
Defer setTimeout(0) until after DOMContentLoaded to fix test timeouts with async events

When async document lifecycle events are enabled, setTimeout(0) calls can execute
before DOMContentLoaded event handlers have run, breaking test assumptions.

This change defers zero-delay timers until after DOMContentLoaded has been dispatched,
ensuring jQuery ready handlers and similar patterns work correctly with async events.
</pre>
----------------------------------------------------------------------
#### c3d98ce6da02827557967413f2ec00ef59d0f5d8
<pre>
Make window load event dispatch asynchronous to improve WPT compatibility.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296649">https://bugs.webkit.org/show_bug.cgi?id=296649</a>
<a href="https://rdar.apple.com/157048720">rdar://157048720</a>

Reviewed by NOBODY (OOPS!).

Implementation Status

The proof-of-concept adds a feature flag AsyncDocumentLifecycleEventsEnabled that makes three key document lifecycle events fire asynchronously:
- DOMContentLoaded
- window load
- pageshow

When enabled, these events are queued via the event loop instead of firing synchronously. The feature is off by default but automatically enabled for WPT tests.

What Needs to Be Done

Immediate
- Run full WPT test suite to verify this fixes the compatibility issues
- Add more comprehensive test coverage beyond the two basic tests

Testing Required
- Event ordering with multiple event listeners
- Microtask/promise interaction timing
- Dynamic content loading scenarios
- iframe load event behavior
- Back/forward cache with async pageshow

Open Questions
- Does document.close() forced synchronous behavior need special handling?
- Any performance impact from async dispatch?
- Will this break existing WebKit-dependent content?

Technical Approach

- Uses incrementLoadEventDelayCount()/decrementLoadEventDelayCount() to prevent the document from thinking it&apos;s finished loading while events are queued.
- Events are dispatched via eventLoop().queueTask(TaskSource::DOMManipulation, ...).

* LayoutTests/http/wpt/dom/events-async-expected.txt: Added.
* LayoutTests/http/wpt/dom/events-async.html: Added.
* LayoutTests/http/wpt/dom/events-sync-expected.txt: Added.
* LayoutTests/http/wpt/dom/events-sync.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchWindowLoadEvent):
(WebCore::Document::finishedParsing):
(WebCore::Document::dispatchPageshowEvent):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::shouldEnableAsyncDocumentLifecycleEvents):
(WTR::TestController::platformSpecificFeatureDefaultsForTest const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65a7e91f24d7b6c19ceb6d6b3bc0264cb7d4d76e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117510 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37186 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27810 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123615 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69517 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119388 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37880 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45770 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/123615 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/69517 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120462 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/37880 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/27810 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/123615 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | ⏳ 🛠 vision-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/37880 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/27810 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67287 "Build is in progress. Recent messages:Printed configuration") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109620 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC; Running jscore-test") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/37880 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/27810 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126735 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116019 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled JSC; Running jscore-test") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44413 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/45770 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/126735 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44771 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/27810 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/126735 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/27810 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40771 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44284 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49959 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Checked out pull request; Running scan-build") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144717 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43741 "Build is in progress. Recent messages:") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37247 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47090 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; Running compile-webkit") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45434 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4") | | | | 
<!--EWS-Status-Bubble-End-->