### PR TITLE
[Site Isolation] Media capabilities should be granted to all WebContent processes with frames playing media

### DIFF
--- a/Source/WebCore/page/MediaProducer.h
+++ b/Source/WebCore/page/MediaProducer.h
@@ -133,6 +133,19 @@ public:
 
     static bool isCapturing(MediaStateFlags state) { return state.containsAny(ActiveCaptureMask) || state.containsAny(MutedCaptureMask); }
 
+#if ENABLE(EXTENSION_CAPABILITIES)
+    static bool needsMediaCapability(MediaStateFlags state)
+    {
+        if (state.contains(MediaProducerMediaState::IsPlayingAudio))
+            return true;
+
+        if (state.contains(MediaProducerMediaState::IsPlayingVideo))
+            return true;
+
+        return MediaProducer::isCapturing(state);
+    }
+#endif
+
     virtual MediaStateFlags mediaState() const = 0;
 
     static constexpr MutedStateFlags AudioAndVideoCaptureIsMuted = { MutedState::AudioCaptureIsMuted, MutedState::VideoCaptureIsMuted };

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
@@ -41,35 +41,23 @@ namespace WebKit {
 
 class ExtensionCapability;
 class ExtensionCapabilityGrant;
-class ExtensionCapabilityGranter;
-class GPUProcessProxy;
 class MediaCapability;
 class WebPageProxy;
-class WebProcessProxy;
-
-struct ExtensionCapabilityGranterClient : public AbstractRefCountedAndCanMakeWeakPtr<ExtensionCapabilityGranterClient> {
-    virtual ~ExtensionCapabilityGranterClient() = default;
-
-    virtual RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) = 0;
-    virtual RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) = 0;
-};
 
 class ExtensionCapabilityGranter : public RefCountedAndCanMakeWeakPtr<ExtensionCapabilityGranter> {
     WTF_MAKE_TZONE_ALLOCATED(ExtensionCapabilityGranter);
     WTF_MAKE_NONCOPYABLE(ExtensionCapabilityGranter);
 public:
-    static RefPtr<ExtensionCapabilityGranter> create(ExtensionCapabilityGranterClient&);
+    static RefPtr<ExtensionCapabilityGranter> create();
 
-    void grant(const ExtensionCapability&);
-    void revoke(const ExtensionCapability&);
+    void grant(const ExtensionCapability&, WebPageProxy&);
+    void revoke(const ExtensionCapability&, WebPageProxy&);
 
     void setMediaCapabilityActive(MediaCapability&, bool);
-    void invalidateGrants(Vector<ExtensionCapabilityGrant>&&);
+    static void invalidateGrants(Vector<ExtensionCapabilityGrant>&&);
 
 private:
-    explicit ExtensionCapabilityGranter(ExtensionCapabilityGranterClient&);
-
-    WeakRef<ExtensionCapabilityGranterClient> m_client;
+    explicit ExtensionCapabilityGranter() = default;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1395,32 +1395,8 @@ void WebProcessPool::suppressEDR(bool suppressEDR)
 ExtensionCapabilityGranter& WebProcessPool::extensionCapabilityGranter()
 {
     if (!m_extensionCapabilityGranter)
-        m_extensionCapabilityGranter = ExtensionCapabilityGranter::create(*this);
+        m_extensionCapabilityGranter = ExtensionCapabilityGranter::create();
     return *m_extensionCapabilityGranter;
-}
-
-RefPtr<GPUProcessProxy> WebProcessPool::gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter& extensionCapabilityGranter)
-{
-    ASSERT_UNUSED(extensionCapabilityGranter, m_extensionCapabilityGranter.get() == &extensionCapabilityGranter);
-    return gpuProcess();
-}
-
-RefPtr<WebProcessProxy> WebProcessPool::webProcessForCapabilityGranter(const ExtensionCapabilityGranter& extensionCapabilityGranter, const String& environmentIdentifier)
-{
-    ASSERT_UNUSED(extensionCapabilityGranter, m_extensionCapabilityGranter.get() == &extensionCapabilityGranter);
-
-    auto index = processes().findIf([&](auto& process) {
-        return process->pages().containsIf([&](auto& page) {
-            if (RefPtr mediaCapability = page->mediaCapability())
-                return mediaCapability->environmentIdentifier() == environmentIdentifier;
-            return false;
-        });
-    });
-
-    if (index == notFound)
-        return nullptr;
-
-    return processes()[index].ptr();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -80,6 +80,7 @@
 
 #if ENABLE(EXTENSION_CAPABILITIES)
 #include "ExtensionCapabilityGrant.h"
+#include "ExtensionCapabilityGranter.h"
 #include "MediaCapability.h"
 #endif
 
@@ -577,12 +578,7 @@ void GPUProcessProxy::gpuProcessExited(ProcessTerminationReason reason)
     }
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    // FIXME: Any ExtensionCapabilityGranter can invalidate the GPUProcessProxy grants, so we pick the first one. In the future ExtensionCapabilityGranter should be made a singleton.
-    for (auto& processPool : WebProcessPool::allProcessPools()) {
-        processPool->extensionCapabilityGranter().invalidateGrants(moveToVector(std::exchange(extensionCapabilityGrants(), { }).values()));
-        break;
-    }
-
+    ExtensionCapabilityGranter::invalidateGrants(moveToVector(std::exchange(extensionCapabilityGrants(), { }).values()));
 #endif
 
     if (keptAliveGPUProcessProxy() == this)

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -56,7 +56,11 @@ public:
     PlatformGrant grantCapability(const PlatformCapability&, BlockPtr<void()>&& invalidationHandler = ^{ }) const;
     RetainPtr<UIInteraction> createVisibilityPropagationInteraction() const;
 
