### PR TITLE
[JSC] Fix wrong member access due to DECLARE_VISIT_CHILDREN macro

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -191,6 +191,8 @@ public:
     static EncodedJSValue constructImpl(JSGlobalObject*, CallFrame*);
     static EncodedJSValue staticFunctionGetterImpl(JSGlobalObject*, EncodedJSValue, PropertyName);
     static EncodedJSValue callbackGetterImpl(JSGlobalObject*, EncodedJSValue, PropertyName);
+
+    DECLARE_VISIT_CHILDREN;
    
 private:
     JSCallbackObject(JSGlobalObject*, Structure*, JSClassRef, void* data);
@@ -217,8 +219,6 @@ private:
 
     static CallData getConstructData(JSCell*);
     static CallData getCallData(JSCell*);
-
-    DECLARE_VISIT_CHILDREN;
 
     void init(JSGlobalObject*);
  

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -520,11 +520,12 @@ private:
 #endif
 
 protected:
-    DECLARE_VISIT_CHILDREN;
     static size_t estimatedSize(JSCell*, VM&);
 
 public:
     DECLARE_INFO;
+
+    DECLARE_VISIT_CHILDREN;
 };
 
 }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1257,7 +1257,7 @@ JSValue Interpreter::executeCall(JSObject* function, const CallData& callData, J
 
     // Only one-level unwrap is enough! We already made JSBoundFunction's nest smaller.
     auto* boundFunction = jsCast<JSBoundFunction*>(function);
-    if (boundFunction->m_isTainted)
+    if (boundFunction->isTainted())
         vm.setMightBeExecutingTaintedCode();
     if (!boundFunction->boundArgsLength()) {
         // This is the simplest path, just replacing |this|. We do not need to go to executeBoundCall.

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -159,11 +159,11 @@ public:
     WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
     WriteBarrier<Unknown> internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
 
+    DECLARE_VISIT_CHILDREN;
+
 protected:
     AbstractModuleRecord(VM&, Structure*, const Identifier&);
     void finishCreation(JSGlobalObject*, VM&);
-
-    DECLARE_VISIT_CHILDREN;
 
     void setModuleEnvironment(JSGlobalObject*, JSModuleEnvironment*);
 

--- a/Source/JavaScriptCore/runtime/EvalExecutable.h
+++ b/Source/JavaScriptCore/runtime/EvalExecutable.h
@@ -63,6 +63,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     unsigned numVariables() { return unlinkedCodeBlock()->numVariables(); }
     std::span<const Identifier> variables() const { return unlinkedCodeBlock()->variables(); }
 
@@ -82,8 +84,6 @@ protected:
 
     using Base::finishCreation;
     EvalExecutable(JSGlobalObject*, const SourceCode&, LexicallyScopedFeatures, DerivedContextType, bool isArrowFunctionContext, bool isInsideOrdinaryFunction, EvalContextType, NeedsClassFieldInitializer, PrivateBrandRequirement);
-
-    DECLARE_VISIT_CHILDREN;
 
     unsigned m_needsClassFieldInitializer : 1;
     unsigned m_privateBrandRequirement : 1;

--- a/Source/JavaScriptCore/runtime/GenericArgumentsImpl.h
+++ b/Source/JavaScriptCore/runtime/GenericArgumentsImpl.h
@@ -38,13 +38,14 @@ public:
     using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
 
+    DECLARE_VISIT_CHILDREN;
+
 protected:
     GenericArgumentsImpl(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
     }
 
-    DECLARE_VISIT_CHILDREN;
     static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     static bool getOwnPropertySlotByIndex(JSObject*, JSGlobalObject*, unsigned propertyName, PropertySlot&);
     static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);

--- a/Source/JavaScriptCore/runtime/IntlCollator.h
+++ b/Source/JavaScriptCore/runtime/IntlCollator.h
@@ -58,6 +58,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     void initializeCollator(JSGlobalObject*, JSValue locales, JSValue optionsValue);
     UCollationResult compareStrings(JSGlobalObject*, StringView, StringView) const;
     JSObject* resolvedOptions(JSGlobalObject*) const;
@@ -81,7 +83,6 @@ public:
 private:
     IntlCollator(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     bool updateCanDoASCIIUCADUCETComparison() const;
 

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -64,6 +64,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     enum class RequiredComponent : uint8_t { Date, Time, Any };
     enum class Defaults : uint8_t { Date, Time, All };
     void initializeDateTimeFormat(JSGlobalObject*, JSValue locales, JSValue options, RequiredComponent, Defaults);
@@ -84,13 +86,10 @@ public:
 private:
     IntlDateTimeFormat(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     static Vector<String> localeData(const String&, RelevantExtensionKey);
 
     UDateIntervalFormat* createDateIntervalFormatIfNecessary(JSGlobalObject*);
-
-    static double handleDateTimeValue(JSGlobalObject*, JSValue);
 
     enum class Weekday : uint8_t { None, Narrow, Short, Long };
     enum class Era : uint8_t { None, Narrow, Short, Long };

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -89,7 +89,7 @@ void IntlDateTimeFormatPrototype::finishCreation(VM& vm, JSGlobalObject* globalO
 
 // HandleDateTimeValue ( dateTimeFormat, x )
 // https://tc39.es/proposal-temporal/#sec-temporal-handledatetimevalue
-double IntlDateTimeFormat::handleDateTimeValue(JSGlobalObject* globalObject, JSValue x)
+static double handleDateTimeValue(JSGlobalObject* globalObject, JSValue x)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -120,7 +120,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatFuncFormatDateTime, (JSGlobalObject* 
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.format called on value that's not a DateTimeFormat"_s));
 
     JSValue date = callFrame->argument(0);
-    double value = IntlDateTimeFormat::handleDateTimeValue(globalObject, date);
+    double value = handleDateTimeValue(globalObject, date);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(format->format(globalObject, value)));
@@ -173,7 +173,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatToParts, (JSGlobal
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.DateTimeFormat.prototype.formatToParts called on value that's not a DateTimeFormat"_s));
 
     JSValue date = callFrame->argument(0);
-    double value = IntlDateTimeFormat::handleDateTimeValue(globalObject, date);
+    double value = handleDateTimeValue(globalObject, date);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatToParts(globalObject, value)));
@@ -196,9 +196,9 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRange, (JSGlobalOb
     if (startDateValue.isUndefined() || endDateValue.isUndefined())
         return throwVMTypeError(globalObject, scope, "startDate or endDate is undefined"_s);
 
-    double startDate = IntlDateTimeFormat::handleDateTimeValue(globalObject, startDateValue);
+    double startDate = handleDateTimeValue(globalObject, startDateValue);
     RETURN_IF_EXCEPTION(scope, { });
-    double endDate = IntlDateTimeFormat::handleDateTimeValue(globalObject, endDateValue);
+    double endDate = handleDateTimeValue(globalObject, endDateValue);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatRange(globalObject, startDate, endDate)));
@@ -221,9 +221,9 @@ JSC_DEFINE_HOST_FUNCTION(intlDateTimeFormatPrototypeFuncFormatRangeToParts, (JSG
     if (startDateValue.isUndefined() || endDateValue.isUndefined())
         return throwVMTypeError(globalObject, scope, "startDate or endDate is undefined"_s);
 
-    double startDate = IntlDateTimeFormat::handleDateTimeValue(globalObject, startDateValue);
+    double startDate = handleDateTimeValue(globalObject, startDateValue);
     RETURN_IF_EXCEPTION(scope, { });
-    double endDate = IntlDateTimeFormat::handleDateTimeValue(globalObject, endDateValue);
+    double endDate = handleDateTimeValue(globalObject, endDateValue);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(dateTimeFormat->formatRangeToParts(globalObject, startDate, endDate)));

--- a/Source/JavaScriptCore/runtime/IntlLocale.h
+++ b/Source/JavaScriptCore/runtime/IntlLocale.h
@@ -52,6 +52,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     void initializeLocale(JSGlobalObject*, const String& tag, JSValue optionsValue);
     void initializeLocale(JSGlobalObject*, JSValue tagValue, JSValue optionsValue);
     const String& maximal();
@@ -82,7 +84,6 @@ public:
 private:
     IntlLocale(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     String keywordValue(ASCIILiteral, bool isBoolean = false) const;
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -50,6 +50,7 @@ enum class IntlTrailingZeroDisplay : uint8_t { Auto, StripIfInteger };
 enum class IntlNotation : uint8_t { Standard, Scientific, Engineering, Compact };
 template<typename IntlType> void setNumberFormatDigitOptions(JSGlobalObject*, IntlType*, JSObject*, unsigned minimumFractionDigitsDefault, unsigned maximumFractionDigitsDefault, IntlNotation);
 template<typename IntlType> void appendNumberFormatDigitOptionsToSkeleton(IntlType*, StringBuilder&);
+template<typename IntlType> void appendNumberFormatNotationOptionsToSkeleton(IntlType*, StringBuilder&);
 
 struct UNumberFormatterDeleter {
     JS_EXPORT_PRIVATE void operator()(UNumberFormatter*);
@@ -155,6 +156,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     void initializeNumberFormat(JSGlobalObject*, JSValue locales, JSValue optionsValue);
     JSValue format(JSGlobalObject*, double) const;
     JSValue format(JSGlobalObject*, IntlMathematicalValue&&) const;
@@ -180,6 +183,8 @@ public:
     friend void setNumberFormatDigitOptions(JSGlobalObject*, IntlType*, JSObject*, unsigned minimumFractionDigitsDefault, unsigned maximumFractionDigitsDefault, IntlNotation);
     template<typename IntlType>
     friend void appendNumberFormatDigitOptionsToSkeleton(IntlType*, StringBuilder&);
+    template<typename IntlType>
+    friend void appendNumberFormatNotationOptionsToSkeleton(IntlType*, StringBuilder&);
 
     static ASCIILiteral notationString(IntlNotation);
 
@@ -187,11 +192,11 @@ public:
 
     static ASCIILiteral roundingModeString(RoundingMode);
     static ASCIILiteral roundingPriorityString(IntlRoundingType);
+    static ASCIILiteral trailingZeroDisplayString(IntlTrailingZeroDisplay);
 
 private:
     IntlNumberFormat(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     static Vector<String> localeData(const String&, RelevantExtensionKey);
 
@@ -208,7 +213,6 @@ private:
     static ASCIILiteral unitDisplayString(UnitDisplay);
     static ASCIILiteral compactDisplayString(CompactDisplay);
     static ASCIILiteral signDisplayString(SignDisplay);
-    static ASCIILiteral trailingZeroDisplayString(IntlTrailingZeroDisplay);
     static JSValue useGroupingValue(VM&, UseGrouping);
 
     WriteBarrier<JSBoundFunction> m_boundFormat;

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.h
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.h
@@ -62,10 +62,14 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     template<typename IntlType>
     friend void setNumberFormatDigitOptions(JSGlobalObject*, IntlType*, JSObject*, unsigned minimumFractionDigitsDefault, unsigned maximumFractionDigitsDefault, IntlNotation);
     template<typename IntlType>
     friend void appendNumberFormatDigitOptionsToSkeleton(IntlType*, StringBuilder&);
+    template<typename IntlType>
+    friend void appendNumberFormatNotationOptionsToSkeleton(IntlType*, StringBuilder&);
 
     void initializePluralRules(JSGlobalObject*, JSValue locales, JSValue options);
     JSValue select(JSGlobalObject*, double value) const;
@@ -75,7 +79,6 @@ public:
 private:
     IntlPluralRules(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     static Vector<String> localeData(const String&, RelevantExtensionKey);
 

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
@@ -56,6 +56,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     void initializeRelativeTimeFormat(JSGlobalObject*, JSValue locales, JSValue options);
     JSValue format(JSGlobalObject*, double, StringView unitString) const;
     JSValue formatToParts(JSGlobalObject*, double, StringView unitString) const;
@@ -64,7 +66,6 @@ public:
 private:
     IntlRelativeTimeFormat(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     static Vector<String> localeData(const String&, RelevantExtensionKey);
 

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -254,8 +254,6 @@ protected:
     
     JS_EXPORT_PRIVATE JSArrayBufferView(VM&, ConstructionContext&);
     JS_EXPORT_PRIVATE void finishCreation(VM&);
-
-    DECLARE_VISIT_CHILDREN;
     
 public:
     TypedArrayMode mode() const { return m_mode; }
@@ -344,6 +342,8 @@ public:
     }
 
     DECLARE_EXPORT_INFO;
+
+    DECLARE_VISIT_CHILDREN;
     
     static constexpr ptrdiff_t offsetOfVector() { return OBJECT_OFFSETOF(JSArrayBufferView, m_vector); }
     static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(JSArrayBufferView, m_length); }

--- a/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h
@@ -37,6 +37,7 @@ public:
     using Base = JSInternalFieldObjectImpl<JSAsyncDisposableStackNumberOfInternalFields>;
 
     DECLARE_EXPORT_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     enum class State : int32_t {
         Pending = 0,
@@ -80,7 +81,6 @@ private:
     }
 
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncDisposableStack);

--- a/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h
@@ -36,6 +36,7 @@ public:
     using Base = JSInternalFieldObjectImpl<JSAsyncFromSyncIteratorNumberOfInternalFields>;
 
     DECLARE_EXPORT_INFO;
+    DECLARE_VISIT_CHILDREN;
 
     enum class Field : uint8_t {
         SyncIterator = 0,
@@ -75,8 +76,6 @@ private:
     }
 
     void finishCreation(VM&, JSValue syncIterator, JSValue nextMethod);
-    DECLARE_VISIT_CHILDREN;
-
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSAsyncFromSyncIterator);

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.h
@@ -126,9 +126,16 @@ public:
         return m_canConstruct == TriState::True;
     }
 
+    bool isTainted() const
+    {
+        return m_isTainted;
+    }
+
     static bool canSkipNameAndLengthMaterialization(JSGlobalObject*, Structure*);
 
     DECLARE_INFO;
+
+    DECLARE_VISIT_CHILDREN;
 
 private:
     JSBoundFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSObject* targetFunction, JSValue boundThis, unsigned boundArgsLength, JSValue arg0, JSValue arg1, JSValue arg2, JSString* nameMayBeNull, double length, const SourceCode&);
@@ -139,7 +146,6 @@ private:
     String nameStringWithoutGCSlow(VM&);
 
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<JSObject> m_targetFunction;
     WriteBarrier<Unknown> m_boundThis;

--- a/Source/JavaScriptCore/runtime/JSCallee.h
+++ b/Source/JavaScriptCore/runtime/JSCallee.h
@@ -75,6 +75,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     static constexpr ptrdiff_t offsetOfScopeChain()
@@ -87,7 +89,6 @@ protected:
     JSCallee(VM&, JSScope*, Structure*);
 
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     friend class LLIntOffsetsExtractor;
 

--- a/Source/JavaScriptCore/runtime/JSDisposableStack.h
+++ b/Source/JavaScriptCore/runtime/JSDisposableStack.h
@@ -38,6 +38,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     enum class State : int32_t {
         Pending = 0,
         Disposed
@@ -80,7 +82,6 @@ private:
     }
 
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSDisposableStack);

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -115,6 +115,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     TaggedNativeFunction nativeFunction();
@@ -202,8 +204,6 @@ protected:
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
     static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
-
-    DECLARE_VISIT_CHILDREN;
 
 private:
     static JSFunction* createImpl(VM& vm, FunctionExecutable* executable, JSScope* scope, Structure* structure)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -161,7 +161,9 @@ public:
 
     inline void copyFromInt32ShapeArray(size_t offset, JSArray*, size_t objectOffset, size_t length);
     inline void copyFromDoubleShapeArray(size_t offset, JSArray*, size_t objectOffset, size_t length);
-    
+
+    DECLARE_VISIT_CHILDREN;
+
 protected:
     friend struct TypedArrayClassInfos;
 
@@ -179,7 +181,6 @@ protected:
     static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
 
     static size_t estimatedSize(JSCell*, VM&);
-    DECLARE_VISIT_CHILDREN;
 
     // Returns true if successful, and false on error; it will throw on error.
     template<typename OtherAdaptor>

--- a/Source/JavaScriptCore/runtime/JSGlobalProxy.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalProxy.h
@@ -59,6 +59,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE);
+
     JSGlobalObject* target() const { return m_target.get(); }
     static constexpr ptrdiff_t targetOffset() { return OBJECT_OFFSETOF(JSGlobalProxy, m_target); }
 
