### PR TITLE
Annotate WebRTC IPC endpoints with PeerConnectionEnabled

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -129,7 +129,9 @@ RTCPeerConnection::RTCPeerConnection(Document& document)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     relaxAdoptionRequirement();
-    lazyInitialize(m_backend, PeerConnectionBackend::create(*this));
+
+    if (document.settings().peerConnectionEnabled())
+        lazyInitialize(m_backend, PeerConnectionBackend::create(*this));
 
 #if !RELEASE_LOG_DISABLED
     auto* page = document.page();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3119,7 +3119,7 @@ RTCDataChannelRemoteManagerProxy& NetworkProcess::rtcDataChannelProxy()
 {
     ASSERT(isMainRunLoop());
     if (!m_rtcDataChannelProxy)
-        m_rtcDataChannelProxy = RTCDataChannelRemoteManagerProxy::create();
+        m_rtcDataChannelProxy = RTCDataChannelRemoteManagerProxy::create(*this);
     return *m_rtcDataChannelProxy;
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -207,6 +207,15 @@ PAL::SessionID NetworkMDNSRegister::sessionID() const
     return m_connection->sessionID();
 }
 
+std::optional<SharedPreferencesForWebProcess> NetworkMDNSRegister::sharedPreferencesForWebProcess() const
+{
+    RefPtr connectionToWebProcess = m_connection.get();
+    if (!connectionToWebProcess)
+        return std::nullopt;
+
+    return connectionToWebProcess->sharedPreferencesForWebProcess();
+}
+
 } // namespace WebKit
 
 #undef MDNS_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "RTCNetwork.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/CheckedRef.h>
@@ -78,6 +79,8 @@ public:
 #endif
 
     bool hasRegisteredName(const String&) const;
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
     void unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(WEB_RTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -541,6 +541,12 @@ void NetworkRTCMonitor::deref()
     m_rtcProvider->deref();
 }
 
+std::optional<SharedPreferencesForWebProcess> NetworkRTCMonitor::sharedPreferencesForWebProcess(IPC::Connection& connection) const
+{
+    Ref protectedProvider = m_rtcProvider.get();
+    return protectedProvider->sharedPreferencesForWebProcess(connection);
+}
+
 } // namespace WebKit
 
 #undef RTC_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 
 #include "RTCNetwork.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
@@ -63,6 +64,8 @@ public:
 
     void ref();
     void deref();
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
 
 private:
     void startUpdatingIfNeeded();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in
@@ -23,9 +23,10 @@
 #if USE(LIBWEBRTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
 ]
 messages -> NetworkRTCMonitor {
     void StartUpdatingIfNeeded()

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -63,6 +63,7 @@ NetworkRTCProvider::NetworkRTCProvider(NetworkConnectionToWebProcess& connection
     : m_connection(&connection)
     , m_ipcConnection(connection.connection())
     , m_rtcMonitor(*this)
+    , m_sharedPreferences(connection.sharedPreferencesForWebProcessValue())
 #if PLATFORM(COCOA)
     , m_sourceApplicationAuditToken(connection.networkProcess().sourceApplicationAuditToken())
     , m_rtcNetworkThreadQueue(WorkQueue::create("NetworkRTCProvider Queue"_s, WorkQueue::QOS::UserInitiated))
@@ -390,6 +391,18 @@ void NetworkRTCProvider::signalSocketIsClosed(LibWebRTCSocketIdentifier identifi
 Ref<NetworkRTCMonitor> NetworkRTCProvider::protectedRTCMonitor()
 {
     return m_rtcMonitor;
+}
+
+std::optional<SharedPreferencesForWebProcess> NetworkRTCProvider::sharedPreferencesForWebProcess(IPC::Connection& connection)
+{
+    Locker locker { m_sharedPreferencesLock };
+    return m_sharedPreferences;
+}
+
+void NetworkRTCProvider::updateSharedPreferencesForWebProcess(const SharedPreferencesForWebProcess& preferences)
+{
+    Locker locker { m_sharedPreferencesLock };
+    m_sharedPreferences = preferences;
 }
 
 #undef RTC_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -125,6 +125,9 @@ public:
     const char* applicationBundleIdentifier() const { return m_applicationBundleIdentifier.data(); }
 #endif
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&);
+    void updateSharedPreferencesForWebProcess(const SharedPreferencesForWebProcess&);
+
 private:
     explicit NetworkRTCProvider(NetworkConnectionToWebProcess&);
     void startListeningForIPC();
@@ -167,6 +170,8 @@ private:
     bool m_isStarted { true };
 
     NetworkRTCMonitor m_rtcMonitor;
+    mutable Lock m_sharedPreferencesLock;
+    SharedPreferencesForWebProcess m_sharedPreferences WTF_GUARDED_BY_LOCK(m_sharedPreferencesLock);
 
 #if PLATFORM(COCOA)
     HashMap<WebPageProxyIdentifier, String> m_attributedBundleIdentifiers;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
@@ -23,9 +23,10 @@
 #if USE(LIBWEBRTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
 ]
 messages -> NetworkRTCProvider {
     CreateUDPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::WebRTCNetwork::SocketAddress localAddress, uint16_t minPort, uint16_t maxPort, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
@@ -23,9 +23,10 @@
 #if ENABLE(WEB_RTC)
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=PeerConnectionEnabled,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection
 ]
 messages -> RTCDataChannelRemoteManagerProxy {
     // To source

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -52,6 +52,10 @@ RefPtr<LibWebRTCNetworkManager> LibWebRTCNetworkManager::getOrCreate(WebCore::Sc
     if (!document)
         return nullptr;
 
+    // Check if PeerConnection is enabled to prevent IPC crashes
+    if (!document->settings().peerConnectionEnabled())
+        return nullptr;
+
     RefPtr networkManager = downcast<LibWebRTCNetworkManager>(document->rtcNetworkManager());
     if (!networkManager) {
         auto newNetworkManager = adoptRef(*new LibWebRTCNetworkManager(identifier));


### PR DESCRIPTION
#### 385eb16d87128c4636b8ffcc3d7cd7f235abe286
<pre>
Annotate WebRTC IPC endpoints with PeerConnectionEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=296736">https://bugs.webkit.org/show_bug.cgi?id=296736</a>
<a href="https://rdar.apple.com/157199232">rdar://157199232</a>

Reviewed by Eric Carlson.

Annotate WebRTC IPC endpoints with PeerConnectionEnabled to ensure they are disabled along with runtime feature flag

* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::RTCPeerConnection):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::rtcDataChannelProxy):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::NetworkMDNSRegister::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkRTCMonitor::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::NetworkRTCProvider):
(WebKit::NetworkRTCProvider::sharedPreferencesForWebProcess):
(WebKit::NetworkRTCProvider::updateSharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.cpp:
(WebKit::RTCDataChannelRemoteManagerProxy::RTCDataChannelRemoteManagerProxy):
(WebKit::RTCDataChannelRemoteManagerProxy::registerConnectionToWebProcess):
(WebKit::RTCDataChannelRemoteManagerProxy::unregisterConnectionToWebProcess):
(WebKit::RTCDataChannelRemoteManagerProxy::sharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h:
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::getOrCreate):

Canonical link: <a href="https://commits.webkit.org/298146@main">https://commits.webkit.org/298146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3e27f81dbf25c36828df6d3f319f00e0aab54ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86770 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20671 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123558 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95387 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37303 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46582 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/43990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->