### PR TITLE
[Grid][Baseline] Fix RowAxisPositioning for baseline alignment in grid layout.

### DIFF
--- a/LayoutTests/fast/grid/grid-baseline-alignment-orthogonal-flow-expected.html
+++ b/LayoutTests/fast/grid/grid-baseline-alignment-orthogonal-flow-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+<style>
+.container {
+    width: 300px;
+    background-color: red;
+    height: 50px;
+}
+
+.baseline, .last-baseline {
+    display: inline-block;
+    height: 50px;
+    width: 100px;
+}
+
+.baseline {
+    background-color: lightblue;
+}
+
+.last-baseline {
+    background-color: lightgreen;
+}
+
+/* Utility margin classes */
+.margin-left-50 {
+    margin-left: 50px;
+}
+
+.margin-right-50 {
+    margin-right: 50px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="baseline margin-right-50"></div><div class="last-baseline margin-left-50"></div>
+</div>
+<div class="container">
+  <div class="baseline margin-right-50"></div><div class="last-baseline margin-left-50"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/grid/grid-baseline-alignment-orthogonal-flow.html
+++ b/LayoutTests/fast/grid/grid-baseline-alignment-orthogonal-flow.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+<head>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 150px 150px;
+    width: 300px;
+    background-color: red;
+}
+
+.baseline, .last-baseline {
+    display: inline-block;
+    height: 50px;
+    width: 100px;
+}
+
+.baseline {
+    justify-self: baseline;
+    background-color: lightblue;
+}
+
+.last-baseline {
+    justify-self: last baseline;
+    background-color: lightgreen;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="baseline"></div>
+  <div class="last-baseline"></div>
+</div>
+<div class="grid" writing-mode="rtl">
+  <div class="baseline"></div>
+  <div class="last-baseline"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt
@@ -16,11 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 0
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 35
+offsetLeft expected 105 but got 140
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 42
+offsetLeft expected 126 but got 168
 PASS #target > div 4
-PASS #target > div 5
-PASS #target > div 6
+FAIL #target > div 5 assert_equals:
+<div data-offset-x="35">line1<br>line2</div>
+offsetLeft expected 35 but got 140
+FAIL #target > div 6 assert_equals:
+<div data-offset-x="42">line1<br>line2</div>
+offsetLeft expected 42 but got 168
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt
@@ -2,13 +2,11 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
+offsetTop expected 20 but got 60
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+offsetTop expected 75 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt
@@ -2,13 +2,11 @@
 
 
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-y="40"><span></span><br><span></span></div>
-offsetTop expected 40 but got 0
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-y="20"><span></span><br><span></span></div>
-offsetTop expected 20 but got 40
+offsetTop expected 20 but got 60
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="75"><span></span><br><span></span></div>
-offsetTop expected 75 but got 35
+offsetTop expected 75 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt
@@ -14,5 +14,5 @@ offsetLeft expected 100 but got 0
 PASS #target > div 3
 FAIL #target > div 4 assert_equals:
 <div style="grid-row: 4; grid-column: span 3; justify-self: last baseline;" data-offset-x="10">line1<br>line2</div>
-offsetLeft expected 10 but got 0
+offsetLeft expected 10 but got 110
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt
@@ -6,39 +6,35 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-x="237" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 237 but got 292
+PASS .item 2
 PASS .item 3
-FAIL .item 4 assert_equals:
-<div data-offset-x="57" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 57 but got 112
+PASS .item 4
 FAIL .item 5 assert_equals:
 <div data-offset-x="475" class="item first">
       <span></span><br><span></span>
     </div>
 offsetLeft expected 475 but got 420
-PASS .item 6
+FAIL .item 6 assert_equals:
+<div data-offset-x="420" class="item last">
+      <span></span><br><span></span>
+    </div>
+offsetLeft expected 420 but got 475
 FAIL .item 7 assert_equals:
 <div data-offset-x="177" class="item small first"></div>
 offsetLeft expected 177 but got 60
 FAIL .item 8 assert_equals:
 <div data-offset-x="102" class="item small last"></div>
-offsetLeft expected 102 but got 40
+offsetLeft expected 102 but got 182
 FAIL .item 9 assert_equals:
 <div data-offset-x="357" class="item small first"></div>
 offsetLeft expected 357 but got 272
 FAIL .item 10 assert_equals:
 <div data-offset-x="282" class="item small last"></div>
-offsetLeft expected 282 but got 252
+offsetLeft expected 282 but got 370
 FAIL .item 11 assert_equals:
 <div data-offset-x="540" class="item small first"></div>
 offsetLeft expected 540 but got 460
 FAIL .item 12 assert_equals:
 <div data-offset-x="465" class="item small last"></div>
-offsetLeft expected 465 but got 440
+offsetLeft expected 465 but got 570
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2189,9 +2189,17 @@ GridAxisPosition RenderGrid::rowAxisPositionForGridItem(const RenderBox& gridIte
     case ItemPosition::Stretch:
         return GridAxisPosition::GridAxisStart;
     case ItemPosition::Baseline:
-    case ItemPosition::LastBaseline:
-        // FIXME: Implement the previous values. For now, we always 'start' align the grid item.
+        // Flip fallback values for opposite-flow children.
+        if (!GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem))
+            return hasSameDirection ? GridAxisPosition::GridAxisStart : GridAxisPosition::GridAxisEnd;
+        // Follow the grid's writing mode for orthogonal grid items.
         return GridAxisPosition::GridAxisStart;
+    case ItemPosition::LastBaseline:
+        // Flip fallback values for opposite-flow children.
+        if (!GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem))
+            return hasSameDirection ? GridAxisPosition::GridAxisEnd : GridAxisPosition::GridAxisStart;
+        // Follow the grid's writing mode for orthogonal grid items.
+        return GridAxisPosition::GridAxisEnd;
     case ItemPosition::Legacy:
     case ItemPosition::Auto:
     case ItemPosition::Normal:


### PR DESCRIPTION
#### 674cb3f99d856fe6a9995ea1211094fd761f7500
<pre>
[Grid][Baseline] Fix RowAxisPositioning for baseline alignment in grid layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296058">https://bugs.webkit.org/show_bug.cgi?id=296058</a>
&lt;<a href="https://rdar.apple.com/155967278">rdar://155967278</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR sets the default alignment for first and last baseline
to `GridAxisPosition::GridAxisStart` and `GridAxisPosition::GridAxisEnd`

as per:

<a href="https://www.w3.org/TR/css-align-3/#baseline-values">https://www.w3.org/TR/css-align-3/#baseline-values</a>

`The fallback alignment for first baseline is safe self-start (for self-alignment)
or safe start (for content-distribution).

The fallback alignment for last baseline is safe self-end (for self-alignment)
or safe end (for content-distribution).`

This PR also handles opposite flow grid items to resolve to the
correct physical direction. Orthogonal flow grid items are set to
follow the grid&apos;s writing mode.

* LayoutTests/fast/grid/grid-baseline-alignment-orthogonal-flow-expected.html: Added.
* LayoutTests/fast/grid/grid-baseline-alignment-orthogonal-flow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-justify-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-009-expected.txt:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::rowAxisPositionForGridItem const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/674cb3f99d856fe6a9995ea1211094fd761f7500

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113920 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/33672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24131 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/120086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34300 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/42233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/120086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116868 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/27304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/102322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/120086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/26500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/20453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/63798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/96671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/20569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/123315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/40960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/42233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/123315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/41333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/98534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/123315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/18138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40833 "Build is in progress. Recent messages:") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/46339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/40467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/43767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/42224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->