### PR TITLE
Media control time fields should be Locale-aware

### DIFF
--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-time-control-styles-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-time-control-styles-expected.txt
@@ -4,8 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS window.getComputedStyle(mediaControls.timeControl.scrubber.element).top is "0px"
-PASS window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top is "8px"
-PASS window.getComputedStyle(mediaControls.timeControl.remainingTimeLabel.element).top is "8px"
+PASS window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top is "auto"
+PASS window.getComputedStyle(mediaControls.timeControl.remainingTimeLabel.element).top is "auto"
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-time-control-styles.html
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-controls-time-control-styles.html
@@ -15,8 +15,8 @@ scheduler.frameDidFire = function()
     document.body.appendChild(mediaControls.element);
 
     shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.scrubber.element).top", "0px");
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top", "8px");
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.remainingTimeLabel.element).top", "8px");
+    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top", "auto");
+    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.remainingTimeLabel.element).top", "auto");
     debug("");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-dropping-controls-expected.txt
+++ b/LayoutTests/media/modern-media-controls/ios-inline-media-controls/ios-inline-media-dropping-controls-expected.txt
@@ -5,13 +5,13 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS ready() became true
 
-TracksButton was dropped at 488.
-PiPButton was dropped at 488.
-SkipForwardButton was dropped at 453.
-SkipBackButton was dropped at 424.
-MuteButton was dropped at 395.
-AirplayButton was dropped at 357.
-FullscreenButton was dropped at 325.
+TracksButton was dropped at 498.
+PiPButton was dropped at 498.
+SkipForwardButton was dropped at 463.
+SkipBackButton was dropped at 434.
+MuteButton was dropped at 405.
+AirplayButton was dropped at 367.
+FullscreenButton was dropped at 335.
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-layout-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-layout-expected.txt
@@ -21,10 +21,11 @@ PASS mediaControls.leftContainer.children.length is 3
 PASS mediaControls.leftContainer.children[0] is mediaControls.skipBackButton
 PASS mediaControls.leftContainer.children[1] is mediaControls.playPauseButton
 PASS mediaControls.leftContainer.children[2] is mediaControls.skipForwardButton
-PASS mediaControls.timeControl.children.length is 3
+PASS mediaControls.timeControl.children.length is 4
 PASS mediaControls.timeControl.children[0] is mediaControls.timeControl.elapsedTimeLabel
 PASS mediaControls.timeControl.children[1] is mediaControls.timeControl.scrubber
-PASS mediaControls.timeControl.children[2] is mediaControls.timeControl.durationTimeLabel
+PASS mediaControls.timeControl.children[2] is mediaControls.timeControl.remainingTimeLabel
+PASS mediaControls.timeControl.children[3] is mediaControls.timeControl.durationTimeLabel
 PASS mediaControls.rightContainer.children.length is 4
 PASS mediaControls.rightContainer.children[0] is mediaControls.muteButton
 PASS mediaControls.rightContainer.children[1] is mediaControls.airplayButton

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-layout.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-layout.html
@@ -47,10 +47,11 @@ scheduler.frameDidFire = function()
     shouldBe("mediaControls.leftContainer.children[1]", "mediaControls.playPauseButton");
     shouldBe("mediaControls.leftContainer.children[2]", "mediaControls.skipForwardButton");
 
-    shouldBe("mediaControls.timeControl.children.length", "3");
+    shouldBe("mediaControls.timeControl.children.length", "4");
     shouldBe("mediaControls.timeControl.children[0]", "mediaControls.timeControl.elapsedTimeLabel");
     shouldBe("mediaControls.timeControl.children[1]", "mediaControls.timeControl.scrubber");
-    shouldBe("mediaControls.timeControl.children[2]", "mediaControls.timeControl.durationTimeLabel");
+    shouldBe("mediaControls.timeControl.children[2]", "mediaControls.timeControl.remainingTimeLabel");
+    shouldBe("mediaControls.timeControl.children[3]", "mediaControls.timeControl.durationTimeLabel");
 
     shouldBe("mediaControls.rightContainer.children.length", "4");
     shouldBe("mediaControls.rightContainer.children[0]", "mediaControls.muteButton");

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-time-control-styles-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-time-control-styles-expected.txt
@@ -4,8 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS window.getComputedStyle(mediaControls.timeControl.scrubber.element).top is "0px"
-PASS window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top is "8px"
-PASS window.getComputedStyle(mediaControls.timeControl.durationTimeLabel.element).top is "8px"
+PASS window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top is "auto"
+PASS window.getComputedStyle(mediaControls.timeControl.durationTimeLabel.element).top is "auto"
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-time-control-styles.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-time-control-styles.html
@@ -15,8 +15,8 @@ scheduler.frameDidFire = function()
     document.body.appendChild(mediaControls.element);
 
     shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.scrubber.element).top", "0px");
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top", "8px");
-    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.durationTimeLabel.element).top", "8px");
+    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.elapsedTimeLabel.element).top", "auto");
+    shouldBeEqualToString("window.getComputedStyle(mediaControls.timeControl.durationTimeLabel.element).top", "auto");
     debug("");
 
     mediaControls.element.remove();

--- a/LayoutTests/media/modern-media-controls/resources/media-controls-loader.js
+++ b/LayoutTests/media/modern-media-controls/resources/media-controls-loader.js
@@ -6,7 +6,7 @@
     const layoutTestsPath = window.location.href.substr(0, window.location.href.indexOf("/LayoutTests/"));
     const modulePath = layoutTestsPath ? layoutTestsPath + "/Source/WebCore/Modules/modern-media-controls" : "/modern-media-controls";
 
