### PR TITLE
Extend Fetch to accept local connections

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1421,6 +1421,7 @@ webkit.org/b/247283 imported/w3c/web-platform-tests/fetch/metadata/generated/css
 # Fetch features that are not implemented.
 imported/w3c/web-platform-tests/fetch/corb [ Skip ]
 imported/w3c/web-platform-tests/fetch/sec-metadata [ Skip ]
+imported/w3c/web-platform-tests/fetch/private-network-access/mixed-content-fetch.tentative.https.window.html [ Skip ]
 
 # These fetch tests time out on ports without web-platform.test domain working (not glib).
 imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https.html [ Skip ]

--- a/LayoutTests/ipc/invalid-url-network-data-task-crash.html
+++ b/LayoutTests/ipc/invalid-url-network-data-task-crash.html
@@ -42,7 +42,8 @@ setTimeout(async () => {
                     m_useAdvancedPrivacyProtections: true,
                     m_didFilterLinkDecoration: true,
                     m_isPrivateTokenUsageByThirdPartyAllowed: true,
-                    m_wasSchemeOptimisticallyUpgraded: false
+                    m_wasSchemeOptimisticallyUpgraded: false,
+                    m_targetAddressSpace: 0
                 }
             },
             cachePartition: '',

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2136,7 +2136,6 @@ imported/w3c/web-platform-tests/fetch/private-network-access/xhr.https.window.ht
 imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.https.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/xhr.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.https.window.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/fetch/private-network-access/mixed-content-fetch.tentative.https.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/preflight-cache.https.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/worker-fetch.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/worker-fetch.https.window.html [ DumpJSConsoleLogInStdErr ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4440,6 +4440,7 @@ LocalFileContentSniffingEnabled:
 LocalNetworkAccessEnabled:
   type: bool
   status: unstable
+  category: networking
   humanReadableName: "Local Network Access"
   humanReadableDescription: "Enable Local Network Access"
   webKitLegacyPreferenceKey: WebKitLocalNetworkAccessEnabledPreferenceKey

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -352,6 +352,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/fetch/FetchRequestMode.idl \
     $(WebCore)/Modules/fetch/FetchRequestRedirect.idl \
     $(WebCore)/Modules/fetch/FetchResponse.idl \
+    $(WebCore)/Modules/fetch/IPAddressSpace.idl \
     $(WebCore)/Modules/fetch/RequestPriority.idl \
     $(WebCore)/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl \
     $(WebCore)/Modules/filesystem/FileSystemDirectoryHandle.idl \
@@ -399,7 +400,6 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/indexeddb/IDBTransactionMode.idl \
     $(WebCore)/Modules/indexeddb/IDBVersionChangeEvent.idl \
     $(WebCore)/Modules/indexeddb/WindowOrWorkerGlobalScope+IndexedDatabase.idl \
-    $(WebCore)/Modules/fetch/IPAddressSpace.idl \
     $(WebCore)/Modules/mediacapabilities/AudioConfiguration.idl \
     $(WebCore)/Modules/mediacapabilities/ColorGamut.idl \
     $(WebCore)/Modules/mediacapabilities/HdrMetadataType.idl \

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -90,7 +90,7 @@ public:
 
     RequestPriority priority() const { return m_priority; }
 
-    const std::optional<IPAddressSpace>& targetAddressSpace() const { return m_targetAddressSpace; }
+    IPAddressSpace targetAddressSpace() const { return m_targetAddressSpace; }
 
     bool shouldEnableContentExtensionsCheck() const { return m_enableContentExtensionsCheck; }
     void disableContentExtensionsCheck() { m_enableContentExtensionsCheck = false; }
@@ -114,7 +114,7 @@ private:
     const Ref<AbortSignal> m_signal;
     Markable<FetchIdentifier> m_navigationPreloadIdentifier;
     bool m_enableContentExtensionsCheck { true };
-    std::optional<IPAddressSpace> m_targetAddressSpace;
+    IPAddressSpace m_targetAddressSpace;
 };
 
 WebCoreOpaqueRoot root(FetchRequest*);

--- a/Source/WebCore/Modules/fetch/FetchRequest.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequest.idl
@@ -55,7 +55,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     // FIXME: Implement 'isHistoryNavigation'.
     // readonly attribute boolean isHistoryNavigation;
     readonly attribute AbortSignal signal;
-    [EnabledBySetting=LocalNetworkAccessEnabled] readonly attribute IPAddressSpace? targetAddressSpace;
+    [EnabledBySetting=LocalNetworkAccessEnabled] readonly attribute IPAddressSpace targetAddressSpace;
 
     [NewObject] FetchRequest clone();
 };

--- a/Source/WebCore/Modules/fetch/FetchRequestInit.h
+++ b/Source/WebCore/Modules/fetch/FetchRequestInit.h
@@ -51,9 +51,8 @@ struct FetchRequestInit {
     JSC::JSValue signal;
     std::optional<RequestPriority> priority;
     JSC::JSValue window;
-    std::optional<IPAddressSpace> targetAddressSpace;
-
-    bool hasMembers() const { return !method.isEmpty() || headers || body || !referrer.isEmpty() || referrerPolicy || mode || credentials || cache || redirect || !integrity.isEmpty() || keepalive || !window.isUndefined() || !signal.isUndefined() || targetAddressSpace; }
+    IPAddressSpace targetAddressSpace { IPAddressSpace::Public };
+    bool hasMembers() const { return !method.isEmpty() || headers || body || !referrer.isEmpty() || referrerPolicy || mode || credentials || cache || redirect || !integrity.isEmpty() || keepalive || !window.isUndefined() || !signal.isUndefined() || targetAddressSpace != IPAddressSpace::Public; }
 };
 
 }