@@ -72,8 +74,6 @@ protected:
     }
 
     DECLARE_DEFAULT_FINISH_CREATION;
-
-    DECLARE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE);
 
     JS_EXPORT_PRIVATE static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     JS_EXPORT_PRIVATE static bool getOwnPropertySlotByIndex(JSObject*, JSGlobalObject*, unsigned, PropertySlot&);

--- a/Source/JavaScriptCore/runtime/JSInternalFieldObjectImpl.h
+++ b/Source/JavaScriptCore/runtime/JSInternalFieldObjectImpl.h
@@ -67,9 +67,9 @@ public:
     static constexpr ptrdiff_t offsetOfInternalFields() { return OBJECT_OFFSETOF(JSInternalFieldObjectImpl, m_internalFields); }
     static constexpr ptrdiff_t offsetOfInternalField(unsigned index) { return OBJECT_OFFSETOF(JSInternalFieldObjectImpl, m_internalFields) + index * sizeof(WriteBarrier<Unknown>); }
 
-protected:
     DECLARE_VISIT_CHILDREN;
 
+protected:
     JSInternalFieldObjectImpl(VM& vm, Structure* structure)
         : Base(vm, structure)
     {

--- a/Source/JavaScriptCore/runtime/JSLexicalEnvironment.h
+++ b/Source/JavaScriptCore/runtime/JSLexicalEnvironment.h
@@ -116,6 +116,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     inline static Structure* createStructure(VM&, JSGlobalObject*);
 
 protected:
@@ -123,7 +125,6 @@ protected:
 
     DECLARE_DEFAULT_FINISH_CREATION;
 
-    DECLARE_VISIT_CHILDREN;
     static void analyzeHeap(JSCell*, HeapAnalyzer&);
 };
 

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -39,6 +39,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     enum class Field : uint8_t {
         Entry = 0,
         IteratedObject,
@@ -170,7 +172,6 @@ private:
 
     JS_EXPORT_PRIVATE void finishCreation(JSGlobalObject*, JSMap*, IterationKind);
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 };
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSMapIterator);
 

