### PR TITLE
[WebGPU] After 32 timestamp queries are created, subsequent query sets may fail to create

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -234,9 +234,9 @@ static auto timestampWriteIndex(auto writeIndex)
     return writeIndex == WGPU_QUERY_SET_INDEX_UNDEFINED ? 0 : writeIndex;
 }
 #if !ENABLE(WEBGPU_SWIFT)
-static NSUInteger timestampWriteIndex(NSUInteger writeIndex, NSUInteger defaultValue)
+static NSUInteger timestampWriteIndex(NSUInteger writeIndex, NSUInteger defaultValue, uint32_t offset)
 {
-    return writeIndex == WGPU_QUERY_SET_INDEX_UNDEFINED ? defaultValue : writeIndex;
+    return writeIndex == WGPU_QUERY_SET_INDEX_UNDEFINED ? defaultValue : (writeIndex + offset);
 }
 
 static NSString* errorValidatingTimestampWrites(const auto& timestampWrites, const CommandEncoder& commandEncoder)
@@ -290,19 +290,19 @@ Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDe
 
     MTLComputePassDescriptor* computePassDescriptor = [MTLComputePassDescriptor new];
     computePassDescriptor.dispatchType = MTLDispatchTypeSerial;
-    id<MTLCounterSampleBuffer> counterSampleBuffer;
+    std::pair<id<MTLCounterSampleBuffer>, uint32_t> counterSampleBuffer;
     if (auto* wgpuTimestampWrites = descriptor.timestampWrites) {
         Ref timestampWrites = protectedFromAPI(wgpuTimestampWrites->querySet);
-        counterSampleBuffer = timestampWrites->counterSampleBuffer();
+        counterSampleBuffer = timestampWrites->counterSampleBufferWithOffset();
         timestampWrites->setCommandEncoder(*this);
     }
 
-    if (m_device->enableEncoderTimestamps() || counterSampleBuffer) {
+    if (m_device->enableEncoderTimestamps() || counterSampleBuffer.first) {
         auto* timestampWrites = descriptor.timestampWrites;
-        computePassDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer ?: m_device->timestampsBuffer(m_commandBuffer, 2);
-        computePassDescriptor.sampleBufferAttachments[0].startOfEncoderSampleIndex = timestampWrites ? timestampWriteIndex(timestampWrites->beginningOfPassWriteIndex, MTLCounterDontSample) : 0;
-        computePassDescriptor.sampleBufferAttachments[0].endOfEncoderSampleIndex = timestampWrites ? timestampWriteIndex(timestampWrites->endOfPassWriteIndex, MTLCounterDontSample) : 1;
-        m_device->trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer);
+        computePassDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer.first ?: m_device->timestampsBuffer(m_commandBuffer, 2);
+        computePassDescriptor.sampleBufferAttachments[0].startOfEncoderSampleIndex = timestampWrites ? timestampWriteIndex(timestampWrites->beginningOfPassWriteIndex, MTLCounterDontSample, counterSampleBuffer.second) : 0;
+        computePassDescriptor.sampleBufferAttachments[0].endOfEncoderSampleIndex = timestampWrites ? timestampWriteIndex(timestampWrites->endOfPassWriteIndex, MTLCounterDontSample, counterSampleBuffer.second) : 1;
+        m_device->trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer.first);
     }
 
     id<MTLComputeCommandEncoder> computeCommandEncoder = [m_commandBuffer computeCommandEncoderWithDescriptor:computePassDescriptor];
@@ -540,21 +540,21 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         return RenderPassEncoder::createInvalid(*this, m_device, @"command buffer has already been committed");
 
     MTLRenderPassDescriptor* mtlDescriptor = [MTLRenderPassDescriptor new];
-    id<MTLCounterSampleBuffer> counterSampleBuffer;
+    std::pair<id<MTLCounterSampleBuffer>, uint32_t> counterSampleBuffer;
     if (auto* wgpuTimestampWrites = descriptor.timestampWrites) {
         Ref timestampWrites = protectedFromAPI(wgpuTimestampWrites->querySet);
         timestampWrites->setCommandEncoder(*this);
-        counterSampleBuffer = timestampWrites->counterSampleBuffer();
+        counterSampleBuffer = timestampWrites->counterSampleBufferWithOffset();
     }
 