--- a/Source/WebCore/Modules/fetch/FetchRequestInit.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequestInit.idl
@@ -43,5 +43,5 @@ dictionary FetchRequestInit {
     any signal;
     RequestPriority priority;
     any window; // can only be set to null
-    [EnabledBySetting=LocalNetworkAccessEnabled] IPAddressSpace targetAddressSpace;
+    IPAddressSpace targetAddressSpace;
 };

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IPAddressSpace.h"
+
+#include <array>
+#include <cstdio>
+#include <wtf/URL.h>
+#include <wtf/Vector.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringToIntegerConversion.h>
+#include <wtf/text/StringView.h>
+
+namespace WebCore {
+
+IPAddressSpace determineIPAddressSpace(const URL& url)
+{
+    // Defined in https://wicg.github.io/local-network-access/#ip-address-space-section
+    String host = url.host().toString();
+    host = makeStringByReplacingAll(host, '[', ""_s);
+    host = makeStringByReplacingAll(host, ']', ""_s);
+
+    if (!URL::hostIsIPAddress(host))
+        return IPAddressSpace::Public;
+
+    // Handle IPv6 addresses (check for colon to distinguish from IPv4)
+    if (host.contains(':')) {
+        // ::1/128 - IPv6 Local - loopback
+        if (host == "::1")
+            return IPAddressSpace::Local;
+
+        // fc00::/7 - Unique Loopback - local
+        if (host.startsWith("fc"_s) || host.startsWith("fd"_s))
+            return IPAddressSpace::Local;
+
+        // fe80::/10 - Link-Loopback Unicast - local
+        if (host.startsWith("fe8"_s) || host.startsWith("fe9"_s) || host.startsWith("fea"_s) || host.startsWith("feb"_s))
+            return IPAddressSpace::Local;
+        // ::ffff: - IPv4 Mapped IPv6 Addresses - format for parsing by IPv4 Algorithm.
+        if (host.startsWith("::ffff:"_s)) {
+            host = host.substring(7);
+            if (!host.contains('.')) {
+                // Parse hex representation like "c0a8:101" -> "192.168.1.1"
+                Vector<String> halves = host.split(':');
+                if (halves.size() != 2)
+                    return IPAddressSpace::Public;
+
+                auto value1 = parseInteger<uint16_t>(halves[0], 16);
+                auto value2 = parseInteger<uint16_t>(halves[1], 16);
+
+                if (!value1.has_value() || !value2.has_value())
+                    return IPAddressSpace::Public;
+
+                // Convert 16-bit hex values to dotted decimal IPv4 format
+                uint16_t val1 = *value1;
+                uint16_t val2 = *value2;
+
+                host = makeString(
+                    static_cast<unsigned>(val1 >> 8), '.',
+                    static_cast<unsigned>(val1 & 0xFF), '.',
+                    static_cast<unsigned>(val2 >> 8), '.',
+                    static_cast<unsigned>(val2 & 0xFF)
+                );
+            }
+        }
+    }
+    if (host.contains('.')) {
+        Vector<String> octets = host.split('.');
+        if (octets.size() != 4)
+            return IPAddressSpace::Public;
+
+        std::array<uint8_t, 4> parts;
+        for (size_t i = 0; i < 4; i++) {
+            auto value = parseInteger<uint8_t>(octets[i]);
+            if (!value)
+                return IPAddressSpace::Public;
+            parts[i] = *value;
+        }
+
+        // Check IPv4 address blocks according to spec table:
+
+        // 127.0.0.0/8 - IPv4 Loopback - loopback
+        if (parts[0] == 127)
+            return IPAddressSpace::Local;
+
+        // 10.0.0.0/8 - Local Use - local
+        if (parts[0] == 10)
+            return IPAddressSpace::Local;
+
+        // 100.64.0.0/10 - Carrier-Grade NAT - local
+        if (parts[0] == 100 && (parts[1] & 0xC0) == 64)
+            return IPAddressSpace::Local;
+
+        // 172.16.0.0/12 - Local Use - local
+        if (parts[0] == 172 && (parts[1] & 0xF0) == 16)
+            return IPAddressSpace::Local;
+
+        // 192.168.0.0/16 - Local Use - local
+        if (parts[0] == 192 && parts[1] == 168)
+            return IPAddressSpace::Local;
+
+        // 198.18.0.0/15 - Benchmarking - local
+        if (parts[0] == 198 && (parts[1] & 0xFE) == 18)
+            return IPAddressSpace::Local;
+
+        // 169.254.0.0/16 - Link Local - local
+        if (parts[0] == 169 && parts[1] == 254)
+            return IPAddressSpace::Local;
+
+        return IPAddressSpace::Public;
+    }
+    return IPAddressSpace::Public;
+}
+
+bool isLocalIPAddressSpace(const URL& url)
+{
+    return determineIPAddressSpace(url) == IPAddressSpace::Local;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/IPAddressSpace.h
+++ b/Source/WebCore/Modules/fetch/IPAddressSpace.h
@@ -32,4 +32,9 @@ enum class IPAddressSpace : bool {
     Local
 };
 
+WEBCORE_EXPORT IPAddressSpace determineIPAddressSpace(const WTF::URL&);
+
+WEBCORE_EXPORT bool isLocalIPAddressSpace(IPAddressSpace);
+WEBCORE_EXPORT bool isLocalIPAddressSpace(const WTF::URL&);
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 
 #include "Document.h"
+#include "Event.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "JSDOMException.h"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -29,6 +29,7 @@
 
 #include "CSSStyleImageValue.h"
 #include "ContextDestructionObserverInlines.h"
+#include "DocumentInlines.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -32,6 +32,10 @@
 #include "RTCRtpSenderBackend.h"
 #include "RealtimeOutgoingAudioSource.h"
 #include "RealtimeOutgoingVideoSource.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <webrtc/api/rtp_sender_interface.h>
+#include <webrtc/api/scoped_refptr.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(NOTIFICATION_EVENT)
 
+#include "EventTargetInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/JSDOMGlobalObject.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -28,6 +28,7 @@
 #include "ChannelCountMode.h"
 #include "ChannelInterpretation.h"
 #include "EventTarget.h"
+#include "ExceptionOr.h"
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -36,6 +36,7 @@
 #include "BufferSource.h"
 #include "CurrentUserDetailsOptions.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "JSAuthenticatorAttachment.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSPublicKeyCredentialCreationOptions.h"

--- a/Source/WebCore/Modules/webdatabase/SQLResultSetRowList.h
+++ b/Source/WebCore/Modules/webdatabase/SQLResultSetRowList.h
@@ -28,11 +28,10 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
 #include "SQLValue.h"
 
 namespace WebCore {
-
-template<typename> class ExceptionOr;
 
 class SQLResultSetRowList : public RefCounted<SQLResultSetRowList> {
 public:

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -136,6 +136,7 @@ Modules/fetch/FetchLoader.cpp
 Modules/fetch/FetchRequest.cpp
 Modules/fetch/FetchResponse.cpp
 Modules/fetch/FormDataConsumer.cpp
+Modules/fetch/IPAddressSpace.cpp
 Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -211,7 +211,8 @@ PolicyContainer SecurityContext::policyContainer() const
         m_contentSecurityPolicy->responseHeaders(),
         crossOriginEmbedderPolicy(),
         crossOriginOpenerPolicy(),
-        referrerPolicy()
+        referrerPolicy(),
+        ipAddressSpace()
     };
 }
 
@@ -224,6 +225,7 @@ void SecurityContext::inheritPolicyContainerFrom(const PolicyContainer& policyCo
     setCrossOriginOpenerPolicy(policyContainer.crossOriginOpenerPolicy);
     setCrossOriginEmbedderPolicy(policyContainer.crossOriginEmbedderPolicy);
     setReferrerPolicy(policyContainer.referrerPolicy);
+    setIPAddressSpace(policyContainer.ipAddressSpace);
 }
 
 CheckedPtr<ContentSecurityPolicy> SecurityContext::checkedContentSecurityPolicy()

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/ReferrerPolicy.h>
 #include <memory>
 #include <wtf/CheckedPtr.h>
@@ -94,6 +95,9 @@ public:
     virtual ReferrerPolicy referrerPolicy() const { return m_referrerPolicy; }
     void setReferrerPolicy(ReferrerPolicy);
 
+    IPAddressSpace ipAddressSpace() const { return m_ipAddressSpace; }
+    void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }
+
     WEBCORE_EXPORT PolicyContainer policyContainer() const;
     virtual void inheritPolicyContainerFrom(const PolicyContainer&);
 
@@ -142,6 +146,7 @@ private:
     SandboxFlags m_creationSandboxFlags;
     SandboxFlags m_sandboxFlags;
     ReferrerPolicy m_referrerPolicy { ReferrerPolicy::Default };
+    IPAddressSpace m_ipAddressSpace { IPAddressSpace::Public };
     bool m_haveInitializedSecurityOrigin { false };
     bool m_geolocationAccessed { false };
     bool m_secureCookiesAccessed { false };

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -40,11 +40,13 @@
 #include "ContainerNode.h"
 #include "CrossOriginAccessControl.h"
 #include "DefaultResourceLoadPriority.h"
+#include "DocumentLoader.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
 #include "FetchRequestDestination.h"
 #include "FrameLoader.h"
 #include "HTMLSrcsetParser.h"
+#include <JavaScriptCore/ConsoleTypes.h>
 #include "JSFetchRequestDestination.h"
 #include "LinkHeader.h"
 #include "LinkPreloadResourceClients.h"

--- a/Source/WebCore/loader/PolicyContainer.h
+++ b/Source/WebCore/loader/PolicyContainer.h
@@ -28,6 +28,7 @@
 #include <WebCore/ContentSecurityPolicyResponseHeaders.h>
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/ReferrerPolicy.h>
 
 namespace WebCore {
@@ -39,11 +40,12 @@ struct PolicyContainer {
     CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     CrossOriginOpenerPolicy crossOriginOpenerPolicy;
     ReferrerPolicy referrerPolicy = ReferrerPolicy::Default;
+    IPAddressSpace ipAddressSpace = IPAddressSpace::Public;
 
     friend bool operator==(const PolicyContainer&, const PolicyContainer&) = default;
 
-    PolicyContainer isolatedCopy() const & { return { contentSecurityPolicyResponseHeaders.isolatedCopy(), crossOriginEmbedderPolicy.isolatedCopy(), crossOriginOpenerPolicy.isolatedCopy(), referrerPolicy }; }
-    PolicyContainer isolatedCopy() && { return { WTFMove(contentSecurityPolicyResponseHeaders).isolatedCopy(), WTFMove(crossOriginEmbedderPolicy).isolatedCopy(), WTFMove(crossOriginOpenerPolicy).isolatedCopy(), referrerPolicy }; }
+    PolicyContainer isolatedCopy() const & { return { contentSecurityPolicyResponseHeaders.isolatedCopy(), crossOriginEmbedderPolicy.isolatedCopy(), crossOriginOpenerPolicy.isolatedCopy(), referrerPolicy, ipAddressSpace }; }
+    PolicyContainer isolatedCopy() && { return { WTFMove(contentSecurityPolicyResponseHeaders).isolatedCopy(), WTFMove(crossOriginEmbedderPolicy).isolatedCopy(), WTFMove(crossOriginOpenerPolicy).isolatedCopy(), referrerPolicy, ipAddressSpace }; }
 };
 
 WEBCORE_EXPORT void addPolicyContainerHeaders(ResourceResponse&, const PolicyContainer&);

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -28,6 +28,7 @@
 
 #include "HTTPHeaderNames.h"
 #include "HTTPStatusCodes.h"
+#include "IPAddressSpace.h"
 #include "Logging.h"
 #include "PublicSuffixStore.h"
 #include "RegistrableDomain.h"

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -38,6 +38,8 @@
 
 namespace WebCore {
 
+enum class IPAddressSpace : bool;
+
 enum class ResourceRequestCachePolicy : uint8_t {
     UseProtocolCachePolicy, // normal load, equivalent to fetch "default" cache mode.
     ReloadIgnoringCacheData, // reload, equivalent to fetch "reload"cache mode.
@@ -68,7 +70,7 @@ public:
     struct RequestData {
         RequestData() { }
 
-        RequestData(URL&& url, URL&& firstPartyForCookies, double timeoutInterval, String&& httpMethod, HTTPHeaderMap&& httpHeaderFields, Vector<String>&& responseContentDispositionEncodingFallbackArray, ResourceRequestCachePolicy cachePolicy, SameSiteDisposition sameSiteDisposition, ResourceLoadPriority priority, ResourceRequestRequester requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false)
+        RequestData(URL&& url, URL&& firstPartyForCookies, double timeoutInterval, String&& httpMethod, HTTPHeaderMap&& httpHeaderFields, Vector<String>&& responseContentDispositionEncodingFallbackArray, ResourceRequestCachePolicy cachePolicy, SameSiteDisposition sameSiteDisposition, ResourceLoadPriority priority, ResourceRequestRequester requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useAdvancedPrivacyProtections = false, bool didFilterLinkDecoration = false, bool isPrivateTokenUsageByThirdPartyAllowed = false, bool wasSchemeOptimisticallyUpgraded = false, IPAddressSpace targetAddressSpace = IPAddressSpace::Public)
             : m_url(WTFMove(url))
             , m_firstPartyForCookies(WTFMove(firstPartyForCookies))
             , m_timeoutInterval(timeoutInterval)
@@ -87,6 +89,7 @@ public:
             , m_didFilterLinkDecoration(didFilterLinkDecoration)
             , m_isPrivateTokenUsageByThirdPartyAllowed(isPrivateTokenUsageByThirdPartyAllowed)
             , m_wasSchemeOptimisticallyUpgraded(wasSchemeOptimisticallyUpgraded)
+            , m_targetAddressSpace(targetAddressSpace)
         {
         }
 
@@ -114,6 +117,7 @@ public:
         bool m_didFilterLinkDecoration : 1 { false };
         bool m_isPrivateTokenUsageByThirdPartyAllowed : 1 { false };
         bool m_wasSchemeOptimisticallyUpgraded : 1 { false };
+        IPAddressSpace m_targetAddressSpace { IPAddressSpace::Public };
     };
 
     ResourceRequestBase(RequestData&& requestData)
@@ -247,6 +251,9 @@ public:
     ResourceRequestRequester requester() const { return m_requestData.m_requester; }
     void setRequester(ResourceRequestRequester requester) { m_requestData.m_requester = requester; }
     
+    IPAddressSpace targetAddressSpace() const { return m_requestData.m_targetAddressSpace; }
+    void setTargetAddressSpace(IPAddressSpace targetAddressSpace) { m_requestData.m_targetAddressSpace = targetAddressSpace; }
+
     // Who initiated the request so the Inspector can associate it with a context. E.g. a Web Worker.
     String initiatorIdentifier() const { return m_initiatorIdentifier; }
     void setInitiatorIdentifier(const String& identifier) { m_initiatorIdentifier = identifier; }

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -31,6 +31,7 @@
 #include "DataURLDecoder.h"
 #include "HTTPHeaderNames.h"
 #include "HTTPParsers.h"
+#include "IPAddressSpace.h"
 #include "MIMETypeRegistry.h"
 #include "ParsedContentRange.h"
 #include "ResourceResponse.h"
@@ -90,6 +91,7 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseData>&&
     , m_tainting(data ? data->tainting : Tainting::Basic)
     , m_source(data ? data->source : Source::Unknown)
     , m_type(data ? data->type : Type::Default)
+    , m_ipAddressSpace(data ? data->ipAddressSpace : IPAddressSpace::Public)
 {
 }
 
@@ -116,6 +118,7 @@ ResourceResponseData ResourceResponseData::isolatedCopy() const
     result.isRangeRequested = isRangeRequested;
     if (certificateInfo)
         result.certificateInfo = certificateInfo->isolatedCopy();
+    result.ipAddressSpace = ipAddressSpace;
     return result;
 }
 
@@ -143,6 +146,7 @@ ResourceResponseData ResourceResponseBase::crossThreadData() const
     data.isRangeRequested = m_isRangeRequested;
     if (m_certificateInfo)
         data.certificateInfo = m_certificateInfo->isolatedCopy();
+    data.ipAddressSpace = m_ipAddressSpace;
 
     return data;
 }
@@ -174,7 +178,7 @@ ResourceResponse ResourceResponseBase::fromCrossThreadData(CrossThreadData&& dat
     response.m_proxyName = WTFMove(data.proxyName);
     response.m_isRangeRequested = data.isRangeRequested;
     response.m_certificateInfo = WTFMove(data.certificateInfo);
-
+    response.m_ipAddressSpace = data.ipAddressSpace;
     return response;
 }
 
@@ -913,7 +917,8 @@ std::optional<ResourceResponseData> ResourceResponseBase::getResponseData() cons
         m_wasPrivateRelayed,
         String { m_proxyName },
         m_isRangeRequested,
-        m_certificateInfo
+        m_certificateInfo,
+        m_ipAddressSpace
     } };
 }
 
