### PR TITLE
[WebXR][OpenXR] Export OpenXR textures to WebProcess for WebGL rendering

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2675,9 +2675,13 @@ webkit.org/b/215912 http/tests/websocket/tests/hybi/handshake-fail-by-no-cr.html
 #////////////////////////////////////////////////////////////////////////////////////////
 
 webkit.org/b/208988 http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html [ Timeout ]
-webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https.html [ Failure ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrViewport_valid.https.html [ Failure ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html [ Failure ]
+
+# WebXROpaqueFramebuffer is not able to properly setup gfx resources
+webkit.org/b/296681 imported/w3c/web-platform-tests/webxr [ Skip ]
+
+webkit.org/b/208988 http/wpt/webxr [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebXR-related bugs
@@ -3285,9 +3289,6 @@ webkit.org/b/279434 fast/text/glyph-display-lists/glyph-display-list-gpu-process
 
 # testRunner.webHistoryItemCount implementation is not implemented in WTR
 webkit.org/b/100238 fast/history/window-open.html [ Skip ]
-
-# WebXR is not fully supported yet
-webkit.org/b/208988 http/wpt/webxr [ Skip ]
 
 # Lockdown Mode does not apply
 dom/xsl/lockdown-mode [ Skip ]

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https-expected.txt
@@ -1,6 +1,0 @@
-
-PASS Creating a webgl context with no device
-PASS Creating a webgl2 context with no device
-FAIL An XR-compatible webgl context can be created promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'gl.makeXRCompatible')"
-FAIL An XR-compatible webgl2 context can be created promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'gl.makeXRCompatible')"
-

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -29,10 +29,11 @@
 
 #if ENABLE(WEBXR) && !PLATFORM(COCOA)
 
-#include "DocumentInlines.h"
+#include "ContextDestructionObserverInlines.h"
 #include "IntSize.h"
-#include "WebGLFramebuffer.h"
+#include "Logging.h"
 #include "WebGL2RenderingContext.h"
+#include "WebGLFramebuffer.h"
 #include "WebGLRenderingContext.h"
 #include "WebGLRenderingContextBase.h"
 #include "WebGLUtilities.h"
@@ -42,6 +43,64 @@
 namespace WebCore {
 
 using GL = GraphicsContextGL;
+
+static void ensure(GL& gl, GCGLOwnedFramebuffer& framebuffer)
+{
+    if (!framebuffer) {
+        auto object = gl.createFramebuffer();
+        if (!object)
+            return;
+        framebuffer.adopt(gl, object);
+    }
+}
+
+static void createAndBindCompositorBuffer(GL& gl, WebXRExternalRenderbuffer& buffer, GCGLenum internalFormat, GL::ExternalImageSource source, GCGLint layer)
+{
+    if (!buffer.renderBufferObject) {
+        auto object = gl.createRenderbuffer();
+        if (!object)
+            return;
+        buffer.renderBufferObject.adopt(gl, object);
+    }
+    gl.bindRenderbuffer(GL::RENDERBUFFER, buffer.renderBufferObject);
+    auto image = gl.createExternalImage(WTFMove(source), internalFormat, layer);
+    if (!image)
+        return;
+    gl.bindExternalImage(GL::RENDERBUFFER, image);
+    buffer.image.adopt(gl, image);
+    LOG(XR, "WebXROpaqueFramebuffer::createAndBindCompositorBuffer(): created and bound external image to renderbuffer");
+}
+
+static GL::ExternalImageSource makeExternalImageSource(const PlatformXR::FrameData::ExternalTexture& imageSource, WebCore::IntSize size)
+{
+    return GraphicsContextGLExternalImageSource {
+        .fds = imageSource.fds.map([](const UnixFileDescriptor& fd) {
+            return fd.duplicate();
+        }),
+        .strides = imageSource.strides,
+        .offsets = imageSource.offsets,
+        .fourcc = imageSource.fourcc,
+        .modifier = imageSource.modifier,
+        .size = size
+    };
+}
+
+static void createAndBindTempBuffer(GL& gl, WebXRExternalRenderbuffer& buffer, GCGLenum internalFormat, IntSize size)
+{
+    if (!buffer.renderBufferObject) {
+        auto object = gl.createRenderbuffer();
+        if (!object)
+            return;
+        buffer.renderBufferObject.adopt(gl, object);
+    }
+    gl.bindRenderbuffer(GL::RENDERBUFFER, buffer.renderBufferObject);
+    gl.renderbufferStorage(GL::RENDERBUFFER, internalFormat, size.width(), size.height());
+}
+
+static IntSize toIntSize(const auto& size)
+{
+    return IntSize(size[0], size[1]);
+}
 
 std::unique_ptr<WebXROpaqueFramebuffer> WebXROpaqueFramebuffer::create(PlatformXR::LayerHandle handle, WebGLRenderingContextBase& context, Attributes&& attributes, IntSize framebufferSize)
 {
@@ -62,9 +121,12 @@ WebXROpaqueFramebuffer::WebXROpaqueFramebuffer(PlatformXR::LayerHandle handle, R
 
 WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 {
+    releaseAllDisplayAttachments();
+
     if (RefPtr gl = m_context->graphicsContextGL()) {
         m_drawAttachments.release(*gl);
         m_resolveAttachments.release(*gl);
+        m_displayFBO.release(*gl);
         m_resolvedFBO.release(*gl);
         m_context->deleteFramebuffer(m_drawFramebuffer.ptr());
     } else {
@@ -101,8 +163,28 @@ void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
     // FIXME: Actually do the clearing (not using invalidateFramebuffer). This will have to be done after we've attached
     // the textures/renderbuffers.
 
-    m_framebufferSize = data.framebufferSize;
-    m_colorTexture = data.opaqueTexture;
+    if (data.layerSetup) {
+        // The drawing target can change size at any point during the session. If this happens, we need
+        // to recreate the framebuffer.
+        if (!setupFramebuffer(*gl, *data.layerSetup))
+            return;
+    }
+    bindCompositorTexturesForDisplay(*gl, data);
+    auto displayAttachmentSet = reusableDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
+    ASSERT(displayAttachmentSet);
+    if (!displayAttachmentSet) {
+        RELEASE_LOG_ERROR(XR, "WebXROpaqueFramebuffer::startFrame(): unable to find display attachments at index: %zu", m_currentDisplayAttachmentIndex);
+        LOG(XR, "WebXROpaqueFramebuffer::startFrame(): unable to find display attachments at index: %zu", m_currentDisplayAttachmentIndex);
+        return;
+    }
+    if (!(*displayAttachmentSet)[0].colorBuffer.image) {
+        RELEASE_LOG_ERROR(XR, "WebXROpaqueFramebuffer::startFrame(): no color texture at index: %zu", m_currentDisplayAttachmentIndex);
+        LOG(XR, "WebXROpaqueFramebuffer::startFrame(): no color texture at index: %zu", m_currentDisplayAttachmentIndex);
+        return;
+    }
+
+    m_renderingFrameIndex = data.renderingFrameIndex;
+    m_blitDepth = data.requestDepth;
 
     // WebXR must always clear for the rAF of the session. Currently we assume content does not do redundant initial clear,
     // as the spec says the buffer always starts cleared.
@@ -128,7 +210,6 @@ void WebXROpaqueFramebuffer::endFrame()
         return;
 
     tracePoint(WebXRLayerEndFrameStart);
-    gl->disableFoveation();
 
     auto scopeExit = makeScopeExit([&]() {
         tracePoint(WebXRLayerEndFrameEnd);
@@ -144,10 +225,6 @@ void WebXROpaqueFramebuffer::endFrame()
         break;
     }
 
-    // FIXME: We have to call finish rather than flush because we only want to disconnect
-    // the IOSurface and signal the DeviceProxy when we know the content has been rendered.
-    // It might be possible to set this up so the completion of the rendering triggers
-    // the endFrame call.
     gl->finish();
 }
 
@@ -156,9 +233,16 @@ bool WebXROpaqueFramebuffer::usesLayeredMode() const
     return m_displayLayout == PlatformXR::Layout::Layered;
 }
 
+void WebXROpaqueFramebuffer::releaseAllDisplayAttachments()
+{
+    for (size_t i = 0; i < m_displayAttachmentsSets.size(); ++i)
+        releaseDisplayAttachmentsAtIndex(i);
+    m_displayAttachmentsSets.clear();
+}
+
 void WebXROpaqueFramebuffer::resolveMSAAFramebuffer(GraphicsContextGL& gl)
 {
-    IntSize size = drawFramebufferSize();
+    IntSize size = m_framebufferSize; // Physical Space
     PlatformGLObject readFBO = m_drawFramebuffer->object();
     PlatformGLObject drawFBO = m_resolvedFBO ? m_resolvedFBO : m_displayFBO;
 
@@ -172,20 +256,70 @@ void WebXROpaqueFramebuffer::resolveMSAAFramebuffer(GraphicsContextGL& gl)
     ASSERT(gl.checkFramebufferStatus(GL::READ_FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
     gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, drawFBO);
     ASSERT(gl.checkFramebufferStatus(GL::DRAW_FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    ScopedDisableScissorTest disableScissorTest { m_context };
     gl.blitFramebuffer(0, 0, size.width(), size.height(), 0, 0, size.width(), size.height(), buffers, GL::NEAREST);
 }
 
 void WebXROpaqueFramebuffer::blitShared(GraphicsContextGL& gl)
 {
-    gl.bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
-    gl.framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, m_colorTexture, 0);
+    ASSERT(!m_resolvedFBO, "blitShared should not require intermediate resolve buffers");
+
+    auto displayAttachmentSet = reusableDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
+    ASSERT(displayAttachmentSet);
+    if (!displayAttachmentSet) {
+        RELEASE_LOG_ERROR(XR, "WebXROpaqueFramebuffer::blitShared(): unable to find display attachments at index: %zu", m_currentDisplayAttachmentIndex);
+        return;
+    }
+
+    ensure(gl, m_displayFBO);
+    gl.bindFramebuffer(GL::FRAMEBUFFER, m_displayFBO);
+    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, (*displayAttachmentSet)[0].colorBuffer.renderBufferObject);
     ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    resolveMSAAFramebuffer(gl);
 }
 
 void WebXROpaqueFramebuffer::blitSharedToLayered(GraphicsContextGL& gl)
 {
-    UNUSED_PARAM(gl);
-    ASSERT_NOT_REACHED();
+    ensure(gl, m_displayFBO);
+
+    PlatformGLObject readFBO = (m_resolvedFBO && m_attributes.antialias) ? m_resolvedFBO : m_drawFramebuffer->object();
+    ASSERT(readFBO, "readFBO shouldn't be the default framebuffer");
+    PlatformGLObject drawFBO = m_displayFBO;
+    ASSERT(drawFBO, "drawFBO shouldn't be the default framebuffer");
+
+    auto displayAttachmentSet = reusableDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
+    ASSERT(displayAttachmentSet);
+    if (!displayAttachmentSet) {
+        RELEASE_LOG_ERROR(XR, "WebXROpaqueFramebuffer::blitSharedToLayered(): unable to find display attachments at index: %zu", m_currentDisplayAttachmentIndex);
+        return;
+    }
+
+    GCGLint xOffset = 0;
+    GCGLint width = m_leftPhysicalSize.width();
+    GCGLint height = m_leftPhysicalSize.height();
+
+    if (m_resolvedFBO && m_attributes.antialias)
+        resolveMSAAFramebuffer(gl);
+
+    for (int layer = 0; layer < 2; ++layer) {
+        gl.bindFramebuffer(GL::READ_FRAMEBUFFER, readFBO);
+        gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, drawFBO);
+
+        GCGLbitfield buffers = GL::COLOR_BUFFER_BIT;
+        gl.framebufferRenderbuffer(GL::DRAW_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, (*displayAttachmentSet)[layer].colorBuffer.renderBufferObject);
+
+        if (m_blitDepth && (*displayAttachmentSet)[layer].depthStencilBuffer.image) {
+            buffers |= GL::DEPTH_BUFFER_BIT;
+            gl.framebufferRenderbuffer(GL::DRAW_FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, (*displayAttachmentSet)[layer].depthStencilBuffer.renderBufferObject);
+        }
+        ASSERT(gl.checkFramebufferStatus(GL::DRAW_FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+
+        gl.blitFramebuffer(xOffset, 0, xOffset + width, height, 0, 0, width, height, buffers, GL::NEAREST);
+
+        xOffset += width;
+        width = m_rightPhysicalSize.width();
+        height = m_rightPhysicalSize.height();
+    }
 }
 
 bool WebXROpaqueFramebuffer::supportsDynamicViewportScaling() const
@@ -195,18 +329,175 @@ bool WebXROpaqueFramebuffer::supportsDynamicViewportScaling() const
 
 IntSize WebXROpaqueFramebuffer::drawFramebufferSize() const
 {
-    return m_framebufferSize;
+    auto framebufferRect = unionRect(m_leftViewport, m_rightViewport);
+    RELEASE_ASSERT(framebufferRect.location().isZero());
+    // rdar://127893021 - Games exported by Unity set the viewport to the reported size of the framebuffer and
+    // adjust the rendering for each eye's viewport in shaders, not with WebGL setViewport/setScissor calls.
+    return framebufferRect.size();
 }
 
 IntRect WebXROpaqueFramebuffer::drawViewport(PlatformXR::Eye eye) const
 {
-    UNUSED_PARAM(eye);
-    return IntRect(IntPoint::zero(), drawFramebufferSize());
+    switch (eye) {
+    case PlatformXR::Eye::None:
+        RELEASE_ASSERT(!m_usingFoveation);
+        return IntRect(IntPoint::zero(), drawFramebufferSize());
+    case PlatformXR::Eye::Left:
+        return m_leftViewport;
+    case PlatformXR::Eye::Right:
+        return m_rightViewport;
+    }
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
-static IntSize toIntSize(const auto& size)
+static PlatformXR::Layout displayLayout(const PlatformXR::FrameData::LayerSetupData& data)
 {
-    return IntSize(size[0], size[1]);
+    return data.physicalSize[1][0] > 0 ? PlatformXR::Layout::Layered : PlatformXR::Layout::Shared;
+}
+
+static IntSize calcFramebufferPhysicalSize(const IntSize& leftPhysicalSize, const IntSize& rightPhysicalSize)
+{
+    if (rightPhysicalSize.isEmpty())
+        return leftPhysicalSize;
+    RELEASE_ASSERT(leftPhysicalSize.height() == rightPhysicalSize.height(), "Only side-by-side shared framebuffer layout is supported");
+    return { leftPhysicalSize.width() + rightPhysicalSize.width(), leftPhysicalSize.height() };
+}
+
+bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const PlatformXR::FrameData::LayerSetupData& data)
+{
+    auto leftPhysicalSize = toIntSize(data.physicalSize[0]);
+    auto rightPhysicalSize = toIntSize(data.physicalSize[1]);
+    auto framebufferSize = calcFramebufferPhysicalSize(leftPhysicalSize, rightPhysicalSize);
+    bool framebufferResize = !m_drawAttachments || m_framebufferSize != framebufferSize || m_displayLayout != displayLayout(data);
+    bool usingFoveation = !data.foveationRateMapDesc.screenSize.isEmpty();
+    bool foveationChange = m_usingFoveation ^ usingFoveation;
+
+    m_displayLayout = displayLayout(data);
+    m_framebufferSize = framebufferSize;
+    m_leftViewport = data.viewports[0];
+    m_leftPhysicalSize = leftPhysicalSize;
+    m_rightViewport = data.viewports[1];
+    m_rightPhysicalSize = rightPhysicalSize;
+    m_usingFoveation = usingFoveation;
+
+    const bool layeredLayout = m_displayLayout == PlatformXR::Layout::Layered;
+    const bool needsIntermediateResolve = m_attributes.antialias && layeredLayout;
+
+    // Set up recommended samples for WebXR.
+    auto sampleCount = m_attributes.antialias ? std::min(4, m_context->maxSamples()) : 0;
+
+    // Drawing target
+    if (framebufferResize) {
+        // FIXME: We always allocate a new drawing target
+        allocateAttachments(gl, m_drawAttachments, sampleCount, m_framebufferSize);
+
+        gl.bindFramebuffer(GL::FRAMEBUFFER, m_drawFramebuffer->object());
+        bindAttachments(gl, m_drawAttachments);
+        ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+    }
+
+    // Calculate viewports of each eye
+    if (foveationChange) {
+        if (m_usingFoveation) {
+            const auto& frmd = data.foveationRateMapDesc;
+            if (!gl.addFoveation(leftPhysicalSize, rightPhysicalSize, frmd.screenSize, frmd.horizontalSamplesLeft, frmd.verticalSamples, frmd.horizontalSamplesRight))
+                return false;
+            gl.enableFoveation(m_drawAttachments.colorBuffer);
+        } else
+            gl.disableFoveation();
+    }
+
+    // Intermediate resolve target
+    if ((!m_resolvedFBO || framebufferResize) && needsIntermediateResolve) {
+        allocateAttachments(gl, m_resolveAttachments, 0, m_framebufferSize);
+
+        ensure(gl, m_resolvedFBO);
+        gl.bindFramebuffer(GL::FRAMEBUFFER, m_resolvedFBO);
+        bindAttachments(gl, m_resolveAttachments);
+        ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
+        if (gl.checkFramebufferStatus(GL::FRAMEBUFFER) != GL::FRAMEBUFFER_COMPLETE)
+            return false;
+    }
+
+    return gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE;
+}
+
+const std::array<WebXRExternalAttachments, 2>* WebXROpaqueFramebuffer::reusableDisplayAttachments(const PlatformXR::FrameData::ExternalTextureData& textureData) const
+{
+    if (!textureData.colorTexture.fds.isEmpty())
+        return nullptr;
+
+    auto reusableTextureIndex = textureData.reusableTextureIndex;
+    if (reusableTextureIndex >= m_displayAttachmentsSets.size() || !m_displayAttachmentsSets[reusableTextureIndex][0]) {
+        RELEASE_LOG_FAULT(XR, "Unable to find reusable texture at index: %lu", reusableTextureIndex);
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return &m_displayAttachmentsSets[reusableTextureIndex];
+}
+
+void WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, const PlatformXR::FrameData::LayerData& layerData)
+{
+    int layerCount = (m_displayLayout == PlatformXR::Layout::Layered) ? 2 : 1;
+
+    m_currentDisplayAttachmentIndex = layerData.textureData ? layerData.textureData->reusableTextureIndex : 0;
+    if (m_displayAttachmentsSets.size() <= m_currentDisplayAttachmentIndex)
+        m_displayAttachmentsSets.resizeToFit(m_currentDisplayAttachmentIndex + 1);
+
+    IntSize framebufferSize = layerData.layerSetup ? toIntSize(layerData.layerSetup->physicalSize[0]) : IntSize(32, 32);
+    if (!layerData.textureData) {
+        m_currentDisplayAttachmentIndex = 0;
+
+        for (int layer = 0; layer < layerCount; ++layer)
+            createAndBindTempBuffer(gl, m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].colorBuffer, GL::RGBA8, framebufferSize);
+        return;
+    }
+
+    auto displayAttachments = reusableDisplayAttachments(*(layerData.textureData));
+    if (displayAttachments)
+        return;
+
+    releaseDisplayAttachmentsAtIndex(m_currentDisplayAttachmentIndex);
+    for (int layer = 0; layer < layerCount; ++layer) {
+        ASSERT(!layerData.textureData->colorTexture.fds.isEmpty());
+        if (layerData.textureData->colorTexture.fds.isEmpty())
+            return;
+
+        auto colorTextureSource = makeExternalImageSource(layerData.textureData->colorTexture, framebufferSize);
+        createAndBindCompositorBuffer(gl, m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].colorBuffer, GL::RGBA8, WTFMove(colorTextureSource), layer);
+        ASSERT(m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].colorBuffer.image);
+        if (!m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].colorBuffer.image)
+            return;
+
+        if (!layerData.textureData->depthStencilBuffer.fds.isEmpty()) {
+            auto depthStencilBufferSource = makeExternalImageSource(layerData.textureData->depthStencilBuffer, framebufferSize);
+            createAndBindCompositorBuffer(gl, m_displayAttachmentsSets[m_currentDisplayAttachmentIndex][layer].depthStencilBuffer, GL::DEPTH24_STENCIL8, WTFMove(depthStencilBufferSource), layer);
+        }
+    }
+}
+
+const std::array<WebXRExternalAttachments, 2>* WebXROpaqueFramebuffer::reusableDisplayAttachmentsAtIndex(size_t index)
+{
+    if (index >= m_displayAttachmentsSets.size())
+        return nullptr;
+
+    return &m_displayAttachmentsSets[index];
+}
+
+void WebXROpaqueFramebuffer::releaseDisplayAttachmentsAtIndex(size_t index)
+{
+    if (index >= m_displayAttachmentsSets.size())
+        return;
+
+    RefPtr gl = m_context->graphicsContextGL();
+    for (auto& attachments : m_displayAttachmentsSets[index]) {
+        if (gl)
+            attachments.release(*gl);
+        else
+            attachments.leakObject();
+    }
 }
 
 void WebXROpaqueFramebuffer::allocateRenderbufferStorage(GraphicsContextGL& gl, GCGLOwnedRenderbuffer& buffer, GCGLsizei samples, GCGLenum internalFormat, IntSize size)
@@ -234,19 +525,13 @@ void WebXROpaqueFramebuffer::bindAttachments(GraphicsContextGL& gl, WebXRAttachm
     gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, attachments.depthStencilBuffer);
 }
 
-IntRect WebXROpaqueFramebuffer::calculateViewportShared(PlatformXR::Eye eye, bool isFoveated, const IntRect& leftViewport, const IntRect& rightViewport)
-{
-    switch (eye) {
-    case PlatformXR::Eye::None:
-        ASSERT_NOT_REACHED();
-        return IntRect();
-    case PlatformXR::Eye::Left:
-        return isFoveated ? leftViewport : IntRect(0, 0, m_framebufferSize.width(), m_framebufferSize.height());
-    case PlatformXR::Eye::Right:
-        return isFoveated ? IntRect(leftViewport.width() + rightViewport.x(), rightViewport.y(), rightViewport.width(), rightViewport.height()) : IntRect(m_framebufferSize.width(), 0, m_framebufferSize.width(), m_framebufferSize.height());
-    }
 
-    return IntRect();
+void WebXROpaqueFramebuffer::bindResolveAttachments(GraphicsContextGL& gl, WebXRAttachments& attachments)
+{
+    gl.framebufferResolveRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, attachments.colorBuffer);
+    // NOTE: In WebGL2, GL::DEPTH_STENCIL_ATTACHMENT is an alias to set GL::DEPTH_ATTACHMENT and GL::STENCIL_ATTACHMENT, which is all we require.
+    ASSERT((m_attributes.stencil || m_attributes.depth) && attachments.depthStencilBuffer);
+    gl.framebufferResolveRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, attachments.depthStencilBuffer);
 }
 
 void WebXRExternalRenderbuffer::destroyImage(GraphicsContextGL& gl)

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -105,26 +105,20 @@ public:
     void endFrame();
     bool usesLayeredMode() const;
 
-#if PLATFORM(COCOA)
     void releaseAllDisplayAttachments();
-#endif
 
 private:
     WebXROpaqueFramebuffer(PlatformXR::LayerHandle, Ref<WebGLFramebuffer>&&, WebGLRenderingContextBase&, Attributes&&, IntSize);
 
-#if PLATFORM(COCOA)
     bool setupFramebuffer(GraphicsContextGL&, const PlatformXR::FrameData::LayerSetupData&);
     const std::array<WebXRExternalAttachments, 2>* reusableDisplayAttachments(const PlatformXR::FrameData::ExternalTextureData&) const;
     void bindCompositorTexturesForDisplay(GraphicsContextGL&, const PlatformXR::FrameData::LayerData&);
     const std::array<WebXRExternalAttachments, 2>* reusableDisplayAttachmentsAtIndex(size_t);
     void releaseDisplayAttachmentsAtIndex(size_t);
-#endif
     void allocateRenderbufferStorage(GraphicsContextGL&, GCGLOwnedRenderbuffer&, GCGLsizei, GCGLenum, IntSize);
     void allocateAttachments(GraphicsContextGL&, WebXRAttachments&, GCGLsizei, IntSize);
     void bindAttachments(GraphicsContextGL&, WebXRAttachments&);
-#if PLATFORM(COCOA)
     void bindResolveAttachments(GraphicsContextGL&, WebXRAttachments&);
-#endif
     void resolveMSAAFramebuffer(GraphicsContextGL&);
     void blitShared(GraphicsContextGL&);
     void blitSharedToLayered(GraphicsContextGL&);
@@ -136,26 +130,22 @@ private:
     Attributes m_attributes;
     PlatformXR::Layout m_displayLayout = PlatformXR::Layout::Shared;
     IntSize m_framebufferSize; // Physical Space
-#if PLATFORM(COCOA)
     IntRect m_leftViewport; // Screen Space
     IntRect m_rightViewport; // Screen Space
     IntSize m_leftPhysicalSize; // Physical Space
     IntSize m_rightPhysicalSize; // Physical Space
-#endif
     WebXRAttachments m_drawAttachments;
     WebXRAttachments m_resolveAttachments;
     GCGLOwnedFramebuffer m_displayFBO;
     GCGLOwnedFramebuffer m_resolvedFBO;
-#if PLATFORM(COCOA)
     Vector<std::array<WebXRExternalAttachments, 2>> m_displayAttachmentsSets;
     size_t m_currentDisplayAttachmentIndex { 0 };
+#if PLATFORM(COCOA)
     MachSendRight m_completionSyncEvent;
+#endif
     uint64_t m_renderingFrameIndex { ~0u };
     bool m_usingFoveation { false };
     bool m_blitDepth { false };
-#else
-    PlatformGLObject m_colorTexture;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -46,6 +46,10 @@
 #include <wtf/MachSendRight.h>
 #endif
 
+#if USE(UNIX_DOMAIN_SOCKETS)
+#include <wtf/unix/UnixFileDescriptor.h>
+#endif
+
 #if OS(WINDOWS)
 // Defined in winerror.h
 #ifdef NO_ERROR
@@ -82,6 +86,18 @@ using GraphicsContextGLExternalImageSource = Variant<
     GraphicsContextGLExternalImageSourceMTLSharedTextureHandle
     >;
 using GraphicsContextGLExternalSyncSource = std::tuple<MachSendRight, uint64_t>;
+
+#elif PLATFORM(GTK) || PLATFORM(WPE)
+
+struct GraphicsContextGLExternalImageSource {
+    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<uint32_t> strides;
+    Vector<uint32_t> offsets;
+    uint32_t fourcc;
+    uint64_t modifier;
+    WebCore::IntSize size;
+};
+using GraphicsContextGLExternalSyncSource = int;
 
 #else
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2474,8 +2474,10 @@ void GraphicsContextGLANGLE::blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLi
     prepareForDrawingBufferWriteIfBound();
     if (m_isForWebGL2)
         GL_BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
-    else
+    else if (isExtensionEnabled("GL_NV_framebuffer_blit"_s))
         GL_BlitFramebufferNV(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    else
+        GL_BlitFramebufferANGLE(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
     checkGPUStatus();
 }
 
@@ -2969,6 +2971,7 @@ GCGLExternalSync GraphicsContextGLANGLE::createExternalSync(ExternalSyncSource&&
     notImplemented();
     return { };
 }
+
 #endif
 
 void GraphicsContextGLANGLE::deleteExternalSync(GCGLExternalSync sync)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h
@@ -43,6 +43,12 @@ public:
     void prepareForDisplayWithFinishedSignal(Function<void()>&&);
     DMABufBuffer* displayBuffer() { return m_displayBuffer.dmabuf.get(); }
 
+#if ENABLE(WEBXR)
+    GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) final;
+    void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
+    bool enableRequiredWebXRExtensions() final;
+#endif
+
 private:
     GraphicsContextGLTextureMapperGBM(GraphicsContextGLAttributes&&, RefPtr<GraphicsLayerContentsDisplayDelegate>&&);
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -33,6 +33,9 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
+#if USE(UNIX_DOMAIN_SOCKETS)
+#include <wtf/unix/UnixFileDescriptor.h>
+#endif
 
 #if PLATFORM(COCOA)
 #include "IOSurface.h"
@@ -267,7 +270,6 @@ struct FrameData {
         Vector<WebCore::FloatPoint> bounds;
     };
 
-#if PLATFORM(COCOA)
     struct RateMapDescription {
         WebCore::IntSize screenSize = { 0, 0 };
         Vector<float> horizontalSamplesLeft;
@@ -281,12 +283,22 @@ struct FrameData {
         std::array<std::array<uint16_t, 2>, 2> physicalSize;
         std::array<WebCore::IntRect, 2> viewports;
         RateMapDescription foveationRateMapDesc;
+#if PLATFORM(COCOA)
         MachSendRight completionSyncEvent;
+#endif
     };
 
     struct ExternalTexture {
+#if PLATFORM(COCOA)
         MachSendRight handle;
         bool isSharedTexture { false };
+#else
+        Vector<WTF::UnixFileDescriptor> fds;
+        Vector<uint32_t> strides;
+        Vector<uint32_t> offsets;
+        uint32_t fourcc;
+        uint64_t modifier;
+#endif
     };
 
     struct ExternalTextureData {
@@ -294,20 +306,14 @@ struct FrameData {
         ExternalTexture colorTexture;
         ExternalTexture depthStencilBuffer;
     };
-#endif
 
     struct LayerData {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(LayerData);
-#if PLATFORM(COCOA)
         std::optional<LayerSetupData> layerSetup = { std::nullopt };
         uint64_t renderingFrameIndex { 0 };
         std::optional<ExternalTextureData> textureData;
         // FIXME: <rdar://134998122> Remove when new CC lands.
         bool requestDepth { false };
-#else
-        WebCore::IntSize framebufferSize;
-        PlatformGLObject opaqueTexture { 0 };
-#endif
     };
 
     struct InputSourceButton {

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -106,12 +106,7 @@ private:
     bool m_supportsShutdownNotification { false };
     Timer m_frameTimer;
     RequestFrameCallback m_FrameCallback;
-#if PLATFORM(COCOA)
     HashMap<PlatformXR::LayerHandle, WebCore::IntSize> m_layers;
-#else
-    HashMap<PlatformXR::LayerHandle, PlatformGLObject> m_layers;
-    RefPtr<WebCore::GraphicsContextGL> m_gl;
-#endif
     uint32_t m_layerIndex { 0 };
     Vector<Ref<WebFakeXRInputController>> m_inputConnections;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8790,7 +8790,20 @@ using WebCore::GraphicsContextGL::ExternalImageSource = Variant<WebCore::Graphic
 using WebCore::GraphicsContextGL::ExternalSyncSource = std::tuple<MachSendRight, uint64_t>
 #endif
 #if !PLATFORM(COCOA) && ENABLE(WEBGL)
+#if (PLATFORM(GTK) || PLATFORM(WPE))
+header: <WebCore/GraphicsContextGL.h>
+[CustomHeader] struct WebCore::GraphicsContextGLExternalImageSource {
+    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<uint32_t> strides;
+    Vector<uint32_t> offsets;
+    uint32_t fourcc;
+    uint64_t modifier;
+    WebCore::IntSize size;
+};
+using WebCore::GraphicsContextGL::ExternalImageSource = WebCore::GraphicsContextGLExternalImageSource;
+#else
 using WebCore::GraphicsContextGL::ExternalImageSource = int
+#endif
 using WebCore::GraphicsContextGL::ExternalSyncSource = int
 #endif
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -110,7 +110,6 @@ header: <WebCore/PlatformXR.h>
     Vector<WebCore::FloatPoint> bounds;
 };
 
-#if PLATFORM(COCOA)
 [Nested] struct PlatformXR::FrameData::RateMapDescription {
     WebCore::IntSize screenSize;
     Vector<float> horizontalSamplesLeft;
@@ -122,12 +121,23 @@ header: <WebCore/PlatformXR.h>
     std::array<std::array<uint16_t, 2>, 2> physicalSize;
     std::array<WebCore::IntRect, 2> viewports;
     PlatformXR::FrameData::RateMapDescription foveationRateMapDesc;
+#if PLATFORM(COCOA)
     MachSendRight completionSyncEvent;
+#endif
 };
 
 [Nested, RValue] struct PlatformXR::FrameData::ExternalTexture {
+#if PLATFORM(COCOA)
     MachSendRight handle;
     bool isSharedTexture;
+#endif
+#if !PLATFORM(COCOA)
+    Vector<WTF::UnixFileDescriptor> fds;
+    Vector<uint32_t> strides;
+    Vector<uint32_t> offsets;
+    uint32_t fourcc;
+    uint64_t modifier;
+#endif
 };
 
 [Nested, RValue] struct PlatformXR::FrameData::ExternalTextureData {
@@ -135,18 +145,12 @@ header: <WebCore/PlatformXR.h>
     PlatformXR::FrameData::ExternalTexture colorTexture;
     PlatformXR::FrameData::ExternalTexture depthStencilBuffer;
 };
-#endif
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerData {
-#if PLATFORM(COCOA)
     std::optional<PlatformXR::FrameData::LayerSetupData> layerSetup;
     uint64_t renderingFrameIndex;
     std::optional<PlatformXR::FrameData::ExternalTextureData> textureData;
     bool requestDepth;
-#else
-    WebCore::IntSize framebufferSize;
-    PlatformGLObject opaqueTexture;
-#endif
 };
 
 [Nested] struct PlatformXR::FrameData::InputSourceButton {

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -67,7 +67,6 @@ std::optional<SharedPreferencesForWebProcess> PlatformXRSystem::sharedPreference
 void PlatformXRSystem::invalidate()
 {
     ASSERT(RunLoop::isMain());
-
     RefPtr page = m_page.get();
     if (!page)
         return;

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -19,9 +19,19 @@
 
 #include "config.h"
 #include "OpenXRLayer.h"
+#if USE(LIBEPOXY)
+#define __GBM__ 1
+#include <epoxy/egl.h>
+#else
+#include <EGL/egl.h>
+#endif
 
 #include "XRDeviceLayer.h"
+#include <WebCore/GLContext.h>
+#include <WebCore/PlatformDisplay.h>
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 #if ENABLE(WEBXR) && USE(OPENXR)
 
@@ -30,34 +40,88 @@ namespace WebKit {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRLayer);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpenXRLayerProjection);
 
+OpenXRLayer::OpenXRLayer(UniqueRef<OpenXRSwapchain>&& swapchain)
+    : m_swapchain(WTFMove(swapchain))
+{
+}
+
+std::optional<PlatformXR::FrameData::ExternalTexture> OpenXRLayer::exportOpenXRTexture(PlatformGLObject openxrTexture)
+{
+    // Texture must be bound to be exported.
+    glBindTexture(GL_TEXTURE_2D, openxrTexture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_swapchain->width(), m_swapchain->height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    auto* glContext = WebCore::GLContext::current();
+    if (!glContext) {
+        RELEASE_LOG(XR, "No current GL context to export OpenXR texture");
+        return std::nullopt;
+    }
+
+    auto& display = glContext->display();
+    auto image = display.createEGLImage(glContext->platformContext(), EGL_GL_TEXTURE_2D, (EGLClientBuffer)(uint64_t)openxrTexture, { });
+
+    auto releaseTextureOnError = makeScopeExit([&] {
+        if (image)
+            display.destroyEGLImage(image);
+        m_swapchain->releaseImage();
+    });
+
+    if (!image) {
+        RELEASE_LOG(XR, "Failed to create EGL image from OpenXR texture");
+        return std::nullopt;
+    }
+
+    int fourcc, planeCount;
+    uint64_t modifier;
+    if (!eglExportDMABUFImageQueryMESA(display.eglDisplay(), image, &fourcc, &planeCount, &modifier)) {
+        RELEASE_LOG(XR, "eglExportDMABUFImageQueryMESA failed");
+        return std::nullopt;
+    }
+
+    Vector<int> fdsOut(planeCount);
+    Vector<int> stridesOut(planeCount);
+    Vector<int> offsetsOut(planeCount);
+    if (!eglExportDMABUFImageMESA(display.eglDisplay(), image, fdsOut.mutableSpan().data(), stridesOut.mutableSpan().data(), offsetsOut.mutableSpan().data())) {
+        RELEASE_LOG(XR, "eglExportDMABUFImageMESA failed");
+        return std::nullopt;
+    }
+
+    display.destroyEGLImage(image);
+
+    releaseTextureOnError.release();
+
+    Vector<UnixFileDescriptor> fds = fdsOut.map([](int fd) {
+        return UnixFileDescriptor(fd, UnixFileDescriptor::Adopt);
+    });
+    Vector<uint32_t> strides = stridesOut.map([](int stride) {
+        return static_cast<uint32_t>(stride);
+    });
+    Vector<uint32_t> offsets = offsetsOut.map([](int offset) {
+        return static_cast<uint32_t>(offset);
+    });
+
+    return PlatformXR::FrameData::ExternalTexture {
+        .fds = WTFMove(fds),
+        .strides = WTFMove(strides),
+        .offsets = WTFMove(offsets),
+        .fourcc = static_cast<uint32_t>(fourcc),
+        .modifier = modifier,
+    };
+}
+
 // OpenXRLayerProjection
 
-std::unique_ptr<OpenXRLayerProjection> OpenXRLayerProjection::create(XrInstance instance, XrSession session, uint32_t width, uint32_t height, int64_t format, uint32_t sampleCount)
+std::unique_ptr<OpenXRLayerProjection> OpenXRLayerProjection::create(std::unique_ptr<OpenXRSwapchain>&& swapchain)
 {
-    if (!width || !height || !sampleCount)
-        return nullptr;
-
-    auto info = createOpenXRStruct<XrSwapchainCreateInfo, XR_TYPE_SWAPCHAIN_CREATE_INFO>();
-    info.arraySize = 1;
-    info.format = format;
-    info.width = width;
-    info.height = height;
-    info.mipCount = 1;
-    info.faceCount = 1;
-    info.arraySize = 1;
-    info.sampleCount = sampleCount;
-    info.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
-
-    auto swapchain = OpenXRSwapchain::create(instance, session, info);
-    if (!swapchain)
-        return nullptr;
-    LOG(XR, "created %ux%u swapchain with format %lu and sample count %u", width, height, format, sampleCount);
-
     return std::unique_ptr<OpenXRLayerProjection>(new OpenXRLayerProjection(makeUniqueRefFromNonNullUniquePtr(WTFMove(swapchain))));
 }
 
 OpenXRLayerProjection::OpenXRLayerProjection(UniqueRef<OpenXRSwapchain>&& swapchain)
-    : m_swapchain(WTFMove(swapchain))
+    : OpenXRLayer(WTFMove(swapchain))
     , m_layerProjection(createOpenXRStruct<XrCompositionLayerProjection, XR_TYPE_COMPOSITION_LAYER_PROJECTION>())
 {
 }
@@ -68,11 +132,36 @@ std::optional<PlatformXR::FrameData::LayerData> OpenXRLayerProjection::startFram
     if (!texture)
         return std::nullopt;
 
-    // FIXME: export the texture to the WebProcess using DMABuf, etc...
-    return PlatformXR::FrameData::LayerData {
-        .framebufferSize = m_swapchain->size(),
-        .opaqueTexture = *texture
+    auto addResult = m_exportedTextures.add(*texture, m_nextReusableTextureIndex);
+    bool needsExport = addResult.isNewEntry;
+
+    PlatformXR::FrameData::LayerData layerData;
+    layerData.renderingFrameIndex = m_renderingFrameIndex++;
+    layerData.textureData = {
+        .reusableTextureIndex = addResult.iterator->value,
+        .colorTexture = { },
+        .depthStencilBuffer = { },
     };
+
+    if (!needsExport)
+        return layerData;
+    m_nextReusableTextureIndex++;
+
+    auto externalTexture = exportOpenXRTexture(*texture);
+    if (!externalTexture)
+        return std::nullopt;
+    layerData.textureData->colorTexture = WTFMove(externalTexture.value());
+
+    auto halfWidth = m_swapchain->width() / 2;
+    layerData.layerSetup = {
+        .physicalSize = { static_cast<uint16_t>(m_swapchain->width()), static_cast<uint16_t>(m_swapchain->height()) },
+        .viewports = { },
+        .foveationRateMapDesc = { }
+    };
+    layerData.layerSetup->viewports[0] = { 0, 0, halfWidth, m_swapchain->height() };
+    layerData.layerSetup->viewports[1] = { halfWidth, 0, halfWidth, m_swapchain->height() };
+
+    return layerData;
 }
 
 XrCompositionLayerBaseHeader* OpenXRLayerProjection::endFrame(const XRDeviceLayer& layer, XrSpace space, const Vector<XrView>& frameViews)

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -38,6 +38,7 @@ class PlatformDisplay;
 namespace WebKit {
 
 class OpenXRLayer;
+class OpenXRSwapchain;
 
 class OpenXRCoordinator final : public PlatformXRCoordinator {
     WTF_MAKE_TZONE_ALLOCATED(OpenXRCoordinator);
@@ -60,12 +61,14 @@ public:
 private:
     void createInstance();
     void createSessionIfNeeded();
+    std::unique_ptr<OpenXRSwapchain> createSwapchain(uint32_t width, uint32_t height, bool alpha);
     void cleanupSessionAndAssociatedResources();
     void initializeDevice();
     void initializeSystem();
     void initializeBlendModes();
     void tryInitializeGraphicsBinding();
     void collectViewConfigurations();
+    bool collectSwapchainFormatsIfNeeded();
 
     struct Idle {
     };
@@ -103,6 +106,7 @@ private:
         m_extensions;
     bool m_isSessionRunning { false };
     HashMap<PlatformXR::LayerHandle, std::unique_ptr<OpenXRLayer>> m_layers;
+    Vector<int64_t> m_supportedSwapchainFormats;
 
     std::unique_ptr<WebCore::PlatformDisplay> m_platformDisplay;
     std::unique_ptr<WebCore::GLContext> m_glContext;


### PR DESCRIPTION
#### 8df544c2d21c57744685ed5d5cf2ee443bf2e1c1
<pre>
[WebXR][OpenXR] Export OpenXR textures to WebProcess for WebGL rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=296617">https://bugs.webkit.org/show_bug.cgi?id=296617</a>

Reviewed by NOBODY (OOPS!).

OpenXR textures are created by OpenXR swapchains in the UIProcess. In order
to get the WebXR content rendered into the OpenXR compositor we need first
to pass the textures to the WebProcess so that WebGL content could be
rendered there. The most obvious match for that in Linux systems is using
DMABuf. We export the textures in the UIProcess and import them in the
WebProcess using the already existing ExternalTexture abstraction created
for Cocoa ports.

WebXROpaqueFramebuffer was updated so that it&apos;s an almost exact copy of
the Cocoa version (we should think about eventually unifying them back
again). The added code uses the GraphicsContext to import the OpenXR
textures into a render buffer which is then used by WebGL commands to
render the WebXR scene. We had to fix a bug added in 295361@main.
Basically it was forcing WebGL1 to use a NV extension for blitting
framebuffers. That was because that extension is available for Cocoa
ports but not for all linux machines. Instead that extension must be
used only if supported, otherwise the ANGLE blit should be chosen.

Thw WebXR fake device used for testing has been also updated as we use
the same data structures than Cocoa platforms from now on (there are
only a few small differences).

On the OpenXR side the main change is the addition of the code that
queries and selects the swapchain format to be used depending on what
is exactly supported by the platform.

Last but not least, some new tests pass now after this change. We had
to disable running WPT WebXR tests in debug mode because
WebXROpaqueFramebuffer is not prepared to work with the WebFakeXRDevice
yet. It tries to initialize some gfx stuff that depends on data coming
from the UI process (like the exported textures). That is not a problem
for release builds because we just bail out, but in debug builds
several assertions are not met.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/webxr/webGLCanvasContext_create_xrcompatible.https-expected.txt: Removed.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::ensure):
(WebCore::createAndBindCompositorBuffer):
(WebCore::makeExternalImageSource):
(WebCore::createAndBindTempBuffer):
(WebCore::toIntSize):
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::releaseAllDisplayAttachments):
(WebCore::WebXROpaqueFramebuffer::resolveMSAAFramebuffer):
(WebCore::WebXROpaqueFramebuffer::blitShared):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
(WebCore::WebXROpaqueFramebuffer::drawFramebufferSize const):
(WebCore::WebXROpaqueFramebuffer::drawViewport const):
(WebCore::displayLayout):
(WebCore::calcFramebufferPhysicalSize):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::reusableDisplayAttachments const):
(WebCore::WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay):
(WebCore::WebXROpaqueFramebuffer::reusableDisplayAttachmentsAtIndex):
(WebCore::WebXROpaqueFramebuffer::releaseDisplayAttachmentsAtIndex):
(WebCore::WebXROpaqueFramebuffer::bindResolveAttachments):
(WebCore::WebXROpaqueFramebuffer::calculateViewportShared): Deleted.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::blitFramebuffer):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::createDrawingBuffer const):
(WebCore::GraphicsContextGLTextureMapperGBM::createExternalImage):
(WebCore::GraphicsContextGLTextureMapperGBM::bindExternalImage):
(WebCore::GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensions):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.h:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
(WebCore::SimulatedXRDevice::shutDownTrackingAndRendering):
(WebCore::SimulatedXRDevice::frameTimerFired):
(WebCore::SimulatedXRDevice::createLayerProjection):
(WebCore::SimulatedXRDevice::deleteLayer):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::invalidate):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp:
(WebKit::OpenXRLayer::OpenXRLayer):
(WebKit::OpenXRLayer::exportOpenXRTexture):
(WebKit::OpenXRLayerProjection::create):
(WebKit::OpenXRLayerProjection::OpenXRLayerProjection):
(WebKit::OpenXRLayerProjection::startFrame):
* Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::collectSwapchainFormatsIfNeeded):
(WebKit::OpenXRCoordinator::createSwapchain):
(WebKit::OpenXRCoordinator::createLayerProjection):
(WebKit::OpenXRCoordinator::scheduleAnimationFrame):
(WebKit::OpenXRCoordinator::populateFrameData):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8df544c2d21c57744685ed5d5cf2ee443bf2e1c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114223 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/33970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/24432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/120389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/116112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/34599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42532 "Build is in progress. Recent messages:") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/120389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/117171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/34599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/24432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/120389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/34599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/24432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/64084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/34599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/24432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/123606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/41242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/42532 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/123606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/41619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/24432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/123606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/24432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/41121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/46632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/40728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/44034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/42479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->