-    if (m_device->enableEncoderTimestamps() || counterSampleBuffer) {
-        if (counterSampleBuffer) {
-            mtlDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer;
-            mtlDescriptor.sampleBufferAttachments[0].startOfVertexSampleIndex = timestampWriteIndex(descriptor.timestampWrites->beginningOfPassWriteIndex, MTLCounterDontSample);
-            mtlDescriptor.sampleBufferAttachments[0].endOfVertexSampleIndex = timestampWriteIndex(descriptor.timestampWrites->endOfPassWriteIndex, MTLCounterDontSample);
-            mtlDescriptor.sampleBufferAttachments[0].startOfFragmentSampleIndex = timestampWriteIndex(descriptor.timestampWrites->endOfPassWriteIndex, MTLCounterDontSample);
-            mtlDescriptor.sampleBufferAttachments[0].endOfFragmentSampleIndex = timestampWriteIndex(descriptor.timestampWrites->endOfPassWriteIndex, MTLCounterDontSample);
-            m_device->trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer);
+    if (m_device->enableEncoderTimestamps() || counterSampleBuffer.first) {
+        if (counterSampleBuffer.first) {
+            mtlDescriptor.sampleBufferAttachments[0].sampleBuffer = counterSampleBuffer.first;
+            mtlDescriptor.sampleBufferAttachments[0].startOfVertexSampleIndex = timestampWriteIndex(descriptor.timestampWrites->beginningOfPassWriteIndex, MTLCounterDontSample, counterSampleBuffer.second);
+            mtlDescriptor.sampleBufferAttachments[0].endOfVertexSampleIndex = timestampWriteIndex(descriptor.timestampWrites->endOfPassWriteIndex, MTLCounterDontSample, counterSampleBuffer.second);
+            mtlDescriptor.sampleBufferAttachments[0].startOfFragmentSampleIndex = timestampWriteIndex(descriptor.timestampWrites->endOfPassWriteIndex, MTLCounterDontSample, counterSampleBuffer.second);
+            mtlDescriptor.sampleBufferAttachments[0].endOfFragmentSampleIndex = timestampWriteIndex(descriptor.timestampWrites->endOfPassWriteIndex, MTLCounterDontSample, counterSampleBuffer.second);
+            m_device->trackTimestampsBuffer(m_commandBuffer, counterSampleBuffer.first);
         } else {
             mtlDescriptor.sampleBufferAttachments[0].sampleBuffer = m_device->timestampsBuffer(m_commandBuffer, 4);
             mtlDescriptor.sampleBufferAttachments[0].startOfVertexSampleIndex = 0;
@@ -2245,7 +2245,8 @@ void CommandEncoder::resolveQuerySet(const QuerySet& querySet, uint32_t firstQue
         [m_commandBuffer encodeSignalEvent:workaround value:1];
         [m_commandBuffer encodeWaitForEvent:workaround value:1];
         ensureBlitCommandEncoder();
-        [m_blitCommandEncoder resolveCounters:querySet.counterSampleBuffer() inRange:NSMakeRange(firstQuery, queryCount) destinationBuffer:destination.buffer() destinationOffset:destinationOffset];
+        std::pair<id<MTLCounterSampleBuffer>, uint32_t> counterSampleBuffer = querySet.counterSampleBufferWithOffset();
+        [m_blitCommandEncoder resolveCounters:counterSampleBuffer.first inRange:NSMakeRange(firstQuery + counterSampleBuffer.second, queryCount) destinationBuffer:destination.buffer() destinationOffset:destinationOffset];
         break;
     }
     default:


### PR DESCRIPTION
#### 282946c99a9fd53e71c89aab62d7fa76a474c23a
<pre>
[WebGPU] After 32 timestamp queries are created, subsequent query sets may fail to create
<a href="https://bugs.webkit.org/show_bug.cgi?id=296646">https://bugs.webkit.org/show_bug.cgi?id=296646</a>
<a href="https://rdar.apple.com/157045167">rdar://157045167</a>

Reviewed by Dan Glastonbury.

Metal has a per-process limit of 32 MTLCounterSampleBuffers
as documented at <a href="https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf">https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf</a>

Several sites or a single site could easily surprass this limit.

However, we can create MTLCounterSampleBuffer instances of size 32kb, but
generally only 16 bytes can be used per render pass. So we can sub-divide
the thirty-two 32kb buffers into 65k &apos;seperate&apos; counter sample buffers.

Increasing the limit from 32 -&gt; 65536 considerably mitigates the issue.

Tests: existing timestamp CTS tests continue to pass.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::timestampWriteIndex):
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::resolveQuerySet):
* Source/WebGPU/WebGPU/QuerySet.h:
(WebGPU::QuerySet::create):
(WebGPU::QuerySet::counterSampleBuffer const):
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
(WebGPU::QuerySet::QuerySet):
(WebGPU::QuerySet::~QuerySet):
(WebGPU::QuerySet::isValid const):
(WebGPU::QuerySet::destroy):
(WebGPU::QuerySet::setCommandEncoder const):
(WebGPU::QuerySet::counterSampleBufferWithOffset const):
(WebGPU::QuerySet::destroyQuerySet):
(WebGPU::QuerySet::counterSampleBufferWithOffset):
(WebGPU::QuerySet::createContainersIfNeeded):

Canonical link: <a href="https://commits.webkit.org/298300@main">https://commits.webkit.org/298300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39c30d4b5bb972f25557b2fd6b3511aebaf9cb5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65630 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f0dccaa-e647-4968-a84a-f50cb42d158e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d4070be-787e-4284-b0bc-13039c6ce212) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67755 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27325 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64745 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124283 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37974 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47355 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->