### PR TITLE
[css-anchor-position-1] Implement position-try for pseudo-elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-backdrop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-backdrop-expected.txt
@@ -1,5 +1,5 @@
 Anchor
 Dialog
 
-FAIL ::backdrop can use position-try-fallbacks assert_equals: expected "300px" but got "9999px"
+PASS ::backdrop can use position-try-fallbacks
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-pseudo-element-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL ::before using second fallback assert_equals: expected "0px" but got "200px"
-FAIL ::after using first fallback assert_equals: expected "100px" but got "0px"
+PASS ::before using second fallback
+PASS ::after using first fallback
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -99,7 +99,7 @@ private:
 
     HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
-    std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree);
+    std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree, const RenderStyle*);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&);
     std::optional<ResolvedStyle> resolveAncestorFirstLinePseudoElement(Element&, const ElementUpdate&);
     std::optional<ResolvedStyle> resolveAncestorFirstLetterPseudoElement(Element&, const ElementUpdate&, ResolutionContext&);
@@ -219,7 +219,7 @@ private:
         bool sorted { false };
         bool chosen { false };
     };
-    HashMap<Ref<Element>, PositionOptions> m_positionOptions;
+    HashMap<AnchorPositionedKey, PositionOptions> m_positionOptions;
 
     HashSet<AtomString> m_changedAnchorNames;
     bool m_allAnchorNamesInvalid { false };


### PR DESCRIPTION
#### cd3003ccda41c24e8dafffe9cbbeee04f8556c6b
<pre>
[css-anchor-position-1] Implement position-try for pseudo-elements
<a href="https://rdar.apple.com/156550553">rdar://156550553</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296410">https://bugs.webkit.org/show_bug.cgi?id=296410</a>

Reviewed by Antti Koivisto.

Implement position-try for pseudo elements. This involves changing the
position-try code to use AnchorPositionedKey to uniquely identify the
pseudo-element, and adding code to generate and try position-try options
for pseudo-elements. Currently, only ::before/::after/::backdrops are
supported; they&apos;re covered by WPT tests and can be tested.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-backdrop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-pseudo-element-expected.txt:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
   - Pipe the existing pseudo-element styles to TreeResolver::resolvePseudoElement

(WebCore::Style::TreeResolver::resolvePseudoElement):
    - Add a new parameter for the existing style of the pseudo-element.
    - Generate and try position-try options if the pseudo-element is ::before/::after/::backdrop

(WebCore::Style::TreeResolver::resolve):
    - Change the loop through m_positionOptions to accommodate the new key type.

(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
    - Use AnchorPositionedKey as the key of the the generated position option.

(WebCore::Style::TreeResolver::tryChoosePositionOption):
    - Use AnchorPositionedKey to lookup the generated position option.

* Source/WebCore/style/StyleTreeResolver.h:
    - m_positionOptions is now keyed by AnchorPositionedKey to support
      storing position-try options for pseudo-elements.

Canonical link: <a href="https://commits.webkit.org/298519@main">https://commits.webkit.org/298519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4086a6d7b8adf54350073d8296185b6b3e1012e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65480 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27b45d4c-9193-4f7e-8a7f-bc8e9527502b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87187 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42119 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d5cf1f4-435f-4c18-83bf-29db484c2c48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67575 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64541 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97330 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124073 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37791 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47108 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41173 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44478 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->