### PR TITLE
Web Inspector: Can't select array element clipped by the console

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -99,6 +99,7 @@ body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree.deemph
     opacity: 0.7;
 }
 
+/* These styles will get overridden by an ancestor matching `.tree-outline.object ol`. Both rules have the same specificity, but that one is defined later. This happens when WI.DOMTreeOutline is nested in WI.ObjectTreeView. */
 .tree-outline.dom ol {
     list-style-type: none;
     margin: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
@@ -80,6 +80,7 @@
 
 .formatted-node > .tree-outline.dom li {
     -webkit-user-select: none !important;
+    white-space: wrap;
 }
 
 .formatted-node > .tree-outline.dom li.selected .selection-area {

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
@@ -125,8 +125,12 @@
 .tree-outline.object ol {
     display: none;
     margin: 0;
-    padding-inline-start: 16px;
     list-style: none;
+}
+
+/* Prevent overriding styles on a descendant `.tree-outline.dom ol` which has the same specificity but is defined earlier. */
+.tree-outline.object:not(:has(.tree-outline.dom)) ol {
+    padding-inline-start: 16px;
 }
 
 .tree-outline.object ol.expanded {


### PR DESCRIPTION
#### 6d620636ad5a8112e83589d1959778da52c72b5b
<pre>
Web Inspector: Can&apos;t select array element clipped by the console
<a href="https://bugs.webkit.org/show_bug.cgi?id=296325">https://bugs.webkit.org/show_bug.cgi?id=296325</a>
<a href="https://rdar.apple.com/157015598">rdar://157015598</a>

Reviewed by Devin Rousso.

There is custom hit testing logic in `WI.TreeOutline.prototype.treeElementFromEvent()`
so that you can expand a node by cliking on the sides of the actual DOM element representing the tree element.

This breaks when the content of the tree element is clipped because the measurements used for
hit testing compute to a target outside the bounds of the tree element itself.

It occurs from the combination of:
- `white-space: nowrap` on `.tree-outline.object li` (from ObjectTreeView.css)
- `display: inline-block` on `.formatted-node` (from FormattedValue.css)

In this situation, the tree element&apos;s `offsetWidth` is larger
than the bounds of the container that clips the element.

Switching from `display: inline-block` to `display: block` is a viable fix,
but has side-effects for the layout of other types of formatted values.

This patch allows DOM tree outline elements descendant of a `.formatted-node`
to wrap so that they&apos;re never clipped. This ensures that they are:
- correctly identified on click
- fully visible to provide complete context

* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:

* Source/WebInspectorUI/UserInterface/Views/FormattedValue.css:
(.formatted-node &gt; .tree-outline.dom li):

* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css:
(.tree-outline.object ol):
(.tree-outline.object:not(:has(.tree-outline.dom)) ol):

Drive-by fix for horizontal shifting on hover of a DOM tree outline nested in a generic
tree outline because its `padding-inline-start` is overridden by a same-specificity rule.

Canonical link: <a href="https://commits.webkit.org/298834@main">https://commits.webkit.org/298834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be638d51fc4f871e2f3e569908e4788980a6d1d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/116725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/36389 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/26955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122800 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/37087 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44978 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122800 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67300 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/119674 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/37087 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/26955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122800 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/37087 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/26955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/66466 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/37087 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125935 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43624 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/44978 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125935 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/26955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125935 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24741 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39589 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/43510 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49105 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42977 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46316 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44682 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->