### PR TITLE
Harden the interpreter dispatchers more for ARM64E.

### DIFF
--- a/Source/JavaScriptCore/interpreter/VMEntryRecord.h
+++ b/Source/JavaScriptCore/interpreter/VMEntryRecord.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,8 @@ struct VMEntryRecord {
     EntryFrame* prevTopEntryFrame() { return m_prevTopEntryFrame; }
     SUPPRESS_ASAN EntryFrame* unsafePrevTopEntryFrame() { return m_prevTopEntryFrame; }
 };
+
+static_assert(OBJECT_OFFSETOF(VMEntryRecord, m_prevTopEntryFrame) == OBJECT_OFFSETOF(VMEntryRecord, m_prevTopCallFrame) + sizeof(void*), "We load/store these using a pair instruction");
 
 extern "C" VMEntryRecord* SYSV_ABI vmEntryRecord(EntryFrame*);
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -205,6 +205,7 @@ macro decodeLEBVarUInt32(offset, dst, scratch1, scratch2, scratch3, scratch4)
     move 7, scratch1
     # take off high bit
     subi 0x80, dst
+    validateOpcodeConfig(scratch2)
 .loop:
     addp 1, tempPC
     loadb [tempPC], scratch2
@@ -264,6 +265,7 @@ end
 
 macro unimplementedInstruction(instrname)
     instructionLabel(instrname)
+    validateOpcodeConfig(a0)
     break
 end
 
@@ -303,6 +305,8 @@ end
 # Operation Calls
 
 macro operationCall(fn)
+    validateOpcodeConfig(a0)
+
     move wasmInstance, a0
     push PC, MC
     if ARM64 or ARM64E
@@ -324,6 +328,7 @@ end
 
 macro operationCallMayThrowImpl(fn, sizeOfExtraRegistersPreserved)
     saveCallSiteIndex()
+    validateOpcodeConfig(a0)
 
     move wasmInstance, a0
     push PC, MC
@@ -406,6 +411,7 @@ end
 
 macro ipintLoopOSR(increment)
 if JIT and not ARMv7
+    validateOpcodeConfig(ws0)
     loadp UnboxedWasmCalleeStackSlot[cfr], ws0
     baddis increment, Wasm::IPIntCallee::m_tierUpCounter + Wasm::IPIntTierUpCounter::m_counter[ws0], .continue
 
@@ -491,8 +497,8 @@ end)
 if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
 .ipint_entry_end_local:
     argumINTInitializeDefaultLocals()
-
     jmp .ipint_entry_end_local
+
 .ipint_entry_finish_zero:
     argumINTFinish()
 
@@ -523,6 +529,7 @@ else
 end
 
 macro ipintCatchCommon()
+    validateOpcodeConfig(t0)
     getVMFromCallFrame(t3, t0)
     restoreCalleeSavesFromVMEntryFrameCalleeSavesBuffer(t3, t0)
 

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -793,6 +793,7 @@ FOR_EACH_IPINT_UINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 namespace JSC { namespace IPInt {
 
 void initialize();
+void verifyInitialization();
 
 } }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -262,6 +262,7 @@ const JSEntryPtrTag = constexpr JSEntryPtrTag
 const HostFunctionPtrTag = constexpr HostFunctionPtrTag
 const JSEntrySlowPathPtrTag = constexpr JSEntrySlowPathPtrTag
 const NativeToJITGatePtrTag = constexpr NativeToJITGatePtrTag
+const VMEntryToJITGatePtrTag = constexpr VMEntryToJITGatePtrTag
 const ExceptionHandlerPtrTag = constexpr ExceptionHandlerPtrTag
 const YarrEntryPtrTag = constexpr YarrEntryPtrTag
 const CSSSelectorPtrTag = constexpr CSSSelectorPtrTag
@@ -337,22 +338,29 @@ macro loadBoolJSCOption(name, reg)
     loadb JSCConfigOffset + JSC::Config::options + OptionsStorage::%name%[reg], reg
 end
 
