### PR TITLE
Introduce standard [ReflectURL] extended attribute

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.idl
@@ -34,7 +34,7 @@
 ] interface HTMLModelElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute unsigned long width;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long height;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [URL] readonly attribute USVString currentSrc;
 
     readonly attribute boolean complete;
@@ -58,7 +58,7 @@
     
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled, Reflect] attribute DOMString stageMode;
 
-    [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled, CEReactions=NotNeeded, Reflect, URL] attribute USVString environmentMap;
+    [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled, CEReactions=NotNeeded, ReflectURL] attribute USVString environmentMap;
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled] readonly attribute Promise<undefined> environmentMapReady;
 
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled&ModelNoPortalAttributeEnabled, Reflect] attribute boolean noportal;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5593,8 +5593,8 @@ sub GenerateAttributeGetterBodyDefinition
     # Reflecting string attributes always need to be AtomStrings. Since such attribute do not have corresponding getters / setters
     # on the implementation object, we don't require the developers to specify [AtomString] in the IDL. The fact that they need
     # to be AtomStrings is an implementation detail.
-    if ($attribute->extendedAttributes->{"Reflect"} && $codeGenerator->IsStringType($attribute->type)) {
-       die "Using [AtomString] on attributes marked as [Reflect] is unnecessary" if $attribute->type->extendedAttributes->{AtomString};
+    if (($attribute->extendedAttributes->{Reflect} || $attribute->extendedAttributes->{ReflectURL}) && $codeGenerator->IsStringType($attribute->type)) {
+       die "Using [AtomString] on attributes marked as [Reflect] or [ReflectURL] is unnecessary" if $attribute->type->extendedAttributes->{AtomString};
        $attribute->type->extendedAttributes->{AtomString} = 1;
     }
 

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -425,6 +425,13 @@
             "contextsAllowed": ["attribute"],
             "values": ["*"]
         },
+        "ReflectURL": {
+            "contextsAllowed": ["attribute"],
+            "values": ["*"],
+            "standard": {
+                "url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflecturl"
+            }
+        },
         "ReflectSetter": {
             "contextsAllowed": ["attribute"],
             "values": ["*"],

--- a/Source/WebCore/bindings/scripts/IDLParser.pm
+++ b/Source/WebCore/bindings/scripts/IDLParser.pm
@@ -2405,6 +2405,10 @@ sub parseExtendedAttributeRest2
         my $name = $self->parseName();
         return $self->parseExtendedAttributeRest3($name);
     }