@@ -1047,7 +1052,8 @@ std::optional<WebCore::ResourceResponseData> Coder<WebCore::ResourceResponseData
         *wasPrivateRelayed,
         WTFMove(*proxyName),
         *isRangeRequested,
-        WTFMove(*certificateInfo)
+        WTFMove(*certificateInfo),
+        WebCore::IPAddressSpace::Public
     };
 }
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -29,6 +29,7 @@
 #include <WebCore/CacheValidation.h>
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/HTTPHeaderMap.h>
+#include <WebCore/IPAddressSpace.h>
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/ParsedContentRange.h>
 #include <span>
@@ -59,6 +60,9 @@ static_assert(static_cast<unsigned>(UsedLegacyTLS::Yes) <= ((1U << bitWidthOfUse
 enum class WasPrivateRelayed : bool { No, Yes };
 static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
+
+static constexpr unsigned bitWidthOfIPAddressSpace = 1;
+static_assert(static_cast<unsigned>(IPAddressSpace::Local) <= ((1U << bitWidthOfIPAddressSpace) - 1));
 
 enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
 enum class ResourceResponseBaseTainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };
@@ -148,6 +152,9 @@ public:
     void setWasPrivateRelayed(WasPrivateRelayed privateRelayed) { m_wasPrivateRelayed = privateRelayed; }
     void setProxyName(String&& proxyName) { m_proxyName = WTFMove(proxyName); }
     const String& proxyName() const { return m_proxyName; }
+
+    IPAddressSpace ipAddressSpace() { return m_ipAddressSpace; }
+    void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }
 
     // These functions return parsed values of the corresponding response headers.
     WEBCORE_EXPORT bool cacheControlContainsNoCache() const;
@@ -289,6 +296,8 @@ private:
     Tainting m_tainting : bitWidthOfTainting { Tainting::Basic };
     Source m_source : bitWidthOfSource { Source::Unknown };
     Type m_type : bitWidthOfType { Type::Default };
+    IPAddressSpace m_ipAddressSpace : bitWidthOfIPAddressSpace { IPAddressSpace::Public };
+
 };
 
 struct ResourceResponseData {
@@ -297,7 +306,7 @@ struct ResourceResponseData {
     ResourceResponseData() = default;
     ResourceResponseData(ResourceResponseData&&) = default;
     ResourceResponseData& operator=(ResourceResponseData&&) = default;
-    ResourceResponseData(URL&& url, String&& mimeType, long long expectedContentLength, String&& textEncodingName, int httpStatusCode, String&& httpStatusText, String&& httpVersion, HTTPHeaderMap&& httpHeaderFields, std::optional<NetworkLoadMetrics>&& networkLoadMetrics, ResourceResponseSource source, ResourceResponseBaseType type, ResourceResponseBaseTainting tainting, bool isRedirected, UsedLegacyTLS usedLegacyTLS, WasPrivateRelayed wasPrivateRelayed, String&& proxyName, bool isRangeRequested, std::optional<CertificateInfo> certificateInfo)
+    ResourceResponseData(URL&& url, String&& mimeType, long long expectedContentLength, String&& textEncodingName, int httpStatusCode, String&& httpStatusText, String&& httpVersion, HTTPHeaderMap&& httpHeaderFields, std::optional<NetworkLoadMetrics>&& networkLoadMetrics, ResourceResponseSource source, ResourceResponseBaseType type, ResourceResponseBaseTainting tainting, bool isRedirected, UsedLegacyTLS usedLegacyTLS, WasPrivateRelayed wasPrivateRelayed, String&& proxyName, bool isRangeRequested, std::optional<CertificateInfo> certificateInfo, IPAddressSpace ipAddressSpace)
         : url(WTFMove(url))
         , mimeType(WTFMove(mimeType))
         , expectedContentLength(expectedContentLength)
@@ -316,6 +325,7 @@ struct ResourceResponseData {
         , proxyName(WTFMove(proxyName))
         , isRangeRequested(isRangeRequested)
         , certificateInfo(certificateInfo)
+        , ipAddressSpace(ipAddressSpace)
     {
     }
 
@@ -339,6 +349,7 @@ struct ResourceResponseData {
     String proxyName;
     bool isRangeRequested;
     std::optional<CertificateInfo> certificateInfo;
+    IPAddressSpace ipAddressSpace;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -167,6 +167,8 @@ enum class WebCore::IDBTransactionMode : uint8_t {
     Versionchange
 };
 
+enum class WebCore::IPAddressSpace : bool;
+
 #if ENABLE(MEDIA_SESSION)
 header: <WebCore/MediaSessionAction.h>
 enum class WebCore::MediaSessionAction : uint8_t {
@@ -2114,6 +2116,7 @@ header: <WebCore/ResourceRequest.h>
     [BitField] bool m_didFilterLinkDecoration;
     [BitField] bool m_isPrivateTokenUsageByThirdPartyAllowed;
     [BitField] bool m_wasSchemeOptimisticallyUpgraded;
+    WebCore::IPAddressSpace m_targetAddressSpace;
 };
 
 #if USE(SOUP)
@@ -3718,6 +3721,7 @@ enum class WebCore::WasPrivateRelayed : bool;
     String proxyName;
     bool isRangeRequested;
     std::optional<WebCore::CertificateInfo> certificateInfo;
+    WebCore::IPAddressSpace ipAddressSpace;
 };
 
 #if PLATFORM(COCOA)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		3ADD8988299F192F005DCE4E /* MetalGenerationTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3ADD897E299F1400005DCE4E /* MetalGenerationTests.cpp */; };
 		3AF4A0952D9DEE0B00B3FF5E /* icon-svg-16.tiff in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3AF4A0932D9DEE0B00B3FF5E /* icon-svg-16.tiff */; };
 		3AF4A0962D9DEE0B00B3FF5E /* icon-svg-256.tiff in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3AF4A0942D9DEE0B00B3FF5E /* icon-svg-256.tiff */; };
+		3CF676F42E4ED17D00D988EC /* IPAddressSpaceTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CF676EC2E4ED17000D988EC /* IPAddressSpaceTests.cpp */; };
 		4102EE1727845ED500D6BE74 /* ServiceWorkerRoutines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4102EE1627845ED500D6BE74 /* ServiceWorkerRoutines.cpp */; };
 		411204CE2D3AAD8E009A8554 /* SharedVideoFrame.mm in Sources */ = {isa = PBXBuildFile; fileRef = 411204CD2D3AAD8E009A8554 /* SharedVideoFrame.mm */; };
 		411223C726035FBF00B0A0B6 /* WebRTC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 411223C626035FBE00B0A0B6 /* WebRTC.mm */; };
