### PR TITLE
Match standardised [ReflectSetter] extended attribute

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -1119,7 +1119,7 @@ sub ContentAttributeName
     die "Do not use both [ReflectURL] and [ReflectSetter] on the same attribute" if $reflectURL && $reflectSetter;
     die "Do not use both [Reflect] and [ReflectSetter] on the same attribute" if $reflect && $reflectSetter;
 
-    my $contentAttributeName = ($getterOrSetter eq "setter" ? UnquoteStringLiteral($reflect || $reflectURL) || $reflectSetter : UnquoteStringLiteral($reflect || $reflectURL));
+    my $contentAttributeName = UnquoteStringLiteral($getterOrSetter eq "setter" ? $reflect || $reflectURL || $reflectSetter : $reflect || $reflectURL);
     return undef if !$contentAttributeName;
 
     $contentAttributeName =~ s/-/_/g;

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -438,7 +438,10 @@
         "ReflectSetter": {
             "contextsAllowed": ["attribute"],
             "values": ["*"],
-            "notes": "Variant of Reflect that relies on C++ implementation for the getter, but automatically generates the setter"
+            "notes": "Variant of Reflect that relies on C++ implementation for the getter, but automatically generates the setter",
+            "standard": {
+                "url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflectsetter"
+            }
         },
         "Replaceable": {
             "contextsAllowed": ["attribute"],

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -4902,7 +4902,7 @@ static inline bool setJSTestObj_reflectedSetterStringAttrSetter(JSGlobalObject& 
     if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::customContentStringAttrAttr, nativeValueConversionResult.releaseReturnValue());
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::custom_content_stringAttr, nativeValueConversionResult.releaseReturnValue());
     });
     return true;
 }
@@ -4935,7 +4935,7 @@ static inline bool setJSTestObj_reflectedSetterCustomIntegralAttrSetter(JSGlobal
     if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setIntegralAttribute(WebCore::HTMLNames::customContentIntegralAttrAttr, nativeValueConversionResult.releaseReturnValue());
+        return impl.setIntegralAttribute(WebCore::HTMLNames::custom_content_integralAttr, nativeValueConversionResult.releaseReturnValue());
     });
     return true;
 }
@@ -4968,7 +4968,7 @@ static inline bool setJSTestObj_reflectedSetterCustomBooleanAttrSetter(JSGlobalO
     if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setBooleanAttribute(WebCore::HTMLNames::customContentBooleanAttrAttr, nativeValueConversionResult.releaseReturnValue());
+        return impl.setBooleanAttribute(WebCore::HTMLNames::custom_content_booleanAttr, nativeValueConversionResult.releaseReturnValue());
     });
     return true;
 }

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -124,9 +124,9 @@ enum TestConfidence { "high", "kinda-low" };
     [ReflectSetter] attribute boolean reflectedSetterBooleanAttr;
     [ReflectSetter] attribute Element reflectedSetterElementAttr;
     [ReflectSetter] attribute FrozenArray<Element> reflectedSetterElementsArrayAttr;
-    [ReflectSetter=customContentStringAttr] attribute DOMString reflectedSetterStringAttr;
-    [ReflectSetter=customContentIntegralAttr] attribute long reflectedSetterCustomIntegralAttr;
-    [ReflectSetter=customContentBooleanAttr] attribute boolean reflectedSetterCustomBooleanAttr;
+    [ReflectSetter="custom-content-string"] attribute DOMString reflectedSetterStringAttr;
+    [ReflectSetter="custom-content-integral"] attribute long reflectedSetterCustomIntegralAttr;
+    [ReflectSetter="custom-content-boolean"] attribute boolean reflectedSetterCustomBooleanAttr;
 
     // [EnabledByDeprecatedGlobalSetting] attributes and operations.
     [Conditional=TEST_FEATURE, EnabledByDeprecatedGlobalSetting=TestFeatureEnabled&TestFeature1Enabled] attribute DOMString enabledAtRuntimeAttribute;

--- a/Source/WebCore/html/HTMLFormElement.idl
+++ b/Source/WebCore/html/HTMLFormElement.idl
@@ -28,7 +28,7 @@
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] USVString action;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString autocomplete;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString enctype;
-    [CEReactions=NotNeeded, ImplementedAs=enctype, ReflectSetter=enctype] attribute [AtomString] DOMString encoding;
+    [CEReactions=NotNeeded, ImplementedAs=enctype, ReflectSetter="enctype"] attribute [AtomString] DOMString encoding;
     [CEReactions=NotNeeded, ReflectSetter] attribute [AtomString] DOMString method;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     [CEReactions=NotNeeded, Reflect] attribute boolean noValidate;


### PR DESCRIPTION
#### 6eaf243b7a5d42e87fb7224cbcd7f33fe4b3a061
<pre>
Match standardised [ReflectSetter] extended attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=296739">https://bugs.webkit.org/show_bug.cgi?id=296739</a>

Reviewed by Darin Adler.

Updates usages of the [ReflectSetter] extended attribute to match the standardised syntax.
This replaces usages of [ReflectSetter=ident] with [ReflectSetter=string].

Canonical link: <a href="https://commits.webkit.org/298131@main">https://commits.webkit.org/298131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbc1bc93941606d694bbfa508f09638900540158

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67277 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97017 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123708 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95708 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24342 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37391 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41228 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46736 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->