+    if ($next->type() == StringToken) {
+        my $token = $self->getToken();
+        return $token->value();
+    }
     if ($next->type() == IntegerToken) {
         my $token = $self->getToken();
         return $token->value();

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2015,18 +2015,12 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterElementAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterElementsArrayAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementsArrayAttr);
-static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterURLAttr);
-static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterURLAttr);
-static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVURLAttr);
-static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUSVURLAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomIntegralAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomIntegralAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomBooleanAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomBooleanAttr);
-static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomURLAttr);
-static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomURLAttr);
 #if ENABLE(TEST_FEATURE)
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_enabledAtRuntimeAttribute);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_enabledAtRuntimeAttribute);
@@ -2346,7 +2340,7 @@ template<> void JSTestObjDOMConstructor::initializeProperties(VM& vm, JSDOMGloba
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 285> JSTestObjPrototypeTableValues {
+static const std::array<HashTableValue, 282> JSTestObjPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObjConstructor, 0 } },
     HashTableValue { "readOnlyLongAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyLongAttr, 0 } },
     HashTableValue { "readOnlyStringAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyStringAttr, 0 } },
@@ -2405,12 +2399,9 @@ static const std::array<HashTableValue, 285> JSTestObjPrototypeTableValues {
     HashTableValue { "reflectedSetterBooleanAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterBooleanAttr, setJSTestObj_reflectedSetterBooleanAttr } },
     HashTableValue { "reflectedSetterElementAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterElementAttr, setJSTestObj_reflectedSetterElementAttr } },
     HashTableValue { "reflectedSetterElementsArrayAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterElementsArrayAttr, setJSTestObj_reflectedSetterElementsArrayAttr } },
-    HashTableValue { "reflectedSetterURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterURLAttr, setJSTestObj_reflectedSetterURLAttr } },
-    HashTableValue { "reflectedSetterUSVURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterUSVURLAttr, setJSTestObj_reflectedSetterUSVURLAttr } },
     HashTableValue { "reflectedSetterStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterStringAttr, setJSTestObj_reflectedSetterStringAttr } },
     HashTableValue { "reflectedSetterCustomIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterCustomIntegralAttr, setJSTestObj_reflectedSetterCustomIntegralAttr } },
     HashTableValue { "reflectedSetterCustomBooleanAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterCustomBooleanAttr, setJSTestObj_reflectedSetterCustomBooleanAttr } },
-    HashTableValue { "reflectedSetterCustomURLAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterCustomURLAttr, setJSTestObj_reflectedSetterCustomURLAttr } },
 #if ENABLE(TEST_FEATURE)
     HashTableValue { "enabledAtRuntimeAttribute"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_enabledAtRuntimeAttribute, setJSTestObj_enabledAtRuntimeAttribute } },
 #else
@@ -4888,72 +4879,6 @@ JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterElementsArrayAttr, (JSGloba
     return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterElementsArrayAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
-static inline JSValue jsTestObj_reflectedSetterURLAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
-{
-    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.reflectedSetterURLAttr())));
-}
-
-JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
-{
-    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterURLAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
-}
-
-static inline bool setJSTestObj_reflectedSetterURLAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
-{
-    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
-    UNUSED_PARAM(vm);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
-    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
-        return false;
-    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedsetterurlattrAttr, nativeValueConversionResult.releaseReturnValue());
-    });
-    return true;
-}
-
-JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
-{
-    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
-}
-
-static inline JSValue jsTestObj_reflectedSetterUSVURLAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
-{
-    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLUSVString>(lexicalGlobalObject, throwScope, impl.reflectedSetterUSVURLAttr())));
-}
-
-JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
-{
-    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterUSVURLAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
-}
-
-static inline bool setJSTestObj_reflectedSetterUSVURLAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
-{
-    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
-    UNUSED_PARAM(vm);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    auto nativeValueConversionResult = convert<IDLUSVString>(lexicalGlobalObject, value);
-    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
-        return false;
-    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::reflectedsetterusvurlattrAttr, nativeValueConversionResult.releaseReturnValue());
-    });
-    return true;
-}
-
-JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterUSVURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
-{
-    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterUSVURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
-}
-
 static inline JSValue jsTestObj_reflectedSetterStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
@@ -5051,39 +4976,6 @@ static inline bool setJSTestObj_reflectedSetterCustomBooleanAttrSetter(JSGlobalO
 JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomBooleanAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterCustomBooleanAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
-}
-
-static inline JSValue jsTestObj_reflectedSetterCustomURLAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
-{
-    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLDOMString>(lexicalGlobalObject, throwScope, impl.reflectedSetterCustomURLAttr())));
-}
-
-JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedSetterCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
-{
-    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedSetterCustomURLAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
-}
-
-static inline bool setJSTestObj_reflectedSetterCustomURLAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
-{
-    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
-    UNUSED_PARAM(vm);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    auto nativeValueConversionResult = convert<IDLDOMString>(lexicalGlobalObject, value);
-    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
-        return false;
-    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::customContentURLAttrAttr, nativeValueConversionResult.releaseReturnValue());
-    });
-    return true;
-}
-
-JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedSetterCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
-{
-    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedSetterCustomURLAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
 #if ENABLE(TEST_FEATURE)

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -109,12 +109,12 @@ enum TestConfidence { "high", "kinda-low" };
     [Reflect] attribute boolean reflectedBooleanAttr;
     [Reflect] attribute Element reflectedElementAttr;
     [Reflect] attribute FrozenArray<Element> reflectedElementsArrayAttr;
-    [Reflect, URL] attribute DOMString reflectedURLAttr;
-    [Reflect, URL] attribute USVString reflectedUSVURLAttr;
+    [ReflectURL] attribute DOMString reflectedURLAttr;
+    [ReflectURL] attribute USVString reflectedUSVURLAttr;
     [Reflect=customContentStringAttr] attribute DOMString reflectedStringAttr;
     [Reflect=customContentIntegralAttr] attribute long reflectedCustomIntegralAttr;
     [Reflect=customContentBooleanAttr] attribute boolean reflectedCustomBooleanAttr;
-    [Reflect=customContentURLAttr, URL] attribute DOMString reflectedCustomURLAttr;
+    [ReflectURL="customContentURLAttr"] attribute DOMString reflectedCustomURLAttr;
 
     // Reflected for setter only DOM attributes
     [ReflectSetter] attribute DOMString reflectedSetterStringAttr;
@@ -124,12 +124,9 @@ enum TestConfidence { "high", "kinda-low" };
     [ReflectSetter] attribute boolean reflectedSetterBooleanAttr;
     [ReflectSetter] attribute Element reflectedSetterElementAttr;
     [ReflectSetter] attribute FrozenArray<Element> reflectedSetterElementsArrayAttr;
-    [ReflectSetter, URL] attribute DOMString reflectedSetterURLAttr;
-    [ReflectSetter, URL] attribute USVString reflectedSetterUSVURLAttr;
     [ReflectSetter=customContentStringAttr] attribute DOMString reflectedSetterStringAttr;
     [ReflectSetter=customContentIntegralAttr] attribute long reflectedSetterCustomIntegralAttr;
     [ReflectSetter=customContentBooleanAttr] attribute boolean reflectedSetterCustomBooleanAttr;
-    [ReflectSetter=customContentURLAttr, URL] attribute DOMString reflectedSetterCustomURLAttr;
 
     // [EnabledByDeprecatedGlobalSetting] attributes and operations.
     [Conditional=TEST_FEATURE, EnabledByDeprecatedGlobalSetting=TestFeatureEnabled&TestFeature1Enabled] attribute DOMString enabledAtRuntimeAttribute;

--- a/Source/WebCore/html/HTMLEmbedElement.idl
+++ b/Source/WebCore/html/HTMLEmbedElement.idl
@@ -28,7 +28,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute DOMString height;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
     [CEReactions=NotNeeded, Reflect] attribute DOMString width;
 

--- a/Source/WebCore/html/HTMLFrameElement.idl
+++ b/Source/WebCore/html/HTMLFrameElement.idl
@@ -25,9 +25,9 @@
 ] interface HTMLFrameElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     [CEReactions=NotNeeded, Reflect] attribute DOMString scrolling;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString frameBorder;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString longDesc;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString longDesc;
     [CEReactions=NotNeeded, Reflect] attribute boolean noResize;
     [CheckSecurityForNode] readonly attribute Document contentDocument;
     readonly attribute WindowProxy contentWindow;