+    ExtensionProcess isolatedCopy() &&;
+
 private:
+    explicit ExtensionProcess(ExtensionProcessVariant&&);
+
     ExtensionProcessVariant m_process;
 };
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -31,6 +31,7 @@
 #import "ExtensionCapability.h"
 #import "ExtensionKitSPI.h"
 #import <BrowserEngineKit/BrowserEngineKit.h>
+#import <wtf/CrossThreadCopier.h>
 
 #if __has_include(<WebKitAdditions/BEKAdditions.h>)
 #import <WebKitAdditions/BEKAdditions.h>
@@ -50,6 +51,11 @@ ExtensionProcess::ExtensionProcess(BENetworkingProcess *process)
 
 ExtensionProcess::ExtensionProcess(BERenderingProcess *process)
     : m_process(process)
+{
+}
+
+ExtensionProcess::ExtensionProcess(ExtensionProcessVariant&& process)
+    : m_process(WTFMove(process))
 {
 }
 
@@ -94,6 +100,11 @@ RetainPtr<UIInteraction> ExtensionProcess::createVisibilityPropagationInteractio
     }, [] (auto& process) {
     });
     return interaction;
+}
+
+ExtensionProcess ExtensionProcess::isolatedCopy() &&
+{
+    return ExtensionProcess { crossThreadCopy(WTFMove(m_process)) };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -160,6 +160,7 @@
 
 #if ENABLE(EXTENSION_CAPABILITIES)
 #include "ExtensionCapabilityGrant.h"
+#include "ExtensionCapabilityGranter.h"
 #include "MediaCapability.h"
 #endif
 
@@ -1240,7 +1241,7 @@ void WebProcessPool::disconnectProcess(WebProcessProxy& process)
     removeProcessFromOriginCacheSet(process);
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    extensionCapabilityGranter().invalidateGrants(moveToVector(std::exchange(process.extensionCapabilityGrants(), { }).values()));
+    ExtensionCapabilityGranter::invalidateGrants(moveToVector(std::exchange(process.extensionCapabilityGrants(), { }).values()));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -83,10 +83,6 @@ OBJC_CLASS WKWebInspectorPreferenceObserver;
 #include "IPCTester.h"
 #endif
 
-#if ENABLE(EXTENSION_CAPABILITIES)
-#include "ExtensionCapabilityGranter.h"
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 #include "HardwareKeyboardState.h"
 #endif
@@ -117,6 +113,7 @@ class PowerSourceNotifier;
 
 namespace WebKit {
 
+class ExtensionCapabilityGranter;
 class LockdownModeObserver;
 class PerActivityStateCPUUsageSampler;
 class SuspendedPageProxy;
@@ -157,9 +154,6 @@ class WebProcessPool final
     , public IPC::MessageReceiver
 #if PLATFORM(MAC)
     , private PAL::SystemSleepListener::Client
-#endif
-#if ENABLE(EXTENSION_CAPABILITIES)
-    , public ExtensionCapabilityGranterClient
 #endif
 {
 public:
@@ -591,8 +585,6 @@ public:
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     ExtensionCapabilityGranter& extensionCapabilityGranter();
-    RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) final;
-    RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) final;
 #endif
 
     bool usesSingleWebProcess() const { return m_configuration->usesSingleWebProcess(); }


### PR DESCRIPTION
#### e1d2afaed471aad60cd2b15efc34bd1280681f02
<pre>
[Site Isolation] Media capabilities should be granted to all WebContent processes with frames playing media
<a href="https://bugs.webkit.org/show_bug.cgi?id=296651">https://bugs.webkit.org/show_bug.cgi?id=296651</a>
<a href="https://rdar.apple.com/157053418">rdar://157053418</a>

Reviewed by Eric Carlson.

ExtensionCapabilityGranter was designed to grant media capabilities to a single WebContent process
responsible for media playback or capture, but with Site Isolation enabled there may be multiple
WebContent processes responsible for media playback or capture for a given page.

Refactored ExtensionCapabilityGranter so that instead of assuming there is one WebContent and one
GPU process needing capability grants, it now collects an array of auxiliary processes needing
grants and issues grants to each.

Tested manually. API tests will be added in a follow-on change.

* Source/WebCore/page/MediaProducer.h:
(WebCore::MediaProducer::needsMediaCapability):
  Added. This logic was moved from WebPageProxy::shouldActivateMediaCapability() so it can be reused
  by ExtensionCapabilityGranter.

* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::grantCapability):
  Changed to take a non-optional ExtensionProcess.