--- a/Source/JavaScriptCore/runtime/JSModuleEnvironment.h
+++ b/Source/JavaScriptCore/runtime/JSModuleEnvironment.h
@@ -52,6 +52,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     inline static Structure* createStructure(VM&, JSGlobalObject*);
 
     static size_t offsetOfModuleRecord(SymbolTable* symbolTable)
@@ -87,8 +89,6 @@ private:
     {
         return *std::bit_cast<WriteBarrierBase<AbstractModuleRecord>*>(std::bit_cast<char*>(this) + offsetOfModuleRecord(symbolTable()));
     }
-
-    DECLARE_VISIT_CHILDREN;
 };
 
 inline JSModuleEnvironment::JSModuleEnvironment(VM& vm, Structure* structure, JSScope* currentScope, SymbolTable* symbolTable, JSValue initialValue, AbstractModuleRecord* moduleRecord)

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
@@ -64,6 +64,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     AbstractModuleRecord* moduleRecord() { return m_moduleRecord.get(); }
@@ -71,7 +73,6 @@ public:
 private:
     JS_EXPORT_PRIVATE JSModuleNamespaceObject(VM&, Structure*);
     JS_EXPORT_PRIVATE void finishCreation(JSGlobalObject*, AbstractModuleRecord*, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&&);