--- a/Source/WebCore/html/HTMLHyperlinkElementUtils.idl
+++ b/Source/WebCore/html/HTMLHyperlinkElementUtils.idl
@@ -25,7 +25,7 @@
 
 // https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils
 interface mixin HTMLHyperlinkElementUtils {
-    [CEReactions=NotNeeded, Reflect, URL] stringifier attribute USVString href;
+    [CEReactions=NotNeeded, ReflectURL] stringifier attribute USVString href;
     readonly attribute USVString origin;
     [CEReactions=NotNeeded] attribute USVString protocol;
     [CEReactions=NotNeeded] attribute USVString username;

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -24,7 +24,7 @@
     Exposed=Window,
     JSGenerateToNativeObject
 ] interface HTMLIFrameElement : HTMLElement {
-    [Reflect, URL, CEReactions=NotNeeded] attribute USVString src;
+    [ReflectURL, CEReactions=NotNeeded] attribute USVString src;
     [CEReactions=NotNeeded] attribute (TrustedHTML or DOMString) srcdoc;
     [Reflect, CEReactions=NotNeeded] attribute DOMString name;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList sandbox;
@@ -43,7 +43,7 @@
     [Reflect, CEReactions=NotNeeded] attribute DOMString align;
     [Reflect, CEReactions=NotNeeded] attribute DOMString scrolling;
     [Reflect, CEReactions=NotNeeded] attribute DOMString frameBorder;
-    [Reflect, URL, CEReactions=NotNeeded] attribute USVString longDesc;
+    [ReflectURL, CEReactions=NotNeeded] attribute USVString longDesc;
 
     [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginHeight;
     [Reflect, CEReactions=NotNeeded] attribute [LegacyNullToEmptyString] DOMString marginWidth;

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -28,7 +28,7 @@
     LegacyFactoryFunction=Image(optional unsigned long width, optional unsigned long height)
 ] interface HTMLImageElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString alt;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [CEReactions=NotNeeded, ImplementedAs=srcsetForBindings, ReflectSetter] attribute [AtomString] USVString srcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString sizes;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;
@@ -49,11 +49,11 @@
 
     // Obsolete: Still part of the HTML specification (https://html.spec.whatwg.org/multipage/obsolete.html#HTMLImageElement-partial)
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString lowsrc;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString lowsrc;
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long hspace;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long vspace;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString longDesc;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString longDesc;
 
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString border;
 

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -71,7 +71,7 @@ enum AutofillButtonType {
     [CEReactions=NotNeeded, Reflect] attribute boolean readOnly;
     [CEReactions=NotNeeded, Reflect] attribute boolean required;
     [CEReactions=NotNeeded] attribute unsigned long size;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString step;
     [EnabledBySetting=SwitchControlEnabled, CEReactions=NotNeeded, Reflect] attribute boolean switch;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString type;

--- a/Source/WebCore/html/HTMLLinkElement.idl
+++ b/Source/WebCore/html/HTMLLinkElement.idl
@@ -26,8 +26,8 @@
 ] interface HTMLLinkElement : HTMLElement {
     [Reflect] attribute boolean disabled;
     [CEReactions=NotNeeded, Reflect] attribute DOMString charset;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString href;
-    [CEReactions=NotNeeded, Conditional=WEB_PAGE_SPATIAL_BACKDROP, EnabledBySetting=WebPageSpatialBackdropEnabled, Reflect, URL] attribute USVString environmentMap;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString href;
+    [CEReactions=NotNeeded, Conditional=WEB_PAGE_SPATIAL_BACKDROP, EnabledBySetting=WebPageSpatialBackdropEnabled, ReflectURL] attribute USVString environmentMap;
     [CEReactions=NotNeeded, Reflect] attribute DOMString hreflang;
     [CEReactions=NotNeeded, Reflect] attribute DOMString media;
     [CEReactions=NotNeeded, Reflect] attribute DOMString rel;

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -51,7 +51,7 @@ typedef (
     readonly attribute MediaError? error;
 
     // network state
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     attribute MediaProvider? srcObject;
     [URL] readonly attribute USVString currentSrc;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString? crossOrigin;

--- a/Source/WebCore/html/HTMLModElement.idl
+++ b/Source/WebCore/html/HTMLModElement.idl
@@ -20,7 +20,7 @@
 [
     Exposed=Window
 ] interface HTMLModElement : HTMLElement {
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString cite;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString cite;
     [CEReactions=NotNeeded, Reflect] attribute DOMString dateTime;
 };
 

--- a/Source/WebCore/html/HTMLObjectElement.idl
+++ b/Source/WebCore/html/HTMLObjectElement.idl
@@ -29,9 +29,9 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute DOMString archive;
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString border;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString codeBase;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString codeBase;
     [CEReactions=NotNeeded, Reflect] attribute DOMString codeType;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString data;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString data;
     [CEReactions=NotNeeded, Reflect] attribute boolean declare;
     [CEReactions=NotNeeded, Reflect] attribute DOMString height;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long hspace;

--- a/Source/WebCore/html/HTMLQuoteElement.idl
+++ b/Source/WebCore/html/HTMLQuoteElement.idl
@@ -20,5 +20,5 @@
 [
     Exposed=Window
 ] interface HTMLQuoteElement : HTMLElement {
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString cite;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString cite;
 };

--- a/Source/WebCore/html/HTMLSourceElement.idl
+++ b/Source/WebCore/html/HTMLSourceElement.idl
@@ -27,7 +27,7 @@
     ActiveDOMObject,
     Exposed=Window
 ] interface HTMLSourceElement : HTMLElement {
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
     [CEReactions=NotNeeded, Reflect] attribute USVString srcset;
     [CEReactions=NotNeeded, Reflect] attribute DOMString sizes;

--- a/Source/WebCore/html/HTMLTrackElement.idl
+++ b/Source/WebCore/html/HTMLTrackElement.idl
@@ -29,7 +29,7 @@
     Exposed=Window
 ] interface HTMLTrackElement : HTMLElement {
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString kind;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString srclang;
     [CEReactions=NotNeeded, Reflect] attribute DOMString label;
     [CEReactions=NotNeeded, Reflect] attribute boolean default;

--- a/Source/WebCore/html/HTMLVideoElement.idl
+++ b/Source/WebCore/html/HTMLVideoElement.idl
@@ -35,7 +35,7 @@
     [CEReactions=NotNeeded, Reflect] attribute unsigned long height;
     readonly attribute unsigned long videoWidth;
     readonly attribute unsigned long videoHeight;
-    [CEReactions=NotNeeded, Reflect, URL] attribute USVString poster;
+    [CEReactions=NotNeeded, ReflectURL] attribute USVString poster;
     [CEReactions=NotNeeded, Reflect] attribute boolean playsInline;
 
     // Non-standard


### PR DESCRIPTION
#### 2f61732dd068c1a4174963be7f01c3e3da526702
<pre>
Introduce standard [ReflectURL] extended attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=296714">https://bugs.webkit.org/show_bug.cgi?id=296714</a>

Reviewed by Darin Adler.

See <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflecturl">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflecturl</a>

This updates the IDL parser to support extended attributes that take string arguments.

It also replaces usages of [Reflect, URL] with the new [ReflectURL] to match the updated spec.

* Source/WebCore/Modules/model-element/HTMLModelElement.idl:
* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(ContentAttributeName):
(UnquoteStringLiteral):
(GetterExpression):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateAttributeGetterBodyDefinition):
* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/bindings/scripts/IDLParser.pm:
(parseExtendedAttributeRest2):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::JSTestObjDOMConstructor::construct):
(WebCore::JSTestObjPrototype::finishCreation):
(WebCore::JSC_DEFINE_CUSTOM_SETTER):
(WebCore::jsTestObj_reflectedSetterURLAttrGetter): Deleted.
(WebCore::setJSTestObj_reflectedSetterURLAttrSetter): Deleted.
(WebCore::jsTestObj_reflectedSetterUSVURLAttrGetter): Deleted.
(WebCore::setJSTestObj_reflectedSetterUSVURLAttrSetter): Deleted.
(WebCore::jsTestObj_reflectedSetterCustomURLAttrGetter): Deleted.
(WebCore::setJSTestObj_reflectedSetterCustomURLAttrSetter): Deleted.
* Source/WebCore/bindings/scripts/test/TestObj.idl:
* Source/WebCore/html/HTMLEmbedElement.idl:
* Source/WebCore/html/HTMLFrameElement.idl:
* Source/WebCore/html/HTMLHyperlinkElementUtils.idl:
* Source/WebCore/html/HTMLIFrameElement.idl:
* Source/WebCore/html/HTMLImageElement.idl:
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/html/HTMLLinkElement.idl:
* Source/WebCore/html/HTMLMediaElement.idl:
* Source/WebCore/html/HTMLModElement.idl:
* Source/WebCore/html/HTMLObjectElement.idl:
* Source/WebCore/html/HTMLQuoteElement.idl:
* Source/WebCore/html/HTMLSourceElement.idl:
* Source/WebCore/html/HTMLTrackElement.idl:
* Source/WebCore/html/HTMLVideoElement.idl:

Canonical link: <a href="https://commits.webkit.org/298101@main">https://commits.webkit.org/298101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6440da9cf7794b2a7f4b87f061e4bf69928fba8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86811 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96933 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95424 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24324 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18396 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46641 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->