### PR TITLE
[SVG] Refactoring accumulate logic for animateMotion

### DIFF
--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -185,19 +185,6 @@ bool SVGAnimateMotionElement::setToAtEndOfDurationValue(const String& toAtEndOfD
     return true;
 }
 
-void SVGAnimateMotionElement::buildTransformForProgress(AffineTransform* transform, float percentage)
-{
-    ASSERT(!m_animationPath.isEmpty());
-
-    float positionOnPath = m_animationPath.length() * percentage;
-    auto traversalState(m_animationPath.traversalStateAtLength(positionOnPath));
-    if (!traversalState.success())
-        return;
-
-    FloatPoint position = traversalState.current();
-    transform->translate(position);
-}
-
 void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned repeatCount)
 {
     RefPtr targetElement = this->targetElement();
@@ -226,15 +213,23 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
         return;
     }
 
-    buildTransformForProgress(transform, percentage);
+    ASSERT(!m_animationPath.isEmpty());
+    float positionOnPath = m_animationPath.length() * percentage;
+    auto traversalState = m_animationPath.traversalStateAtLength(positionOnPath);
+    if (!traversalState.success())
+        return;
+    FloatPoint position = traversalState.current();
+    transform->translate(position);
 
     // Handle accumulate="sum".
     if (isAccumulated() && repeatCount) {
-        for (unsigned i = 0; i < repeatCount; ++i)
-            buildTransformForProgress(transform, 1);
+        float pathLength = m_animationPath.length();
+        auto endTraversalState = m_animationPath.traversalStateAtLength(pathLength);
+        if (endTraversalState.success()) {
+            FloatPoint endPoint = endTraversalState.current();
+            transform->translate(endPoint.x() * repeatCount, endPoint.y() * repeatCount);
+        }
     }
-    float positionOnPath = m_animationPath.length() * percentage;
-    auto traversalState(m_animationPath.traversalStateAtLength(positionOnPath));
 
     // The 'angle' below is in 'degrees'.
     float angle = traversalState.normalAngle();

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -57,7 +57,6 @@ private:
         RotateAutoReverse
     };
     RotateMode rotateMode() const;
-    void buildTransformForProgress(AffineTransform*, float percentage);
 
     void updateAnimationMode() override;
     void childrenChanged(const ChildChange&) final;


### PR DESCRIPTION
#### 9e9fd42c96c3a2c66beb6224e3d932b9b923ff3e
<pre>
[SVG] Refactoring accumulate logic for animateMotion
<a href="https://bugs.webkit.org/show_bug.cgi?id=296723">https://bugs.webkit.org/show_bug.cgi?id=296723</a>

Reviewed by NOBODY (OOPS!).

Inspired by: <a href="https://chromium.googlesource.com/chromium/src/+/629e8ce3ef3deaf9b8fe705aba73061f7b2caa05">https://chromium.googlesource.com/chromium/src/+/629e8ce3ef3deaf9b8fe705aba73061f7b2caa05</a>

This removes helper function `buildTransformForProgress`, which only had
one use case and inlines the logic near call site. This patch is just
simpification of accumulate logic and paves way for future work.

* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::calculateAnimatedValue):
(WebCore::SVGAnimateMotionElement::buildTransformForProgress): Deleted.
* Source/WebCore/svg/SVGAnimateMotionElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e9fd42c96c3a2c66beb6224e3d932b9b923ff3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86746 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41846 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20642 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95581 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95364 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18317 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46549 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->