-    DECLARE_VISIT_CHILDREN;
     bool getOwnPropertySlotCommon(JSGlobalObject*, PropertyName, PropertySlot&);
 
     struct ExportEntry {

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.h
@@ -42,6 +42,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
@@ -65,8 +67,6 @@ private:
     JSModuleRecord(VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&, CodeFeatures);
 
     void finishCreation(JSGlobalObject*, VM&);
-
-    DECLARE_VISIT_CHILDREN;
 
     void instantiateDeclarations(JSGlobalObject*, ModuleProgramExecutable*, JSValue scriptFetcher);
 

--- a/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
+++ b/Source/JavaScriptCore/runtime/JSNativeStdFunction.h
@@ -52,6 +52,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     JS_EXPORT_PRIVATE static JSNativeStdFunction* create(VM&, JSGlobalObject*, unsigned length, const String& name, NativeStdFunction&&, Intrinsic = NoIntrinsic, NativeFunction nativeConstructor = callHostFunctionAsConstructor);
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
@@ -61,7 +63,6 @@ public:
 private:
     JSNativeStdFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, NativeStdFunction&&);
     void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
-    DECLARE_VISIT_CHILDREN;
 
     NativeStdFunction m_function;
 };

--- a/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
+++ b/Source/JavaScriptCore/runtime/JSRegExpStringIterator.h
@@ -37,6 +37,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     enum class Field : uint8_t {
         RegExp = 0,
         String,
@@ -82,8 +84,6 @@ private:
     }
 
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
-
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSRegExpStringIterator);

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -76,13 +76,14 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
 private:
     JSRemoteFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSObject* targetCallable);
 
     void copyNameAndLength(JSGlobalObject*);
 
     void finishCreation(JSGlobalObject*, VM&);
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<JSObject> m_targetFunction;
     WriteBarrier<JSString> m_nameMayBeNull;

