### PR TITLE
Enable `allowTestOnlyIPC` by default in WebKitTestRunner

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-paste-attachment.html
+++ b/LayoutTests/editing/pasteboard/copy-paste-attachment.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body>
 <div contenteditable="true" id="test1">This is a paragraph with an attachment

--- a/LayoutTests/fast/attachment/attachment-dom.html
+++ b/LayoutTests/fast/attachment/attachment-dom.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <head>
 <meta charset="utf-8">

--- a/LayoutTests/fast/attachment/attachment-folder-icon-expected.html
+++ b/LayoutTests/fast/attachment/attachment-folder-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment title=" "></attachment>

--- a/LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html
+++ b/LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/attachment-label-highlight.html
+++ b/LayoutTests/fast/attachment/attachment-label-highlight.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body>
 <script>

--- a/LayoutTests/fast/attachment/attachment-progress.html
+++ b/LayoutTests/fast/attachment/attachment-progress.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body>
 <attachment progress="-1.5"></attachment>

--- a/LayoutTests/fast/attachment/attachment-select-on-click-inside-user-select-all.html
+++ b/LayoutTests/fast/attachment/attachment-select-on-click-inside-user-select-all.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body onload="runTest()">
 <div style="-webkit-user-select: all;">text before <attachment id="attachment"></attachment> text after</div>

--- a/LayoutTests/fast/attachment/attachment-select-on-click.html
+++ b/LayoutTests/fast/attachment/attachment-select-on-click.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body onload="runTest()">
 <div id="container">text before <attachment id="attachment"></attachment> text after</div>

--- a/LayoutTests/fast/attachment/attachment-subtitle.html
+++ b/LayoutTests/fast/attachment/attachment-subtitle.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body>
 <attachment id="attachment" subtitle="1024 bytes"></attachment>

--- a/LayoutTests/fast/attachment/attachment-title.html
+++ b/LayoutTests/fast/attachment/attachment-title.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html>
 <body>
 <attachment id="attachment" title="overridden title" subtitle="1024 bytes"></attachment>

--- a/LayoutTests/fast/attachment/attachment-type-attribute-expected.html
+++ b/LayoutTests/fast/attachment/attachment-type-attribute-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment id="attachment" title="  "></attachment>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-dom.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-dom.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true  ] -->
 <html>
 <head>
 <meta charset="utf-8">

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-folder-icon-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-folder-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true  ] -->
 <html class="reftest-wait">
 <body>
 <attachment title=" "></attachment>

--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-icon-from-file-extension-expected.html
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-icon-from-file-extension-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true  ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/attachment-keynote-icon-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-keynote-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/attachment-numbers-icon-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-numbers-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/attachment-pages-icon-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-pages-icon-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment></attachment>

--- a/LayoutTests/fast/attachment/mac/wide-attachment-type-attribute-expected.html
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-type-attribute-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
 <html class="reftest-wait">
 <body>
 <attachment id="attachment" title="  "></attachment>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true  ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html
