### PR TITLE
[JSC] Improve the Performance of `String.prototype.repeat()` with a Single Character Input

### DIFF
--- a/JSTests/microbenchmarks/string-repeat-single-ascii.js
+++ b/JSTests/microbenchmarks/string-repeat-single-ascii.js
@@ -1,0 +1,14 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(str, count) {
+    return str.repeat(count);
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test("a", i).length, i);
+}

--- a/JSTests/microbenchmarks/string-repeat-single-emoji.js
+++ b/JSTests/microbenchmarks/string-repeat-single-emoji.js
@@ -1,0 +1,14 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(str, count) {
+    return str.repeat(count);
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test("🐟", i).length, i * 2); // surrogate pair
+}

--- a/JSTests/microbenchmarks/string-repeat-single-japanese.js
+++ b/JSTests/microbenchmarks/string-repeat-single-japanese.js
@@ -1,0 +1,14 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(str, count) {
+    return str.repeat(count);
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test("あ", i).length, i);
+}

--- a/JSTests/microbenchmarks/string-repeat-single-not-resolving.js
+++ b/JSTests/microbenchmarks/string-repeat-single-not-resolving.js
@@ -4,5 +4,5 @@ function test(str, count)
     return str.repeat(count);
 }
 
-for (var i = 0; i < 1e4; ++i)
+for (var i = 0; i < testLoopCount; ++i)
     test(' ', i);

--- a/JSTests/microbenchmarks/string-repeat-single-resolving.js
+++ b/JSTests/microbenchmarks/string-repeat-single-resolving.js
@@ -6,5 +6,5 @@ function test(str, count)
     return repeated[0] + repeated[count >> 1] + repeated[repeated.length - 1];
 }
 
-for (var i = 0; i < 1e4; ++i)
+for (var i = 0; i < testLoopCount; ++i)
     test(' ', i);


### PR DESCRIPTION
#### b387ccf16b61df7c4f5db9d800197c6e11d0d1a2
<pre>
[JSC] Improve the Performance of `String.prototype.repeat()` with a Single Character Input
<a href="https://bugs.webkit.org/show_bug.cgi?id=296716">https://bugs.webkit.org/show_bug.cgi?id=296716</a>

Reviewed by Yusuke Suzuki.

This patch improves the performance of `String.prototype.repeat()` with a single character input
by using `memcpySpan` instead of `std::fill_n`.

                                          TipOfTree                 Patched               Ratio
string-repeat-single-resolving            3.2659+-0.1832     ^      2.4420+-0.0411        ^ definitely 1.3374x faster
string-repeat-single-not-resolving        3.0360+-0.2815     ^      2.3202+-0.0921        ^ definitely 1.3085x faster
string-repeat-single-japanese             7.4144+-0.2740     ^      6.1467+-0.1137        ^ definitely 1.2062x faster
string-repeat-single-emoji                1.5444+-0.0277            1.5292+-0.0292
string-repeat-single-ascii                3.3713+-0.0674     ^      2.4255+-0.1631        ^ definitely 1.3900x faster

* JSTests/microbenchmarks/string-repeat-single-ascii.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/string-repeat-single-emoji.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/string-repeat-single-japanese.js: Added.
(shouldBe):
(test):
* JSTests/microbenchmarks/string-repeat-single-not-resolving.js:
* JSTests/microbenchmarks/string-repeat-single-resolving.js:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::repeatCharacter):

Canonical link: <a href="https://commits.webkit.org/298110@main">https://commits.webkit.org/298110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/982aafc1fd8dddb9253616a1ca67926f6dd5b899

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64898 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86755 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64013 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106562 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123536 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112714 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95589 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95372 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18327 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37289 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18312 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46560 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/136913 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40666 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36653 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->