--- a/Source/JavaScriptCore/runtime/JSSetIterator.h
+++ b/Source/JavaScriptCore/runtime/JSSetIterator.h
@@ -39,6 +39,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     enum class Field : uint8_t {
         Entry = 0,
         IteratedObject,
@@ -146,7 +148,6 @@ private:
 
     JS_EXPORT_PRIVATE void finishCreation(JSGlobalObject*, JSSet*, IterationKind);
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 };
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSSetIterator);
 

--- a/Source/JavaScriptCore/runtime/JSSymbolTableObject.h
+++ b/Source/JavaScriptCore/runtime/JSSymbolTableObject.h
@@ -50,6 +50,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
 protected:
     JSSymbolTableObject(VM& vm, Structure* structure, JSScope* scope)
         : Base(vm, structure, scope)
@@ -70,8 +72,6 @@ protected:
         symbolTable->notifyCreation(vm, this, "Allocated a scope");
         m_symbolTable.set(vm, this, symbolTable);
     }
-    
-    DECLARE_VISIT_CHILDREN;
     
 private:
     WriteBarrier<SymbolTable> m_symbolTable;

--- a/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
+++ b/Source/JavaScriptCore/runtime/JSWrapForValidIterator.h
@@ -38,6 +38,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     enum class Field : uint8_t {
         IteratedIterator = 0,
         IteratedNextMethod,
@@ -79,7 +81,6 @@ private:
     }
 
     void finishCreation(VM&, JSValue iterator, JSValue nextMethod);
-    DECLARE_VISIT_CHILDREN;
 };
 
 STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(JSWrapForValidIterator);

--- a/Source/JavaScriptCore/runtime/JSWrapperObject.h
+++ b/Source/JavaScriptCore/runtime/JSWrapperObject.h
@@ -61,10 +61,10 @@ public:
 #endif
     }
 
+    DECLARE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE);
+
 protected:
     explicit JSWrapperObject(VM&, Structure*);
-
-    DECLARE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE);
 };
 
 inline JSWrapperObject::JSWrapperObject(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
@@ -68,6 +68,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     bool isAsync() const { return features() & AwaitFeature; }
 
     SymbolTable* moduleEnvironmentSymbolTable() { return m_moduleEnvironmentSymbolTable.get(); }
@@ -79,8 +81,6 @@ private:
     friend class ScriptExecutable;
 
     ModuleProgramExecutable(JSGlobalObject*, const SourceCode&);
-
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<SymbolTable> m_moduleEnvironmentSymbolTable;
     std::unique_ptr<TemplateObjectMap> m_templateObjectMap;

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.h
@@ -74,6 +74,8 @@ public:
         
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     TemplateObjectMap& ensureTemplateObjectMap(VM&);
 
 private:
@@ -81,8 +83,6 @@ private:
     friend class ScriptExecutable;
 
     ProgramExecutable(JSGlobalObject*, const SourceCode&);
-
-    DECLARE_VISIT_CHILDREN;
 
     std::unique_ptr<TemplateObjectMap> m_templateObjectMap;
 };

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -77,6 +77,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     JSObject* target() const { return jsCast<JSObject*>(internalField(Field::Target).get()); }
     JSValue handler() const { return internalField(Field::Handler).get(); }
 
@@ -117,7 +119,6 @@ private:
     static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
     static bool setPrototype(JSObject*, JSGlobalObject*, JSValue prototype, bool shouldThrowIfCantSet);
     static JSValue getPrototype(JSObject*, JSGlobalObject*);
-    DECLARE_VISIT_CHILDREN;
 
     bool getOwnPropertySlotCommon(JSGlobalObject*, PropertyName, PropertySlot&);
     bool performInternalMethodGetOwnProperty(JSGlobalObject*, PropertyName, PropertySlot&);

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -99,6 +99,11 @@ public:
         return m_lastIndex.get();
     }
 