@@ -2785,6 +2786,7 @@
 		3AEA55B22CB0897200A9ECAA /* WKPreferences.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPreferences.mm; sourceTree = "<group>"; };
 		3AF4A0932D9DEE0B00B3FF5E /* icon-svg-16.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "icon-svg-16.tiff"; sourceTree = "<group>"; };
 		3AF4A0942D9DEE0B00B3FF5E /* icon-svg-256.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "icon-svg-256.tiff"; sourceTree = "<group>"; };
+		3CF676EC2E4ED17000D988EC /* IPAddressSpaceTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressSpaceTests.cpp; sourceTree = "<group>"; };
 		3F1B52681D3D7129008D60C4 /* FullscreenLayoutConstraints.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLayoutConstraints.mm; sourceTree = "<group>"; };
 		3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenLayoutConstraints.html; sourceTree = "<group>"; };
 		3FCC4FE41EC4E8520076E37C /* PictureInPictureDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PictureInPictureDelegate.mm; sourceTree = "<group>"; };
@@ -5184,6 +5186,7 @@
 				7A909A731D877475007E10F8 /* IntPointTests.cpp */,
 				7A909A741D877475007E10F8 /* IntRectTests.cpp */,
 				7A909A751D877475007E10F8 /* IntSizeTests.cpp */,
