### PR TITLE
Protect Local/Session storage ipc endpoints

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4477,6 +4477,7 @@ LocalStorageEnabled:
       default: true
     WebCore:
       default: false
+  sharedPreferenceForWebProcess: true
 
 LockdownFontParserEnabled:
   type: bool
@@ -6821,6 +6822,20 @@ ServiceWorkersUserGestureEnabled:
       default: true
     WebCore:
       default: true
+      
+SessionStorageEnabled:
+  type: bool
+  status: mature
+  humanReadableName: "Session Storage"
+  humanReadableDescription: "Enable Session Storage"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
 
 ShadowRootReferenceTargetEnabled:
   type: bool

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -643,6 +643,7 @@ namespace WebCore {
     macro(isSecureContext) \
     macro(kind) \
     macro(language) \
+    macro(localStorage) \
     macro(localStreams) \
     macro(location) \
     macro(makeDOMException) \
@@ -711,6 +712,7 @@ namespace WebCore {
     macro(responseCacheIsValid) \
     macro(retrieveResponse) \
     macro(self) \
+    macro(sessionStorage) \
     macro(setBody) \
     macro(setBodyFromInputRequest) \
     macro(setStatus) \

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -889,6 +889,9 @@ ExceptionOr<Storage*> LocalDOMWindow::sessionStorage()
     if (!page)
         return nullptr;
 
+    if (!page->settings().sessionStorageEnabled())
+        return nullptr;
+
     Ref storageArea = page->storageNamespaceProvider().sessionStorageArea(*document);
     m_sessionStorage = Storage::create(*this, WTFMove(storageArea));
     if (hasEventListeners(eventNames().storageEvent))

--- a/Source/WebCore/page/WindowLocalStorage.idl
+++ b/Source/WebCore/page/WindowLocalStorage.idl
@@ -25,5 +25,5 @@
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#the-localstorage-attribute
 interface mixin WindowLocalStorage {
-    readonly attribute Storage localStorage;
+    [EnabledBySetting=LocalStorageEnabled] readonly attribute Storage localStorage;
 };

--- a/Source/WebCore/page/WindowSessionStorage.idl
+++ b/Source/WebCore/page/WindowSessionStorage.idl
@@ -25,5 +25,5 @@
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#windowsessionstorage
 interface mixin WindowSessionStorage {
-    readonly attribute Storage sessionStorage;
+    [EnabledBySetting=SessionStorageEnabled] readonly attribute Storage sessionStorage;
 };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -30,6 +30,7 @@
 #include "FileSystemSyncAccessHandleInfo.h"
 #include "OriginStorageManager.h"
 #include "SharedPreferencesForWebProcess.h"
+#include "StorageAreaBase.h"
 #include "StorageAreaIdentifier.h"
 #include "StorageAreaImplIdentifier.h"
 #include "StorageAreaMapIdentifier.h"
@@ -156,6 +157,8 @@ private:
 
     RefPtr<NetworkProcess> protectedProcess() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
+    bool isStorageTypeEnabled(IPC::Connection&, WebCore::StorageType) const;
+    bool isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
 
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -51,13 +51,13 @@
     [EnabledBy=FileSystemEnabled] GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemEnabled] GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, WebKit::FileSystemStorageError> result)
 
-    ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier)
-    ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous
-    CancelConnectToStorageArea(WebCore::StorageType type, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin)
-    DisconnectFromStorageArea(WebKit::StorageAreaIdentifier identifier)
-    SetItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String value, String urlString) -> (bool hasError, HashMap<String, String> allItems)
-    RemoveItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String urlString) -> (bool hasError, HashMap<String, String> allItems)
-    Clear(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String urlString) -> ()
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] ConnectToStorageArea(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier)
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] ConnectToStorageAreaSync(WebCore::StorageType type, WebKit::StorageAreaMapIdentifier sourceIdentifier, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin) -> (std::optional<WebKit::StorageAreaIdentifier> identifier, HashMap<String, String> items, uint64_t messageIdentifier) Synchronous
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] CancelConnectToStorageArea(WebCore::StorageType type, std::optional<WebKit::StorageNamespaceIdentifier> namespaceIdentifier, struct WebCore::ClientOrigin origin)
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] DisconnectFromStorageArea(WebKit::StorageAreaIdentifier identifier)
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] SetItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String value, String urlString) -> (bool hasError, HashMap<String, String> allItems)
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] RemoveItem(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String key, String urlString) -> (bool hasError, HashMap<String, String> allItems)
+    [EnabledBy=LocalStorageEnabled || SessionStorageEnabled] Clear(WebKit::StorageAreaIdentifier identifier, WebKit::StorageAreaImplIdentifier implIdentifier, String urlString) -> ()
 
     [EnabledBy=IndexedDBAPIEnabled] OpenDatabase(WebCore::IDBOpenRequestData requestData)
     [EnabledBy=IndexedDBAPIEnabled] OpenDBRequestCancelled(WebCore::IDBOpenRequestData requestData)


### PR DESCRIPTION
#### 20c5072b3c465c03822d9ca2eb0cbfbb34d03592
<pre>
Protect Local/Session storage ipc endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=296743">https://bugs.webkit.org/show_bug.cgi?id=296743</a>
<a href="https://rdar.apple.com/157216538">rdar://157216538</a>

Reviewed by Sihui Liu.

Add a SessionStorageEnabled preference which can be used along with LocalStorageEnabled to protect the relevant IPC endpoints

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::findStorageArea):
* Source/WebCore/page/LocalDOMWindow.cpp:
* Source/WebCore/page/WindowLocalStorage.idl:
* Source/WebCore/page/WindowSessionStorage.idl:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::connectToStorageArea):
(WebKit::NetworkStorageManager::setItem):
(WebKit::NetworkStorageManager::removeItem):
(WebKit::NetworkStorageManager::clear):
(WebKit::NetworkStorageManager::isStorageTypeEnabled const):
(WebKit::NetworkStorageManager::isStorageAreaTypeEnabled const):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/298311@main">https://commits.webkit.org/298311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8fdfd8d9ccd0de47a2407120ede26a03378d637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65716 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7319918-0948-4d4f-8323-b39b9e1c89c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87456 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f1ab84e-9ed7-4d26-a729-81e4bbff9fa4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67852 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21434 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64843 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107351 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124378 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113618 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96249 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96035 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24438 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19072 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38045 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47455 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137823 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41460 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36834 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44779 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43195 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->