### PR TITLE
Use of MESSAGE_CHECK for stream connection messages is invalid

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -41,7 +41,7 @@
 #include <WebCore/GraphicsContext.h>
 #include <wtf/StdLibExtras.h>
 
-#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, &m_renderingBackend->gpuConnectionToWebProcess().connection(), message)
+#define MESSAGE_CHECK(assertion, message) STREAM_MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_renderingBackend->streamConnection(), message)
 
 namespace WebKit {
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -40,7 +40,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, &m_renderingBackend->gpuConnectionToWebProcess().connection(), message)
+#define MESSAGE_CHECK(assertion, message) STREAM_MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_renderingBackend->streamConnection(), message)
 
 namespace WebKit {
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -88,7 +88,7 @@
 #import "DynamicContentScalingImageBufferBackend.h"
 #endif
 
-#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, &m_gpuConnectionToWebProcess->connection(), message);
+#define MESSAGE_CHECK(assertion, message) STREAM_MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, streamConnection(), message);
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -197,6 +197,15 @@ extern ASCIILiteral errorAsString(Error);
     } \
 } while (0)
 
+#define STREAM_MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, connection, message) do { \
+    if (!(assertion)) [[unlikely]] { \
+        RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid stream message dispatched %" PUBLIC_LOG_STRING ": " message, WTF_PRETTY_FUNCTION); \
+        connection.markCurrentlyDispatchedMessageAsInvalid(); \
+        CRASH_IF_TESTING \
+        return; \
+    } \
+} while (0)
+
 template<typename AsyncReplyResult> struct AsyncReplyError {
     static AsyncReplyResult create() { return AsyncReplyResult { }; };
 };

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -242,7 +242,11 @@ bool StreamServerConnection::processOutOfStreamMessage(Decoder& decoder)
         receiver = m_receivers.get(key);
     }
     if (receiver) {
-        if (!dispatchStreamMessage(*message, *receiver))
+        ASSERT(!m_isProcessingStreamMessage);
+        m_isProcessingStreamMessage = true;
+        bool res = dispatchStreamMessage(*message, *receiver);
+        m_isProcessingStreamMessage = false;
+        if (!res)
             return false;
     }
 


### PR DESCRIPTION
#### 5632b9b60d675cbad5021c87452ce32ccd5e1e8c
<pre>
Use of MESSAGE_CHECK for stream connection messages is invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=296697">https://bugs.webkit.org/show_bug.cgi?id=296697</a>
<a href="https://rdar.apple.com/157109453">rdar://157109453</a>

Reviewed by NOBODY (OOPS!).

MESSAGE_CHECK calls IPC::Connection::markCurrentlyDispatchedMessageAsInvalid, which ASSERTs if it is called while not currently handling an IPC message. Stream connections dispatch and handle messages slightly differently and customise the behaviour of markCurrentlyDispatchedMessageAsInvalid to account for this. This patch introduces a STREAM_MESSAGE_CHECK_WITH_MESSAGE_BASE macro which accepts the StreamServerConnection rather than the underlying IPC::Connection, so the right invalidation behaviour can be used. This patch also addresses accounting for message dispatch of out of stream messages and adopts STREAM_MESSAGE_CHECK_WITH_MESSAGE_BASE in a few interfaces that were previously using it incorrectly.

* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::processOutOfStreamMessage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5632b9b60d675cbad5021c87452ce32ccd5e1e8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64986 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86656 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41767 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116961 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27380 "Found 60 new test failures: compositing/background-color/background-color-alpha-with-opacity.html compositing/visibility/visibility-simple-webgl-layer.html fast/canvas/2d.composite.globalAlpha.fillPath.html fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/DrawImageSinglePixelStretch.html fast/canvas/canvas-ImageData-cache.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102398 "Found 11 new API test failures: TestWebKitAPI.WebKit.SaveDataToFile, TestWebKitAPI.AdvancedPrivacyProtections.VerifyHashFromNoisyCanvas2DAPI, TestWebKitAPI.WKWebExtensionAPIAction.SetIconWithMixedValidAndInvalidVariants, TestWebKitAPI.WKWebExtensionAPIMenus.MenuItemWithMixedValidAndInvalidIconVariants, TestWebKitAPI.WKWebExtensionAPIAction.SetIconWithImageDataAndVariants, TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker, TestWebKitAPI.WKWebExtensionAPIAction.SetIconWithMultipleImageDataSizes, TestWebKitAPI.WKWebExtensionAPIMenus.MenuItemWithImageDataVariants, TestWebKitAPI.AdvancedPrivacyProtections.VerifyPixelsFromNoisyCanvas2DAPI, TestWebKitAPI.WKWebView.SnapshotWebGL ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67039 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26565 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-012.html imported/w3c/web-platform-tests/density-size-correction/density-corrected-image-in-canvas.html imported/w3c/web-platform-tests/html/canvas/element/2d.conformance.requirements.basics.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.clear.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.copy.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.destination-atop.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.destination-in.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.destination-out.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.destination-over.html imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.canvas.lighter.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63888 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96745 "Found 9 new API test failures: TestWebKitAPI.AdvancedPrivacyProtections.VerifyHashFromNoisyCanvas2DAPI, TestWebKitAPI.WKWebExtensionAPIAction.SetIconWithMixedValidAndInvalidVariants, TestWebKitAPI.WKWebExtensionAPIMenus.MenuItemWithMixedValidAndInvalidIconVariants, TestWebKitAPI.WKWebExtensionAPIAction.SetIconWithImageDataAndVariants, TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker, TestWebKitAPI.WKWebExtensionAPIAction.SetIconWithMultipleImageDataSizes, TestWebKitAPI.WKWebExtensionAPIMenus.MenuItemWithImageDataVariants, TestWebKitAPI.AdvancedPrivacyProtections.VerifyPixelsFromNoisyCanvas2DAPI, TestWebKitAPI.AdvancedPrivacyProtections.VerifyDataURLFromNoisyWebGLAPI (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20646 "Found 60 new test failures: compositing/backface-visibility/backface-visibility-webgl.html compositing/webgl/webgl-no-alpha.html compositing/webgl/webgl-reflection.html compositing/webgl/webgl-repaint.html fast/canvas/2d.composite.globalAlpha.fillPath.html fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html fast/canvas/webgl/antialiasing-enabled.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41046 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30572 "Found 60 new test failures: compositing/backface-visibility/backface-visibility-webgl.html compositing/webgl/webgl-background-color.html compositing/webgl/webgl-no-alpha.html compositing/webgl/webgl-reflection.html compositing/webgl/webgl-repaint.html fast/canvas/2d.composite.globalAlpha.fillPath.html fast/canvas/2d.fillText.gradient.html fast/canvas/2d.text.draw.fill.maxWidth.negative.html fast/canvas/2d.text.draw.fill.maxWidth.veryLarge.html fast/canvas/2d.text.draw.fill.maxWidth.verySmall.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95483 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41424 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95260 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40400 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18208 "Found 60 new test failures: compositing/masks/mask-and-drop-shadow.html compositing/overflow/absolute-in-overflow.html compositing/repaint/copy-forward-dirty-region-purged.html compositing/webgl/webgl-background-color.html compositing/webgl/webgl-no-alpha.html compositing/webgl/webgl-reflection.html compositing/webgl/webgl-repaint.html css3/blending/background-blend-mode-image-color-dynamic.html css3/masking/clip-path-border-radius-content-box-000.html fast/canvas/2d.composite.globalAlpha.fillPath.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37163 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46423 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->