+macro validateOpcodeConfig(scratchReg)
+    if ARM64E
+        leap _g_opcodeConfigStorage, scratchReg
+        loadp [scratchReg], scratchReg
+    end
+end
+
 macro nextInstruction()
     loadb [PB, PC, 1], t0
-    leap _g_opcodeMap, t1
-    jmp [t1, t0, PtrSize], BytecodePtrTag, AddressDiversified
+    leap _g_opcodeConfigStorage, t1
+    jmp JSC::LLInt::OpcodeConfig::opcodeMap[t1, t0, PtrSize]
 end
 
 macro nextInstructionWide16()
     loadb OpcodeIDNarrowSize[PB, PC, 1], t0
-    leap _g_opcodeMapWide16, t1
-    jmp [t1, t0, PtrSize], BytecodePtrTag, AddressDiversified
+    leap _g_opcodeConfigStorage, t1
+    jmp JSC::LLInt::OpcodeConfig::opcodeMapWide16[t1, t0, PtrSize]
 end
 
 macro nextInstructionWide32()
     loadb OpcodeIDNarrowSize[PB, PC, 1], t0
-    leap _g_opcodeMapWide32, t1
-    jmp [t1, t0, PtrSize], BytecodePtrTag, AddressDiversified
+    leap _g_opcodeConfigStorage, t1
+    jmp JSC::LLInt::OpcodeConfig::opcodeMapWide32[t1, t0, PtrSize]
 end
 
 macro dispatch(advanceReg)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -327,7 +327,7 @@ _llint_call_javascript:
     elsif ARM64E
         move entry, t5
         leap _g_config, a7
-        jmp JSCConfigGateMapOffset + (constexpr Gate::vmEntryToJavaScript) * PtrSize[a7], NativeToJITGatePtrTag # JSEntryPtrTag
+        jmp JSCConfigGateMapOffset + (constexpr Gate::vmEntryToJavaScript) * PtrSize[a7], VMEntryToJITGatePtrTag # JSEntryPtrTag
         global _vmEntryToJavaScriptTrampoline
         _vmEntryToJavaScriptTrampoline:
         call t5, JSEntryPtrTag

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -991,6 +991,7 @@ end)
 macro jumpToException()
     if ARM64E
         move r0, a0
+        validateOpcodeConfig(a1)
         leap _g_config, a1
         jmp JSCConfigGateMapOffset + (constexpr Gate::exceptionHandler) * PtrSize[a1], NativeToJITGatePtrTag # ExceptionHandlerPtrTag
     else
