### PR TITLE
Use forwardable logging in WebRTC WebProcess code

### DIFF
--- a/Source/WTF/wtf/Logger.cpp
+++ b/Source/WTF/wtf/Logger.cpp
@@ -39,13 +39,13 @@ Lock messageHandlerLoggerObserverLock;
 String Logger::LogSiteIdentifier::toString() const
 {
     if (className)
-        return makeString(className, "::"_s, unsafeSpan(methodName), '(', hex(objectIdentifier), ") "_s);
-    return makeString(unsafeSpan(methodName), '(', hex(objectIdentifier), ") "_s);
+        return makeString(className, "::"_s, unsafeSpan(methodName), '(', objectIdentifier, ") "_s);
+    return makeString(unsafeSpan(methodName), '(', objectIdentifier, ") "_s);
 }
 
 String LogArgument<const void*>::toString(const void* argument)
 {
-    return makeString('(', hex(reinterpret_cast<uintptr_t>(argument)), ')');
+    return makeString('(', reinterpret_cast<uintptr_t>(argument), ')');
 }
 
 Vector<std::reference_wrapper<Logger::Observer>>& Logger::observers()

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -251,7 +251,9 @@ void PeerConnectionBackend::createOffer(RTCOfferOptions&& options, CreateCallbac
 void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
 {
     ASSERT(isMainThread());
-    ALWAYS_LOG(LOGIDENTIFIER, "Create offer succeeded:\n", sdp);
+
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "to:\n", sdp);
+    RELEASE_LOG_FORWARDABLE(WebRTC, PEERCONNECTIONBACKEND_CREATEOFFERSUCCEEDED, logIdentifier(), sdp.utf8().data());
 
     ASSERT(m_offerAnswerCallback);
     validateSDP(sdp);
@@ -263,7 +265,7 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
 void PeerConnectionBackend::createOfferFailed(Exception&& exception)
 {
     ASSERT(isMainThread());
-    ALWAYS_LOG(LOGIDENTIFIER, "Create offer failed:", exception.message());
+    ALWAYS_LOG(LOGIDENTIFIER, exception.message());
 
     ASSERT(m_offerAnswerCallback);
     ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)](auto&) mutable {
@@ -283,7 +285,9 @@ void PeerConnectionBackend::createAnswer(RTCAnswerOptions&& options, CreateCallb
 void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
 {
     ASSERT(isMainThread());
-    ALWAYS_LOG(LOGIDENTIFIER, "Create answer succeeded:\n", sdp);
+
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "to:\n", sdp);
+    RELEASE_LOG_FORWARDABLE(WebRTC, PEERCONNECTIONBACKEND_CREATEANSWERSUCCEEDED, logIdentifier(), sdp.utf8().data());
 
     ASSERT(m_offerAnswerCallback);
     ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)](auto&) mutable {
@@ -294,7 +298,7 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
 void PeerConnectionBackend::createAnswerFailed(Exception&& exception)
 {
     ASSERT(isMainThread());
-    ALWAYS_LOG(LOGIDENTIFIER, "Create answer failed:", exception.message());
+    ALWAYS_LOG(LOGIDENTIFIER, exception.message());
 
     ASSERT(m_offerAnswerCallback);
     ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)](auto&) mutable {

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -403,7 +403,10 @@ void RTCPeerConnection::setLocalDescription(std::optional<RTCLocalSessionDescrip
         return;
     }
 
-    ALWAYS_LOG(LOGIDENTIFIER, "Setting local description to:\n", localDescription ? localDescription->sdp : "''"_s);
+    String sdp = localDescription.value_or(RTCLocalSessionDescriptionInit { }).sdp;
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "Setting local description to:\n", sdp);
+    RELEASE_LOG_FORWARDABLE(WebRTC, RTCPEERCONNECTION_SETLOCALDESCRIPTION, logIdentifier(), sdp.utf8().data());
+
     chainOperation(WTFMove(promise), [this, localDescription = WTFMove(localDescription)](Ref<DeferredPromise>&& promise) mutable {
         auto type = typeForSetLocalDescription(localDescription, m_signalingState);
         String sdp;
@@ -432,7 +435,9 @@ void RTCPeerConnection::setRemoteDescription(RTCSessionDescriptionInit&& remoteD
         return;
     }
 
-    ALWAYS_LOG(LOGIDENTIFIER, "Setting remote description to:\n", remoteDescription.sdp);
+    logger().toObservers(LogWebRTC, WTFLogLevel::Always, LOGIDENTIFIER, "Setting remote description to:\n", remoteDescription.sdp);
+    RELEASE_LOG_FORWARDABLE(WebRTC, RTCPEERCONNECTION_SETREMOTEDESCRIPTION, logIdentifier(), remoteDescription.sdp.utf8().data());
+
     chainOperation(WTFMove(promise), [this, remoteDescription = WTFMove(remoteDescription)](Ref<DeferredPromise>&& promise) mutable {
         auto description = RTCSessionDescription::create(WTFMove(remoteDescription));
         if (description->type() == RTCSdpType::Offer && m_signalingState != RTCSignalingState::Stable && m_signalingState != RTCSignalingState::HaveRemoteOffer) {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -893,11 +893,10 @@ void LibWebRTCMediaEndpoint::OnStatsDelivered(const webrtc::scoped_refptr<const 
             }
 #endif
 
-            if (logger().willLog(logChannel(), WTFLogLevel::Debug)) {
-                // Stats are very verbose, let's only display them in inspector console in verbose mode.
-                logger().debug(LogWebRTC, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
-            } else
-                logger().logAlways(LogWebRTCStats, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
+            // Stats are very verbose, let's only display them in inspector console in verbose mode.
+            logger().toObservers(LogWebRTC, WTFLogLevel::Debug, Logger::LogSiteIdentifier("LibWebRTCMediaEndpoint"_s, "OnStatsDelivered"_s, logIdentifier()), statsLogger);
+
+            RELEASE_LOG_FORWARDABLE(WebRTCStats, LIBWEBRTCMEDIAENDPOINT_ONSTATSDELIVERED, logIdentifier(), statsLogger.toJSONString().utf8().data());
         }
     });
 #else // !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -160,9 +160,19 @@ PERFORMANCEMONITOR_MEASURE_CPUUSAGE_IN_ACTIVITYSTATE, "PerformanceMonitor::measu
 POLICYCHECKIER_CHECKNAVIGATIONPOLICY_CONTINUE_LOAD_IN_ANOTHER_PROCESS, "[pageID=%" PRIu64 ", frameID=%" PRIu64 "] PolicyChecker::checkNavigationPolicy: stopping because policyAction from dispatchDecidePolicyForNavigationAction is LoadWillContinueInAnotherProcess", (uint64_t, uint64_t), DEFAULT, Loading
 POLICYCHECKIER_CHECKNAVIGATIONPOLICY_CONTINUE_INITIAL_EMPTY_DOCUMENT, "[pageID=%" PRIu64 ", frameID=%" PRIu64 "] PolicyChecker::checkNavigationPolicy: continuing because this is an initial empty document", (uint64_t, uint64_t), DEFAULT, Loading
 
+LIBWEBRTCMEDIAENDPOINT_ONSTATSDELIVERED, "RTCStats (%" PRIu64 ") %s", (uint64_t, CString), DEFAULT, WebRTCStats
+LIBWEBRTC_LOG_ERROR, "LibWebRTC error: %s", (CString), DEFAULT, WebRTC
+LIBWEBRTC_LOG_MESSAGE, "LibWebRTC message: %s", (CString), DEFAULT, WebRTC
+
 LOCALFRAMEVIEW_FIRING_FIRST_VISUALLY_NON_EMPTY_LAYOUT_MILESTONE, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::fireLayoutRelatedMilestonesIfNeeded: Firing first visually non-empty layout milestone on the main frame", (uint64_t, uint64_t, int), DEFAULT, Layout
 LOCALFRAMEVIEW_FIRING_RESIZE_EVENTS_DISABLED_FOR_PAGE, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::scheduleResizeEventIfNeeded: Not firing resize events because they are temporarily disabled for this page", (uint64_t, uint64_t, int), DEFAULT, Events
 LOCALFRAMEVIEW_NOT_PAINTING_LAYOUT_NEEDED, "    [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::paintContents: Not painting because render tree needs layout", (uint64_t, uint64_t, int), DEFAULT, Layout
+
+PEERCONNECTIONBACKEND_CREATEOFFERSUCCEEDED, "PeerConnectionBackend::createOfferSucceeded (%" PRIu64 ") to: '%s'", (uint64_t, CString), DEFAULT, WebRTC
+PEERCONNECTIONBACKEND_CREATEANSWERSUCCEEDED, "PeerConnectionBackend::createAnswerSucceeded (%" PRIu64 ") to: '%s'", (uint64_t, CString), DEFAULT, WebRTC
+
+RTCPEERCONNECTION_SETLOCALDESCRIPTION, "RTCPeerConnection::setLocalDescription (%" PRIu64 ") to: '%s'", (uint64_t, CString), DEFAULT, WebRTC
+RTCPEERCONNECTION_SETREMOTEDESCRIPTION, "RTCPeerConnection::setRemoteDescription (%" PRIu64 ") to: '%s'", (uint64_t, CString), DEFAULT, WebRTC
 
 SERVICEWORKERTHREADPROXY_REMOVEFETCH, "ServiceWorkerThreadProxy::removeFetch %" PRIu64, (uint64_t), DEFAULT, ServiceWorker
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -143,9 +143,9 @@ static void doReleaseLogging(webrtc::LoggingSeverity severity, const char* messa
     UNUSED_PARAM(message);
 #else
     if (severity == webrtc::LS_ERROR)
-        RELEASE_LOG_ERROR(WebRTC, "LibWebRTC error: %" PUBLIC_LOG_STRING, message);
+        RELEASE_LOG_ERROR_FORWARDABLE(WebRTC, LIBWEBRTC_LOG_ERROR, message);
     else
-        RELEASE_LOG(WebRTC, "LibWebRTC message: %" PUBLIC_LOG_STRING, message);
+        RELEASE_LOG_FORWARDABLE(WebRTC, LIBWEBRTC_LOG_MESSAGE, message);
 #endif
 }
 


### PR DESCRIPTION
#### bd1e24d04518411e0543fc9b37239eb944b2030e
<pre>
Use forwardable logging in WebRTC WebProcess code
<a href="https://rdar.apple.com/157117303">rdar://157117303</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296701">https://bugs.webkit.org/show_bug.cgi?id=296701</a>

Reviewed by Eric Carlson and Per Arne Vollan.

We make sure that logs that can be very long are forwarded properly so that they are not shortened by the default log forwarding mechanism.
We apply this to WebRTC stats, libwebrtc messages and SDP logging.
We introduce a new Logger method so that the above logging can keep being seen in web inspector.

As a side fix, we no longer convert to hexa log identifiers given we sometimes log them as pointers, which end up being printed as integers.
We are simply printing them as integers to make it easier to relate the logs.

* Source/WTF/wtf/Logger.cpp:
(WTF::Logger::LogSiteIdentifier::toString const):
(WTF::&gt;::toString):
* Source/WTF/wtf/Logger.h:
(WTF::Logger::toObservers const):
(WTF::Logger::Logger):
(WTF::Logger::log):
(WTF::Logger::sendMessageToObservers):
(WTF::Logger::logVerbose):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::createOfferSucceeded):
(WebCore::PeerConnectionBackend::createOfferFailed):
(WebCore::PeerConnectionBackend::createAnswerSucceeded):
(WebCore::PeerConnectionBackend::createAnswerFailed):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::setLocalDescription):
(WebCore::RTCPeerConnection::setRemoteDescription):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::OnStatsDelivered):
* Source/WebCore/platform/LogMessages.in:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::doReleaseLogging):

Originally-landed-as: 06d8dd827285. <a href="https://rdar.apple.com/157117303">rdar://157117303</a>
Canonical link: <a href="https://commits.webkit.org/298889@main">https://commits.webkit.org/298889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b1641a6d48b57faba7ee29caafdb67f26f64b98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68996 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0c7ac1db-12da-4a59-b562-b1ab395a736a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88847 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43561 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/40edd5f1-a5c3-4c04-a288-cdcbe1544009) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69308 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23054 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66719 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109095 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126194 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115506 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97517 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97317 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40273 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49363 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144205 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43230 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37129 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->