### PR TITLE
Adopt more smart pointers in WebProcessPoolCocoa.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -30,7 +30,6 @@ UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
 UIProcess/Cocoa/ModelElementControllerCocoa.mm
 UIProcess/Cocoa/PageClientImplCocoa.mm
-UIProcess/Cocoa/WebProcessPoolCocoa.mm
 UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
 UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
 UIProcess/WebAuthentication/Cocoa/LocalConnection.mm


### PR DESCRIPTION
#### b7606dbaa7ea229f5fdd279d6b429995846b66b3
<pre>
Adopt more smart pointers in WebProcessPoolCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=296680">https://bugs.webkit.org/show_bug.cgi?id=296680</a>

Reviewed by Darin Adler.

The remaining RetainPtrCtorAdoptChecker in this file is fixed. A couple
of false positive warnings are turned off by tagging global NSString*
variables as const and using *Singleton wrapper functions for NSApplication
and dispatch_queue_t. Other warnings for ObjectiveC object are left for now,
they could be handled similarly, or fixed by the checker.

* Source/WebKit/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:  Remove WebProcessPoolCocoa.mm.
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm: Mark some NSString* keys as const.
(WebKit::globalQueueSingleton): New helper function to turn off warnings with dispatch_get_global_queue().
(WebKit::mainQueueSingleton): Ditto for dispatch_get_main_queue().
(WebKit::NSAppSingleton): Same for NSApp.
(WebKit::WebProcessPool::setMediaAccessibilityPreferences): Fix a RetainPtrCtorAdoptChecker error.
(WebKit::WebProcessPool::platformInitialize): Fix UnretainedCallArgsChecker erros.
(WebKit::WebProcessPool::platformInitializeWebProcess): Ditto.
(WebKit::WebProcessPool::initializeHardwareKeyboardAvailability): Ditto.
(WebKit::WebProcessPool::startObservingPreferenceChanges): Ditto.
(WebKit::WebProcessPool::registerNotificationObservers): Ditto.
(WebKit::WebProcessPool::clearPermanentCredentialsForProtectionSpace): Ditto.
(WebKit::WebProcessPool::registerAssetFonts): Ditto.

Canonical link: <a href="https://commits.webkit.org/299748@main">https://commits.webkit.org/299748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c91879dea60df7ab2631bbf9009d5bd3279da1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91170 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60484 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71723 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31340 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99630 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25299 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52542 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->