### PR TITLE
REGRESSION(297950@main?): [macOS iOS Debug] fast/mediastream/getDisplayMedia-frame-rate.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html
@@ -11,24 +11,27 @@
         <video id=video1 autoplay playsInline width=100px></video>
         <video id=video2 autoplay playsInline width=100px></video>
         <script>
-promise_test(async () => {
+promise_test(async t => {
     if (!window.internals)
         return;
 
     const stream = await callGetDisplayMedia({ video: true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     internals.observeMediaStreamTrack(stream.getVideoTracks()[0]);
     let currentCount = internals.trackVideoSampleCount;
     while (currentCount === internals.trackVideoSampleCount)
         await new Promise(resolve => setTimeout(resolve, 50));
 }, "Ensure getDisplayMedia generate frames");
 
-promise_test(async () => {
+promise_test(async t => {
     const stream = await callGetDisplayMedia({ video: { frameRate : 30 } });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     assert_equals(stream.getVideoTracks()[0].getSettings().frameRate, 30, "before cloning");
     assert_equals(stream.getVideoTracks()[0].getSettings().width, 1920, "before cloning");
     assert_equals(stream.getVideoTracks()[0].getSettings().height, 1080, "before cloning");
 
     const stream2 = stream.clone();
+    t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     await stream2.getVideoTracks()[0].applyConstraints({ width:320, height:240, frameRate : 1 });
     assert_equals(stream2.getVideoTracks()[0].getSettings().frameRate, 1);
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8184,9 +8184,6 @@ webkit.org/b/296639 [ Release ] imported/w3c/web-platform-tests/html/browsers/br
 
 webkit.org/b/296657 fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element.html [ Pass Failure ]
 
-webkit.org/b/296660 [ Debug ] fast/mediastream/getDisplayMedia-frame-rate.html [ Pass Failure ]
-
 webkit.org/b/296707 imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html [ Pass Failure ]
 
 webkit.org/b/296709 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html [ ImageOnlyFailure ]
-

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2361,8 +2361,6 @@ webkit.org/b/296655 http/tests/resourceLoadStatistics/website-data-removal-for-s
 webkit.org/b/296655 http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-after-short-deletion.html [ Failure ]
 webkit.org/b/296655 http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-without-link-decoration.html [ Failure ]
 
-webkit.org/b/296660 [ Debug ] fast/mediastream/getDisplayMedia-frame-rate.html [ Pass Failure ]
-
 webkit.org/b/294152 http/tests/misc/timer-vs-loading.html [ Pass Timeout ]
 
 webkit.org/b/296755 [ Debug ] imported/w3c/web-platform-tests/content-security-policy/worker-src/service-worker-src-child-fallback.https.sub.html [ Pass Failure ]


### PR DESCRIPTION
#### 1502cc459987b3a9943b7e44c32ea3e9794f8572
<pre>
REGRESSION(297950@main?): [macOS iOS Debug] fast/mediastream/getDisplayMedia-frame-rate.html is a consistent failure
<a href="https://rdar.apple.com/157057450">rdar://157057450</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296660">https://bugs.webkit.org/show_bug.cgi?id=296660</a>

Reviewed by Jean-Yves Avenard.

Make sure we stop tracks at cleanup test time to prevent tracks to be stopped by GC.

* LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298129@main">https://commits.webkit.org/298129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bee2c36374cfc837e9c04559de911dae15e3d2a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86898 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67290 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20823 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64204 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123724 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95723 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24340 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37406 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41244 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->