### PR TITLE
Get 298038@main compiling with GCC

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1500,8 +1500,10 @@ namespace detail {
 template<typename T, typename U> using copy_const = std::conditional_t<std::is_const_v<T>, const U, U>;
 template<typename T, typename U> using override_ref = std::conditional_t<std::is_rvalue_reference_v<T>, std::remove_reference_t<U>&&, U&>;
 template<typename T, typename U> using forward_like_impl = override_ref<T&&, copy_const<std::remove_reference_t<T>, std::remove_reference_t<U>>>;
+template<typename T, typename U> using forward_like_preserving_const_impl = override_ref<T&&, std::remove_reference_t<U>>;
 } // namespace detail
 template<typename T, typename U> constexpr auto forward_like(U&& value) -> detail::forward_like_impl<T, U> { return static_cast<detail::forward_like_impl<T, U>>(value); }
+template<typename T, typename U> constexpr auto forward_like_preserving_const(U&& value) -> detail::forward_like_preserving_const_impl<T, U> { return static_cast<detail::forward_like_preserving_const_impl<T, U>>(value); }
 } // namespace WTF
 
 using WTF::GB;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -650,14 +650,9 @@ SerializedNode Element::serializeNode(CloningOperation type) const
 
     // FIXME: Make an equivalent of cloneShadowTreeIfPossible.
 
-    // FIXME: Get this compiling with GCC.
-#if PLATFORM(COCOA)
     auto attributes = this->elementData() ? WTF::map(this->attributes(), [] (const auto& attribute) {
         return SerializedNode::Element::Attribute { { attribute.name() }, attribute.value() };
     }) : Vector<SerializedNode::Element::Attribute>();
-#else
-    Vector<SerializedNode::Element::Attribute> attributes;
-#endif
 
     return { SerializedNode::Element { { WTFMove(children) }, { tagQName() }, WTFMove(attributes) } };
 }

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -141,14 +141,9 @@ SerializedNode HTMLTemplateElement::serializeNode(CloningOperation type) const
         break;
     }
 
-    // FIXME: Get this compiling with GCC.
-#if PLATFORM(COCOA)
     auto attributes = this->elementData() ? WTF::map(this->attributes(), [] (const auto& attribute) {
         return SerializedNode::Element::Attribute { { attribute.name() }, attribute.value() };
     }) : Vector<SerializedNode::Element::Attribute>();
-#else
-    Vector<SerializedNode::Element::Attribute> attributes;
-#endif
 
     return { SerializedNode::HTMLTemplateElement { { { WTFMove(children) }, { tagQName() }, WTFMove(attributes) } } };
 }


### PR DESCRIPTION
#### 4040e34eb77ce64f6b7e8d1b72c92875eea6ed53
<pre>
Get 298038@main compiling with GCC
<a href="https://bugs.webkit.org/show_bug.cgi?id=296705">https://bugs.webkit.org/show_bug.cgi?id=296705</a>
<a href="https://rdar.apple.com/157131936">rdar://157131936</a>

Reviewed by Abrar Rahman Protyasha.

In order to get WTF::map to work with a std::span&lt;const Attribute&gt;
as input, we need something like std::forward_like that doesn&apos;t
apply the constness of the first template parameter to the
second template parameter.  The second template parameter should
keep its constness.  Otherwise, we get lots of compiler errors,
especially in our use of copyToVectorOf&lt;Ref&lt;T&gt;&gt; from const collections
of non-const members, such as this in SVGElement.cpp:

copyToVectorOf&lt;Ref&lt;SVGElement&gt;&gt;(instances())

I&apos;m still not completely sure why this worked with clang but not gcc,
but std::enable_if&lt;std::is_rvalue_reference&lt;SourceType&amp;&amp;&gt; is suspicious,
and gcc said we were calling WTFMove with a const parameter.  Removing
the enable_if in Mapper made it work with both compilers.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::forward_like_non_const):
* Source/WTF/wtf/Vector.h:
(WTF::Mapper::map):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::serializeNode const):
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::serializeNode const):

Canonical link: <a href="https://commits.webkit.org/298052@main">https://commits.webkit.org/298052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a08af9fbb9891c98b57d09b824ea1235ad98dd0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67078 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63937 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106492 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/96792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123460 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112627 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30618 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95318 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18252 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18286 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/40972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46474 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136828 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40597 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36637 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->