+    bool lastIndexIsWritable() const
+    {
+        return !(m_regExpAndFlags & lastIndexIsNotWritableFlag);
+    }
+
     bool test(JSGlobalObject* globalObject, JSString* string) { return !!match(globalObject, string); }
     bool testInline(JSGlobalObject* globalObject, JSString* string) { return !!matchInline(globalObject, string); }
     JS_EXPORT_PRIVATE JSValue exec(JSGlobalObject*, JSString*);
@@ -110,6 +115,8 @@ public:
     static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
 
     DECLARE_EXPORT_INFO;
+
+    DECLARE_VISIT_CHILDREN;
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
@@ -136,13 +143,6 @@ private:
 #if ASSERT_ENABLED
     JS_EXPORT_PRIVATE void finishCreation(VM&);
 #endif
-
-    DECLARE_VISIT_CHILDREN;
-
-    bool lastIndexIsWritable() const
-    {
-        return !(m_regExpAndFlags & lastIndexIsNotWritableFlag);
-    }
 
     void setLastIndexIsNotWritable()
     {

--- a/Source/JavaScriptCore/runtime/ShadowRealmObject.h
+++ b/Source/JavaScriptCore/runtime/ShadowRealmObject.h
@@ -46,6 +46,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     static ShadowRealmObject* create(VM&, Structure*, JSGlobalObject*);
 
     JSGlobalObject* globalObject() { return m_globalObject.get(); }
@@ -53,7 +55,6 @@ public:
 private:
     ShadowRealmObject(VM&, Structure*);
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<JSGlobalObject> m_globalObject;
 };

--- a/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/SyntheticModuleRecord.h
@@ -42,6 +42,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
@@ -66,8 +68,6 @@ private:
     static SyntheticModuleRecord* tryCreateWithExportNamesAndValues(JSGlobalObject*, const Identifier& moduleKey, const Vector<Identifier, 4>& exportNames, const MarkedArgumentBuffer& exportValues);
 
     void finishCreation(JSGlobalObject*, VM&);
-
-    DECLARE_VISIT_CHILDREN;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2089,6 +2089,7 @@ public:
 
     DECLARE_INFO;
 
+private:
     WriteBarrier<JSPromise> m_promise;
     const Ref<Wasm::StreamingCompiler> m_streamingCompiler;
 };

--- a/Source/JavaScriptCore/tools/JSDollarVM.h
+++ b/Source/JavaScriptCore/tools/JSDollarVM.h
@@ -47,6 +47,8 @@ public:
     }
     
     DECLARE_EXPORT_INFO;
+
+    DECLARE_VISIT_CHILDREN;
     
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
     {
@@ -76,8 +78,6 @@ private:
     void addConstructibleFunction(VM&, JSGlobalObject*, ASCIILiteral name, NativeFunction, unsigned arguments);
 
     static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
-
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrierStructureID m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID;
 };

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h
@@ -53,13 +53,14 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     Wasm::Global* global() { return m_global.ptr(); }
     JSObject* type(JSGlobalObject*);
 
 private:
     JSWebAssemblyGlobal(VM&, Structure*, Ref<Wasm::Global>&&);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     const Ref<Wasm::Global> m_global;
 };

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -83,6 +83,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     void initializeImports(JSGlobalObject*, JSObject* importObject, Wasm::CreationMode);
     void finalizeCreation(VM&, JSGlobalObject*, Ref<Wasm::CalleeGroup>&&, Wasm::CreationMode);
     
@@ -304,7 +306,6 @@ private:
     JSWebAssemblyInstance(VM&, Structure*, JSWebAssemblyModule*, WebAssemblyModuleRecord*, RefPtr<SourceProvider>&&);
     ~JSWebAssemblyInstance();
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 
     static size_t allocationSize(const Wasm::ModuleInformation&);
     bool evaluateConstantExpression(uint64_t, Wasm::Type, uint64_t&);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -55,6 +55,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     JS_EXPORT_PRIVATE void adopt(Ref<Wasm::Memory>&&);
     Wasm::Memory& memory() { return m_memory.get(); }
     JSArrayBuffer* buffer(JSGlobalObject*);
@@ -73,7 +75,6 @@ public:
 private:
     JSWebAssemblyMemory(VM&, Structure*);
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 
     Ref<Wasm::Memory> m_memory;
     WriteBarrier<JSArrayBuffer> m_bufferWrapper;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
@@ -63,6 +63,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     JS_EXPORT_PRIVATE static JSWebAssemblyModule* create(VM&, Structure*, Ref<Wasm::Module>&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
@@ -75,7 +77,6 @@ public:
 private:
     JSWebAssemblyModule(VM&, Structure*, Ref<Wasm::Module>&&);
     void finishCreation(VM&);
-    DECLARE_VISIT_CHILDREN;
 
     const Ref<Wasm::Module> m_module;
     WriteBarrier<SymbolTable> m_exportSymbolTable;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h
@@ -53,6 +53,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     static bool isValidLength(uint32_t length) { return Wasm::Table::isValidLength(length); }
     std::optional<uint32_t> maximum() const { return m_table->maximum(); }
     uint32_t length() const { return m_table->length(); }
@@ -69,7 +71,6 @@ public:
 private:
     JSWebAssemblyTable(VM&, Structure*, Ref<Wasm::Table>&&);
     DECLARE_DEFAULT_FINISH_CREATION;
-    DECLARE_VISIT_CHILDREN;
 
     const Ref<Wasm::Table> m_table;
 };

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -40,6 +40,8 @@ struct ProtoCallFrame;
 class WebAssemblyInstance;
 
 class WebAssemblyFunction final : public WebAssemblyFunctionBase {
+    friend JSC::LLIntOffsetsExtractor;
+
 public:
     using Base = WebAssemblyFunctionBase;
 
@@ -55,6 +57,8 @@ public:
     }
 
     DECLARE_EXPORT_INFO;
