### PR TITLE
SharedBufferBuilder::take() should return a contiguous SharedBuffer if it only contains a single DataSegment.

### DIFF
--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -97,6 +97,9 @@ struct RemoveSmartPointerHelper<T, Ref<Pointee>> {
 template<typename T>
 struct RemoveSmartPointer : detail::RemoveSmartPointerHelper<T, std::remove_cv_t<T>> { };
 
+template<typename T>
+using RemoveCVSmartPointer = std::remove_cvref_t<typename RemoveSmartPointer<T>::type>;
+
 // HasRefPtrMemberFunctions implementation
 namespace detail {
 

--- a/Source/WebCore/Modules/highlight/AppHighlight.h
+++ b/Source/WebCore/Modules/highlight/AppHighlight.h
@@ -38,7 +38,7 @@ enum class CreateNewGroupForHighlight : bool { No, Yes };
 enum class HighlightRequestOriginatedInApp : bool { No, Yes };
 
 struct AppHighlight {
-    Ref<WebCore::FragmentedSharedBuffer> highlight;
+    Ref<WebCore::SharedBuffer> highlight;
     std::optional<String> text;
     CreateNewGroupForHighlight isNewGroup;
     HighlightRequestOriginatedInApp requestOriginatedInApp;
@@ -51,7 +51,7 @@ namespace IPC {
 template<typename AsyncReplyResult> struct AsyncReplyError;
 
 template<> struct AsyncReplyError<WebCore::AppHighlight> {
-    static WebCore::AppHighlight create() { return { WebCore::FragmentedSharedBuffer::create(), std::nullopt, WebCore::CreateNewGroupForHighlight::No, WebCore::HighlightRequestOriginatedInApp::No }; }
+    static WebCore::AppHighlight create() { return { WebCore::SharedBuffer::create(), std::nullopt, WebCore::CreateNewGroupForHighlight::No, WebCore::HighlightRequestOriginatedInApp::No }; }
 };
 
 } // namespace IPC

--- a/Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp
@@ -46,16 +46,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AppHighlightRangeData);
 
-std::optional<AppHighlightRangeData> AppHighlightRangeData::create(const FragmentedSharedBuffer& buffer)
+std::optional<AppHighlightRangeData> AppHighlightRangeData::create(const SharedBuffer& buffer)
 {
-    auto contiguousBuffer = buffer.makeContiguous();
-    auto decoder = contiguousBuffer->decoder();
+    auto decoder = buffer.decoder();
     std::optional<AppHighlightRangeData> data;
     decoder >> data;
     return data;
 }
 
-Ref<FragmentedSharedBuffer> AppHighlightRangeData::toSharedBuffer() const
+Ref<SharedBuffer> AppHighlightRangeData::toSharedBuffer() const
 {
     WTF::Persistence::Encoder encoder;
     encoder << *this;

--- a/Source/WebCore/Modules/highlight/AppHighlightRangeData.h
+++ b/Source/WebCore/Modules/highlight/AppHighlightRangeData.h
@@ -34,12 +34,12 @@ namespace WebCore {
 
 #if ENABLE(APP_HIGHLIGHTS)
 
-class FragmentedSharedBuffer;
+class SharedBuffer;
 
 class AppHighlightRangeData {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(AppHighlightRangeData, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT static std::optional<AppHighlightRangeData> create(const FragmentedSharedBuffer&);
+    WEBCORE_EXPORT static std::optional<AppHighlightRangeData> create(const SharedBuffer&);
     struct NodePathComponent {
         String identifier;
         String nodeName;
@@ -98,7 +98,7 @@ public:
     const NodePath& endContainer() const { return m_endContainer; }
     uint32_t endOffset() const { return m_endOffset; }
 
-    Ref<FragmentedSharedBuffer> toSharedBuffer() const;
+    Ref<SharedBuffer> toSharedBuffer() const;
 
 private:
     String m_identifier;

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -252,7 +252,7 @@ void AppHighlightStorage::storeAppHighlight(Ref<StaticRange>&& range, Completion
     completionHandler(WTFMove(highlight));
 }
 
-void AppHighlightStorage::restoreAndScrollToAppHighlight(Ref<FragmentedSharedBuffer>&& buffer, ScrollToHighlight scroll)
+void AppHighlightStorage::restoreAndScrollToAppHighlight(Ref<SharedBuffer>&& buffer, ScrollToHighlight scroll)
 {
     auto appHighlightRangeData = AppHighlightRangeData::create(buffer);
     if (!appHighlightRangeData)

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.h
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.h
@@ -56,7 +56,7 @@ public:
     ~AppHighlightStorage();
 
     WEBCORE_EXPORT void storeAppHighlight(Ref<StaticRange>&&, CompletionHandler<void(AppHighlight&&)>&&);
-    WEBCORE_EXPORT void restoreAndScrollToAppHighlight(Ref<FragmentedSharedBuffer>&&, ScrollToHighlight);
+    WEBCORE_EXPORT void restoreAndScrollToAppHighlight(Ref<SharedBuffer>&&, ScrollToHighlight);
     void restoreUnrestoredAppHighlights();
 
     bool shouldRestoreHighlights(MonotonicTime timestamp);

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp
@@ -357,7 +357,7 @@ void MediaRecorder::fetchData(FetchDataCallback&& callback, TakePrivateRecorder 
         pendingActivity->object().m_isFetchingData = false;
         callback(pendingActivity->object(), WTFMove(buffer), mimeType, timeCode);
         for (auto& task : std::exchange(pendingActivity->object().m_pendingFetchDataTasks, { }))
-            task(pendingActivity->object(), FragmentedSharedBuffer::create(), mimeType, timeCode);
+            task(pendingActivity->object(), SharedBuffer::create(), mimeType, timeCode);
     });
 }
 

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -63,7 +63,7 @@ public:
         if (!m_buffer->isContiguous())
             m_buffer = RefPtr { m_buffer }->makeContiguous();
 
-        return Ref { downcast<SharedBuffer>(*m_buffer) }->span().data();
+        return downcast<SharedBuffer>(m_buffer)->span().data();
     }
 
     void lockUnderlyingBufferImpl() final

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -454,11 +454,11 @@ void Editor::insertMultiRepresentationHEIC(const std::span<const uint8_t>& data,
     Ref document = this->document();
 
     String primaryType = "image/x-apple-adaptive-glyph"_s;
-    auto primaryBuffer = FragmentedSharedBuffer::create(data);
+    Ref primaryBuffer = SharedBuffer::create(data);
 
     String fallbackType = "image/png"_s;
     auto fallbackData = encodeData(fallbackImageForMultiRepresentationHEIC(data).get(), fallbackType, std::nullopt);
-    auto fallbackBuffer = FragmentedSharedBuffer::create(WTFMove(fallbackData));
+    Ref fallbackBuffer = SharedBuffer::create(WTFMove(fallbackData));
 
     auto picture = HTMLPictureElement::create(HTMLNames::pictureTag, document);
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -835,7 +835,7 @@ bool DocumentLoader::tryLoadingRequestFromApplicationCache()
 void DocumentLoader::setRedirectionAsSubstituteData(ResourceResponse&& response)
 {
     ASSERT(response.isRedirection());
-    m_substituteData = { FragmentedSharedBuffer::create(), { }, WTFMove(response), SubstituteData::SessionHistoryVisibility::Visible };
+    m_substituteData = { SharedBuffer::create(), { }, WTFMove(response), SubstituteData::SessionHistoryVisibility::Visible };
 }
 
 bool DocumentLoader::tryLoadingSubstituteData()

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -61,36 +61,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedBufferBuilder);
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create()
-{
-    return adoptRef(*new FragmentedSharedBuffer);
-}
-
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(std::span<const uint8_t> data)
-{
-    return adoptRef(*new FragmentedSharedBuffer(data));
-}
-
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(FileSystem::MappedFileData&& mappedFileData)
-{
-    return adoptRef(*new FragmentedSharedBuffer(WTFMove(mappedFileData)));
-}
-
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(Ref<SharedBuffer>&& buffer)
-{
-    return adoptRef(*new FragmentedSharedBuffer(WTFMove(buffer)));
-}
-
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(Vector<uint8_t>&& vector)
-{
-    return adoptRef(*new FragmentedSharedBuffer(WTFMove(vector)));
-}
-
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(DataSegment::Provider&& provider)
-{
-    return adoptRef(*new FragmentedSharedBuffer(WTFMove(provider)));
-}
-
 std::optional<Ref<FragmentedSharedBuffer>> FragmentedSharedBuffer::fromIPCData(IPCData&& ipcData)
 {
     return WTF::switchOn(WTFMove(ipcData), [](Vector<std::span<const uint8_t>>&& data) -> std::optional<Ref<FragmentedSharedBuffer>> {
@@ -125,35 +95,12 @@ std::optional<Ref<FragmentedSharedBuffer>> FragmentedSharedBuffer::fromIPCData(I
 
 FragmentedSharedBuffer::FragmentedSharedBuffer() = default;
 
-FragmentedSharedBuffer::FragmentedSharedBuffer(FileSystem::MappedFileData&& fileData)
-    : m_size(fileData.size())
+FragmentedSharedBuffer::FragmentedSharedBuffer(Ref<const DataSegment>&& segment, Contiguous contiguous)
+    : m_size(segment->size())
+    , m_segments(DataSegmentVector::from(DataSegmentVectorEntry { 0, WTFMove(segment) }))
+    , m_contiguous(contiguous == Contiguous::Yes)
 {
-    m_segments.append({ 0, DataSegment::create(WTFMove(fileData)) });
 }
-
-FragmentedSharedBuffer::FragmentedSharedBuffer(DataSegment::Provider&& provider)
-    : m_size(provider.span().size())
-{
-    m_segments.append({ 0, DataSegment::create(WTFMove(provider)) });
-}
-
-FragmentedSharedBuffer::FragmentedSharedBuffer(Ref<SharedBuffer>&& buffer)
-{
-    append(WTFMove(buffer));
-}
-
-#if USE(GSTREAMER)
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(GstMappedOwnedBuffer& mappedBuffer)
-{
-    return adoptRef(*new FragmentedSharedBuffer(mappedBuffer));
-}
-
-FragmentedSharedBuffer::FragmentedSharedBuffer(GstMappedOwnedBuffer& mappedBuffer)
-    : m_size(mappedBuffer.size())
-{
-    m_segments.append({ 0, DataSegment::create(&mappedBuffer) });
-}
-#endif
 
 static Vector<uint8_t> combineSegmentsData(const FragmentedSharedBuffer::DataSegmentVector& segments, size_t size)
 {
@@ -283,7 +230,7 @@ RefPtr<ArrayBuffer> FragmentedSharedBuffer::tryCreateArrayBuffer() const
 
 void FragmentedSharedBuffer::append(const FragmentedSharedBuffer& data)
 {
-    ASSERT(!m_contiguous);
+    ASSERT(!m_contiguous || segmentsCount() + data.segmentsCount() <= 1);
     m_segments.appendContainerWithMapping(data.m_segments, [&](auto& element) {
         DataSegmentVectorEntry entry { m_size, element.segment.copyRef() };
         m_size += element.segment->size();
@@ -294,7 +241,7 @@ void FragmentedSharedBuffer::append(const FragmentedSharedBuffer& data)
 
 void FragmentedSharedBuffer::append(std::span<const uint8_t> data)
 {
-    ASSERT(!m_contiguous);
+    ASSERT(!m_contiguous || !segmentsCount());
     m_segments.append({ m_size, DataSegment::create(data) });
     m_size += data.size();
     ASSERT(internallyConsistent());
@@ -302,7 +249,7 @@ void FragmentedSharedBuffer::append(std::span<const uint8_t> data)
 
 void FragmentedSharedBuffer::append(Vector<uint8_t>&& data)
 {
-    ASSERT(!m_contiguous);
+    ASSERT(!m_contiguous || !segmentsCount());
     auto dataSize = data.size();
     m_segments.append({ m_size, DataSegment::create(WTFMove(data)) });
     m_size += dataSize;
@@ -451,6 +398,8 @@ void FragmentedSharedBuffer::copyTo(std::span<uint8_t> destination, size_t offse
 #if ASSERT_ENABLED
 bool FragmentedSharedBuffer::internallyConsistent() const
 {
+    if (isContiguous() && segmentsCount() > 1)
+        return false;
     size_t position = 0;
     for (const auto& element : m_segments) {
         if (element.beginPosition != position)
@@ -516,32 +465,42 @@ bool FragmentedSharedBuffer::operator==(const FragmentedSharedBuffer& other) con
     return true;
 }
 
-SharedBuffer::SharedBuffer()
-{
-    m_contiguous = true;
-}
-
 SharedBuffer::SharedBuffer(Ref<const DataSegment>&& segment)
+    : FragmentedSharedBuffer(WTFMove(segment))
 {
-    m_size = segment->size();
-    m_segments.append({ 0, WTFMove(segment) });
-    m_contiguous = true;
 }
 
-SharedBuffer::SharedBuffer(Ref<FragmentedSharedBuffer>&& contiguousBuffer)
+SharedBuffer::SharedBuffer(FileSystem::MappedFileData&& fileData)
+    : FragmentedSharedBuffer(DataSegment::create(WTFMove(fileData)))
 {
-    ASSERT(contiguousBuffer->hasOneSegment() || contiguousBuffer->isEmpty());
-    m_size = contiguousBuffer->size();
-    if (contiguousBuffer->hasOneSegment())
-        m_segments.append({ 0, contiguousBuffer->m_segments[0].segment.copyRef() });
-    m_contiguous = true;
 }
 
-SharedBuffer::SharedBuffer(FileSystem::MappedFileData&& data)
-    : FragmentedSharedBuffer(WTFMove(data))
+SharedBuffer::SharedBuffer(DataSegment::Provider&& provider)
+    : FragmentedSharedBuffer(DataSegment::create(WTFMove(provider)))
 {
-    m_contiguous = true;
 }
+
+SharedBuffer::SharedBuffer(std::span<const uint8_t> data)
+    : FragmentedSharedBuffer(DataSegment::create(data))
+{
+}
+
+SharedBuffer::SharedBuffer(Vector<uint8_t>&& data)
+    : FragmentedSharedBuffer(DataSegment::create(WTFMove(data)))
+{
+}
+
+#if USE(GSTREAMER)
+Ref<SharedBuffer> SharedBuffer::create(GstMappedOwnedBuffer& mappedBuffer)
+{
+    return adoptRef(*new SharedBuffer(mappedBuffer));
+}
+
+SharedBuffer::SharedBuffer(GstMappedOwnedBuffer& mappedBuffer)
+    : FragmentedSharedBuffer(DataSegment::create(&mappedBuffer))
+{
+}
+#endif
 
 RefPtr<SharedBuffer> SharedBuffer::createWithContentsOfFile(const String& filePath, FileSystem::MappedFileMode mappedFileMode, MayUseFileMapping mayUseFileMapping)
 {
@@ -559,15 +518,14 @@ RefPtr<SharedBuffer> SharedBuffer::createWithContentsOfFile(const String& filePa
 
 std::span<const uint8_t> SharedBuffer::span() const
 {
-    if (m_segments.isEmpty())
+    if (!segmentsCount())
         return { };
-    return m_segments[0].segment->span();
+    return segments()[0].segment->span();
 }
 
-const uint8_t& SharedBuffer::operator[](size_t i) const
+uint8_t SharedBuffer::operator[](size_t i) const
 {
-    RELEASE_ASSERT(i < size() && !m_segments.isEmpty());
-    return m_segments[0].segment->span()[i];
+    return segments()[0].segment->span()[i];
 }
 
 WTF::Persistence::Decoder SharedBuffer::decoder() const
@@ -655,11 +613,9 @@ SharedBufferBuilder::SharedBufferBuilder(RefPtr<FragmentedSharedBuffer>&& buffer
 
 SharedBufferBuilder& SharedBufferBuilder::operator=(RefPtr<FragmentedSharedBuffer>&& buffer)
 {
-    if (!buffer) {
-        m_buffer = nullptr;
-        return *this;
-    }
     m_buffer = nullptr;
+    if (!buffer)
+        return *this;
     initialize(buffer.releaseNonNull());
     return *this;
 }
@@ -669,7 +625,7 @@ void SharedBufferBuilder::initialize(Ref<FragmentedSharedBuffer>&& buffer)
     ASSERT(!m_buffer);
     // We do not want to take a reference to the SharedBuffer as all SharedBuffer should be immutable
     // once created.
-    if (buffer->hasOneRef() && !buffer->isContiguous()) {
+    if (buffer->hasOneRef()) {
         m_buffer = WTFMove(buffer);
         return;
     }
@@ -684,7 +640,9 @@ RefPtr<ArrayBuffer> SharedBufferBuilder::tryCreateArrayBuffer() const
 
 Ref<FragmentedSharedBuffer> SharedBufferBuilder::take()
 {
-    return m_buffer ? m_buffer.releaseNonNull() : FragmentedSharedBuffer::create();
+    if (RefPtr buffer = std::exchange(m_buffer, { }))
+        return buffer.releaseNonNull();
+    return SharedBuffer::create();
 }
 
 Ref<SharedBuffer> SharedBufferBuilder::takeAsContiguous()
@@ -699,10 +657,10 @@ RefPtr<ArrayBuffer> SharedBufferBuilder::takeAsArrayBuffer()
     return take()->tryCreateArrayBuffer();
 }
 
-void SharedBufferBuilder::ensureBuffer()
+void SharedBufferBuilder::ensureBuffer(size_t segments)
 {
     if (!m_buffer)
-        m_buffer = FragmentedSharedBuffer::create();
+        m_buffer = segments > 1 ? FragmentedSharedBuffer::create() : static_cast<Ref<FragmentedSharedBuffer>>(SharedBuffer::create());
 }
 
 SharedBufferDataView::SharedBufferDataView(Ref<const DataSegment>&& segment, size_t positionWithinSegment, std::optional<size_t> size)
@@ -748,11 +706,6 @@ RefPtr<SharedBuffer> utf8Buffer(const String& string)
 
     buffer.shrink(result.buffer.size());
     return SharedBuffer::create(WTFMove(buffer));
-}
-
-Ref<SharedBuffer> SharedBuffer::create(Ref<FragmentedSharedBuffer>&& fragmentedBuffer)
-{
-    return fragmentedBuffer->makeContiguous();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cf/SharedBufferCF.cpp
+++ b/Source/WebCore/platform/cf/SharedBufferCF.cpp
@@ -33,9 +33,10 @@
 
 namespace WebCore {
 
-FragmentedSharedBuffer::FragmentedSharedBuffer(CFDataRef data)
+SharedBuffer::SharedBuffer(CFDataRef data)
+    : FragmentedSharedBuffer(DataSegment::create(data))
 {
-    append(data);
+    ASSERT(data);
 }
 
 // Using Foundation allows for an even more efficient implementation of this function,
@@ -43,17 +44,19 @@ FragmentedSharedBuffer::FragmentedSharedBuffer(CFDataRef data)
 #if !USE(FOUNDATION)
 RetainPtr<CFDataRef> SharedBuffer::createCFData() const
 {
-    if (hasOneSegment()) {
-        if (auto* data = std::get_if<RetainPtr<CFDataRef>>(&m_segments[0].segment->m_immutableData))
+    if (size()) {
+        if (auto* data = std::get_if<RetainPtr<CFDataRef>>(&segments()[0].segment->m_immutableData))
             return *data;
     }
     return adoptCF(CFDataCreate(nullptr, data(), size()));
 }
 #endif
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(CFDataRef data)
+Ref<SharedBuffer> SharedBuffer::create(CFDataRef data)
 {
-    return adoptRef(*new FragmentedSharedBuffer(data));
+    if (!data)
+        return SharedBuffer::create();
+    return adoptRef(*new SharedBuffer(data));
 }
 
 void FragmentedSharedBuffer::hintMemoryNotNeededSoon() const
@@ -68,8 +71,8 @@ void FragmentedSharedBuffer::hintMemoryNotNeededSoon() const
 
 void FragmentedSharedBuffer::append(CFDataRef data)
 {
-    ASSERT(!m_contiguous);
     if (data) {
+        ASSERT(!m_contiguous || !segmentsCount());
         m_segments.append({m_size, DataSegment::create(data)});
         m_size += CFDataGetLength(data);
     }

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -91,14 +91,15 @@
 
 namespace WebCore {
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(NSData *data)
+Ref<SharedBuffer> SharedBuffer::create(NSData *data)
 {
-    return adoptRef(*new FragmentedSharedBuffer(bridge_cast(data)));
+    if (!data)
+        return SharedBuffer::create();
+    return adoptRef(*new SharedBuffer(bridge_cast(data)));
 }
 
 void FragmentedSharedBuffer::append(NSData *data)
 {
-    ASSERT(!m_contiguous);
     return append(bridge_cast(data));
 }
 
@@ -158,14 +159,14 @@ RetainPtr<NSData> SharedBuffer::createNSData() const
 
 RetainPtr<CFDataRef> SharedBuffer::createCFData() const
 {
-    if (!m_segments.size())
+    if (!size())
         return adoptCF(CFDataCreate(nullptr, nullptr, 0));
-    return bridge_cast(m_segments[0].segment->createNSData());
+    return bridge_cast(segments()[0].segment->createNSData());
 }
 
 RetainPtr<NSArray> FragmentedSharedBuffer::createNSDataArray() const
 {
-    return createNSArray(m_segments, [] (auto& segment) {
+    return createNSArray(segments(), [] (auto& segment) {
         return segment.segment->createNSData();
     });
 }

--- a/Source/WebCore/platform/glib/SharedBufferGlib.cpp
+++ b/Source/WebCore/platform/glib/SharedBufferGlib.cpp
@@ -26,16 +26,17 @@
 
 namespace WebCore {
 
-FragmentedSharedBuffer::FragmentedSharedBuffer(GBytes* bytes)
+SharedBuffer::SharedBuffer(GBytes* bytes)
+    : FragmentedSharedBuffer(DataSegment::create(GRefPtr<GBytes>(bytes)))
 {
     ASSERT(bytes);
-    m_size = g_bytes_get_size(bytes);
-    m_segments.append({ 0, DataSegment::create(GRefPtr<GBytes>(bytes)) });
 }
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(GBytes* bytes)
+Ref<SharedBuffer> SharedBuffer::create(GBytes* bytes)
 {
-    return adoptRef(*new FragmentedSharedBuffer(bytes));
+    if (!bytes)
+        return SharedBuffer::create();
+    return adoptRef(*new SharedBuffer(bytes));
 }
 
 GRefPtr<GBytes> SharedBuffer::createGBytes() const

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -139,7 +139,7 @@ String descriptionString(ImageDecodingError error)
 
 Expected<std::pair<String, Vector<IntSize>>, ImageDecodingError> utiAndAvailableSizesFromImageData(std::span<const uint8_t> data)
 {
-    Ref buffer = FragmentedSharedBuffer::create(data);
+    Ref buffer = SharedBuffer::create(data);
     Ref imageDecoder = ImageDecoderCG::create(buffer.get(), AlphaOption::Premultiplied, GammaAndColorProfileOption::Applied);
     imageDecoder->setData(buffer.get(), true);
     if (imageDecoder->encodedDataStatus() == EncodedDataStatus::Error)
@@ -164,7 +164,7 @@ Expected<std::pair<String, Vector<IntSize>>, ImageDecodingError> utiAndAvailable
 
 static RefPtr<NativeImage> tryCreateNativeImageFromBitmapImageData(std::span<const uint8_t> data, std::optional<FloatSize> preferredSize)
 {
-    Ref buffer = FragmentedSharedBuffer::create(data);
+    Ref buffer = SharedBuffer::create(data);
     Ref imageDecoder = ImageDecoderCG::create(buffer.get(), AlphaOption::Premultiplied, GammaAndColorProfileOption::Applied);
     imageDecoder->setData(buffer.get(), true);
     if (imageDecoder->encodedDataStatus() == EncodedDataStatus::Error)

--- a/Source/WebCore/platform/graphics/win/ImageAdapterWin.cpp
+++ b/Source/WebCore/platform/graphics/win/ImageAdapterWin.cpp
@@ -42,7 +42,7 @@ Ref<Image> ImageAdapter::loadPlatformResource(const char *name)
     auto data = FileSystem::readEntireFile(path);
     auto img = BitmapImage::create();
     if (data)
-        img->setData(FragmentedSharedBuffer::create(WTFMove(*data)), true);
+        img->setData(SharedBuffer::create(WTFMove(*data)), true);
     return img;
 }
 

--- a/Source/WebCore/platform/ios/PreviewConverterIOS.mm
+++ b/Source/WebCore/platform/ios/PreviewConverterIOS.mm
@@ -84,7 +84,7 @@
 namespace WebCore {
 
 PreviewConverter::PreviewConverter(const ResourceResponse& response, PreviewConverterProvider& provider)
-    : m_previewData { FragmentedSharedBuffer::create() }
+    : m_previewData { SharedBuffer::create() }
     , m_originalResponse { response }
     , m_provider { provider }
     , m_platformDelegate { adoptNS([[WebPreviewConverterDelegate alloc] initWithDelegate:*this]) }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -262,7 +262,7 @@ void MediaRecorderPrivateBackend::fetchData(MediaRecorderPrivate::FetchDataCallb
     callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }, completionHandler = WTFMove(completionHandler), mimeType = this->mimeType()]() mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis) {
-            completionHandler(FragmentedSharedBuffer::create(), mimeType, 0);
+            completionHandler(SharedBuffer::create(), mimeType, 0);
             return;
         }
         double timeCode = 0;

--- a/Source/WebCore/platform/skia/SharedBufferSkia.cpp
+++ b/Source/WebCore/platform/skia/SharedBufferSkia.cpp
@@ -28,16 +28,15 @@
 
 namespace WebCore {
 
-FragmentedSharedBuffer::FragmentedSharedBuffer(sk_sp<SkData>&& data)
+SharedBuffer::SharedBuffer(sk_sp<SkData>&& data)
+    : FragmentedSharedBuffer(DataSegment::create(WTFMove(data)))
 {
-    ASSERT(data);
-    m_size = data->size();
-    m_segments.append({ 0, DataSegment::create(WTFMove(data)) });
 }
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(sk_sp<SkData>&& data)
+Ref<SharedBuffer> SharedBuffer::create(sk_sp<SkData>&& data)
 {
-    return adoptRef(*new FragmentedSharedBuffer(WTFMove(data)));
+    ASSERT(data);
+    return adoptRef(*new SharedBuffer(WTFMove(data)));
 }
 
 sk_sp<SkData> SharedBuffer::createSkData() const

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -562,7 +562,7 @@ void SVGImage::subresourcesAreFinished(Document* embedderDocument, CompletionHan
 void SVGImage::tryCreateFromData(std::span<const uint8_t> data, CompletionHandler<void(RefPtr<SVGImage>&&)>&& completionHandler)
 {
     Ref svgImage = SVGImage::create(nullptr);
-    Ref buffer = FragmentedSharedBuffer::create(data);
+    Ref buffer = SharedBuffer::create(data);
     svgImage->setData(buffer.ptr(), true);
     if (!svgImage->rootElement()) {
         completionHandler(nullptr);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -48,7 +48,7 @@ SpeculativeLoad::SpeculativeLoad(Cache& cache, const GlobalFrameID& globalFrameI
     : m_cache(cache)
     , m_completionHandler(WTFMove(completionHandler))
     , m_originalRequest(request)
-    , m_bufferedDataForCache(FragmentedSharedBuffer::create())
+    , m_bufferedDataForCache(SharedBuffer::create())
     , m_cacheEntry(WTFMove(cacheEntryForValidation))
 {
     ASSERT(!m_cacheEntry || m_cacheEntry->needsValidation());

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4896,7 +4896,7 @@ enum class WebCore::CreateNewGroupForHighlight : bool
 enum class WebCore::HighlightRequestOriginatedInApp : bool
 
 struct WebCore::AppHighlight {
-    Ref<WebCore::FragmentedSharedBuffer> highlight;
+    Ref<WebCore::SharedBuffer> highlight;
     std::optional<String> text;
     WebCore::CreateNewGroupForHighlight isNewGroup;
     WebCore::HighlightRequestOriginatedInApp requestOriginatedInApp;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -504,7 +504,7 @@ void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebC
         if (requiresInteraction == WebCore::DOMPasteRequiresInteraction::No) {
             auto* clipboard = wpe_display_get_clipboard(wpe_view_get_display(view));
             if (GRefPtr<GBytes> bytes = adoptGRef(wpe_clipboard_read_bytes(clipboard, WebCore::PasteboardCustomData::wpeType().characters()))) {
-                auto buffer = WebCore::FragmentedSharedBuffer::create(bytes.get())->makeContiguous();
+                Ref buffer = WebCore::SharedBuffer::create(bytes.get());
                 if (WebCore::PasteboardCustomData::fromSharedBuffer(buffer.get()).origin() == originIdentifier) {
                     completionHandler(WebCore::DOMPasteAccessResponse::GrantedForGesture);
                     return;

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -98,7 +98,7 @@ void WebPasteboardProxy::readBuffer(IPC::Connection&, const String&, const Strin
     if (WKWPE::isUsingWPEPlatformAPI()) {
         auto* clipboard = wpe_display_get_clipboard(wpe_display_get_primary());
         if (GRefPtr<GBytes> bytes = adoptGRef(wpe_clipboard_read_bytes(clipboard, pasteboardType.utf8().data()))) {
-            completionHandler(FragmentedSharedBuffer::create(bytes.get())->makeContiguous());
+            completionHandler(SharedBuffer::create(bytes.get()));
             return;
         }
     }
@@ -157,7 +157,7 @@ void WebPasteboardProxy::typesSafeForDOMToReadAndWrite(IPC::Connection&, const S
         auto* clipboard = wpe_display_get_clipboard(wpe_display_get_primary());
         if (GRefPtr<GBytes> bytes = adoptGRef(wpe_clipboard_read_bytes(clipboard, PasteboardCustomData::wpeType().characters()))) {
             ListHashSet<String> domTypes;
-            auto buffer = FragmentedSharedBuffer::create(bytes.get())->makeContiguous();
+            Ref buffer = SharedBuffer::create(bytes.get());
             auto customData = PasteboardCustomData::fromSharedBuffer(buffer.get());
             if (customData.origin() == origin) {
                 for (auto& type : customData.orderedTypes())
@@ -299,7 +299,7 @@ void WebPasteboardProxy::readURLFromPasteboard(IPC::Connection& connection, uint
 
         auto* clipboard = wpe_display_get_clipboard(wpe_display_get_primary());
         if (GRefPtr<GBytes> bytes = adoptGRef(wpe_clipboard_read_bytes(clipboard, "text/uri-list"))) {
-            auto buffer = FragmentedSharedBuffer::create(bytes.get())->makeContiguous();
+            auto buffer = SharedBuffer::create(bytes.get());
             completionHandler(String(buffer->span()), { });
             return;
         }
@@ -320,7 +320,7 @@ void WebPasteboardProxy::readBufferFromPasteboard(IPC::Connection& connection, s
 
         auto* clipboard = wpe_display_get_clipboard(wpe_display_get_primary());
         if (GRefPtr<GBytes> bytes = adoptGRef(wpe_clipboard_read_bytes(clipboard, pasteboardType.utf8().data()))) {
-            completionHandler(FragmentedSharedBuffer::create(bytes.get())->makeContiguous());
+            completionHandler(SharedBuffer::create(bytes.get()));
             return;
         }
     }

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -415,7 +415,7 @@ void WebPrintOperationGtk::endPrint()
     }
     document->close();
 
-    printDone(WebCore::FragmentedSharedBuffer::create(memoryBuffer.detachAsData()), { });
+    printDone(WebCore::SharedBuffer::create(memoryBuffer.detachAsData()), { });
 
     m_pages.clear();
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
@@ -55,10 +55,12 @@ TEST_F(FragmentedSharedBufferTest, createNSDataArray)
 
         NSData *helloData = [NSData dataWithBytes:"hello" length:5];
         builder.append(span(helloData));
+        EXPECT_TRUE(builder.get()->isContiguous());
         expectDataArraysEqual(@[ helloData ], builder.get()->createNSDataArray().get());
 
         NSData *worldData = [NSData dataWithBytes:"world" length:5];
         builder.append((__bridge CFDataRef)worldData);
+        EXPECT_FALSE(builder.get()->isContiguous());
         expectDataArraysEqual(@[ helloData, worldData ], builder.get()->createNSDataArray().get());
 
         expectDataArraysEqual(@[ helloData ], SharedBuffer::create(helloData)->createNSDataArray().get());


### PR DESCRIPTION
#### a20b10db9c2de64a37e2eb32579ec465db2bb73d
<pre>
SharedBufferBuilder::take() should return a contiguous SharedBuffer if it only contains a single DataSegment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296684">https://bugs.webkit.org/show_bug.cgi?id=296684</a>
<a href="https://rdar.apple.com/157093750">rdar://157093750</a>

Reviewed by Youenn Fablet.

Make SharedBufferBuilder always return a SharedBuffer if the data it holds
is contiguous, and a FragmentedSharedBuffer otherwise.
Following this change, you can no longer create an object of the base class
FragmentedSharedBuffer if it is contiguous: it will always be a SharedBuffer
instead.
A side benefits is that it allows to remove a memory allocation whenever
we want to convert a FragmentedSharedBuffer into a SharedBuffer such as when
when using a SharedBufferBuilder and appending a single segment to it:
SharedBufferBuilder::takeAsContiguous() is now a no-op if the underlying
buffer is already contiguous.

API tests added.

* Source/WTF/wtf/TypeTraits.h: Adding RemoveCVSmartPointer convenience template.
* Source/WebCore/Modules/highlight/AppHighlight.h:
(IPC::AsyncReplyError&lt;WebCore::AppHighlight&gt;::create): Remove use of FragmentedSharedBuffer
that was in effect always contiguous.
* Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp:
(WebCore::AppHighlightRangeData::create): Ditto
(WebCore::AppHighlightRangeData::toSharedBuffer const):
* Source/WebCore/Modules/highlight/AppHighlightRangeData.h:
* Source/WebCore/Modules/highlight/AppHighlightStorage.cpp: Ditto
(WebCore::AppHighlightStorage::restoreAndScrollToAppHighlight):
* Source/WebCore/Modules/highlight/AppHighlightStorage.h: Ditto

Canonical link: <a href="https://commits.webkit.org/298168@main">https://commits.webkit.org/298168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d80e03f2121fb53ae4029d947da0727ef2bce7dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87010 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117435 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/27776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20943 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64333 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106883 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123858 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113050 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95613 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37532 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46889 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137267 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40967 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36705 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->