+				3CF676EC2E4ED17000D988EC /* IPAddressSpaceTests.cpp */,
 				F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */,
 				CD5FF4962162E27E004BD86F /* ISOBox.cpp */,
 				278E3E1823CD82FA005A6B80 /* KeyedCoding.cpp */,
@@ -7768,6 +7771,7 @@
 				7A909A831D877480007E10F8 /* IntSizeTests.cpp in Sources */,
 				CDE4E4E52B7E787900B3AE35 /* InWindowFullscreen.mm in Sources */,
 				7BB62ABE29BB4BAA00228CD6 /* IOSurfaceTests.mm in Sources */,
+				3CF676F42E4ED17D00D988EC /* IPAddressSpaceTests.cpp in Sources */,
 				F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */,
 				5C0BF8931DD599BD00B00328 /* IsNavigationActionTrusted.mm in Sources */,
 				CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/IPAddressSpace.h>
+#include <wtf/URL.h>
+
+namespace TestWebKitAPI {
+
+// Test IPv4 loopback addresses (127.0.0.0/8)
+TEST(IPAddressSpace, IPv4Loopback)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.2/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.255.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://127.1.2.3:8080/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+// Test IPv4 private address ranges
+TEST(IPAddressSpace, IPv4PrivateAddresses)
+{
+    // 10.0.0.0/8 - Local Use
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://10.0.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://10.255.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://10.192.168.1:443/"_s)), WebCore::IPAddressSpace::Local);
+
+    // 172.16.0.0/12 - Local Use
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.16.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.31.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://172.20.1.2:8443/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.15.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.32.0.1/"_s)), WebCore::IPAddressSpace::Public);
+
+    // 192.168.0.0/16 - Local Use
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.100:8080/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.167.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.169.0.1/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test Carrier-Grade NAT addresses (100.64.0.0/10)
+TEST(IPAddressSpace, IPv4CarrierGradeNAT)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.64.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.127.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://100.100.100.100:443/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.63.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.128.0.1/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test Link Local addresses (169.254.0.0/16)
+TEST(IPAddressSpace, IPv4LinkLocal)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.254.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.254.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://169.254.1.1:8080/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.253.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://169.255.0.1/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test Benchmarking addresses (198.18.0.0/15)
+TEST(IPAddressSpace, IPv4Benchmarking)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://198.18.100.50:443/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.1/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test IPv4 public addresses
+TEST(IPAddressSpace, IPv4PublicAddresses)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://8.8.8.8/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://1.1.1.1/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://172.64.0.1:443/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://208.67.222.222/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://64.233.160.0:443/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test IPv6 loopback (::1/128)
+TEST(IPAddressSpace, IPv6Loopback)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::1]:8080/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+// Test IPv6 Unique Local addresses (fc00::/7)
+TEST(IPAddressSpace, IPv6UniqueLocal)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fc00::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fd00::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fcff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:8080/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fbff::1]/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe00::1]/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test IPv6 Link-Local addresses (fe80::/10)
+TEST(IPAddressSpace, IPv6LinkLocal)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe80::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe90::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fea0::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[feb0::1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:8080/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Edge cases - should NOT be local
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fe7f::1]/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[fec0::1]/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test IPv4-Mapped IPv6 addresses (::ffff:0:0/96) with dotted decimal notation
+TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)
+{
+    // Local IPv4 addresses mapped to IPv6
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:127.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:10.0.0.1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:192.168.1.1]/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:172.16.0.1]:443/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Public IPv4 addresses mapped to IPv6
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:8.8.8.8]/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:1.1.1.1]:8080/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test IPv4-Mapped IPv6 addresses with hex notation
+TEST(IPAddressSpace, IPv6MappedIPv4HexNotation)
+{
+    // 127.0.0.1 = 0x7f000001 -> c0a8:101 represents 192.168.1.1
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:c0a8:101]/"_s)), WebCore::IPAddressSpace::Local);
+
+    // 10.0.0.1 = 0x0a000001
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:a00:1]/"_s)), WebCore::IPAddressSpace::Local);
+
+    // 8.8.8.8 = 0x08080808
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::ffff:808:808]/"_s)), WebCore::IPAddressSpace::Public);
+
+    // 172.16.0.1 = 0xac100001
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[::ffff:ac10:1]:443/"_s)), WebCore::IPAddressSpace::Local);
+}
+
+// Test IPv6 public addresses
+TEST(IPAddressSpace, IPv6PublicAddresses)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2001:4860:4860::8888]/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[2606:4700:4700::1111]/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[2001:db8::1]:443/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::2]/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test non-IP addresses (hostnames)
+TEST(IPAddressSpace, HostnameAddresses)
+{
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://example.com/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://www.google.com/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://localhost/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://internal.company.local:8080/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ftp://ftp.example.org/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test edge cases and malformed addresses
+TEST(IPAddressSpace, EdgeCasesAndMalformed)
+{
+    // Empty or invalid URLs
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL(""_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://"_s)), WebCore::IPAddressSpace::Public);
+
+    // URLs without hosts
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("file:///path/to/file"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("data:text/plain,hello"_s)), WebCore::IPAddressSpace::Public);
+
+    // Malformed IP addresses
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://256.256.256.256/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.1.1.1/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[invalid::ipv6::address]/"_s)), WebCore::IPAddressSpace::Public);
+
+    // IPv6 addresses without brackets (should be treated as hostnames)
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://::1/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://2001:db8::1/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test the utility functions
+TEST(IPAddressSpace, UtilityFunctions)
+{
+    // Test isLocalIPAddressSpace(const URL&)
+    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://127.0.0.1/"_s)));
+    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://192.168.1.1/"_s)));
+    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://[::1]/"_s)));
+    EXPECT_TRUE(WebCore::isLocalIPAddressSpace(URL("http://[fc00::1]/"_s)));
+
+    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("http://8.8.8.8/"_s)));
+    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("https://www.example.com/"_s)));
+    EXPECT_FALSE(WebCore::isLocalIPAddressSpace(URL("http://[2001:db8::1]/"_s)));
+}
+
+// Test different URL schemes
+TEST(IPAddressSpace, DifferentURLSchemes)
+{
+    // HTTP and HTTPS
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Other schemes
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ftp://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ws://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("wss://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Custom schemes
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("custom://192.168.1.1/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Public addresses with different schemes
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://8.8.8.8/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("ftp://8.8.8.8/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test URLs with ports
+TEST(IPAddressSpace, URLsWithPorts)
+{
+    // Local addresses with various ports
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://127.0.0.1:8080/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://192.168.1.1:443/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://[::1]:3000/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[fc00::1]:8443/"_s)), WebCore::IPAddressSpace::Local);
+
+    // Public addresses with ports
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://8.8.8.8:53/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("https://[2001:4860:4860::8888]:443/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+// Test comprehensive IPv4 boundary conditions
+TEST(IPAddressSpace, IPv4BoundaryConditions)
+{
+    // Test exact boundaries for 172.16.0.0/12
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.16.0.0/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.31.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.15.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://172.32.0.0/"_s)), WebCore::IPAddressSpace::Public);
+
+    // Test exact boundaries for 100.64.0.0/10
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.64.0.0/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.127.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.63.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://100.128.0.0/"_s)), WebCore::IPAddressSpace::Public);
+
+    // Test exact boundaries for 198.18.0.0/15
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.18.0.0/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.19.255.255/"_s)), WebCore::IPAddressSpace::Local);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.17.255.255/"_s)), WebCore::IPAddressSpace::Public);
+    EXPECT_EQ(WebCore::determineIPAddressSpace(URL("http://198.20.0.0/"_s)), WebCore::IPAddressSpace::Public);
+}
+
+}
+