-    ["activity-indicator", "airplay-button", "background-tint", "button", "buttons-container", "controls-bar", "inline-media-controls", "macos-fullscreen-media-controls", "macos-inline-media-controls", "media-controls", "media-document", "placard", "slider-base", "slider", "status-label", "text-tracks", "time-label"].forEach(cssFile => {
+    ["activity-indicator", "airplay-button", "background-tint", "button", "buttons-container", "controls-bar", "inline-media-controls", "macos-fullscreen-media-controls", "macos-inline-media-controls", "media-controls", "media-document", "placard", "slider-base", "slider", "status-label", "text-tracks", "time-control", "time-label"].forEach(cssFile => {
         document.write(`<link rel="stylesheet" type="text/css" href="${modulePath}/controls/${cssFile}.css">`);
     });
 

--- a/LayoutTests/media/modern-media-controls/time-control/time-control-expected.txt
+++ b/LayoutTests/media/modern-media-controls/time-control/time-control-expected.txt
@@ -4,66 +4,47 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS timeControl.element.localName is "div"
-PASS timeControl.element.className is "time-control"
+PASS timeControl.element.classList.contains('time-control') is true
 
 PASS timeControl.elapsedTimeLabel is an instance of TimeLabel
 PASS timeControl.scrubber is an instance of Slider
 PASS timeControl.durationTimeLabel is an instance of TimeLabel
 PASS timeControl.remainingTimeLabel is an instance of TimeLabel
 
-timeControl.width = 500;
-PASS timeControl.children.length is 3
+PASS timeControl.children.length is 4
 PASS timeControl.children[0] is timeControl.elapsedTimeLabel
 PASS timeControl.children[1] is timeControl.scrubber
-PASS timeControl.children[2] is timeControl.durationTimeLabel
-PASS timeControl.elapsedTimeLabel.x is 0
-PASS timeControl.elapsedTimeLabel.visible is true
-PASS timeControl.scrubber.x is 32
-PASS timeControl.scrubber.width is 436
-PASS timeControl.durationTimeLabel.x is 473
+PASS timeControl.children[2] is timeControl.remainingTimeLabel
+PASS timeControl.children[3] is timeControl.durationTimeLabel
+
+timeControl.width = 500;
+PASS timeControl.durationTimeLabel.x is 0
+PASS getComputedStyle(timeControl.elapsedTimeLabel.element).display is not 'none'
+PASS getComputedStyle(timeControl.remainingTimeLabel.element).display is 'none'
+PASS getComputedStyle(timeControl.durationTimeLabel.element).display is not 'none'
 
 timeControl.width = 100;
-PASS timeControl.children.length is 3
-PASS timeControl.children[0] is timeControl.elapsedTimeLabel
-PASS timeControl.children[1] is timeControl.scrubber
-PASS timeControl.children[2] is timeControl.remainingTimeLabel
-PASS timeControl.elapsedTimeLabel.visible is false
-PASS timeControl.scrubber.x is 0
-PASS timeControl.scrubber.width is 62
-PASS timeControl.remainingTimeLabel.x is 67
+PASS getComputedStyle(timeControl.elapsedTimeLabel.element).display is 'none'
+PASS getComputedStyle(timeControl.remainingTimeLabel.element).display is not 'none'
+PASS getComputedStyle(timeControl.durationTimeLabel.element).display is 'none'
 
 timeControl.width = 200;
-PASS timeControl.children.length is 3
-PASS timeControl.children[0] is timeControl.elapsedTimeLabel
-PASS timeControl.children[1] is timeControl.scrubber
-PASS timeControl.children[2] is timeControl.durationTimeLabel
 PASS timeControl.elapsedTimeLabel.x is 0
-PASS timeControl.elapsedTimeLabel.visible is true
-PASS timeControl.scrubber.x is 32
-PASS timeControl.scrubber.width is 136
-PASS timeControl.durationTimeLabel.x is 173
+PASS getComputedStyle(timeControl.elapsedTimeLabel.element).display is not 'none'
+PASS getComputedStyle(timeControl.remainingTimeLabel.element).display is 'none'
+PASS getComputedStyle(timeControl.durationTimeLabel.element).display is not 'none'
 
 timeControl.durationTimeLabel.element.click();
-PASS timeControl.children.length is 3
-PASS timeControl.children[0] is timeControl.elapsedTimeLabel
-PASS timeControl.children[1] is timeControl.scrubber
-PASS timeControl.children[2] is timeControl.remainingTimeLabel
 PASS timeControl.elapsedTimeLabel.x is 0
-PASS timeControl.elapsedTimeLabel.visible is true
-PASS timeControl.scrubber.x is 32
-PASS timeControl.scrubber.width is 130
-PASS timeControl.remainingTimeLabel.x is 167
+PASS getComputedStyle(timeControl.elapsedTimeLabel.element).display is not 'none'
+PASS getComputedStyle(timeControl.remainingTimeLabel.element).display is not 'none'
+PASS getComputedStyle(timeControl.durationTimeLabel.element).display is 'none'
 
 timeControl.remainingTimeLabel.element.click();
-PASS timeControl.children.length is 3
-PASS timeControl.children[0] is timeControl.elapsedTimeLabel
-PASS timeControl.children[1] is timeControl.scrubber
-PASS timeControl.children[2] is timeControl.durationTimeLabel
 PASS timeControl.elapsedTimeLabel.x is 0
-PASS timeControl.elapsedTimeLabel.visible is true
-PASS timeControl.scrubber.x is 32
-PASS timeControl.scrubber.width is 136
-PASS timeControl.durationTimeLabel.x is 173
+PASS getComputedStyle(timeControl.elapsedTimeLabel.element).display is not 'none'
+PASS getComputedStyle(timeControl.remainingTimeLabel.element).display is 'none'
+PASS getComputedStyle(timeControl.durationTimeLabel.element).display is not 'none'
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/time-control/time-control.html
+++ b/LayoutTests/media/modern-media-controls/time-control/time-control.html
@@ -9,7 +9,7 @@ const timeControl = new TimeControl({ layoutTraits: new MacOSLayoutTraits(Layout
 document.body.appendChild(timeControl.element);
 
 shouldBeEqualToString("timeControl.element.localName", "div");
-shouldBeEqualToString("timeControl.element.className", "time-control");
+shouldBeTrue("timeControl.element.classList.contains('time-control')");
 
 debug("");
 shouldBeType("timeControl.elapsedTimeLabel", "TimeLabel");
@@ -18,73 +18,56 @@ shouldBeType("timeControl.durationTimeLabel", "TimeLabel");
 shouldBeType("timeControl.remainingTimeLabel", "TimeLabel");
 
 debug("");
+scheduler.flushScheduledLayoutCallbacks();
+shouldBe("timeControl.children.length", "4");
+shouldBe("timeControl.children[0]", "timeControl.elapsedTimeLabel");
+shouldBe("timeControl.children[1]", "timeControl.scrubber");
+shouldBe("timeControl.children[2]", "timeControl.remainingTimeLabel");
+shouldBe("timeControl.children[3]", "timeControl.durationTimeLabel");
+
+debug("");
 debug("timeControl.width = 500;");
 timeControl.width = 500;
 scheduler.flushScheduledLayoutCallbacks();
-shouldBe("timeControl.children.length", "3");
-shouldBe("timeControl.children[0]", "timeControl.elapsedTimeLabel");
-shouldBe("timeControl.children[1]", "timeControl.scrubber");
-shouldBe("timeControl.children[2]", "timeControl.durationTimeLabel");
-shouldBe("timeControl.elapsedTimeLabel.x", "0");
-shouldBe("timeControl.elapsedTimeLabel.visible", "true");
-shouldBe("timeControl.scrubber.x", "32");
-shouldBe("timeControl.scrubber.width", "436");
-shouldBe("timeControl.durationTimeLabel.x", "473");
+shouldBe("timeControl.durationTimeLabel.x", "0");
+shouldNotBe("getComputedStyle(timeControl.elapsedTimeLabel.element).display", "'none'");
+shouldBe("getComputedStyle(timeControl.remainingTimeLabel.element).display", "'none'");
+shouldNotBe("getComputedStyle(timeControl.durationTimeLabel.element).display", "'none'");
 
 debug("");
 debug("timeControl.width = 100;");
 timeControl.width = 100;
 scheduler.flushScheduledLayoutCallbacks();
-shouldBe("timeControl.children.length", "3");
-shouldBe("timeControl.children[0]", "timeControl.elapsedTimeLabel");
-shouldBe("timeControl.children[1]", "timeControl.scrubber");
-shouldBe("timeControl.children[2]", "timeControl.remainingTimeLabel");
-shouldBe("timeControl.elapsedTimeLabel.visible", "false");
-shouldBe("timeControl.scrubber.x", "0");
-shouldBe("timeControl.scrubber.width", "62");
-shouldBe("timeControl.remainingTimeLabel.x", "67");
+shouldBe("getComputedStyle(timeControl.elapsedTimeLabel.element).display", "'none'");
+shouldNotBe("getComputedStyle(timeControl.remainingTimeLabel.element).display", "'none'");
+shouldBe("getComputedStyle(timeControl.durationTimeLabel.element).display", "'none'");
 
 debug("");
 debug("timeControl.width = 200;");
 timeControl.width = 200;
 scheduler.flushScheduledLayoutCallbacks();
-shouldBe("timeControl.children.length", "3");
-shouldBe("timeControl.children[0]", "timeControl.elapsedTimeLabel");
-shouldBe("timeControl.children[1]", "timeControl.scrubber");
-shouldBe("timeControl.children[2]", "timeControl.durationTimeLabel");
 shouldBe("timeControl.elapsedTimeLabel.x", "0");
-shouldBe("timeControl.elapsedTimeLabel.visible", "true");
-shouldBe("timeControl.scrubber.x", "32");
-shouldBe("timeControl.scrubber.width", "136");
-shouldBe("timeControl.durationTimeLabel.x", "173");
+shouldNotBe("getComputedStyle(timeControl.elapsedTimeLabel.element).display", "'none'");
+shouldBe("getComputedStyle(timeControl.remainingTimeLabel.element).display", "'none'");
+shouldNotBe("getComputedStyle(timeControl.durationTimeLabel.element).display", "'none'");
 
 debug("");
 debug("timeControl.durationTimeLabel.element.click();");
 timeControl.durationTimeLabel.element.click()
 scheduler.flushScheduledLayoutCallbacks();
-shouldBe("timeControl.children.length", "3");
-shouldBe("timeControl.children[0]", "timeControl.elapsedTimeLabel");
-shouldBe("timeControl.children[1]", "timeControl.scrubber");
-shouldBe("timeControl.children[2]", "timeControl.remainingTimeLabel");
 shouldBe("timeControl.elapsedTimeLabel.x", "0");
-shouldBe("timeControl.elapsedTimeLabel.visible", "true");
-shouldBe("timeControl.scrubber.x", "32");
-shouldBe("timeControl.scrubber.width", "130");
-shouldBe("timeControl.remainingTimeLabel.x", "167");
+shouldNotBe("getComputedStyle(timeControl.elapsedTimeLabel.element).display", "'none'");
+shouldNotBe("getComputedStyle(timeControl.remainingTimeLabel.element).display", "'none'");
+shouldBe("getComputedStyle(timeControl.durationTimeLabel.element).display", "'none'");
 
 debug("");
 debug("timeControl.remainingTimeLabel.element.click();");
 timeControl.remainingTimeLabel.element.click();
 scheduler.flushScheduledLayoutCallbacks();
-shouldBe("timeControl.children.length", "3");
-shouldBe("timeControl.children[0]", "timeControl.elapsedTimeLabel");
-shouldBe("timeControl.children[1]", "timeControl.scrubber");
-shouldBe("timeControl.children[2]", "timeControl.durationTimeLabel");
 shouldBe("timeControl.elapsedTimeLabel.x", "0");
-shouldBe("timeControl.elapsedTimeLabel.visible", "true");
-shouldBe("timeControl.scrubber.x", "32");
-shouldBe("timeControl.scrubber.width", "136");
-shouldBe("timeControl.durationTimeLabel.x", "173");
+shouldNotBe("getComputedStyle(timeControl.elapsedTimeLabel.element).display", "'none'");
+shouldBe("getComputedStyle(timeControl.remainingTimeLabel.element).display", "'none'");
+shouldNotBe("getComputedStyle(timeControl.durationTimeLabel.element).display", "'none'");
 
 debug("");
 

--- a/LayoutTests/media/modern-media-controls/time-label/ios-time-label-expected.txt
+++ b/LayoutTests/media/modern-media-controls/time-label/ios-time-label-expected.txt
@@ -6,7 +6,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS timeLabel.value is 0
 PASS timeLabel.element.localName is "div"
 PASS timeLabel.element.className is "time-label"
-PASS style.position is "absolute"
 PASS style.fontFamily is "-apple-system-monospaced-numbers"
 PASS style.fontSize is "12px"
 
@@ -16,33 +15,17 @@ PASS elaspedLabel is "Elapsed"
 PASS remainingLabel is "Remaining"
 PASS durationLabel is "Duration"
 
-elapsedTimeLabels[3].element.textContent = 0:01
-elapsedTimeLabels[3].width = 27
-remainingTimeLabels[3].element.textContent = -0:01
-remainingTimeLabels[3].width = 33
-durationTimeLabels[3].element.textContent = 0:01
-durationTimeLabels[3].width = 27
-
 elapsedTimeLabels[4].element.textContent = 00:01
-elapsedTimeLabels[4].width = 35
 remainingTimeLabels[4].element.textContent = -00:01
-remainingTimeLabels[4].width = 40
 durationTimeLabels[4].element.textContent = 00:01
-durationTimeLabels[4].width = 35
 
 elapsedTimeLabels[5].element.textContent = 0:00:01
-elapsedTimeLabels[5].width = 46
 remainingTimeLabels[5].element.textContent = -0:00:01
-remainingTimeLabels[5].width = 52
 durationTimeLabels[5].element.textContent = 0:00:01
-durationTimeLabels[5].width = 46
 
 elapsedTimeLabels[6].element.textContent = 00:00:01
-elapsedTimeLabels[6].width = 54
 remainingTimeLabels[6].element.textContent = -00:00:01
-remainingTimeLabels[6].width = 59
 durationTimeLabels[6].element.textContent = 00:00:01
-durationTimeLabels[6].width = 54
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/time-label/ios-time-label.html
+++ b/LayoutTests/media/modern-media-controls/time-label/ios-time-label.html
@@ -19,7 +19,7 @@ timeLabel.element.id = "elasped";
 const NaNTimeLabel = new TimeLabel;
 NaNTimeLabel.setValueWithNumberOfDigits(NaN, 4);
 
-const digits = [3, 4, 5, 6];
+const digits = [4, 5, 6];
 let elapsedTimeLabels = new Map;
 let remainingTimeLabels = new Map;
 let durationTimeLabels = new Map;
@@ -27,7 +27,7 @@ for (let numberOfDigits of digits) {
     elapsedTimeLabels[numberOfDigits] = new TimeLabel(TimeLabel.Type.Elapsed);
     elapsedTimeLabels[numberOfDigits].setValueWithNumberOfDigits(1, numberOfDigits);
     remainingTimeLabels[numberOfDigits] = new TimeLabel(TimeLabel.Type.Remaining);
-    remainingTimeLabels[numberOfDigits].setValueWithNumberOfDigits(1, numberOfDigits);
+    remainingTimeLabels[numberOfDigits].setValueWithNumberOfDigits(-1, numberOfDigits);
     durationTimeLabels[numberOfDigits] = new TimeLabel(TimeLabel.Type.Duration);
     durationTimeLabels[numberOfDigits].setValueWithNumberOfDigits(1, numberOfDigits);
 }
@@ -57,7 +57,6 @@ scheduler.frameDidFire = function()
 
     style = window.getComputedStyle(timeLabel.element);
 
-    shouldBeEqualToString("style.position", "absolute");
     shouldBeEqualToString("style.fontFamily", "-apple-system-monospaced-numbers");
     shouldBeEqualToString("style.fontSize", "12px");
 
@@ -81,11 +80,8 @@ scheduler.frameDidFire = function()
     for (numberOfDigits of digits) {
         debug("");
         debug(`elapsedTimeLabels[${numberOfDigits}].element.textContent = ${elapsedTimeLabels[numberOfDigits].element.textContent}`);
-        debug(`elapsedTimeLabels[${numberOfDigits}].width = ${elapsedTimeLabels[numberOfDigits].width}`);
         debug(`remainingTimeLabels[${numberOfDigits}].element.textContent = ${remainingTimeLabels[numberOfDigits].element.textContent}`);
-        debug(`remainingTimeLabels[${numberOfDigits}].width = ${remainingTimeLabels[numberOfDigits].width}`);
         debug(`durationTimeLabels[${numberOfDigits}].element.textContent = ${durationTimeLabels[numberOfDigits].element.textContent}`);
-        debug(`durationTimeLabels[${numberOfDigits}].width = ${durationTimeLabels[numberOfDigits].width}`);
     }
 
     debug("");

--- a/LayoutTests/media/modern-media-controls/time-label/time-label-expected.txt
+++ b/LayoutTests/media/modern-media-controls/time-label/time-label-expected.txt
@@ -6,7 +6,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS timeLabel.value is 0
 PASS timeLabel.element.localName is "div"
 PASS timeLabel.element.className is "time-label"
-PASS style.position is "absolute"
 PASS style.fontFamily is "-apple-system-monospaced-numbers"
 PASS style.fontSize is "12px"
 
@@ -19,33 +18,17 @@ PASS accessibilityController.accessibleElementById('duration').role is "AXRole: 
 PASS accessibilityController.accessibleElementById('remaining').role is "AXRole: AXStaticText"
 PASS accessibilityController.accessibleElementById('elasped').role is "AXRole: AXStaticText"
 
-elapsedTimeLabels[3].element.textContent = 0:01
-elapsedTimeLabels[3].width = 27
-remainingTimeLabels[3].element.textContent = -0:01
-remainingTimeLabels[3].width = 33
-durationTimeLabels[3].element.textContent = 0:01
-durationTimeLabels[3].width = 27
-
 elapsedTimeLabels[4].element.textContent = 00:01
-elapsedTimeLabels[4].width = 35
 remainingTimeLabels[4].element.textContent = -00:01
-remainingTimeLabels[4].width = 40
 durationTimeLabels[4].element.textContent = 00:01
-durationTimeLabels[4].width = 35
 
 elapsedTimeLabels[5].element.textContent = 0:00:01
-elapsedTimeLabels[5].width = 46
 remainingTimeLabels[5].element.textContent = -0:00:01
-remainingTimeLabels[5].width = 52
 durationTimeLabels[5].element.textContent = 0:00:01
-durationTimeLabels[5].width = 46
 
 elapsedTimeLabels[6].element.textContent = 00:00:01
-elapsedTimeLabels[6].width = 54
 remainingTimeLabels[6].element.textContent = -00:00:01
-remainingTimeLabels[6].width = 59
 durationTimeLabels[6].element.textContent = 00:00:01
-durationTimeLabels[6].width = 54
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/media/modern-media-controls/time-label/time-label.html
+++ b/LayoutTests/media/modern-media-controls/time-label/time-label.html
@@ -17,7 +17,7 @@ shouldBeEqualToString("timeLabel.element.className", "time-label");
 const NaNTimeLabel = new TimeLabel;
 NaNTimeLabel.setValueWithNumberOfDigits(NaN, 4);
 
-const digits = [3, 4, 5, 6];
+const digits = [4, 5, 6];
 let elapsedTimeLabels = new Map;
 let remainingTimeLabels = new Map;
 let durationTimeLabels = new Map;
@@ -25,7 +25,7 @@ for (let numberOfDigits of digits) {
     elapsedTimeLabels[numberOfDigits] = new TimeLabel(TimeLabel.Type.Elapsed);
     elapsedTimeLabels[numberOfDigits].setValueWithNumberOfDigits(1, numberOfDigits);
     remainingTimeLabels[numberOfDigits] = new TimeLabel(TimeLabel.Type.Remaining);
-    remainingTimeLabels[numberOfDigits].setValueWithNumberOfDigits(1, numberOfDigits);
+    remainingTimeLabels[numberOfDigits].setValueWithNumberOfDigits(-1, numberOfDigits);
     durationTimeLabels[numberOfDigits] = new TimeLabel(TimeLabel.Type.Duration);
     durationTimeLabels[numberOfDigits].setValueWithNumberOfDigits(1, numberOfDigits);
 }
@@ -55,7 +55,6 @@ scheduler.frameDidFire = function()
 
     style = window.getComputedStyle(timeLabel.element);
 
-    shouldBeEqualToString("style.position", "absolute");
     shouldBeEqualToString("style.fontFamily", "-apple-system-monospaced-numbers");
     shouldBeEqualToString("style.fontSize", "12px");
 
@@ -81,11 +80,8 @@ scheduler.frameDidFire = function()
     for (numberOfDigits of digits) {
         debug("");
         debug(`elapsedTimeLabels[${numberOfDigits}].element.textContent = ${elapsedTimeLabels[numberOfDigits].element.textContent}`);
-        debug(`elapsedTimeLabels[${numberOfDigits}].width = ${elapsedTimeLabels[numberOfDigits].width}`);
         debug(`remainingTimeLabels[${numberOfDigits}].element.textContent = ${remainingTimeLabels[numberOfDigits].element.textContent}`);
-        debug(`remainingTimeLabels[${numberOfDigits}].width = ${remainingTimeLabels[numberOfDigits].width}`);
         debug(`durationTimeLabels[${numberOfDigits}].element.textContent = ${durationTimeLabels[numberOfDigits].element.textContent}`);
-        debug(`durationTimeLabels[${numberOfDigits}].width = ${durationTimeLabels[numberOfDigits].width}`);
     }
 
     debug("");

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -734,6 +734,7 @@ $(PROJECT_DIR)/Modules/modern-media-controls/controls/slider.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/status-label.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/status-label.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/text-tracks.css
+$(PROJECT_DIR)/Modules/modern-media-controls/controls/time-control.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/time-control.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/time-label.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/time-label.js

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2122,6 +2122,7 @@ MODERN_MEDIA_CONTROLS_STYLE_SHEETS = \
     $(WebCore)/Modules/modern-media-controls/controls/slider.css \
     $(WebCore)/Modules/modern-media-controls/controls/status-label.css \
     $(WebCore)/Modules/modern-media-controls/controls/text-tracks.css \
+    $(WebCore)/Modules/modern-media-controls/controls/time-control.css \
     $(WebCore)/Modules/modern-media-controls/controls/time-label.css \
     $(WebCore)/Modules/modern-media-controls/controls/tvos-media-controls.css \
     $(WebCore)/Modules/modern-media-controls/controls/vision-media-controls.css \

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.css
@@ -41,8 +41,21 @@
 .slider.default > .appearance > .fill {
     position: relative;
     height: 100%;
-    border-radius: 4.5px;
-    overflow: hidden;
+    display: flex;
+}
+
+.slider.default > .appearance > .fill {
+    --fill-border-radius: 4.5px;
+}
+
+.slider.default > .appearance > .fill > :first-child {
+    border-top-left-radius: var(--fill-border-radius);
+    border-bottom-left-radius: var(--fill-border-radius);
+}
+
+.slider.default > .appearance > .fill > :last-child {
+    border-top-right-radius: var(--fill-border-radius);
+    border-bottom-right-radius: var(--fill-border-radius);
 }
 
 .slider.default.allows-relative-scrubbing > .appearance > .fill {
@@ -51,11 +64,10 @@
 }
 
 .slider.default.allows-relative-scrubbing > .appearance.changing > .fill {
-    border-radius: 7.5px;
+    --fill-border-radius: 7.5px;
 }
 
 .slider.default > .appearance > .fill > * {
-    position: absolute;
     top: 0;
     height: 100%;
     mix-blend-mode: plus-lighter;
@@ -66,7 +78,6 @@
 }
 
 .slider.default > .appearance > .fill > .primary {
-    left: 0;
     background-color: rgba(255, 255, 255, 0.45);
 }
 
@@ -75,7 +86,6 @@
 }
 
 .slider.default > .appearance > .fill > .track {
-    right: 0;
     background-color: rgba(255, 255, 255, 0.1);
 }
 
@@ -87,32 +97,30 @@
     background-color: rgba(255, 255, 255, 0.08);
 }
 
-.slider.default.allows-relative-scrubbing > .appearance > .fill > .secondary {
+.slider.default.allows-relative-scrubbing > .appearance > .fill > .track > .secondary {
     background-color: rgb(128, 128, 128);
 }
 
-.slider.default > .appearance > .knob {
-    position: absolute;
+.slider.default > .appearance > .fill > .knob {
+    align-self: center;
     background-color: white;
-    transform: translateX(-50%);
 }
 
-.slider.default > .appearance > .knob.circle {
-    top: -2px;
+.slider.default > .appearance > .fill > .knob.circle {
     width: 9px;
     height: 9px;
     border-radius: 50%;
+    margin: -4.5px;
 }
 
-.slider.default > .appearance > .knob.bar {
-    top: -6px;
+.slider.default > .appearance > .fill > .knob.bar {
     width: 4px;
     height: 17px;
     border-radius: 4px;
+    margin: 1px;
 }
 
-.slider.default > .appearance > .knob.none {
-    top: -2px;
+.slider.default > .appearance > .fill > .knob.none {
     width: 9px;
     height: 9px;
     border-radius: 50%;
@@ -121,7 +129,6 @@
 
 /* When disabled, we only want to show the track and turn off interaction. */
 
-.slider.default.disabled > .appearance > .fill > :is(.primary, .secondary),
-.slider.default.disabled > .appearance > .knob {
+.slider.default.disabled > .appearance > .fill > :is(.primary, .secondary) {
     display: none;
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.js
@@ -32,13 +32,13 @@ class Slider extends SliderBase
         this._primaryFill = new LayoutNode(`<div class="primary"></div>`);
         this._trackFill = new LayoutNode(`<div class="track"></div>`);
         this._secondaryFill = new LayoutNode(`<div class="secondary"></div>`);
+        this._trackFill.children = [this._secondaryFill];
 
         let fillContainer = new LayoutNode(`<div class="fill"></div>`);
-        fillContainer.children = [this._primaryFill, this._trackFill, this._secondaryFill];
-
         this._knob = new LayoutNode(`<div class="knob ${knobStyle}"></div>`);
+        fillContainer.children = [this._primaryFill, this._knob, this._trackFill];
 
-        this.appearanceContainer.children = [fillContainer, this._knob];
+        this.appearanceContainer.children = [fillContainer];
 
         this.height = 16;
         this._knobStyle = knobStyle;
@@ -71,38 +71,8 @@ class Slider extends SliderBase
     {
         super.commit();
 
-        const scrubberWidth = (style => {
-            switch (style) {
-            case Slider.KnobStyle.Bar:
-                return 4;
-            case Slider.KnobStyle.Circle:
-                return 9;
-            case Slider.KnobStyle.None:
-                return 0;
-            }
-            console.error("Unknown Slider.KnobStyle");
-            return 0;
-        })(this._knobStyle);
-
-        const scrubberBorder = (style => {
-            switch (style) {
-            case Slider.KnobStyle.Bar:
-                return 1;
-            case Slider.KnobStyle.Circle:
-                return (-1 * scrubberWidth / 2);
-            case Slider.KnobStyle.None:
-                return 0;
-            }
-            console.error("Unknown Slider.KnobStyle");
-            return 0;
-        })(this._knobStyle);
-
-        const scrubberCenterX = (scrubberWidth / 2) + Math.round((this.width - scrubberWidth) * this.value);
-        this._primaryFill.element.style.width = `${scrubberCenterX - (scrubberWidth / 2) - scrubberBorder}px`;
-        this._trackFill.element.style.left = `${scrubberCenterX + (scrubberWidth / 2) + scrubberBorder}px`;
-        this._secondaryFill.element.style.left = `${scrubberCenterX + (scrubberWidth / 2) + scrubberBorder}px`;
-        this._secondaryFill.element.style.right = `${(1 - this.secondaryValue) * 100}%`;
-        this._knob.element.style.left = `${scrubberCenterX}px`;
+        this._primaryFill.element.style.flexGrow = 100 * this.value;
+        this._trackFill.element.style.flexGrow = 100 * (1 - this.value);
     }
 
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,63 +23,42 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.activity-indicator {
-    position: absolute;
-    mix-blend-mode: plus-lighter;
-    width: 14px;
-    height: 14px;
+.time-control {
+    display: flex;
+    column-gap: 5px;
+    container: time-control-container / size;
+    justify-content: space-between;
 }
 
-.activity-indicator > div {
-    position: absolute;
-    left: 6px;
-    width: 2px;
-    height: 4px;
-    border-radius: 1px;
-    background-color: white;
-    animation-name: activity-indicator-pulse;
-    animation-duration: 1s;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
-    transform-origin: 50% 7px;
+.time-control .scrubber {
+    flex-grow: 1;
 }
 
-.activity-indicator > .ne {
-    transform: rotate(45deg);
-    animation-delay: -875ms;
+/* Support displaying the time labels above or below the scrubber, rather than side-by-side: */
+.time-control.above,
+.time-control.below {
+
+    flex-wrap: wrap;
+    .scrubber { width: 100%; }
+}
+.time-control.above {
+    .scrubber { order: 2; }
+    .time-label { order: 1; }
+}
+.time-control.below {
+    .scrubber { order: 1; }
+    .time-label { order: 2; }
 }
 
-.activity-indicator > .e {
-    transform: rotate(90deg);
-    animation-delay: -750ms;
-}
+/* Support toggling the duration and remaining time labels: */
+.time-control.duration > #time-label-remaining { display: none; }
+.time-control.remaining > #time-label-duration { display: none; }
 
-.activity-indicator > .se {
-    transform: rotate(135deg);
-    animation-delay: -625ms;
-}
-
-.activity-indicator > .s {
-    transform: rotate(180deg);
-    animation-delay: -500ms;
-}
-
-.activity-indicator > .sw {
-    transform: rotate(-135deg);
-    animation-delay: -375ms;
-}
-
-.activity-indicator > .w {
-    transform: rotate(-90deg);
-    animation-delay: -250ms;
-}
-
-.activity-indicator > .nw {
-    transform: rotate(-45deg);
-    animation-delay: -125ms;
-}
-
-@keyframes activity-indicator-pulse {
-    from { opacity: 0.9  }
-    to   { opacity: 0.25 }
+@container time-control-container (width < 160px) {
+    .time-control > #time-label-duration,
+    .time-control > #time-label-elapsed {
+        display: none;
+    }
+    /* Override the duration/remaining toggle when in small control mode: */
+    .time-control.duration > #time-label-remaining { display: revert; }
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-label.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-label.css
@@ -24,8 +24,6 @@
  */
 
 .time-label {
-    position: absolute;
-
     font-family: -apple-system-monospaced-numbers;
     font-size: 12px;
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
@@ -46,7 +46,7 @@ class TVOSMediaControls extends MediaControls
 
         this.timeControl.scrubber.allowsRelativeScrubbing = true;
         this.timeControl.scrubber.knobStyle = Slider.KnobStyle.None;
-        this.timeControl.timeLabelsAttachment = TimeControl.TimeLabelsAttachment.Below;
+        this.timeControl.style = TimeControl.Style.Below;
 
         this.skipBackButton = new SkipBackButton(this);
         this.skipForwardButton = new SkipForwardButton(this);

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
@@ -260,7 +260,7 @@ class VisionInlineMediaControls extends VisionMediaControls
         this.overflowButton.style = Button.Styles.Rounded;
         this.overflowButton.circular = true;
 
-        this.timeControl.timeLabelsAttachment = TimeControl.TimeLabelsAttachment.Above;
+        this.timeControl.style = TimeControl.Style.Above;
 
         this.bottomControlsBar.hasBackgroundTint = false;
 
@@ -377,7 +377,7 @@ class VisionInlineMediaControls extends VisionMediaControls
         this.muteButton.circular = true;
         this.overflowButton.style = Button.Styles.Bar;
 
-        this.timeControl.timeLabelsAttachment = TimeControl.TimeLabelsAttachment.Side;
+        this.timeControl.style = TimeControl.Style.Side;
 
         this.bottomControlsBar.hasBackgroundTint = true;
         

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -63,10 +63,11 @@ function formatTimeByUnit(value)
 {
     const time = value || 0;
     const absTime = Math.abs(time);
+    const sign = Math.sign(time);
     return {
-        seconds: Math.floor(absTime % 60).toFixed(0),
-        minutes: Math.floor((absTime / 60) % 60).toFixed(0),
-        hours: Math.floor(absTime / (60 * 60)).toFixed(0)
+        seconds: sign * Math.floor(absTime % 60).toFixed(0),
+        minutes: sign * Math.floor((absTime / 60) % 60).toFixed(0),
+        hours: sign * Math.floor(absTime / (60 * 60)).toFixed(0)
     };
 }
 


### PR DESCRIPTION
#### e23794f045e76d54f592ca67e57c5ad481bed967
<pre>
Media control time fields should be Locale-aware
<a href="https://rdar.apple.com/141281469">rdar://141281469</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296748">https://bugs.webkit.org/show_bug.cgi?id=296748</a>

Reviewed by Andy Estes.

The current time, elapsed time, and duration fields in the UA media controls currently are
hard-coded to a western digital time format, regardless of the number format for the user&apos;s
preferred locale.

Adopt Int.DurationFormat() as the mechanism for formatting the duration strings in those time
fields. Because the width of those fields is no longer fixed and statically calulatable, the layout
of the TimeControl object must be made more flexable.

Update the TimeContol object to use flex-box to layout the elapsedTime, scrubber, remainingTime, and
duration objects. Use CSS rather than JavaScript to control object visibility. Add container layout
style rules to dynamically hide and show time labels as the TimeControl object resizes.

* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-layout-expected.txt:
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-layout.html:
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-time-control-styles-expected.txt:
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-time-control-styles.html:
* LayoutTests/media/modern-media-controls/resources/media-controls-loader.js:
* LayoutTests/media/modern-media-controls/time-control/time-control-expected.txt:
* LayoutTests/media/modern-media-controls/time-control/time-control.html:
* LayoutTests/media/modern-media-controls/time-label/ios-time-label-expected.txt:
* LayoutTests/media/modern-media-controls/time-label/ios-time-label.html:
* LayoutTests/media/modern-media-controls/time-label/time-label-expected.txt:
* LayoutTests/media/modern-media-controls/time-label/time-label.html:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/modern-media-controls/controls/activity-indicator.css:
(.activity-indicator):
* Source/WebCore/Modules/modern-media-controls/controls/slider.css:
(.slider.default &gt; .appearance &gt; .fill):
(.slider.default &gt; .appearance &gt; .fill &gt; :first-child):
(.slider.default &gt; .appearance &gt; .fill &gt; :last-child):
(.slider.default.allows-relative-scrubbing &gt; .appearance.changing &gt; .fill):
(.slider.default &gt; .appearance &gt; .fill &gt; *):
(.slider.default &gt; .appearance &gt; .fill &gt; .primary):
(.slider.default &gt; .appearance &gt; .fill &gt; .track):
(.slider.default.allows-relative-scrubbing &gt; .appearance &gt; .fill &gt; .track &gt; .secondary):
(.slider.default &gt; .appearance &gt; .fill &gt; .knob):
(.slider.default &gt; .appearance &gt; .fill &gt; .knob.circle):
(.slider.default &gt; .appearance &gt; .fill &gt; .knob.bar):
(.slider.default &gt; .appearance &gt; .fill &gt; .knob.none):
(.slider.default.disabled &gt; .appearance &gt; .fill &gt; :is(.primary, .secondary)):
(.slider.default.allows-relative-scrubbing &gt; .appearance &gt; .fill &gt; .secondary): Deleted.
(.slider.default &gt; .appearance &gt; .knob): Deleted.
(.slider.default &gt; .appearance &gt; .knob.circle): Deleted.
(.slider.default &gt; .appearance &gt; .knob.bar): Deleted.
(.slider.default &gt; .appearance &gt; .knob.none): Deleted.
(.slider.default.disabled &gt; .appearance &gt; .fill &gt; :is(.primary, .secondary),): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/slider.js:
(Slider.prototype.commit):
* Source/WebCore/Modules/modern-media-controls/controls/time-control.css: Copied from Source/WebCore/Modules/modern-media-controls/controls/time-label.css.
(.time-control):
(.time-control .scrubber):
(.time-control.above,):
(.time-control.above):
(.time-label):
(.time-control.below):
(.time-control.duration &gt; #time-label-remaining):
(.time-control.remaining &gt; #time-label-duration):
(@container time-control-container (width &lt; 160px)):
* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.prototype.this.remainingTimeLabel):
(TimeControl.prototype.get minimumWidth):
(TimeControl.prototype.get idealMinimumWidth):
(TimeControl.prototype.layout):
(TimeControl.prototype.handleEvent):
(TimeControl.prototype._performIdealLayout):
(TimeControl.prototype._toggleDurationRemainingLabel):
(TimeControl.): Deleted.
(TimeControl.prototype.get timeLabelsAttachment): Deleted.
(TimeControl.prototype.set timeLabelsAttachment): Deleted.
(TimeControl.prototype.get _timeLabelsDisplayOnScrubberSide): Deleted.
(TimeControl.prototype.get _canShowDurationTimeLabel): Deleted.
(TimeControl.prototype._durationOrRemainingTimeLabel): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/time-label.css:
(.time-label):
* Source/WebCore/Modules/modern-media-controls/controls/time-label.js:
(TimeLabel.prototype.set value):
(TimeLabel.prototype.get numberOfDigits):
(TimeLabel.prototype.set numberOfDigits):
(TimeLabel.prototype.setValueWithNumberOfDigits):
(TimeLabel.prototype._formattedTime):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js:
* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js:
(VisionInlineMediaControls.prototype._createControls):
(VisionInlineMediaControls.prototype._performSingleBarLayout):
(VisionInlineMediaControls):
* Source/WebCore/Modules/modern-media-controls/main.js:
(UIString):
(formatTimeByUnit): Deleted.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/299348@main">https://commits.webkit.org/299348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b461b6fa5c07ac8fb7cd6b9fc3b83ab8a89c9153

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69388 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4bf6ff75-ebb5-42d6-9104-b5fb06746c80) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89086 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43750 "Too many flaky failures: css3/filters/drop-shadow-current-color.html, fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/ToNumber.html, js/dom/eval-contained-syntax-error.html, js/dom/webassembly-memory-shared-fail.html, storage/indexeddb/exception-in-event-aborts-private.html, storage/indexeddb/modern/get-index-failures.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-rg16f-rg-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-3d-srgb8_alpha8-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgb5_a1-rgba-unsigned_byte.html, webgl/2.0.y/conformance/more/functions/vertexAttribPointerBadArgs.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8810ca0-8360-4fb7-8db9-af9a12780b09) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69596 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c336d470-b581-4a66-b9bf-01a909d77466) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23377 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67172 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126620 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97752 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40647 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49829 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43627 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->