### PR TITLE
Include element attributes in _WKSerializedNode

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -647,8 +647,19 @@ SerializedNode Element::serializeNode(CloningOperation type) const
         children = serializeChildNodes();
         break;
     }
-    // FIXME: Make an equivalent of Element::cloneDataFromElement and cloneShadowTreeIfPossible.
-    return { SerializedNode::Element { { WTFMove(children) }, { tagQName() } } };
+
+    // FIXME: Make an equivalent of cloneShadowTreeIfPossible.
+
+    // FIXME: Get this compiling with GCC.
+#if PLATFORM(COCOA)
+    auto attributes = this->elementData() ? WTF::map(this->attributes(), [] (const auto& attribute) {
+        return SerializedNode::Element::Attribute { { attribute.name() }, attribute.value() };
+    }) : Vector<SerializedNode::Element::Attribute>();
+#else
+    Vector<SerializedNode::Element::Attribute> attributes;
+#endif
+
+    return { SerializedNode::Element { { WTFMove(children) }, { tagQName() }, WTFMove(attributes) } };
 }
 
 void Element::cloneShadowTreeIfPossible(Element& newHost) const

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -80,7 +80,12 @@ struct SerializedNode {
         String systemId;
     };
     struct Element : public ContainerNode {
+        struct Attribute {
+            QualifiedName name;
+            String value;
+        };
         QualifiedName name;
+        Vector<Attribute> attributes;
     };
     struct ShadowRoot : public DocumentFragment {
         // FIXME: Implement.

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -140,7 +140,17 @@ SerializedNode HTMLTemplateElement::serializeNode(CloningOperation type) const
         children = serializeChildNodes();
         break;
     }
-    return { SerializedNode::HTMLTemplateElement { { { WTFMove(children) }, { tagQName() } } } };
+
+    // FIXME: Get this compiling with GCC.
+#if PLATFORM(COCOA)
+    auto attributes = this->elementData() ? WTF::map(this->attributes(), [] (const auto& attribute) {
+        return SerializedNode::Element::Attribute { { attribute.name() }, attribute.value() };
+    }) : Vector<SerializedNode::Element::Attribute>();
+#else
+    Vector<SerializedNode::Element::Attribute> attributes;
+#endif
+
+    return { SerializedNode::HTMLTemplateElement { { { WTFMove(children) }, { tagQName() }, WTFMove(attributes) } } };
 }
 
 void HTMLTemplateElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebKit/Shared/SerializedNode.serialization.in
+++ b/Source/WebKit/Shared/SerializedNode.serialization.in
@@ -57,8 +57,13 @@
     String publicId;
     String systemId;
 };
+[Nested] struct WebCore::SerializedNode::Element::Attribute {
+    WebCore::SerializedNode::QualifiedName name;
+    String value;
+}
 [Nested] struct WebCore::SerializedNode::Element : WebCore::SerializedNode::ContainerNode {
     WebCore::SerializedNode::QualifiedName name;
+    Vector<WebCore::SerializedNode::Element::Attribute> attributes;
 };
 [Nested] struct WebCore::SerializedNode::Comment : WebCore::SerializedNode::CharacterData {
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NodeInfo.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NodeInfo.mm
@@ -151,8 +151,8 @@ TEST(SerializedNode, Basic)
     auto documentAccessor = "n.URL + ',' + n.documentURI + ',' + new XMLSerializer().serializeToString(n)";
     verifyNodeSerialization("document.implementation.createDocument('http://www.w3.org/2000/svg', 'svg', null)", documentAccessor, "about:blank,about:blank,<svg xmlns=\"http://www.w3.org/2000/svg\"/>", "XMLDocument");
     verifyNodeSerialization("document.implementation.createHTMLDocument('test title')", documentAccessor, "about:blank,about:blank,<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>test title</title></head><body></body></html>", "HTMLDocument");
-    verifyNodeSerialization("document", documentAccessor, "https://webkit.org/,https://webkit.org/,<html xmlns=\"http://www.w3.org/1999/xhtml\"><head></head><body><div><div>test</div></div><template></template></body></html>", "HTMLDocument");
-    verifyNodeSerialization("document.getElementById('testid')", documentAccessor, "undefined,undefined,<div xmlns=\"http://www.w3.org/1999/xhtml\"></div>", "HTMLDivElement", "");
+    verifyNodeSerialization("document", documentAccessor, "https://webkit.org/,https://webkit.org/,<html xmlns=\"http://www.w3.org/1999/xhtml\"><head></head><body><div id=\"testid\"><div>test</div></div><template id=\"outerTemplate\"></template></body></html>", "HTMLDocument");
+    verifyNodeSerialization("document.getElementById('testid')", documentAccessor, "undefined,undefined,<div xmlns=\"http://www.w3.org/1999/xhtml\" id=\"testid\"></div>", "HTMLDivElement", "");
 }
 
 }


### PR DESCRIPTION
#### 62c71791a3ca078c7f136b3e1e6e8fff2a16380e
<pre>
Include element attributes in _WKSerializedNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=296659">https://bugs.webkit.org/show_bug.cgi?id=296659</a>
<a href="https://rdar.apple.com/157056613">rdar://157056613</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::serializeNode const):
* Source/WebCore/dom/SerializedNode.cpp:
(WebCore::setAttributes):
(WebCore::SerializedNode::deserialize):
* Source/WebCore/dom/SerializedNode.h:
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::serializeNode const):
* Source/WebKit/Shared/SerializedNode.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NodeInfo.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):

Canonical link: <a href="https://commits.webkit.org/298038@main">https://commits.webkit.org/298038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3e7d00f519a7ce37bf68ed8bab85936542ede4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120196 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42341 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67048 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/26578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63903 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123424 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41061 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/30588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95279 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18221 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18279 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40936 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/46438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->