### PR TITLE
Update state if WKNavigationDelegate responds with WKNavigationActionPolicyCancel when RemoteFrames are being navigated

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -454,6 +454,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
         return makeUniqueRefWithoutRefCountedCheck<WebLocalFrameLoaderClient>(localFrame, frameLoader, WTFMove(protectedThis), makeInvalidator());
     };
     auto localFrame = parent ? LocalFrame::createProvisionalSubframe(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, parameters.scrollingMode, *parent, Ref { remoteFrame->frameTreeSyncData() }) : LocalFrame::createMainFrame(*corePage, WTFMove(clientCreator), m_frameID, parameters.effectiveSandboxFlags, nullptr, Ref { remoteFrame->frameTreeSyncData() });
+    ASSERT(!m_provisionalFrame);
     m_provisionalFrame = localFrame.ptr();
     m_frameIDBeforeProvisionalNavigation = parameters.frameIDBeforeProvisionalNavigation;
     localFrame->init();


### PR DESCRIPTION
#### 3ecc04282f35569923cd1629efadeaae7d84ee94
<pre>
Update state if WKNavigationDelegate responds with WKNavigationActionPolicyCancel when RemoteFrames are being navigated
<a href="https://bugs.webkit.org/show_bug.cgi?id=296461">https://bugs.webkit.org/show_bug.cgi?id=296461</a>
<a href="https://rdar.apple.com/116203453">rdar://116203453</a>

Reviewed by Alex Christensen.

After an investigation it was discovered that WKNavigationActionPolicyCancel and WKNavigationResponsePolicyCancel both call didFailProvisionalNavigation() or one of its variants, effectively cleaning up any cross process state pollution, even with site isolation enabled. This confirms cleanup by adding an assert on the existence of a provisional frame in createProvisionalFrame() and having a test which would trigger the assert as a fail condition.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, CancelNavigationResponseCleansUpProvisionalFrame)):
(TestWebKitAPI::TEST(SiteIsolation, CancelNavigationActionCleansUpProvisionalFrame)):

Canonical link: <a href="https://commits.webkit.org/298599@main">https://commits.webkit.org/298599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ba33b31e711a82479a0d6a9b5f485bc1e49d10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65830 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87423 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42299 "Too many flaky failures: fast/dom/Window/setTimeout-string-argument.html, fast/events/dispatch-message-string-data.html, fast/forms/change-input-type-in-focus-handler.html, fast/html/script-must-not-run-when-child-is-removed.html, fast/html/tab-order.html, fetch/fetch-worker-crash.html, imported/w3c/web-platform-tests/event-timing/event-click-counts.html, imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html, imported/w3c/web-platform-tests/wasm/core/utf8-import-field.wast.js.html, js/arrowfunction-block-1.html, js/call-apply-crash.html, js/dom/call-link-info-recursion.html, js/dom/callback-function-with-handle-event.html, performance-api/performance-mark-name.html, performance-api/performance-observer-exception.html, performance-api/performance-observer-nested.html, resize-observer/element-leak.html, resize-observer/modify-frametree-in-callback.html, resize-observer/multi-frames.html, storage/indexeddb/basics-workers.html, storage/indexeddb/basics.html, storage/indexeddb/keypath-intrinsic-properties.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image/tex-3d-r32f-red-float.html, webgl/2.0.0/conformance2/textures/image_data/tex-2d-rgb8-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/misc/active-3d-texture-bug.html, webgl/2.0.y/conformance2/extensions/nv-shader-noperspective-interpolation.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21408 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124355 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96223 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96008 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19050 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38026 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18539 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->