+++ b/LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
+++ b/LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/video-created-while-interrupted.html
+++ b/LayoutTests/fast/mediastream/video-created-while-interrupted.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/http/wpt/cache-storage/cache-quota-after-restart.any.html
+++ b/LayoutTests/http/wpt/cache-storage/cache-quota-after-restart.any.html
@@ -1,1 +1,1 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test --><!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: CTAP HID failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/ctap-hid-success.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-hid-success.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: CTAP HID success cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/ctap-nfc-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/ctap-nfc-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: CTAP NFC failure cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/idl.https.html
+++ b/LayoutTests/http/wpt/webauthn/idl.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!doctype html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <html>
 <head>
     <meta charset=utf-8>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] silent failure cases with a mock local authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock local authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock ccid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock local authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[create]] success cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-cross-origin.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-cross-origin.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <script>
     if (window.testRunner) {
         testRunner.dumpAsText();

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock hid authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] failure cases.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock nfc authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] success cases with a mock u2f authenticator.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-with-invalid-parameters.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-with-invalid-parameters.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <title>Web Authentication API: PublicKeyCredential's [[get]] with invalid parameters.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-ip-address.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-ip-address.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=true ] -->
 <script>
     if (window.testRunner) {
         testRunner.dumpAsText();

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html
+++ b/LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ WebAuthenticationModernEnabled=false ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html
+++ b/LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <title>Web Authentication API: Invoke PublicKeyCredential in ip addresses.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/ipc/restrictedendpoints/allow-access-testOnlyIPC.html
+++ b/LayoutTests/ipc/restrictedendpoints/allow-access-testOnlyIPC.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false allowTestOnlyIPC=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false ] -->
 <title>Test that calling a message which should be blocked behind AllowTestOnlyIPC is allowed if AllowTestOnlyIPC is set</title>
 <script src="../../resources/ipc.js"></script>
 <script src="../../resources/testharness.js"></script>

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-testOnlyIPC.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-testOnlyIPC.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false allowTestOnlyIPC=false ] -->
 <title>Test that calling a message which should be blocked behind AllowTestOnlyIPC kills the calling process if AllowTestOnlyIPC isn't set</title>
 <script src="../../resources/ipc.js"></script>
 <script src="../../resources/testharness.js"></script>

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false allowTestOnlyIPC=false ] -->
 <title>Test that calling updateQuotaBasedOnSpaceUsageForTesting (which should be blocked behind AllowTestOnlyIPC) kills the calling process if AllowTestOnlyIPC isn't set</title>
 <script src="../../resources/ipc.js"></script>
 <script src="../../resources/testharness.js"></script>

--- a/LayoutTests/media/audio-play-with-video-element-interrupted.html
+++ b/LayoutTests/media/audio-play-with-video-element-interrupted.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
     <script src="media-file.js"></script>

--- a/LayoutTests/media/audioSession/audioSessionState.html
+++ b/LayoutTests/media/audioSession/audioSessionState.html
@@ -1,4 +1,4 @@
-<!doctype html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/media/audioSession/ios/audioSessionState-getUserMedia.html
+++ b/LayoutTests/media/audioSession/ios/audioSessionState-getUserMedia.html
@@ -1,4 +1,4 @@
-<!doctype html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!doctype html>
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html
+++ b/LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
     <head>
         <script src="../video-test.js"></script>

--- a/LayoutTests/media/media-source/media-source-video-renders.html
+++ b/LayoutTests/media/media-source/media-source-video-renders.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="fuzzy" content="maxDifference=0-39; totalPixels=0-180000" />

--- a/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
+++ b/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<!DOCTYPE html>
 <html>
     <head>
         <title>override interruption with getUserMedia</title>

--- a/LayoutTests/platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html
+++ b/LayoutTests/platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true SWVPDecodersAlwaysEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [  SWVPDecodersAlwaysEnabled=true ] -->
 <html>
 <head>
     <script src=../../../../media/video-test.js></script>

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1000,8 +1000,8 @@ WKRetainPtr<WKPageConfigurationRef> TestController::generatePageConfiguration(co
         WKPageConfigurationSetWebsiteDataStore(pageConfiguration.get(), ephemeralDataStore.get());
     }
 