@@ -999,6 +1000,7 @@ macro jumpToException()
 end
 
 op(wasm_throw_from_slow_path_trampoline, macro ()
+    validateOpcodeConfig(t5)
     loadp JSWebAssemblyInstance::m_vm[wasmInstance], t5
     loadp VM::topEntryFrame[t5], t5
     copyCalleeSavesToEntryFrameCalleeSavesBuffer(t5)

--- a/Source/JavaScriptCore/offlineasm/arm64e.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64e.rb
@@ -116,7 +116,7 @@ class Instruction
                 emitARM64Unflipped("blrab", operands, :ptr)
             end
         when "jmp"
-            if operands[0].label?
+            if operands.size == 1 or operands[0].label?
                 lowerARM64
             else
                 emitARM64Unflipped("brab", operands, :ptr)

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@
 #include "AssemblyComments.h"
 #include "AssertInvariants.h"
 #include "ExecutableAllocator.h"
-#include "InPlaceInterpreter.h"
 #include "JITOperationList.h"
 #include "JSCConfig.h"
 #include "JSCPtrTag.h"
@@ -116,10 +115,6 @@ void initialize()
         JITOperationList::populatePointersInJavaScriptCore();
 
         AssemblyCommentRegistry::initialize();
-#if ENABLE(WEBASSEMBLY)
-        if (Options::useWasmIPInt())
-            IPInt::initialize();
-#endif
         LLInt::initialize();
         AssertNoGC::initialize();
 

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -82,7 +82,6 @@ struct Config {
 #if CPU(ARM64E)
     bool canUseFPAC;
 #endif
-
     ExecutableAllocator* executableAllocator;
     FixedVMPoolExecutableAllocator* fixedVMPoolExecutableAllocator;
     void* startExecutableMemory;
@@ -92,12 +91,6 @@ struct Config {
     uintptr_t sizeOfStructureHeap;
     void* defaultCallThunk;
     void* arityFixupThunk;
-
-    void* ipint_dispatch_base;
-    void* ipint_gc_dispatch_base;
-    void* ipint_conversion_dispatch_base;
-    void* ipint_simd_dispatch_base;
-    void* ipint_atomic_dispatch_base;
 
 #if ENABLE(SEPARATED_WX_HEAP)
     JITWriteSeparateHeapsFunction jitWriteSeparateHeaps;

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2020 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -36,6 +36,8 @@
 #include <wtf/text/MakeString.h>
 
 namespace JSC {
+
+constinit const char radixDigits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 double JSValue::toIntegerPreserveNaN(JSGlobalObject* globalObject) const
 {

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.h
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,6 +62,7 @@ using PtrTag = WTF::PtrTag;
     v(ReturnAddressPtrTag, PtrTagCalleeType::Native, PtrTagCallerType::Native) \
     /* Callee:JIT Caller:Native */ \
     v(NativeToJITGatePtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
+    v(VMEntryToJITGatePtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
     v(YarrEntryPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
     v(LLIntToWasmEntryPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
     v(CSSSelectorPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -233,7 +233,7 @@ static ALWAYS_INLINE typename std::invoke_result<CallbackWhenNoException, String
 }
 
 // Mapping from integers 0..35 to digit identifying this value, for radix 2..36.
-const char radixDigits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+extern const char radixDigits[37]; // in JSCJSValue.cpp
 
 } // namespace JSC
 

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,6 +117,14 @@ static_assert(Gigacage::reservedBytesForGigacageConfig + sizeof(WTF::Config) <= 
 static_assert(roundUpToMultipleOf<alignmentOfWTFConfig>(startOffsetOfWTFConfig) == startOffsetOfWTFConfig);
 
 WTF_EXPORT_PRIVATE void setPermissionsOfConfigPage();
+
+WTF_EXPORT_PRIVATE void makePagesFreezable(void* base, size_t); // Works together with permanentlyFreezePages().
+
+enum class FreezePagePermission {
+    None, // Remove all permissions i.e. no permissions at all.
+    ReadOnly, // The pages can be read.
+};
+WTF_EXPORT_PRIVATE void permanentlyFreezePages(void* base, size_t, FreezePagePermission);
 
 // Workaround to localize bounds safety warnings to this file.
 // FIXME: Use real types to make materializing WTF::Config* bounds-safe and type-safe.


### PR DESCRIPTION
#### d5e7d2a3eeeeab55e93553b2fc91fc61327a6ffb
<pre>
Harden the interpreter dispatchers more for ARM64E.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295595">https://bugs.webkit.org/show_bug.cgi?id=295595</a>
<a href="https://rdar.apple.com/155356829">rdar://155356829</a>

Reviewed by Daniel Liu.

We have 3 goals:
1. Ensure that LLInt opcode maps are robust against corruption.
2. Ensure that processes that don&apos;t need the LLInt can disable it.
3. Ensure that opcode maps are properly initialized before use.

Goal 1: Ensure that LLInt opcode maps are robust against corruption.
====================================================================
We previously achieve this by PAC signing (address diversified) the handlers PCs in
g_opcodeMap (and peers).  The handler PCs are authenticated on each bytecode dispatch.
This is slow because PAC authentication is slow.

We now achieve this goal by moving g_opcodeMap (and peers) into a g_opcodeConfigStorage
page that can be permanently frozen as Read Only.  With this, the opcode map can no longer
be corrupted, and we can do away with the PAC signing.  The handler PCs will now be stored
as naked pointers.

Here are the steps we use to initialize this Read Only opcode maps:

 1.1. Call llint_entry to fill in the PAC signed handler PCs into a temp buffer.  Next, we
      strip these handler PCs of their PAC signatures and store them as naked code pointers
      into the g_opcodeConfigStorage.

 1.2. Permanently freeze (protect) the g_opcodeConfigStorage page with PROT_READ permission
      only.

 1.3. For each handler PC in the opcode maps, PAC authenticate their counterpart in the
      temp buffer, and then, assert that the naked handler PC matches the authenticated
      counterpart.

      This steps guarantees that the opcode maps have been initialized properly, and
      are not corrupted in any way.

 1.4. Initialize g_jscConfig.llint.gateMap[Gate::vmEntryToJavaScript] with its PAC signed
      pointer.  This pointer is the vector thru which vmEntryToJavaScript calls into the
      interpreter (or JIT generated functions). See makeJavaScriptCall().

Goal 2. Ensure that processes that don&apos;t need the LLInt can disable it.
=======================================================================
We previously achieve this using a neuterOpcodeMaps() function that fills the opcode maps
with the PC of a function that will crash.

We now achieve this by permanently freeze (protect) the g_opcodeConfigStorage page with
PROT_NONE.  This ensures that LLInt cannot use the opcode maps.  Any attempt to use them
will now result in a crash.

We also do NOT initialize g_jscConfig.llint.gateMap[Gate::vmEntryToJavaScript] (nor any
of the other values initialized by LLInt:initialize()).

Also added a check for a &quot;com.apple.security.script-restrictions&quot; entitlement that can be
used by processes to opt into disabling the LLInt.  This is not currently used by any
processes.

We may change the implementation of this goal in the future if a more performant way becomes
available.  See <a href="https://rdar.apple.com/158509720">rdar://158509720</a>.

Goal 3. Ensure that opcode maps are properly initialized before use.
====================================================================
&quot;before use&quot; means cases where the process&apos; code will naturally call into the LLInt.  What
we&apos;re hardening against here are cases where the LLInt hasn&apos;t been initialized yet, but
its data has been corrupted such that LLInt will mistakenly think that it has already been
initialized.

However, all code paths to enter the LLInt will have to dispatch through
g_jscConfig.llint.gateMap[Gate::vmEntryToJavaScript], which will PAC authenticate its
pointer.  Hence, the only way to enter the LLInt is if the Gate::vmEntryToJavaScript
pointer is properly signed.  And the only way it will be properly signed is if we have
already gone through LLInt::initialized(), and properly initialized the opcode maps.

Just to ensure that g_jscConfig.llint.gateMap[Gate::vmEntryToJavaScript] is uniquely signed,
we introduce a new VMEntryToJITGatePtrTag that is only used exclusively for this pointer.

See <a href="https://rdar.apple.com/155356829">rdar://155356829</a> for more details.

We also made these additional changes:

1. Secure IPInt dispatchers
   ========================
   This is achieved by calling validateOpcodeConfig() at all the following places:
   a. the top of all IPInt handler for Wasm opcode that concerns control flow.
   b. before any operation calls.
   c. the top of loops in IPInt, unless it the loop is already covered by (a) or (b).

   The idea is to only validateOpcodeConfig() at all places that concerns control flow.
   The alternative would be do it on every bytecode dispatch, but that turns out to be
   too costly in terms of performance (~2-5% overhead on non-JIT IPInt only).

   validateOpcodeConfig() simply loads a word from g_opcodeConfigStorage.  If the LLint
   is disabled, g_opcodeConfigStorage will be mapped PROT_NONE, and this load will result
   in a crash.  The word loaded by validateOpcodeConfig() is ignored.  No other
   instructions depend on it.  Hence, this should help reduce the impact of that load in
   terms of performance.

   We also make the IPInt gc_dispatch, conversion_dispatch, simd_dispatch, and
   atomic_dispatch use base pointers from g_opcodeConfigStorage.  These have not been
   shown to impact performance so far.  So, they are fine for now.

   See <a href="https://rdar.apple.com/155356829">rdar://155356829</a> for more details.

2. Moved IPInt initialization into LLInt::initialize() so that it can be done at the right
   time before we protect the g_opcodeConfigStorage.  IPInt dispatch base pointers are
   now moved from g_config into g_opcodeConfigStorage.

3. Now that we only store naked code pointers in the opcode maps, a lot of the LLInt
   bytecode accessor methods can be simplified significantly.  This has been done.

4. Move the error handling crash case out of argumINTDispatch(), mintArgDispatch(),
   mintRetDispatch(), and uintDispatch().  This makes the code slightly more performant.

5. Initially, this set of changes resulted in a RAMification memory regression.  To fix
   this, we do the following:

   a. Move the definition of the radixDigits const array from ParseInt.h to JSCJSValue.cpp.
      The contents of the array is not used to enable any constant folding.  So, it doesn&apos;t
      help anything to make the array inlineable.  This move reduces the memory use of this
      array from ~280K down to 37 bytes.

   b. Put g_config and g_opcodeConfigStorage pages in their own custom __DATA sections
      (using the __attribute__ modifier).  Previously, these 2 globals were linked in between
      other globals in __DATA.  Due to their page alignment requirements, the linker
      padded the space before them with multiple KBs of unused memory.  Putting them into
      their own sections allows the linker to pack in other global variables more
      efficiently.

   With (a) and (b), the RAMification regression was completely resolved.

7. Added a static_assert to ensure that VMEntryRecord::m_prevTopEntryFrame is located
   adjacent to VMEntryRecord::m_prevTopCallFrame.  We have pre-existing code that rely
   on this invariant.

This change was shown to be performance neutral on benchmarks with JIT enabled.
With JIT disabled, the IPInt hardening also appears to be performance neutral.

* Source/JavaScriptCore/bytecode/Opcode.h:
* Source/JavaScriptCore/interpreter/VMEntryRecord.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
(JSC::IPInt::initialize):
(JSC::IPInt::verifyInitialization):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/llint/LLIntData.cpp:
(JSC::LLInt::scriptingIsForbidden):
(JSC::LLInt::initialize):
(JSC::LLInt::neuterOpcodeMaps): Deleted.
* Source/JavaScriptCore/llint/LLIntData.h:
(JSC::LLInt::addressOfOpcodeConfig):
(JSC::LLInt::getCodePtrImpl):
(JSC::LLInt::getCodePtr):
(JSC::LLInt::getWide16CodePtr):
(JSC::LLInt::getWide32CodePtr):
(JSC::LLInt::getOpcodeAddress): Deleted.
(JSC::LLInt::getOpcodeWide16Address): Deleted.
(JSC::LLInt::getOpcodeWide32Address): Deleted.
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/offlineasm/arm64e.rb:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCConfig.h:
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
* Source/JavaScriptCore/runtime/JSCPtrTag.h:
* Source/JavaScriptCore/runtime/ParseInt.h:
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::permanentlyFreeze):
(WTF::permanentlyFreezePages):
* Source/WTF/wtf/WTFConfig.h:

Canonical link: <a href="https://commits.webkit.org/298816@main">https://commits.webkit.org/298816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1908edb3e3ab562aa0772cf32db8809251910982

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116770 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67353 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/437ab98e-9f84-49f8-b2fd-90002406b342) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/517b0b04-04ee-4eea-993e-7c307e48eeeb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119719 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/29604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/104748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69142 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66511 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108884 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125980 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115298 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32792 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100950 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42464 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49150 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143996 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43022 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37071 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44727 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->