### PR TITLE
Add extern template declarations for JavaScriptCore/bytecode

### DIFF
--- a/Source/JavaScriptCore/bytecode/ArithProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArithProfile.h
@@ -181,6 +181,8 @@ protected:
     BitfieldType m_bits { 0 }; // We take care to update m_bits only in a single operation. We don't ever store an inconsistent bit representation to it.
 };
 
+extern template class ArithProfile<uint16_t>;
+
 /* This class stores the following components in 16 bits:
  * - ObservedResults
  * - ObservedType for the argument

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.h
@@ -79,6 +79,9 @@ protected:
     typename InstructionStreamType::Offset m_currentLocation { 0 };
 };
 
+extern template class BytecodeDumperBase<JSInstructionStream>;
+extern template class BytecodeDumperBase<WasmInstructionStream>;
+
 template<class Block>
 class BytecodeDumper : public BytecodeDumperBase<JSInstructionStream> {
 public:
@@ -106,6 +109,8 @@ private:
     Block* m_block;
 };
 
+extern template class BytecodeDumper<CodeBlock>;
+
 template<class Block>
 class CodeBlockBytecodeDumper final : public BytecodeDumper<Block> {
 public:
@@ -125,6 +130,9 @@ private:
 
     const Identifier& identifier(int index) const;
 };
+
+extern template class CodeBlockBytecodeDumper<UnlinkedCodeBlockGenerator>;
+extern template class CodeBlockBytecodeDumper<CodeBlock>;
 
 #if ENABLE(WEBASSEMBLY)
 

--- a/Source/JavaScriptCore/bytecode/ExecutionCounter.h
+++ b/Source/JavaScriptCore/bytecode/ExecutionCounter.h
@@ -100,6 +100,9 @@ public:
     int32_t m_activeThreshold;
 };
 
+extern template class ExecutionCounter<CountingForBaseline>;
+extern template class ExecutionCounter<CountingForUpperTiers>;
+
 WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<CountingVariant countingVariant>, ExecutionCounter<countingVariant>);
 
 typedef ExecutionCounter<CountingForBaseline> BaselineExecutionCounter;


### PR DESCRIPTION
#### 130cbb889fc756ebe192e98d715ea6fa1179e71f
<pre>
Add extern template declarations for JavaScriptCore/bytecode
<a href="https://bugs.webkit.org/show_bug.cgi?id=296672">https://bugs.webkit.org/show_bug.cgi?id=296672</a>
<a href="https://rdar.apple.com/problem/157074353">rdar://problem/157074353</a>

Reviewed by Darin Adler.

This should prevent any future redundant implicit instantiations that
might occur in a different translation unit.

* Source/JavaScriptCore/bytecode/ArithProfile.h:
* Source/JavaScriptCore/bytecode/BytecodeDumper.h:
* Source/JavaScriptCore/bytecode/ExecutionCounter.h:

Canonical link: <a href="https://commits.webkit.org/298035@main">https://commits.webkit.org/298035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ddcd3483b63f4a3b8bba2633a30c9872bab57c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/113954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64732 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86606 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/66988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63829 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106391 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123347 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112517 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/40987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95214 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40353 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37120 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46364 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136723 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40493 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36607 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->