+
+    DECLARE_VISIT_CHILDREN;
 
     JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee& wasmCallee, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
@@ -89,7 +93,6 @@ public:
     static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(WebAssemblyFunction, m_frameSize); }
 
 private:
-    DECLARE_VISIT_CHILDREN;
     WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee& wasmCallee, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>&&);
 
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -38,12 +38,16 @@ using Wasm::WasmToWasmImportableFunction;
 using Wasm::WasmOrJSImportableFunctionCallLinkInfo;
 
 class WebAssemblyFunctionBase : public JSFunction {
+    friend JSC::LLIntOffsetsExtractor;
+
 public:
     using Base = JSFunction;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     DECLARE_INFO;
+
+    DECLARE_VISIT_CHILDREN;
 
     JSWebAssemblyInstance* instance() const { return m_instance.get(); }
 
@@ -66,7 +70,6 @@ public:
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyFunctionBase, m_importableFunction) + WasmToWasmImportableFunction::offsetOfRTT(); }
 
 protected:
-    DECLARE_VISIT_CHILDREN;
     void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);
     WebAssemblyFunctionBase(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::WasmOrJSImportableFunction&&, Wasm::WasmOrJSImportableFunctionCallLinkInfo*);
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -41,12 +41,12 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     const WebAssemblyGCStructure* gcStructure() const { return uncheckedDowncast<WebAssemblyGCStructure>(structure()); }
     Ref<const Wasm::RTT> rtt() const { return gcStructure()->rtt(); }
 
 protected:
-    DECLARE_VISIT_CHILDREN;
-
     WebAssemblyGCObjectBase(VM&, WebAssemblyGCStructure*);
 
     DECLARE_DEFAULT_FINISH_CREATION;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
@@ -55,6 +55,8 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
     static WebAssemblyModuleRecord* create(JSGlobalObject*, VM&, Structure*, const Identifier&, const Wasm::ModuleInformation&);
 
@@ -73,8 +75,6 @@ private:
 
     void finishCreation(JSGlobalObject*, VM&, const Wasm::ModuleInformation&);
     JSValue evaluateConstantExpression(JSGlobalObject*, const Vector<uint8_t>&, const Wasm::ModuleInformation&, Wasm::Type, uint64_t&);
-
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<JSWebAssemblyInstance> m_instance;
     WriteBarrier<JSObject> m_startFunction;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h
@@ -45,6 +45,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     static WebAssemblyWrapperFunction* create(VM&, JSGlobalObject*, Structure*, JSObject*, unsigned importIndex, JSWebAssemblyInstance*, Wasm::TypeIndex, RefPtr<const Wasm::RTT>&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
@@ -52,7 +54,6 @@ public:
 
 private:
     WebAssemblyWrapperFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, JSObject* function, Wasm::WasmOrJSImportableFunction&&, Wasm::WasmOrJSImportableFunctionCallLinkInfo*);
-    DECLARE_VISIT_CHILDREN;
 
     WriteBarrier<JSObject> m_function;
 };

--- a/Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.h
+++ b/Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.h
@@ -36,13 +36,13 @@ public:
         return subspaceForImpl(vm);
     }
 
+    DECLARE_VISIT_CHILDREN;
+
 protected:
     JSDOMBuiltinConstructorBase(JSC::VM& vm, JSC::Structure* structure, JSC::NativeFunction functionForConstruct)
         : Base(vm, structure, functionForConstruct)
     {
     }
-
-    DECLARE_VISIT_CHILDREN;
 
     JSC::JSFunction* initializeFunction();
     void setInitializeFunction(JSC::VM&, JSC::JSFunction&);

--- a/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h
@@ -40,6 +40,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     ShadowRealmGlobalScope& wrapped() const { return *m_wrapped; }
 
     const JSDOMGlobalObject* incubatingRealm() const;
@@ -59,8 +61,6 @@ private:
 protected:
     JSShadowRealmGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<ShadowRealmGlobalScope>&&);
     void finishCreation(JSC::VM&, JSC::JSGlobalProxy*);
-
-    DECLARE_VISIT_CHILDREN;
 
     static const JSC::GlobalObjectMethodTable* globalObjectMethodTable();
 

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -43,6 +43,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     WorkerGlobalScope& wrapped() const { return *m_wrapped; }
     ScriptExecutionContext* scriptExecutionContext() const;
 
@@ -62,8 +64,6 @@ public:
 protected:
     JSWorkerGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkerGlobalScope>&&);
     void finishCreation(JSC::VM&, JSC::JSGlobalProxy*);
-
-    DECLARE_VISIT_CHILDREN;
 
     static const JSC::GlobalObjectMethodTable* globalObjectMethodTable();
 

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -44,6 +44,8 @@ public:
 
     DECLARE_INFO;
 
