### PR TITLE
[Navigation API] navigate.back doesn't work in main frame when preceded by navigate.back in child frame

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.forward() goes to the nearest forward entry assert_equals: expected 0 but got 1
+PASS navigation.forward() goes to the nearest forward entry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.traverseTo() goes to the nearest entry when going forward assert_equals: expected 0 but got 2
+PASS navigation.traverseTo() goes to the nearest entry when going forward
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -404,9 +404,10 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
             return;
 
         Vector<FrameToNavigate> framesToNavigate;
-        if (RefPtr fromItem = page->backForward().currentItem()) {
-            if (RefPtr localMainFrame = page->localMainFrame())
-                recursiveGatherFramesToNavigate(*localMainFrame, framesToNavigate, targetItem, fromItem.get());
+
+        if (auto targetItemFrameID = targetItem->frameID()) {
+            if (RefPtr fromItem = page->backForward().currentItem(*targetItemFrameID))
+                recursiveGatherFramesToNavigate(frame, framesToNavigate, targetItem, fromItem.get());
         }
 
         page->setIsInSwipeAnimation(isInSwipeAnimation);

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -338,27 +338,7 @@ public:
         if (!entry)
             return std::nullopt;
 
-        Ref historyItem = entry.value()->associatedHistoryItem();
-
-        if (localFrame.isMainFrame())
-            return historyItem;
-
-        // FIXME: heuristic to fix disambigaute-* tests, we should find something more exact.
-        bool backwards = entry.value()->index() < localFrame.window()->navigation().currentEntry()->index();
-
-        RefPtr page { localFrame.page() };
-        auto items = page->checkedBackForward()->allItems();
-        for (size_t i = 0 ; i < items.size(); i++) {
-            Ref item = items[backwards ? items.size() - 1 - i: i];
-            auto index = item->children().findIf([&historyItem](const auto& child) {
-                return child->itemSequenceNumber() == historyItem->itemSequenceNumber();
-            });
-            if (index != notFound) {
-                historyItem = item;
-                break;
-            }
-        }
-        return historyItem;
+        return entry.value()->associatedHistoryItem();
     }
 
     void fire(Frame& frame) override
@@ -386,9 +366,8 @@ public:
 
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
 
-        Ref rootFrame = localFrame->rootFrame();
         RefPtr upcomingTraverseMethodTracker = localFrame->window()->navigation().upcomingTraverseMethodTracker(m_key);
-        page->goToItemForNavigationAPI(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, *localFrame, upcomingTraverseMethodTracker.get());
+        page->goToItemForNavigationAPI(*localFrame, *historyItem, FrameLoadType::IndexedBackForward, *localFrame, upcomingTraverseMethodTracker.get());
 
         completionHandler(ScheduleHistoryNavigationResult::Completed);
     }

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -629,6 +629,35 @@ void Navigation::notifyCommittedToEntry(NavigationAPIMethodTracker* apiMethodTra
         Ref { apiMethodTracker->committedPromise }->resolve<IDLInterface<NavigationHistoryEntry>>(*entry);
 }
 
+void Navigation::updateNavigationEntry(Ref<HistoryItem>&& item, ShouldCopyStateObjectFromCurrentEntry shouldCopyStateObjectFromCurrentEntry)
+{
+    if (!m_currentEntryIndex)
+        return;
+
+    m_entries[*m_currentEntryIndex] = NavigationHistoryEntry::create(*this, item.copyRef());
+
+    if (!frame())
+        return;
+
+    RefPtr firstChild = frame()->tree().firstChild();
+    if (!firstChild)
+        return;
+
+    for (RefPtr child = firstChild.get(); child; child = child->tree().nextSibling()) {
+        RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
+        if (!localChild)
+            continue;
+
+        if (RefPtr childItem = item->childItemWithFrameID(localChild->frameID())) {
+            RefPtr window = localChild->window();
+            if (!window)
+                continue;
+
+            window->protectedNavigation()->updateNavigationEntry(childItem.releaseNonNull(), shouldCopyStateObjectFromCurrentEntry);
+        }
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation
 void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigationType navigationType, ShouldCopyStateObjectFromCurrentEntry shouldCopyStateObjectFromCurrentEntry)
 {
@@ -661,7 +690,7 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
     }
 
     if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace) {
-        m_entries[*m_currentEntryIndex] = NavigationHistoryEntry::create(*this, WTFMove(item));
+        updateNavigationEntry(WTFMove(item), shouldCopyStateObjectFromCurrentEntry);
         if (shouldCopyStateObjectFromCurrentEntry == ShouldCopyStateObjectFromCurrentEntry::Yes)
             Ref { m_entries[*m_currentEntryIndex] }->setState(oldCurrentEntry->state());
     }

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -184,6 +184,8 @@ public:
 
     RefPtr<NavigateEvent> protectedOngoingNavigateEvent() { return m_ongoingNavigateEvent; }
 
+    void updateNavigationEntry(Ref<HistoryItem>&&, ShouldCopyStateObjectFromCurrentEntry);
+
 private:
     explicit Navigation(LocalDOMWindow&);
 