### PR DESCRIPTION
#### d4e2bd45ea23cd556ef21a9ae002ac277245a7e8
<pre>
Extend Fetch to accept local connections
<a href="https://bugs.webkit.org/show_bug.cgi?id=296710">https://bugs.webkit.org/show_bug.cgi?id=296710</a>
<a href="https://rdar.apple.com/154439024">rdar://154439024</a>

Reviewed by Alex Christensen.

Integration with fetch as per the local network access spec: (<a href="https://wicg.github.io/local-network-access/#integration-with-fetch)">https://wicg.github.io/local-network-access/#integration-with-fetch)</a>
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c4ab993576ca17eafd7108853e112d1e97aeaacc">https://github.com/web-platform-tests/wpt/commit/c4ab993576ca17eafd7108853e112d1e97aeaacc</a>

* LayoutTests/TestExpectations:
* LayoutTests/ipc/invalid-url-network-data-task-crash.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::updateTargetAddressSpaceIfNeeded):
(WebCore::FetchRequest::initializeWith):
(WebCore::FetchRequest::resourceRequest const):
(WebCore::FetchRequest::clone):
* Source/WebCore/Modules/fetch/FetchRequest.h:
* Source/WebCore/Modules/fetch/FetchRequest.idl:
* Source/WebCore/Modules/fetch/FetchRequestInit.h:
(WebCore::FetchRequestInit::hasMembers const):
* Source/WebCore/Modules/fetch/FetchRequestInit.idl:
* Source/WebCore/Modules/fetch/IPAddressSpace.cpp: Added.
(WebCore::determineIPAddressSpace):
(WebCore::isLocalIPAddressSpace):
* Source/WebCore/Modules/fetch/IPAddressSpace.h:
* Source/WebCore/Modules/mediasession/MediaSessionCoordinator.cpp:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h:
* Source/WebCore/Modules/notifications/NotificationEvent.cpp:
* Source/WebCore/Modules/streams/WritableStream.h:
* Source/WebCore/Modules/webaudio/AudioNode.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
* Source/WebCore/Modules/webdatabase/SQLResultSetRowList.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::policyContainer const):
(WebCore::SecurityContext::inheritPolicyContainerFrom):
* Source/WebCore/dom/SecurityContext.h:
(WebCore::SecurityContext::ipAddressSpace const):
(WebCore::SecurityContext::setIPAddressSpace):
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/loader/PolicyContainer.h:
(WebCore::PolicyContainer::isolatedCopy const):
(WebCore::PolicyContainer::isolatedCopy):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
(WebCore::ResourceRequestBase::targetAddressSpace const):
(WebCore::ResourceRequestBase::setTargetAddressSpace):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::m_ipAddressSpace):
(WebCore::ResourceResponseData::isolatedCopy const):
(WebCore::ResourceResponseBase::crossThreadData const):
(WebCore::ResourceResponseBase::fromCrossThreadData):
(WebCore::ResourceResponseBase::getResponseData const):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseData&gt;::decodeForPersistence):
(WebCore::m_type): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBase::ipAddressSpace):
(WebCore::ResourceResponseBase::setIPAddressSpace):
(WebCore::ResourceResponseData::ResourceResponseData):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressSpaceTests.cpp: Added.
(TestWebKitAPI::TEST(IPAddressSpace, IPv4Loopback)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4PrivateAddresses)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4CarrierGradeNAT)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4LinkLocal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4Benchmarking)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4PublicAddresses)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6Loopback)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6UniqueLocal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6LinkLocal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6MappedIPv4DottedDecimal)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6MappedIPv4HexNotation)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv6PublicAddresses)):
(TestWebKitAPI::TEST(IPAddressSpace, HostnameAddresses)):
(TestWebKitAPI::TEST(IPAddressSpace, EdgeCasesAndMalformed)):
(TestWebKitAPI::TEST(IPAddressSpace, UtilityFunctions)):
(TestWebKitAPI::TEST(IPAddressSpace, DifferentURLSchemes)):
(TestWebKitAPI::TEST(IPAddressSpace, URLsWithPorts)):
(TestWebKitAPI::TEST(IPAddressSpace, IPv4BoundaryConditions)):

Canonical link: <a href="https://commits.webkit.org/298921@main">https://commits.webkit.org/298921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3130ad07c4b0d5538c19806c7cb6177cc6a2f49b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116891 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66632 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109007 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126103 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115419 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97444 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97243 "Passed tests") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24796 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Checked out pull request; Reviewed by Alex Christensen; Failed to compile WebKit") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20511 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40186 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18698 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49272 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144118 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43143 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37115 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->