### PR TITLE
[CoordinatedGraphics] Merge AcceleratedSurface resize() and clearIfNeeded() into willRenderFrame()

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -84,7 +84,6 @@ public:
 public:
     uint64_t window() const;
     uint64_t surfaceID() const;
-    bool resize(const WebCore::IntSize&);
     bool shouldPaintMirrored() const
     {
 #if PLATFORM(WPE) || (PLATFORM(GTK) && USE(GTK4))
@@ -95,9 +94,8 @@ public:
     }
 
     void willDestroyGLContext();
-    void willRenderFrame();
+    void willRenderFrame(const WebCore::IntSize&);
     void didRenderFrame();
-    void clearIfNeeded();
 
 #if ENABLE(DAMAGE_TRACKING)
     void setFrameDamage(WebCore::Damage&&);
@@ -293,7 +291,8 @@ private:
         };
 
         Type type() const { return m_type; }
-        void resize(const WebCore::IntSize&);
+        bool resize(const WebCore::IntSize&);
+        const WebCore::IntSize& size() const { return m_size; }
         RenderTarget* nextTarget();
         void releaseTarget(uint64_t, UnixFileDescriptor&& releaseFence);
         void reset();
@@ -302,8 +301,6 @@ private:
 #if ENABLE(DAMAGE_TRACKING)
         void addDamage(const std::optional<WebCore::Damage>&);
 #endif
-
-        unsigned size() const { return m_freeTargets.size() + m_lockedTargets.size(); }
 
 #if USE(GBM) && (PLATFORM(GTK) || ENABLE(WPE_PLATFORM))
         void setupBufferFormat(const Vector<RendererBufferFormat>&, bool);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -358,22 +358,12 @@ void ThreadedCompositor::renderLayerTree()
     TransformationMatrix viewportTransform;
     viewportTransform.scale(deviceScaleFactor);
 
-    // Resize the surface, if necessary, before the will-render-frame call is dispatched.
-    // GL viewport is updated separately, if necessary. This establishes sequencing where
-    // everything inside the will-render and did-render scope is done for a constant-sized scene,
-    // and similarly all GL operations are done inside that specific scope.
-    bool needsGLViewportResize = m_surface->resize(viewportSize);
+    m_surface->willRenderFrame(viewportSize);
 
-    m_surface->willRenderFrame();
     RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }] {
         if (m_layerTreeHost)
             m_layerTreeHost->willRenderFrame();
     });
-
-    if (needsGLViewportResize)
-        glViewport(0, 0, viewportSize.width(), viewportSize.height());
-
-    m_surface->clearIfNeeded();
 
     WTFBeginSignpost(this, PaintToGLContext);
     paintToCurrentGLContext(viewportTransform, viewportSize);


### PR DESCRIPTION
#### ea5aa7d86deeb97992a52fcfdee1fde5fb42af40
<pre>
[CoordinatedGraphics] Merge AcceleratedSurface resize() and clearIfNeeded() into willRenderFrame()
<a href="https://bugs.webkit.org/show_bug.cgi?id=296700">https://bugs.webkit.org/show_bug.cgi?id=296700</a>

Reviewed by Adrian Perez de Castro.

Passing the viewport size to willRenderFrame(), we do the resize and clean internally simplifying the caller.

Canonical link: <a href="https://commits.webkit.org/298078@main">https://commits.webkit.org/298078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81d7c66078cb419ffa0d8402f15560a327f2b8bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86664 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/116972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26579 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95495 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41435 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95276 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40410 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37176 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18299 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->