-    if (options.allowTestOnlyIPC())
-        WKPageConfigurationSetAllowTestOnlyIPC(pageConfiguration.get(), true);
+    if (!options.allowTestOnlyIPC())
+        WKPageConfigurationSetAllowTestOnlyIPC(pageConfiguration.get(), false);
     WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(pageConfiguration.get(), true);
 
     m_userContentController = adoptWK(WKUserContentControllerCreate());

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -174,7 +174,7 @@ const TestFeatures& TestOptions::defaults()
         };
         features.boolTestRunnerFeatures = {
             { "allowsLinkPreview", true },
-            { "allowTestOnlyIPC", false },
+            { "allowTestOnlyIPC", true },
             { "appHighlightsEnabled", false },
             { "dumpJSConsoleLogInStdErr", false },
             { "editable", false },


### PR DESCRIPTION
#### 76f47310b1f9adb667320466851c198940980c12
<pre>
Enable `allowTestOnlyIPC` by default in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=296722">https://bugs.webkit.org/show_bug.cgi?id=296722</a>
<a href="https://rdar.apple.com/157159935">rdar://157159935</a>

Reviewed by NOBODY (OOPS!).

Some imported tests might require allowTestOnlyIPC to be enabled. If each layout test must explicitly
specify it, the setting will be lost when the tests are re-imported. Let&apos;s just enable it by default in
WKTR.

* LayoutTests/editing/pasteboard/copy-paste-attachment.html:
* LayoutTests/fast/attachment/attachment-dom.html:
* LayoutTests/fast/attachment/attachment-folder-icon-expected.html:
* LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html:
* LayoutTests/fast/attachment/attachment-label-highlight.html:
* LayoutTests/fast/attachment/attachment-progress.html:
* LayoutTests/fast/attachment/attachment-select-on-click-inside-user-select-all.html:
* LayoutTests/fast/attachment/attachment-select-on-click.html:
* LayoutTests/fast/attachment/attachment-subtitle.html:
* LayoutTests/fast/attachment/attachment-title.html:
* LayoutTests/fast/attachment/attachment-type-attribute-expected.html:
* LayoutTests/fast/attachment/cocoa/wide-attachment-dom.html:
* LayoutTests/fast/attachment/cocoa/wide-attachment-folder-icon-expected.html:
* LayoutTests/fast/attachment/cocoa/wide-attachment-icon-from-file-extension-expected.html:
* LayoutTests/fast/attachment/mac/attachment-keynote-icon-expected.html:
* LayoutTests/fast/attachment/mac/attachment-numbers-icon-expected.html:
* LayoutTests/fast/attachment/mac/attachment-pages-icon-expected.html:
* LayoutTests/fast/attachment/mac/wide-attachment-type-attribute-expected.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html:
* LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html:
* LayoutTests/fast/mediastream/microphone-interruption-and-audio-session.html:
* LayoutTests/fast/mediastream/video-created-while-interrupted.html:
* LayoutTests/http/wpt/cache-storage/cache-quota-after-restart.any.html:
* LayoutTests/http/wpt/webauthn/ctap-hid-failure.https.html:
* LayoutTests/http/wpt/webauthn/ctap-hid-success.https.html:
* LayoutTests/http/wpt/webauthn/ctap-nfc-failure.https.html:
* LayoutTests/http/wpt/webauthn/idl.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-local.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-nfc.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-u2f.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-ccid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-u2f.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-cross-origin.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-local.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-nfc.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-ccid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-local.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-nfc.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-with-invalid-parameters.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-ip-address.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html:
* LayoutTests/http/wpt/webauthn/resources/public-key-credential-cross-origin.https.html:
* LayoutTests/http/wpt/webauthn/resources/public-key-credential-ip-address.https.html:
* LayoutTests/ipc/restrictedendpoints/allow-access-testOnlyIPC.html:
* LayoutTests/ipc/restrictedendpoints/deny-access-testOnlyIPC.html:
* LayoutTests/ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html:
* LayoutTests/media/audio-play-with-video-element-interrupted.html:
* LayoutTests/media/audioSession/audioSessionState.html:
* LayoutTests/media/audioSession/ios/audioSessionState-getUserMedia.html:
* LayoutTests/media/media-source/media-source-istypesupported-vp8-without-vp9.html:
* LayoutTests/media/media-source/media-source-video-renders.html:
* LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html:
* LayoutTests/platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::generatePageConfiguration):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76f47310b1f9adb667320466851c198940980c12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/115989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86715 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20603 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/63967 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123489 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41125 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30645 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-screenx-screeny.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95551 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41503 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98690 "Exiting early after 10 failures. 5277 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95334 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18279 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41005 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43922 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->