### PR TITLE
[WPE] WPE Platform: add WPEDRMDevice

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -195,7 +195,7 @@ static String dmabufRendererWithSupportedBuffers()
     auto mode = AcceleratedBackingStore::rendererBufferTransportMode();
 #else
     OptionSet<RendererBufferTransportMode> mode;
-    if (wpe_display_get_drm_render_node(wpe_display_get_primary()))
+    if (wpe_display_get_drm_device(wpe_display_get_primary()))
         mode.add(RendererBufferTransportMode::Hardware);
     mode.add(RendererBufferTransportMode::SharedMemory);
 #endif
@@ -634,7 +634,10 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #if USE(GBM)
         UnixFileDescriptor fd;
         struct gbm_device* device = nullptr;
-        if (const char* node = wpe_display_get_drm_render_node(wpe_display_get_primary())) {
+        if (auto* drmDevice = wpe_display_get_drm_device(wpe_display_get_primary())) {
+            const char* node = wpe_drm_device_get_render_node(drmDevice);
+            if (!node)
+                node = wpe_drm_device_get_primary_node(drmDevice);
             fd = UnixFileDescriptor { open(node, O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
             if (fd) {
                 device = gbm_create_device(fd.value());

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -199,7 +199,7 @@ GPUProcessProxy::GPUProcessProxy()
 #endif
 
 #if USE(GBM)
-    parameters.renderDeviceFile = drmRenderNodeDevice();
+    parameters.renderDeviceFile = drmRenderNodeOrPrimaryDevice();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/glib/DRMDevice.cpp
+++ b/Source/WebKit/UIProcess/glib/DRMDevice.cpp
@@ -172,7 +172,10 @@ const String& drmPrimaryDevice()
     std::call_once(once, [] {
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
         if (WKWPE::isUsingWPEPlatformAPI()) {
-            primaryDevice.construct(String::fromUTF8(wpe_display_get_drm_device(wpe_display_get_primary())));
+            if (auto* drmDevice = wpe_display_get_drm_device(wpe_display_get_primary()))
+                primaryDevice.construct(String::fromUTF8(wpe_drm_device_get_primary_node(drmDevice)));
+            else
+                primaryDevice.construct();
             return;
         }
 #endif
@@ -195,7 +198,10 @@ const String& drmRenderNodeDevice()
     std::call_once(once, [] {
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
         if (WKWPE::isUsingWPEPlatformAPI()) {
-            renderNodeDevice.construct(String::fromUTF8(wpe_display_get_drm_render_node(wpe_display_get_primary())));
+            if (auto* drmDevice = wpe_display_get_drm_device(wpe_display_get_primary()))
+                renderNodeDevice.construct(String::fromUTF8(wpe_drm_device_get_render_node(drmDevice)));
+            else
+                renderNodeDevice.construct();
             return;
         }
 #endif
@@ -215,6 +221,14 @@ const String& drmRenderNodeDevice()
         renderNodeDevice.construct();
     });
     return renderNodeDevice.get();
+}
+
+const String& drmRenderNodeOrPrimaryDevice()
+{
+    const auto& node = drmRenderNodeDevice();
+    if (!node.isEmpty())
+        return node;
+    return drmPrimaryDevice();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/glib/DRMDevice.h
+++ b/Source/WebKit/UIProcess/glib/DRMDevice.h
@@ -33,6 +33,7 @@ namespace WebKit {
 
 const String& drmPrimaryDevice();
 const String& drmRenderNodeDevice();
+const String& drmRenderNodeOrPrimaryDevice();
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -191,7 +191,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if USE(GBM)
-    parameters.renderDeviceFile = drmRenderNodeDevice();
+    parameters.renderDeviceFile = drmRenderNodeOrPrimaryDevice();
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -10,7 +10,7 @@ configure_file(wpe-platform-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-platform-$
 configure_file(wpe/WPEConfig.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h)
 configure_file(wpe/WPEVersion.h.in ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEVersion.h)
 
-set(WPEPlatform_SOURCES_FOR_INTROSPECTION
+set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABufFormats.cpp
@@ -18,6 +18,7 @@ set(WPEPlatform_SOURCES_FOR_INTROSPECTION
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEClipboard.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEColor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPECursorTheme.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDRMDevice.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDisplay.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEvent.cpp
@@ -43,11 +44,6 @@ set(WPEPlatform_SOURCES_FOR_INTROSPECTION
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
 )
 
-set(WPEPlatform_SOURCES
-    ${WPEPlatform_SOURCES_FOR_INTROSPECTION}
-    ${WEBKIT_DIR}/WPEPlatform/wpe/LibDRMUtilities.cpp
-)
-
 set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBuffer.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferDMABuf.h
@@ -55,6 +51,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEBufferSHM.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEClipboard.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEColor.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDRMDevice.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDefines.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEDisplay.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.h
@@ -201,7 +198,7 @@ GI_INTROSPECT(WPEPlatform ${WPE_API_VERSION} wpe/wpe-platform.h
         -I${WPEPlatform_DERIVED_SOURCES_DIR}
     SOURCES
         ${WPEPlatform_INSTALLED_HEADERS}
-        ${WPEPlatform_SOURCES_FOR_INTROSPECTION}
+        ${WPEPlatform_SOURCES}
     NO_IMPLICIT_SOURCES
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/GRefPtrWPE.h
+++ b/Source/WebKit/WPEPlatform/wpe/GRefPtrWPE.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wpe/WPEClipboard.h>
+#include <wpe/WPEDRMDevice.h>
 #include <wpe/WPEEvent.h>
 #include <wtf/glib/GRefPtr.h>
 
@@ -56,5 +57,19 @@ template<> inline void derefGPtr(WPEClipboardContent* ptr)
     if (ptr) [[likely]]
         wpe_clipboard_content_unref(ptr);
 }
+
+template<> inline WPEDRMDevice* refGPtr(WPEDRMDevice* ptr)
+{
+    if (ptr) [[likely]]
+        wpe_drm_device_ref(ptr);
+    return ptr;
+}
+
+template<> inline void derefGPtr(WPEDRMDevice* ptr)
+{
+    if (ptr) [[likely]]
+        wpe_drm_device_unref(ptr);
+}
+
 
 } // namespace WTF

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABuf.cpp
@@ -187,7 +187,13 @@ static bool wpeBufferDMABufTryEnsureGBMDevice(WPEBufferDMABuf* buffer)
     if (!display)
         return false;
 
-    const char* filename = wpe_display_get_drm_render_node(display);
+    auto* drmDevice = wpe_display_get_drm_device(display);
+    if (!drmDevice)
+        return false;
+
+    const char* filename = wpe_drm_device_get_render_node(drmDevice);
+    if (!filename)
+        filename = wpe_drm_device_get_primary_node(drmDevice);
     if (!filename)
         return false;
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABufFormats.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEBufferDMABufFormats.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <glib-object.h>
+#include <wpe/WPEDRMDevice.h>
 #include <wpe/WPEDefines.h>
 
 G_BEGIN_DECLS
@@ -52,11 +53,11 @@ typedef enum {
     WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT
 } WPEBufferDMABufFormatUsage;
 
-WPE_API const char                *wpe_buffer_dma_buf_formats_get_device           (WPEBufferDMABufFormats *formats);
+WPE_API WPEDRMDevice              *wpe_buffer_dma_buf_formats_get_device           (WPEBufferDMABufFormats *formats);
 WPE_API guint                      wpe_buffer_dma_buf_formats_get_n_groups         (WPEBufferDMABufFormats *formats);
 WPE_API WPEBufferDMABufFormatUsage wpe_buffer_dma_buf_formats_get_group_usage      (WPEBufferDMABufFormats *formats,
                                                                                     guint                   group);
-WPE_API const char                *wpe_buffer_dma_buf_formats_get_group_device     (WPEBufferDMABufFormats *formats,
+WPE_API WPEDRMDevice              *wpe_buffer_dma_buf_formats_get_group_device     (WPEBufferDMABufFormats *formats,
                                                                                     guint                   group);
 WPE_API guint                      wpe_buffer_dma_buf_formats_get_group_n_formats  (WPEBufferDMABufFormats *formats,
                                                                                     guint                   group);
@@ -71,11 +72,11 @@ WPE_API GArray                    *wpe_buffer_dma_buf_formats_get_format_modifie
 typedef struct _WPEBufferDMABufFormatsBuilder WPEBufferDMABufFormatsBuilder;
 
 WPE_API GType                          wpe_buffer_dma_buf_formats_builder_get_type      (void);
-WPE_API WPEBufferDMABufFormatsBuilder *wpe_buffer_dma_buf_formats_builder_new           (const char *device);
+WPE_API WPEBufferDMABufFormatsBuilder *wpe_buffer_dma_buf_formats_builder_new           (WPEDRMDevice                  *device);
 WPE_API WPEBufferDMABufFormatsBuilder *wpe_buffer_dma_buf_formats_builder_ref           (WPEBufferDMABufFormatsBuilder *builder);
 WPE_API void                           wpe_buffer_dma_buf_formats_builder_unref         (WPEBufferDMABufFormatsBuilder *builder);
 WPE_API void                           wpe_buffer_dma_buf_formats_builder_append_group  (WPEBufferDMABufFormatsBuilder *builder,
-                                                                                         const char                    *device,
+                                                                                         WPEDRMDevice                  *device,
                                                                                          WPEBufferDMABufFormatUsage     usage);
 WPE_API void                           wpe_buffer_dma_buf_formats_builder_append_format (WPEBufferDMABufFormatsBuilder *builder,
                                                                                          guint32                        fourcc,

--- a/Source/WebKit/WPEPlatform/wpe/WPEDRMDevice.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDRMDevice.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEDRMDevice.h"
+
+#include "WPEDRMDevicePrivate.h"
+#include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/CString.h>
+
+#if USE(LIBDRM)
+#include <xf86drm.h>
+#endif
+
+/**
+ * WPEDRMDevice:
+ *
+ * Boxed type representing a DRM device.
+ */
+struct _WPEDRMDevice {
+    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(_WPEDRMDevice);
+
+    _WPEDRMDevice(const char* primaryNode, const char *renderNode)
+        : primaryNode(primaryNode)
+        , renderNode(renderNode)
+    {
+    }
+
+    CString primaryNode;
+    CString renderNode;
+
+    int referenceCount { 1 };
+};
+G_DEFINE_BOXED_TYPE(WPEDRMDevice, wpe_drm_device, wpe_drm_device_ref, wpe_drm_device_unref)
+
+// If deviceFilename is nullpr, it returns the first device having a render node if found or the first device.
+GRefPtr<WPEDRMDevice> wpeDRMDeviceCreateForDevice(const char* deviceFilename)
+{
+#if USE(LIBDRM)
+    std::array<drmDevicePtr, 64> devices { };
+
+    int numDevices = drmGetDevices2(0, devices.data(), std::size(devices));
+    if (numDevices <= 0)
+        return nullptr;
+
+    unsigned primaryNodesCount = 0;
+    GRefPtr<WPEDRMDevice> drmDevice;
+    for (int i = 0; i < numDevices; ++i) {
+        drmDevicePtr device = devices[i];
+        bool hasPrimaryNode = device->available_nodes & (1 << DRM_NODE_PRIMARY);
+        if (!hasPrimaryNode)
+            continue;
+
+        bool hasRenderNode = device->available_nodes & (1 << DRM_NODE_RENDER);
+        const char* primaryNode = device->nodes[DRM_NODE_PRIMARY];
+        const char* renderNode = hasRenderNode ? device->nodes[DRM_NODE_RENDER] : nullptr;
+        if (deviceFilename) {
+            if (!g_strcmp0(deviceFilename, primaryNode) || !g_strcmp0(deviceFilename, renderNode)) {
+                drmDevice = adoptGRef(wpe_drm_device_new(primaryNode, renderNode));
+                break;
+            }
+            continue;
+        }
+
+        primaryNodesCount++;
+        if (drmDevice) {
+            if (wpe_drm_device_get_render_node(drmDevice.get()))
+                break;
+
+            if (!hasRenderNode)
+                continue;
+        }
+
+        drmDevice = adoptGRef(wpe_drm_device_new(primaryNode, renderNode));
+    }
+    drmFreeDevices(devices.data(), numDevices);
+
+    if (!deviceFilename && drmDevice && primaryNodesCount > 1)
+        g_warning("Infered DRM device (%s) using libdrm but multiple were found, you can override this with WPE_DRM_DEVICE", wpe_drm_device_get_primary_node(drmDevice.get()));
+
+    return drmDevice;
+#else
+    return nullptr;
+#endif
+}
+
+/**
+ * wpe_drm_device_new:
+ * @primary_node: the filename of the primary node
+ * @render_node: (nullable): the filename of the render node, or %NULL
+ *
+ * Create a new #WPEDRMDevice for the given @primary_node and @render_node.
+ *
+ * Returns: (transfer full): a new #WPEDRMDevice
+ */
+WPEDRMDevice* wpe_drm_device_new(const char* primaryNode, const char *renderNode)
+{
+    g_return_val_if_fail(primaryNode, nullptr);
+
+    auto* device = static_cast<WPEDRMDevice*>(fastMalloc(sizeof(WPEDRMDevice)));
+    new (device) WPEDRMDevice(primaryNode, renderNode);
+    return device;
+}
+
+/**
+ * wpe_drm_device_ref:
+ * @device: a #WPEDRMDevice
+ *
+ * Atomically acquires a reference on the given @device.
+ *
+ * This function is MT-safe and may be called from any thread.
+ *
+ * Returns: (transfer full): The same @device with an additional reference.
+ */
+WPEDRMDevice* wpe_drm_device_ref(WPEDRMDevice* device)
+{
+    g_return_val_if_fail(device, nullptr);
+
+    g_atomic_int_inc(&device->referenceCount);
+    return device;
+}
+
+/**
+ * wpe_drm_device_unref:
+ * @device: a #WPEDRMDevice
+ *
+ * Atomically releases a reference on the given @device.
+ *
+ * If the reference was the last, the resources associated to the
+ * @device are freed. This function is MT-safe and may be called from
+ * any thread.
+ */
+void wpe_drm_device_unref(WPEDRMDevice* device)
+{
+    g_return_if_fail(device);
+
+    if (g_atomic_int_dec_and_test(&device->referenceCount)) {
+        device->~WPEDRMDevice();
+        fastFree(device);
+    }
+}
+
+/**
+ * wpe_drm_device_get_primary_node:
+ * @device: a #WPEDRMDevice
+ *
+ * Get the filename of primary node of @device.
+ *
+ * Returns: (transfer none): the filename of primary node.
+ */
+const char* wpe_drm_device_get_primary_node(WPEDRMDevice* device)
+{
+    g_return_val_if_fail(device, nullptr);
+
+    return device->primaryNode.data();
+}
+
+/**
+ * wpe_drm_device_get_render_node:
+ * @device: a #WPEDRMDevice
+ *
+ * Get the filename of render node of @device.
+ *
+ * Returns: (transfer none) (nullable): the filename of render node or %NULL
+ */
+const char* wpe_drm_device_get_render_node(WPEDRMDevice* device)
+{
+    g_return_val_if_fail(device, nullptr);
+
+    return device->renderNode.data();
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEDRMDevicePrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDRMDevicePrivate.h
@@ -22,12 +22,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #pragma once
 
-#if USE(LIBDRM)
+#include "GRefPtrWPE.h"
+#include "WPEDRMDevice.h"
 
-#include <wtf/text/CString.h>
-
-std::pair<CString, CString> lookupNodesWithLibDRM();
-
-#endif /* USE(LIBDRM) */
+GRefPtr<WPEDRMDevice> wpeDRMDeviceCreateForDevice(const char*);

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -33,6 +33,7 @@
 #include <glib-object.h>
 #include <wpe/WPEBufferDMABufFormats.h>
 #include <wpe/WPEClipboard.h>
+#include <wpe/WPEDRMDevice.h>
 #include <wpe/WPEDefines.h>
 #include <wpe/WPEGamepadManager.h>
 #include <wpe/WPEInputMethodContext.h>
@@ -70,8 +71,7 @@ struct _WPEDisplayClass
     guint                   (* get_n_screens)                 (WPEDisplay *display);
     WPEScreen              *(* get_screen)                    (WPEDisplay *display,
                                                                guint       index);
-    const char             *(* get_drm_device)                (WPEDisplay *display);
-    const char             *(* get_drm_render_node)           (WPEDisplay *display);
+    WPEDRMDevice           *(* get_drm_device)                (WPEDisplay *display);
     gboolean                (* use_explicit_sync)             (WPEDisplay *display);
     WPEInputMethodContext  *(* create_input_method_context)   (WPEDisplay *display,
                                                                WPEView    *view);
@@ -112,8 +112,7 @@ WPE_API void                     wpe_display_screen_added                  (WPED
                                                                             WPEScreen *screen);
 WPE_API void                     wpe_display_screen_removed                (WPEDisplay *display,
                                                                             WPEScreen *screen);
-WPE_API const char              *wpe_display_get_drm_device                (WPEDisplay *display);
-WPE_API const char              *wpe_display_get_drm_render_node           (WPEDisplay *display);
+WPE_API WPEDRMDevice            *wpe_display_get_drm_device                (WPEDisplay *display);
 WPE_API gboolean                 wpe_display_use_explicit_sync             (WPEDisplay *display);
 
 WPE_API WPESettings             *wpe_display_get_settings                  (WPEDisplay *display);

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -624,7 +624,7 @@ WPEBufferDMABufFormats* wpe_toplevel_get_preferred_dma_buf_formats(WPEToplevel* 
                     else if (tokens[2] == "scanout"_s)
                         usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT;
                 }
-                auto* builder = wpe_buffer_dma_buf_formats_builder_new(priv->display ? wpe_display_get_drm_render_node(priv->display.get()) : nullptr);
+                auto* builder = wpe_buffer_dma_buf_formats_builder_new(priv->display ? wpe_display_get_drm_device(priv->display.get()) : nullptr);
                 wpe_buffer_dma_buf_formats_builder_append_group(builder, nullptr, usage);
                 wpe_buffer_dma_buf_formats_builder_append_format(builder, format, modifier);
                 priv->overridenDMABufFormats = adoptGRef(wpe_buffer_dma_buf_formats_builder_end(builder));

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -27,7 +27,9 @@
 #include "WPEDisplayDRM.h"
 
 #include "DRMUniquePtr.h"
+#include "GRefPtrWPE.h"
 #include "RefPtrUdev.h"
+#include "WPEDRMDevice.h"
 #include "WPEDRMSession.h"
 #include "WPEDisplayDRMPrivate.h"
 #include "WPEExtensions.h"
@@ -39,6 +41,7 @@
 #include <gio/gio.h>
 #include <libudev.h>
 #include <wtf/ASCIICType.h>
+#include <wtf/Scope.h>
 #include <wtf/dtoa.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
@@ -51,8 +54,8 @@
  */
 struct _WPEDisplayDRMPrivate {
     std::unique_ptr<WPE::DRM::Session> session;
-    CString drmDevice;
-    CString drmRenderNode;
+    GRefPtr<WPEDRMDevice> displayDevice;
+    GRefPtr<WPEDRMDevice> renderDevice;
     UnixFileDescriptor fd;
     struct gbm_device* device;
     bool atomicSupported;
@@ -98,14 +101,20 @@ static void wpeDisplayDRMDispose(GObject* object)
 }
 
 struct DisplayDevice {
-    CString filename;
-    UnixFileDescriptor fd;
-
     bool isNull() const
     {
-        return !fd && filename.isNull();
+        return !fd && !drmDevice;
     }
+
+    UnixFileDescriptor fd;
+    GRefPtr<WPEDRMDevice> drmDevice;
 };
+
+static GRefPtr<WPEDRMDevice> createDisplayDevice(const UnixFileDescriptor& fd, const char* filename)
+{
+    std::unique_ptr<char, decltype(free)*> renderNodePath(drmGetRenderDeviceNameFromFd(fd.value()), free);
+    return adoptGRef(wpe_drm_device_new(filename, renderNodePath.get()));
+}
 
 // This is based on weston function find_primary_gpu(). It tries to find the boot VGA device that is KMS capable, or the first KMS device.
 static struct DisplayDevice findTargetDevice(struct udev* udev, const char* seatID)
@@ -146,7 +155,8 @@ static struct DisplayDevice findTargetDevice(struct udev* udev, const char* seat
         if (!resources || !resources->count_crtcs || !resources->count_connectors || !resources->count_encoders)
             continue;
 
-        displayDevice = { CString(filename), WTFMove(fd) };
+        auto drmDevice = createDisplayDevice(fd, filename);
+        displayDevice = { WTFMove(fd), WTFMove(drmDevice) };
         if (isBootVGA)
             return displayDevice;
     }
@@ -154,7 +164,7 @@ static struct DisplayDevice findTargetDevice(struct udev* udev, const char* seat
     return displayDevice;
 }
 
-static CString findFirstRenderNodeName()
+static GRefPtr<WPEDRMDevice> findFirstDeviceWithRenderNode()
 {
     std::array<drmDevicePtr, 64> devices = { };
 
@@ -162,7 +172,7 @@ static CString findFirstRenderNodeName()
     if (numDevices <= 0)
         return { };
 
-    CString filename;
+    GRefPtr<WPEDRMDevice> drmDevice;
     for (int i = 0; i < numDevices; ++i) {
         const auto* device = devices[i];
         const auto nodes = unsafeMakeSpan(device->nodes, DRM_NODE_MAX);
@@ -175,12 +185,12 @@ static CString findFirstRenderNodeName()
         if (!hasRenderNode)
             continue;
 
-        filename = CString { nodes[DRM_NODE_RENDER] };
+        drmDevice = adoptGRef(wpe_drm_device_new(nodes[DRM_NODE_PRIMARY], nodes[DRM_NODE_RENDER]));
         break;
     }
 
     drmFreeDevices(devices.data(), numDevices);
-    return filename;
+    return drmDevice;
 }
 
 static bool wpeDisplayDRMInitializeCapabilities(WPEDisplayDRM* display, int fd, GError** error)
@@ -301,7 +311,8 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
             return FALSE;
         }
         WTF::UnixFileDescriptor unixFd(fd, WTF::UnixFileDescriptor::Adopt);
-        displayDevice = { deviceName, WTFMove(unixFd) };
+        auto drmDevice = createDisplayDevice(unixFd, deviceName);
+        displayDevice = { WTFMove(unixFd), WTFMove(drmDevice) };
     }
     auto fd = WTFMove(displayDevice.fd);
     if (drmSetMaster(fd.value()) == -1) {
@@ -344,12 +355,11 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
         return FALSE;
     }
 
-    std::unique_ptr<char, decltype(free)*> renderNodePath(drmGetRenderDeviceNameFromFd(fd.value()), free);
-
     displayDRM->priv->session = WTFMove(session);
     displayDRM->priv->fd = WTFMove(fd);
-    displayDRM->priv->drmDevice = WTFMove(displayDevice.filename);
-    displayDRM->priv->drmRenderNode = renderNodePath ? renderNodePath.get() : findFirstRenderNodeName();
+    displayDRM->priv->displayDevice = WTFMove(displayDevice.drmDevice);
+    if (!wpe_drm_device_get_render_node(displayDRM->priv->displayDevice.get()))
+        displayDRM->priv->renderDevice = findFirstDeviceWithRenderNode();
     displayDRM->priv->device = device;
     displayDRM->priv->connector = WTFMove(connector);
 
@@ -426,7 +436,7 @@ static WPEView* wpeDisplayDRMCreateView(WPEDisplay* display)
 static WPEBufferDMABufFormats* wpeDisplayDRMGetPreferredDMABufFormats(WPEDisplay* display)
 {
     auto* displayDRM = WPE_DISPLAY_DRM(display);
-    auto* builder = wpe_buffer_dma_buf_formats_builder_new(displayDRM->priv->drmDevice.data());
+    auto* builder = wpe_buffer_dma_buf_formats_builder_new(displayDRM->priv->displayDevice.get());
     wpe_buffer_dma_buf_formats_builder_append_group(builder, nullptr, WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT);
     for (const auto& format : displayDRM->priv->primaryPlane->formats()) {
         for (auto modifier : format.modifiers)
@@ -448,17 +458,10 @@ static WPEScreen* wpeDisplayDRMGetScreen(WPEDisplay* display, guint index)
     return WPE_DISPLAY_DRM(display)->priv->screen.get();
 }
 
-static const char* wpeDisplayDRMGetDRMDevice(WPEDisplay* display)
-{
-    return WPE_DISPLAY_DRM(display)->priv->drmDevice.data();
-}
-
-static const char* wpeDisplayDRMGetDRMRenderNode(WPEDisplay* display)
+static WPEDRMDevice* wpeDisplayDRMGetDRMDevice(WPEDisplay* display)
 {
     auto* priv = WPE_DISPLAY_DRM(display)->priv;
-    if (!priv->drmRenderNode.isNull())
-        return priv->drmRenderNode.data();
-    return priv->drmDevice.data();
+    return priv->renderDevice ? priv->renderDevice.get() : priv->displayDevice.get();
 }
 
 static gboolean wpeDisplayDRMUseExplicitSync(WPEDisplay* display)
@@ -479,13 +482,17 @@ static void wpe_display_drm_class_init(WPEDisplayDRMClass* displayDRMClass)
     displayClass->get_n_screens = wpeDisplayDRMGetNScreens;
     displayClass->get_screen = wpeDisplayDRMGetScreen;
     displayClass->get_drm_device = wpeDisplayDRMGetDRMDevice;
-    displayClass->get_drm_render_node = wpeDisplayDRMGetDRMRenderNode;
     displayClass->use_explicit_sync = wpeDisplayDRMUseExplicitSync;
 }
 
 const WPE::DRM::Connector& wpeDisplayDRMGetConnector(WPEDisplayDRM* display)
 {
     return *display->priv->connector;
+}
+
+WPEDRMDevice* wpeDisplayDRMGetDisplayDevice(WPEDisplayDRM* display)
+{
+    return display->priv->displayDevice.get();
 }
 
 WPEScreen* wpeDisplayDRMGetScreen(WPEDisplayDRM* display)

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRMPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRMPrivate.h
@@ -27,10 +27,13 @@
 
 #include "WPEDRM.h"
 #include "WPEDRMCursor.h"
+#include "WPEDRMDevice.h"
 #include "WPEDRMSeat.h"
+#include "WPEDisplayDRM.h"
 #include "WPEScreen.h"
 
 const WPE::DRM::Connector& wpeDisplayDRMGetConnector(WPEDisplayDRM*);
+WPEDRMDevice* wpeDisplayDRMGetDisplayDevice(WPEDisplayDRM*);
 WPEScreen* wpeDisplayDRMGetScreen(WPEDisplayDRM*);
 const WPE::DRM::Plane& wpeDisplayDRMGetPrimaryPlane(WPEDisplayDRM*);
 WPE::DRM::Cursor* wpeDisplayDRMGetCursor(WPEDisplayDRM*);

--- a/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
+++ b/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
@@ -34,6 +34,7 @@
 #include <wpe/WPEClipboard.h>
 #include <wpe/WPEColor.h>
 #include <wpe/WPEConfig.h>
+#include <wpe/WPEDRMDevice.h>
 #include <wpe/WPEDefines.h>
 #include <wpe/WPEDisplay.h>
 #include <wpe/WPEEGLError.h>


### PR DESCRIPTION
#### a2b0df6f37af5235490c39a2615dcf6d7a6b67e7
<pre>
[WPE] WPE Platform: add WPEDRMDevice
<a href="https://bugs.webkit.org/show_bug.cgi?id=296682">https://bugs.webkit.org/show_bug.cgi?id=296682</a>

Reviewed by Adrian Perez de Castro.

Instead of exposing DRM nodes individually, add WPEDRMDevice with
getters for primary and render node. Make wpe_display_get_drm_device()
return a WPEDRMDEvice instead of the path of a node and remove
wpe_display_get_drm_render_node(). Also change WPEBufferDMABufFormats to
use WPEDRMDEvice for the main and target devices instead of paths for
nodes.

Canonical link: <a href="https://commits.webkit.org/298125@main">https://commits.webkit.org/298125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e4de7f476afc2f3f90c03a560ad85d3d7dba949

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123715 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95714 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95498 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37397 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18321 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41235 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46743 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->