### PR TITLE
WebVTT rendering tests' reference cue x-positions do not match actual vtt

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-expected.html
@@ -14,8 +14,8 @@ body { margin:0 }
 .cue {
     position: absolute;
     top: 0;
-    right: 51.2px;
-    width: 64px;
+    left: 80%;
+    width: 20%;
     text-align: left
 }
 .cue > span {

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html
@@ -14,8 +14,8 @@ body { margin:0 }
 .cue {
     position: absolute;
     top: 0;
-    right: 51.2px;
-    width: 64px;
+    left: 80%;
+    width: 20%;
     text-align: left
 }
 .cue > span {

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-expected.html
@@ -14,8 +14,8 @@ body { margin:0 }
 .cue {
     position: absolute;
     top: 0;
-    right: 51.2px;
-    width: 64px;
+    left: 80%;
+    width: 20%;
     text-align: left
 }
 .cue > span {

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html
@@ -14,8 +14,8 @@ body { margin:0 }
 .cue {
     position: absolute;
     top: 0;
-    right: 51.2px;
-    width: 64px;
+    left: 80%;
+    width: 20%;
     text-align: left
 }
 .cue > span {


### PR DESCRIPTION
#### 85b245b8d68633ad701d721174c47f9183ae5725
<pre>
WebVTT rendering tests&apos; reference cue x-positions do not match actual vtt
<a href="https://bugs.webkit.org/show_bug.cgi?id=296665">https://bugs.webkit.org/show_bug.cgi?id=296665</a>
<a href="https://rdar.apple.com/136809019">rdar://136809019</a>

Reviewed by Eric Carlson.

In dom_override_cue_align_position_line_size and dom_override_cue_align_position_line_size_while_paused,
the vtt is given a position of 80%. However, in the corresponding ref files, the cue is given css style
&quot;right: 51.2px.&quot; But the video has a width of 320px, so the ref cue should have &quot;right:64px&quot; (20%)
or &quot;left:256px&quot; (80%). This patch replaces &quot;right: 51.2px&quot; with &quot;left: 80%&quot;. This patch also replaces
&quot;width:64px&quot; with &quot;width:20%&quot; so that the value is not hardcoded.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused-ref.html:

Canonical link: <a href="https://commits.webkit.org/298087@main">https://commits.webkit.org/298087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02510903fef19663376d6aba588a8523ccbd8986

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64817 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63919 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123440 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95513 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95295 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37240 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18303 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40951 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->