### PR TITLE
Safari ignores style-src-elem in CSP

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Inline style should be applied
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="style-src 'none'; style-src-elem 'self'">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+      var t = async_test("Inline style should be applied");
+      window.addEventListener('securitypolicyviolation', t.unreached_func("Should not have fired a spv event"));
+    </script>
+    <link rel="stylesheet" href="/content-security-policy/style-src/resources/allowed.css">
+</head>
+<body>
+    <script>
+      t.step(function() {
+        assert_equals(document.styleSheets.length, 1);
+        t.done();
+      });
+    </script>
+</body>
+
+</html>

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -448,7 +448,7 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
 
 const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violatedDirectiveForStyle(const URL& url, bool didReceiveRedirectResponse, const String& nonce) const
 {
-    auto* operativeDirective = this->operativeDirective(m_styleSrc.get(), ContentSecurityPolicyDirectiveNames::styleSrcElem);
+    auto* operativeDirective = this->operativeDirectiveStyle(m_styleSrcElem.get(), ContentSecurityPolicyDirectiveNames::styleSrcElem);
     if (checkNonce(operativeDirective, nonce)
         || checkSource(operativeDirective, url, didReceiveRedirectResponse))
         return nullptr;


### PR DESCRIPTION
#### 3b36e1e3244a97eff6b779d1c97d9c3d9a1e1705
<pre>
Safari ignores style-src-elem in CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=276931">https://bugs.webkit.org/show_bug.cgi?id=276931</a>
<a href="https://rdar.apple.com/132783992">rdar://132783992</a>

Reviewed by Brent Fulgham.

We should be checking the more specific directive before falling back to the more general one.

For CSS stylesheet resource loads we were ignoring the style-src-elem directive and instead
skipping straight to style-src. This means if you had a CSP like
    `style-src &apos;self&apos;; style-src-elem &apos;self&apos; example.com;`
and then tried to load a stylesheet from example.com we would block the load.

This change makes us first check the style-src-elem directive before falling back to style-src
if style-src-elem is not present, matching the CSP3 spec.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/style-src-attr-elem/style-src-elem-allowed-src-blocked-link.html: Added.
        Added wpt to cover the case where `style-src-elem` allows but `style-src` would disallow.

* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::violatedDirectiveForStyle const):

Canonical link: <a href="https://commits.webkit.org/298104@main">https://commits.webkit.org/298104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e37375c7f6d47432aa8e0383b88b86d9e1d3719d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64091 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95639 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95422 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18392 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46639 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->