### PR TITLE
[WTF] Strengthen Box when it's build bare

### DIFF
--- a/Source/WTF/wtf/Box.h
+++ b/Source/WTF/wtf/Box.h
@@ -55,13 +55,20 @@ public:
         return result;
     }
 
-    T* get() const { return &m_data->value; }
+    bool isValid() const { return static_cast<bool>(m_data); }
 
-    T& operator*() const { return m_data->value; }
-    T* operator->() const { return &m_data->value; }
+    T* get() const
+    {
+        if (!isValid())
+            return nullptr;
+        return &m_data->value;
+    }
 
-    explicit operator bool() const { return static_cast<bool>(m_data); }
-    
+    T& operator*() const { RELEASE_ASSERT(isValid()); return m_data->value; }
+    T* operator->() const { RELEASE_ASSERT(isValid()); return &m_data->value; }
+
+    explicit operator bool() const { return isValid(); }
+
 private:
     struct Data : ThreadSafeRefCounted<Data> {
         template<typename... Arguments>
@@ -69,7 +76,7 @@ private:
             : value(std::forward<Arguments>(arguments)...)
         {
         }
-        
+
         T value;
     };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp
@@ -50,11 +50,23 @@ void boxPtrLoggerDeleter(BoxPtrLogger* logger)
     delete logger;
 }
 
+class BoxPtrClassTest {
+public:
+    void method() { ++value; }
+    int value { 1 };
+};
+
+void boxPtrClassTestDeleter(BoxPtrClassTest* theObject)
+{
+    delete theObject;
+}
+
 };
 
 namespace WTF {
 
 WTF_DEFINE_BOXPTR_DELETER(TestWebKitAPI::BoxPtrLogger, TestWebKitAPI::boxPtrLoggerDeleter);
+WTF_DEFINE_BOXPTR_DELETER(TestWebKitAPI::BoxPtrClassTest, TestWebKitAPI::boxPtrClassTestDeleter);
 
 }
 
@@ -121,6 +133,14 @@ TEST(WTF_BoxPtr, Basic)
         EXPECT_EQ(false, static_cast<bool>(ptr));
     }
     EXPECT_STREQ("create(a) delete(a) ", takeLogStr().c_str());
+}
+
+TEST(WTF_BoxPtr, NoCrash)
+{
+    BoxPtr<BoxPtrClassTest> ptr;
+    EXPECT_EQ(false, static_cast<bool>(ptr));
+    EXPECT_EQ(false, ptr.isValid());
+    EXPECT_EQ(nullptr, ptr.get());
 }
 
 TEST(WTF_BoxPtr, Assignment)


### PR DESCRIPTION
#### 382ecf0bfe89723e8f3d01fc8294b5844011e583
<pre>
[WTF] Strengthen Box when it&apos;s build bare
<a href="https://bugs.webkit.org/show_bug.cgi?id=296689">https://bugs.webkit.org/show_bug.cgi?id=296689</a>

Reviewed by Chris Dumez.

When building an empty Box you can end up with an empty RefPtr. We should ensure it&apos;s valid before accessing it.

Test: Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp

* Source/WTF/wtf/Box.h:
(WTF::Box::isValid const):
(WTF::Box::get const):
(WTF::Box::operator* const):
(WTF::Box::operator-&gt; const):
(WTF::Box::operator bool const):
* Tools/TestWebKitAPI/Tests/WTF/BoxPtr.cpp:
(TestWebKitAPI::BoxPtrClassTest::method):
(TestWebKitAPI::boxPtrClassTestDeleter):
(TestWebKitAPI::TEST(WTF_BoxPtr, NoCrash)):

Canonical link: <a href="https://commits.webkit.org/300573@main">https://commits.webkit.org/300573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/875143001378445888fbcb86b3c76c197c72cc3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/42800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/129742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51395 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/93565 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/62087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28316 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73259 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/115245 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132474 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/121617 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106381 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101917 "Found 3 new API test failures: TestWTF:CompletionHandlerDeathTest.MainThreadHandlerOnThreadAssertsDeathTest, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, TestWTF:CompletionHandlerDeathTest.ConstructionThreadHandlerOnThreadAssertsDeathTest (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25904 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25488 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/46809 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49891 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/55652 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/151882 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49359 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38832 "Found 8 new JSC stress test failures: wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.default-wasm, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-bbq-no-consts, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-js-string-builtins-returnStrictInt32.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/52711 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->