(WebKit::CapabilityGrantForAuxiliaryProcess::isolatedCopy):
  Added.
(WebKit::grantCapabilityInternal):
  Changed to take a Vector of AuxiliaryProcessProxys rather than a single GPUProcessProxy and
  WebProcessProxy.
(WebKit::auxiliaryProcessesForPage):
  Added a helper for enumerating the auxiliary processes for a given WebPageProxy.
(WebKit::processesNeedingGrant):
  Added a helper to filter for the auxiliary processes needing a media capability grant.
(WebKit::finalizeGrant):
  Changed to take a Vector of AuxiliaryProcessProxys rather than a single GPUProcessProxy and
  WebProcessProxy.
(WebKit::ExtensionCapabilityGranter::create):
(WebKit::ExtensionCapabilityGranter::grant):
(WebKit::ExtensionCapabilityGranter::revoke):
  Removed the need for a ExtensionCapabilityGranterClient; passed in a WebPageProxy instead.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::deactivateMediaCapability):
  Passed *this to ExtensionCapabilityGranter::revoke.
(WebKit::WebPageProxy::updateMediaCapability):
  Ditto for ExtensionCapabilityGranter::grant.
(WebKit::WebPageProxy::shouldActivateMediaCapability const):
  Moved some logic to MediaProducer::needsMediaCapability.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::extensionCapabilityGranter):
  Changed to stop passing *this as a client.
(WebKit::WebProcessPool::gpuProcessForCapabilityGranter):
(WebKit::WebProcessPool::webProcessForCapabilityGranter):
  Deleted. There is no longer a need to conform to ExtensionCapabilityGranterClient.

* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::gpuProcessExited):
  Changed to call ExtensionCapabilityGranter::invalidateGrants (which is now static).

* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm:
(WebKit::ExtensionProcess::ExtensionProcess):
(WebKit::ExtensionProcess::isolatedCopy):
  Added a move contructor and isolatedCopy() method.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::disconnectProcess):
  Changed to call ExtensionCapabilityGranter::invalidateGrants (which is now static).

* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/298156@main">https://commits.webkit.org/298156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cadc7d7ccca4a1fe5d72374c1e967cbbacb3608a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114279 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65004 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9df9a9a1-465b-469b-a86a-5330994af964) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67235 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20765 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64133 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95672 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95455 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40603 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18437 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37361 "Hash cadc7d7c for PR 48682 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46681 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->