+    DECLARE_VISIT_CHILDREN;
+
     WorkletGlobalScope& wrapped() const { return *m_wrapped; }
     ScriptExecutionContext* scriptExecutionContext() const;
 
@@ -63,8 +65,6 @@ public:
 protected:
     JSWorkletGlobalScopeBase(JSC::VM&, JSC::Structure*, RefPtr<WorkletGlobalScope>&&);
     void finishCreation(JSC::VM&, JSC::JSGlobalProxy*);
-
-    DECLARE_VISIT_CHILDREN;
 
     static const JSC::GlobalObjectMethodTable* globalObjectMethodTable();
 


### PR DESCRIPTION
#### b0498801e751395d6776b6d459d2010737c217b1
<pre>
[JSC] Fix wrong member access due to DECLARE_VISIT_CHILDREN macro
<a href="https://bugs.webkit.org/show_bug.cgi?id=296688">https://bugs.webkit.org/show_bug.cgi?id=296688</a>

Reviewed by Yusuke Suzuki.

Using the DECLARE_VISIT_CHILDREN macro in private/protected sections can leak
subsequent members, as the macro ends with a public access specifier.

This change moves all uses of the macro into the public section of their
respective classes and selectively makes members used in existing
code public.

* Source/JavaScriptCore/runtime/JSBoundFunction.h:
Move DECLARE_VISIT_CHILDREN macro to the public section.
(JSC::JSBoundFunction::isTainted): New public getter for m_isTainted.
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeCall): Use new isTainted() getter.

* Source/JavaScriptCore/runtime/IntlDateTimeFormat.h:
Move DECLARE_VISIT_CHILDREN macro to the public section.
* Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp:
(JSC::handleDateTimeValue): Made TU-local as it is only used by host
functions within this file.
(JSC::IntlDateTimeFormat::handleDateTimeValue): Deleted.

* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
Move DECLARE_VISIT_CHILDREN macro to the public section.
Add missing friend declarations.
(JSC::IntlNumberFormat::trailingZeroDisplayString): Made public for
use in IntlPluralRules::resolvedOptions.

* Source/JavaScriptCore/runtime/IntlPluralRules.h:
Move DECLARE_VISIT_CHILDREN macro to the public section.
Add missing friend declaration.

* Source/JavaScriptCore/runtime/RegExpObject.h:
Move DECLARE_VISIT_CHILDREN macro to the public section.
(JSC::RegExpObject::lastIndexIsWritable): Make public for
use in regExpProtoFuncSearch.

* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSDollarVM::WasmStreamingCompiler): Add missing private
access specifier.

* Source/JavaScriptCore/API/JSCallbackObject.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/EvalExecutable.h:
* Source/JavaScriptCore/runtime/GenericArgumentsImpl.h:
* Source/JavaScriptCore/runtime/IntlCollator.h:
* Source/JavaScriptCore/runtime/IntlLocale.h:
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h:
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
* Source/JavaScriptCore/runtime/JSAsyncDisposableStack.h:
* Source/JavaScriptCore/runtime/JSAsyncFromSyncIterator.h:
* Source/JavaScriptCore/runtime/JSCallee.h:
* Source/JavaScriptCore/runtime/JSDisposableStack.h:
* Source/JavaScriptCore/runtime/JSFunction.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGlobalProxy.h:
* Source/JavaScriptCore/runtime/JSInternalFieldObjectImpl.h:
* Source/JavaScriptCore/runtime/JSLexicalEnvironment.h:
* Source/JavaScriptCore/runtime/JSMapIterator.h:
* Source/JavaScriptCore/runtime/JSModuleEnvironment.h:
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h:
* Source/JavaScriptCore/runtime/JSModuleRecord.h:
* Source/JavaScriptCore/runtime/JSNativeStdFunction.h:
* Source/JavaScriptCore/runtime/JSRegExpStringIterator.h:
* Source/JavaScriptCore/runtime/JSRemoteFunction.h:
* Source/JavaScriptCore/runtime/JSSetIterator.h:
* Source/JavaScriptCore/runtime/JSSymbolTableObject.h:
* Source/JavaScriptCore/runtime/JSWrapForValidIterator.h:
* Source/JavaScriptCore/runtime/JSWrapperObject.h:
* Source/JavaScriptCore/runtime/ModuleProgramExecutable.h:
* Source/JavaScriptCore/runtime/ProgramExecutable.h:
* Source/JavaScriptCore/runtime/ProxyObject.h:
* Source/JavaScriptCore/runtime/ShadowRealmObject.h:
* Source/JavaScriptCore/runtime/SyntheticModuleRecord.h:
* Source/JavaScriptCore/tools/JSDollarVM.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyGlobal.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyTable.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h:
* Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.h:
* Source/WebCore/bindings/js/JSShadowRealmGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
Move DECLARE_VISIT_CHILDREN macro to the public section.

Canonical link: <a href="https://commits.webkit.org/298066@main">https://commits.webkit.org/298066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6e908535c2fb7d433de4d0770f1e8d75b798523

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24284 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120242 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42386 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/120242 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102456 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/120242 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63946 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106500 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123469 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112637 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95533 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95316 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40450 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18261 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46484 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136837 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40606 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36641 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->