### PR TITLE
[WIP] [css-anchor-position-1] Anchored box detaches from anchor when scrolled partially out of view

### DIFF
--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1257,16 +1257,12 @@ bool AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock(const Render
     if (!anchoredBox.isOutOfFlowPositioned())
         return false;
 
-    auto inlineConstraints = PositionedLayoutConstraints { anchoredBox, LogicalBoxAxis::Inline };
-    auto blockConstraints = PositionedLayoutConstraints { anchoredBox, LogicalBoxAxis::Block };
-    inlineConstraints.computeInsets();
-    blockConstraints.computeInsets();
-
-    auto anchorInlineSize = anchoredBox.logicalWidth() + anchoredBox.marginStart() + anchoredBox.marginEnd();
-    auto anchorBlockSize = anchoredBox.logicalHeight() + anchoredBox.marginBefore() + anchoredBox.marginAfter();
-
-    return inlineConstraints.insetModifiedContainingSize() < anchorInlineSize
-        || blockConstraints.insetModifiedContainingSize() < anchorBlockSize;
+    auto containerBox = anchoredBox.containingBlock();
+    if (!containerBox)
+        return false;
+    auto anchorBoxRect = anchoredBox.absoluteBoundingBoxRect();
+    auto anchorContainerBoxRect = containerBox->absoluteBoundingBoxRect();
+    return !anchorContainerBoxRect.contains(anchorBoxRect);
 }
 
 bool AnchorPositionEvaluator::isDefaultAnchorInvisibleOrClippedByInterveningBoxes(const RenderBox& anchoredBox)


### PR DESCRIPTION
#### 527488fc1bfe01876bcbcfec71ca260b0f514f0a
<pre>
[WIP] [css-anchor-position-1] Anchored box detaches from anchor when scrolled partially out of view
<a href="https://bugs.webkit.org/show_bug.cgi?id=295006">https://bugs.webkit.org/show_bug.cgi?id=295006</a>

Reviewed by NOBODY (OOPS!).

When using position-try-fallbacks on an anchored element within a scrollable box,
it fails because the overflow calculation does not take the containing block&apos;s scroll offset into account,

Fix this by using BoundingBox to take scroll offset in consideration
while checking if anchored element overflows containing block.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::overflowsInsetModifiedContainingBlock):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/527488fc1bfe01876bcbcfec71ca260b0f514f0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42459 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86752 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41852 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67140 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26676 "Found 23 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html imported/w3c/web-platform-tests/css/css-anchor-position/inherit-height-from-fallback.html imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-basic.html imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-fallbacks.html imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-change-try-rule.html imported/w3c/web-platform-tests/css/css-anchor-position/last-successful-iframe.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20649 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96865 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20766 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41170 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30689 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95584 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95367 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40505 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18323 "Found 28 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-001.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-004.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-007.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-008.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-009.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-010.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-011.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-013.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-014.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37287 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46557 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->