### PR DESCRIPTION
#### 1ea8636a1baf6f48134a8dffb6a58f607d997f3a
<pre>
[Navigation API] navigate.back doesn&apos;t work in main frame when preceded by navigate.back in child frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=296673">https://bugs.webkit.org/show_bug.cgi?id=296673</a>
<a href="https://rdar.apple.com/157078677">rdar://157078677</a>

Reviewed by Charlie Wolfe.

The test disambigaute-forward.html fails on this line:
&quot;assert_equals(navigation.currentEntry.index, start_index);&quot;
because the mainframe&apos;s back navigation fails.

This is what the test is doing:
1. Load a main frame and an iframe
2. Fragment navigate the main frame
3. Fragment navigate the iframe
4. Go back in the iframe (this succeeds)
5. Go back in the main frame (this fails to go back)

The first problem is this:

The iframe&apos;s navigation appears to succeed, but it&apos;s falsely succeeding.
Right before the iframe&apos;s back, the history tree looks like this:

1. MainFrame (URL: disambigaute-forward.html, itemID: A)
   -- Child: iFrame (URL: blank.html, itemID: A)
2. MainFrame (URL: disambigaute-forward.html#top, itemID: B)
   -- Child: iFrame (URL: blank.html, itemID: B)
3. MainFrame (URL: disambigaute-forward.html#top, itemID: C)
   -- Child: iFrame (URL: blank.html#1, itemID: C)

When the iframe goes back, we look for the history item iFrame
(URL: blank.html, itemID: B) in the iframe&apos;s navigation&apos;s m_entries.
But m_entries contains:

iFrame (URL: blank.html, itemID: A)
iFrame (URL: blank.html#1, itemID: C)

Yet we match to item A because we are comparing by document sequence number.
The test checks that we&apos;ve navigated to the item with index 0 in m_entries,
which we have. So the iframe&apos;s back navigation succeeds, but really we&apos;ve
navigated to the wrong item. We should have gone to item B.

The issue here is that when the main frame navigated from A to B, that was
a &quot;Push&quot; navigation and we should have replaced the A entry in all of it&apos;s
children&apos;s m_entries with their new B entry. And then we should look up
items in this list by their itemID instead. So we add updateNavigationEntry()
to do this.

Now the iframe&apos;s m_entries will be this:

iFrame (URL: blank.html, itemID: B)
iFrame (URL: blank.html#1, itemID: C)

And we correctly navigate to the right item.

But our main frame&apos;s back still fails. This is the second issue:

The main frame&apos;s m_entries correctly looks like:

MainFrame (URL: disambigaute-forward.html, itemID: A)
MainFrame (URL: disambigaute-forward.html#top, itemID: B)

But on the navigate.back, the item we&apos;re looking for is wrong.
We&apos;re looking for item B when we should have been looking for item A.

Why? On navigate.back, for most of the code path, we are correctly
using item A. But then:

FrameLoader::loadInSameDocument() ends up calling
HistoryController::recursiveUpdateForSameDocumentNavigation()
which sets the currentItem to the provisionalItem. The currentItem
is the item we&apos;re looking for. Up to this point, it has correctly
been item A. But here, we set it to item B.

Turns out, the provisionalItem got set to item B by the iframe&apos;s
back navigation in HistoryController::recursiveSetProvisionalItem().
In the iframe&apos;s back, we actually call recursiveSetProvisionalItem
from the main frame&apos;s history controller. This means that we set the
provisional item for the main frame--even though the main frame is not
actually navigating. Since the main frame isn&apos;t navigating, this
provisional item does not get set to nullptr when the iframe&apos;s load
finishes. So later on, this causes the main frame&apos;s back to
look for the wrong item and for the back to fail.

So instead of calling recursiveSetProvisionalItem from the main frame&apos;s
history controller, we call it from the iframe&apos;s history controller.
We do this by calling Page::goToItemForNavigationAPI with the iframe
passed in instead of the main frame (in ScheduledHistoryNavigationByKey::fire).
This way, the provisional item won&apos;t be set for the main frame.

And since we are calling goToItemForNavigationAPI with the iframe, we
will ensure that the HistoryItems which are used (targetItem and
fromItem) also correspond to the iframe instead of the main frame
like they do currently.

I made these changes to fix disambigaute-forward.html, but it also
fixes disambigaute-traverseTo-forward-multiple.html.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItemForNavigationAPI):

Previously, the HistoryController always used the targetItem
and fromItem of the main frame rather than the frame that owns it.

Now that it&apos;s being passed the targetItem of the owning frame, we
change it to use the fromItem of the owning frame as well. (We use
the targetItem&apos;s frameID to get the fromItem with the same frameID).

* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey):

This should always lookup the item in the navigating frame&apos;s list of
entries. We should not use any heuristics.

(WebCore::ScheduledHistoryNavigationByKey::fire):

This should call goToItemForNavigationAPI on the frame that is actually
navigating, not always the main frame. Accordingly, it should use the
historyItem from that navigating frame, not always the main frame.

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::updateNavigationEntry):
(WebCore::Navigation::updateForNavigation):

On a push navigation, we must update the subframes as well, not just
the navigating frame.

* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/298121@main">https://commits.webkit.org/298121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7211003d0d14b9705f0200b4723c5b3e30b33cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86871 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67263 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20793 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123693 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95696 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41710 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95480 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37377 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18320 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46721 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40808 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->