### PR TITLE
[Style] Convert opacity properties to strong style types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2770,6 +2770,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/color/StyleCurrentColor.h
     style/values/color/StyleDynamicRangeLimit.h
     style/values/color/StyleDynamicRangeLimitMix.h
+    style/values/color/StyleOpacity.h
     style/values/color/StyleResolvedColor.h
 
     style/values/color-adjust/StyleColorScheme.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3151,6 +3151,7 @@ style/values/color/StyleDynamicRangeLimitMix.cpp
 style/values/color/StyleHexColor.cpp
 style/values/color/StyleKeywordColor.cpp
 style/values/color/StyleLightDarkColor.cpp
+style/values/color/StyleOpacity.cpp
 style/values/color/StyleResolvedColor.cpp
 style/values/content/StyleContent.cpp
 style/values/content/StyleQuotes.cpp

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -493,7 +493,7 @@ bool AXObjectCache::isNodeVisible(const Node* node) const
     // The resulting opacity of a RenderObject is computed as the multiplication
     // of its opacity times the opacities of its ancestors.
     for (auto* ancestor = renderer; ancestor; ancestor = ancestor->parent()) {
-        if (!ancestor->style().opacity())
+        if (ancestor->style().opacity().isTransparent())
             return false;
     }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -158,7 +158,7 @@ float AccessibilityObjectAtspi::opacity() const
         return 1;
 
     if (auto* renderer = m_coreObject->renderer())
-        return renderer->style().opacity();
+        return renderer->style().opacity().value.value;
 
     return 1;
 }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4454,9 +4454,9 @@
             "inherited": true,
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
-                "style-converter": "Opacity",
+                "style-converter": "StyleType<Opacity>",
                 "svg": true,
                 "parser-grammar": "<opacity-value>"
             },
@@ -4527,9 +4527,9 @@
             "animation-type": "by computed value",
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
-                "style-converter": "Opacity",
+                "style-converter": "StyleType<Opacity>",
                 "svg": true,
                 "parser-grammar": "<opacity-value>"
             },
@@ -6561,9 +6561,9 @@
                 "aliases": [
                     "-webkit-opacity"
                 ],
-                "animation-wrapper": "Wrapper",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-acceleration": "always",
-                "style-converter": "Opacity",
+                "style-converter": "StyleType<Opacity>",
                 "parser-grammar": "<opacity-value>"
             },
             "status": {
@@ -7473,9 +7473,9 @@
             "animation-type": "by computed value",
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
-                "style-converter": "Opacity",
+                "style-converter": "StyleType<Opacity>",
                 "svg": true,
                 "parser-grammar": "<opacity-value>"
             },
@@ -7621,9 +7621,9 @@
             "inherited": true,
             "initial": "1",
             "codegen-properties": {
-                "animation-wrapper": "Wrapper",
+                "animation-wrapper": "StyleTypeWrapper",
                 "animation-wrapper-requires-render-style": true,
-                "style-converter": "Opacity",
+                "style-converter": "StyleType<Opacity>",
                 "svg": true,
                 "parser-grammar": "<opacity-value>"
             },

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6198,7 +6198,7 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
         if (ancestorStyle->display() == DisplayType::None)
             return false;
 
-        if ((options.opacityProperty || options.checkOpacity) && ancestorStyle->opacity() == 0.0f)
+        if ((options.opacityProperty || options.checkOpacity) && ancestorStyle->opacity().isTransparent())
             return false;
     }
 

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1266,7 +1266,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
                 return true;
 
             return targetRenderer->isOutOfFlowPositioned()
-                && (!style.hasBackground() || !style.opacity())
+                && (!style.hasBackground() || style.opacity().isTransparent())
                 && targetRenderer->usedPointerEvents() == PointerEvents::None;
         }();
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4942,7 +4942,7 @@ float LocalFrameView::adjustVerticalPageScrollStepForFixedContent(float step)
     float bottomObscuredArea = 0;
     for (const auto& viewPositionedOutOfFlowBox : *viewPositionedOutOfFlowBoxes) {
         const RenderStyle& style = viewPositionedOutOfFlowBox.style();
-        if (style.position() != PositionType::Fixed || style.usedVisibility() == Visibility::Hidden || !style.opacity())
+        if (style.position() != PositionType::Fixed || style.usedVisibility() == Visibility::Hidden || style.opacity().isTransparent())
             continue;
 
         FloatQuad contentQuad = viewPositionedOutOfFlowBox.absoluteContentQuad();

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -101,7 +101,7 @@ bool ContentChangeObserver::isVisuallyHidden(const Node& node)
     if (style.usedVisibility() == Visibility::Hidden)
         return true;
 
-    if (!style.opacity())
+    if (style.opacity().isTransparent())
         return true;
 
     auto fixedWidth = style.logicalWidth().tryFixed();
@@ -130,7 +130,7 @@ bool ContentChangeObserver::isVisuallyHidden(const Node& node)
     constexpr static unsigned numberOfAncestorsToCheckForOpacity = 4;
     unsigned i = 0;
     for (auto* parent = node.parentNode(); parent && i < numberOfAncestorsToCheckForOpacity; parent = parent->parentNode(), ++i) {
-        if (!parent->renderStyle() || !parent->renderStyle()->opacity())
+        if (!parent->renderStyle() || parent->renderStyle()->opacity().isTransparent())
             return true;
     }
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -114,7 +114,7 @@ template<typename T> static RefPtr<TransformOperation> resolveCalculateValuesFor
 
 AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const IntRect& borderBoxRect, const RenderLayerModelObject* renderer)
 {
-    opacity = style.opacity();
+    opacity = style.opacity().value.value;
 
     auto borderBoxSize = borderBoxRect.size();
 

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -38,7 +38,7 @@ inline bool RenderElement::hasMask() const { return style().hasMask(); }
 inline bool RenderElement::hasOutline() const { return style().hasOutline() || hasOutlineAnnotation(); }
 inline bool RenderElement::hasShapeOutside() const { return !style().shapeOutside().isNone(); }
 inline bool RenderElement::isTransparent() const { return style().hasOpacity(); }
-inline float RenderElement::opacity() const { return style().opacity(); }
+inline float RenderElement::opacity() const { return style().opacity().value.value; }
 inline FloatRect RenderElement::transformReferenceBoxRect() const { return transformReferenceBoxRect(style()); }
 inline FloatRect RenderElement::transformReferenceBoxRect(const RenderStyle& style) const { return referenceBoxRect(transformBoxToCSSBoxType(style.transformBox())); }
 inline Element* RenderElement::element() const { return downcast<Element>(RenderObject::node()); }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6115,14 +6115,14 @@ bool RenderLayer::hasVisibleBoxDecorations() const
 
 bool RenderLayer::isVisibilityHiddenOrOpacityZero() const
 {
-    return !hasVisibleContent() || renderer().style().hasZeroOpacity();
+    return !hasVisibleContent() || renderer().style().opacity().isTransparent();
 }
 
 bool RenderLayer::isVisuallyNonEmpty(PaintedContentRequest* request) const
 {
     ASSERT(!m_visibleContentStatusDirty);
 
-    if (!hasVisibleContent() || renderer().style().hasZeroOpacity())
+    if (!hasVisibleContent() || renderer().style().opacity().isTransparent())
         return false;
 
     if (renderer().isRenderReplaced() || (m_scrollableArea && m_scrollableArea->hasOverflowControls())) {
@@ -6196,7 +6196,7 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
         if (oldStyle->isOverflowVisible() != renderer().style().isOverflowVisible())
             setSelfAndDescendantsNeedPositionUpdate();
 
-        if (oldStyle->hasZeroOpacity() != renderer().style().hasZeroOpacity())
+        if (oldStyle->opacity().isTransparent() != renderer().style().opacity().isTransparent())
             setNeedsPositionUpdate();
 
         if (oldStyle->preserves3D() != preserves3D()) {
@@ -6458,7 +6458,7 @@ bool RenderLayer::isTransparentRespectingParentFrames() const
 
     float currentOpacity = 1;
     for (auto* layer = this; layer; layer = parentLayerCrossFrame(*layer)) {
-        currentOpacity *= layer->renderer().style().opacity();
+        currentOpacity *= layer->renderer().style().opacity().value.value;
         if (currentOpacity < minimumVisibleOpacity)
             return true;
     }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -709,7 +709,7 @@ static LayoutRect overflowControlsHostLayerRect(const RenderBox& renderBox)
 
 void RenderLayerBacking::updateOpacity(const RenderStyle& style)
 {
-    m_graphicsLayer->setOpacity(compositingOpacity(style.opacity()));
+    m_graphicsLayer->setOpacity(compositingOpacity(style.opacity().value.value));
 }
 
 void RenderLayerBacking::updateTransform(const RenderStyle& style)
@@ -4369,7 +4369,7 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& anim
             transformVector.insert(makeUnique<TransformAnimationValue>(offset, keyframeStyle->transform(), tf));
 
         if (currentKeyframe.animatesProperty(CSSPropertyOpacity))
-            opacityVector.insert(makeUnique<FloatAnimationValue>(offset, keyframeStyle->opacity(), tf));
+            opacityVector.insert(makeUnique<FloatAnimationValue>(offset, keyframeStyle->opacity().value.value, tf));
 
         if (currentKeyframe.animatesProperty(CSSPropertyFilter))
             filterVector.insert(makeUnique<FilterAnimationValue>(offset, keyframeStyle->filter(), tf));

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2292,7 +2292,7 @@ void RenderLayerCompositor::layerStyleChanged(StyleDifference diff, RenderLayer&
             }
             // If we're changing to/from 0 opacity, then we need to reconfigure the layer since we try to
             // skip backing store allocation for opacity:0.
-            if (oldStyle && oldStyle->opacity() != newStyle.opacity() && (!oldStyle->opacity() || !newStyle.opacity()))
+            if (oldStyle && oldStyle->opacity() != newStyle.opacity() && (oldStyle->opacity().isTransparent() || newStyle.opacity().isTransparent()))
                 layer.setNeedsCompositingConfigurationUpdate();
         }
         if (oldStyle && recompositeChangeRequiresGeometryUpdate(*oldStyle, newStyle)) {

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -361,7 +361,7 @@ float RenderScrollbar::opacity() const
     if (!partRenderer)
         return 1;
 
-    return partRenderer->style().opacity();
+    return partRenderer->style().opacity().value.value;
 }
 
 bool RenderScrollbar::isHiddenByStyle() const

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -165,16 +165,16 @@ void RenderScrollbarPart::paintIntoRect(GraphicsContext& graphicsContext, const 
     setWidth(rect.width());
     setHeight(rect.height());
 
-    if (graphicsContext.paintingDisabled() || !style().opacity())
+    if (graphicsContext.paintingDisabled() || style().opacity().isTransparent())
         return;
 
     // We don't use RenderLayers for scrollbar parts, so we need to handle opacity here.
     // Opacity for ScrollbarBGPart is handled by RenderScrollbarTheme::willPaintScrollbar().
-    bool needsTransparencyLayer = m_part != ScrollbarBGPart && style().opacity() < 1;
+    bool needsTransparencyLayer = m_part != ScrollbarBGPart && !style().opacity().isOpaque();
     if (needsTransparencyLayer) {
         graphicsContext.save();
         graphicsContext.clip(rect);
-        graphicsContext.beginTransparencyLayer(style().opacity());
+        graphicsContext.beginTransparencyLayer(style().opacity().value.value);
     }
     
     // Now do the paint.

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -375,7 +375,7 @@ RenderElement* RenderView::rendererForRootBackground() const
 static inline bool rendererObscuresBackground(const RenderElement& rootElement)
 {
     auto& style = rootElement.style();
-    if (style.usedVisibility() != Visibility::Visible || style.opacity() != 1 || style.hasTransform())
+    if (style.usedVisibility() != Visibility::Visible || !style.opacity().isOpaque() || style.hasTransform())
         return false;
 
     if (style.hasBorderRadius())

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -800,7 +800,7 @@ static bool miscDataChangeRequiresLayout(const StyleMiscNonInheritedData& first,
         }
     }
 
-    if (first.hasOpacity() != second.hasOpacity()) {
+    if (first.opacity.isOpaque() != second.opacity.isOpaque()) {
         // FIXME: We would like to use SimplifiedLayout here, but we can't quite do that yet.
         // We need to make sure SimplifiedLayout can operate correctly on RenderInlines (we will need
         // to add a selfNeedsSimplifiedLayout bit in order to not get confused and taint every line).
@@ -1238,7 +1238,7 @@ static bool requiresPainting(const RenderStyle& style)
 {
     if (style.usedVisibility() == Visibility::Hidden)
         return false;
-    if (!style.opacity())
+    if (style.opacity().isTransparent())
         return false;
     return true;
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -301,6 +301,7 @@ struct OffsetDistance;
 struct OffsetPath;
 struct OffsetPosition;
 struct OffsetRotate;
+struct Opacity;
 struct PaddingEdge;
 struct Perspective;
 struct Position;
@@ -844,9 +845,8 @@ public:
     OptionSet<HangingPunctuation> hangingPunctuation() const;
 
     inline Style::WebkitTextStrokeWidth textStrokeWidth() const;
-    inline float opacity() const;
+    inline Style::Opacity opacity() const;
     inline bool hasOpacity() const;
-    inline bool hasZeroOpacity() const;
     inline StyleAppearance appearance() const;
     inline StyleAppearance usedAppearance() const;
 
@@ -1512,7 +1512,7 @@ public:
     inline void setHasAutoCaretColor();
     inline void setAccentColor(Style::Color&&);
     inline void setHasAutoAccentColor();
-    inline void setOpacity(float);
+    inline void setOpacity(Style::Opacity);
     inline void setAppearance(StyleAppearance);
     inline void setUsedAppearance(StyleAppearance);
     inline void setBoxAlign(BoxAlignment);
@@ -1769,6 +1769,8 @@ public:
     inline void setStrokeMiterLimit(float);
     static constexpr float initialStrokeMiterLimit();
 
+    static constexpr Style::Opacity initialFillOpacity();
+    static constexpr Style::Opacity initialStrokeOpacity();
     static inline Style::SVGStrokeDasharray initialStrokeDashArray();
     static inline Style::SVGStrokeDashoffset initialStrokeDashOffset();
 
@@ -1781,15 +1783,15 @@ public:
     inline void setVisitedLinkFill(Style::SVGPaint&&);
     inline void setHasExplicitlySetColor(bool);
     inline bool hasExplicitlySetColor() const;
-    inline float fillOpacity() const;
-    inline void setFillOpacity(float);
+    inline Style::Opacity fillOpacity() const;
+    inline void setFillOpacity(Style::Opacity);
 
     inline const Style::SVGPaint& stroke() const;
     inline const Style::SVGPaint& visitedLinkStroke() const;
     inline void setStroke(Style::SVGPaint&&);
     inline void setVisitedLinkStroke(Style::SVGPaint&&);
-    inline float strokeOpacity() const;
-    inline void setStrokeOpacity(float);
+    inline Style::Opacity strokeOpacity() const;
+    inline void setStrokeOpacity(Style::Opacity);
     inline const Style::SVGStrokeDasharray& strokeDashArray() const;
     inline void setStrokeDashArray(Style::SVGStrokeDasharray&&);
     inline const Style::SVGStrokeDashoffset& strokeDashOffset() const;
@@ -1814,11 +1816,13 @@ public:
     inline StylePathData* d() const;
     static StylePathData* initialD() { return nullptr; }
 
-    inline float floodOpacity() const;
-    inline void setFloodOpacity(float);
+    inline Style::Opacity floodOpacity() const;
+    inline void setFloodOpacity(Style::Opacity);
+    static constexpr Style::Opacity initialFloodOpacity();
 
-    inline float stopOpacity() const;
-    inline void setStopOpacity(float);
+    inline Style::Opacity stopOpacity() const;
+    inline void setStopOpacity(Style::Opacity);
+    static constexpr Style::Opacity initialStopOpacity();
 
     inline void setStopColor(Style::Color&&);
     inline void setFloodColor(Style::Color&&);
@@ -2023,7 +2027,7 @@ public:
     static float initialZoom() { return 1.0f; }
     static constexpr TextZoom initialTextZoom();
     static constexpr Style::Length<> initialOutlineOffset();
-    static float initialOpacity() { return 1.0f; }
+    static constexpr Style::Opacity initialOpacity();
     static constexpr BoxAlignment initialBoxAlign();
     static constexpr BoxDecorationBreak initialBoxDecorationBreak();
     static constexpr BoxDirection initialBoxDirection();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -303,7 +303,7 @@ inline bool RenderStyle::hasMargin() const { return !Style::isZero(marginBox());
 inline bool RenderStyle::hasMask() const { return maskLayers().hasImage() || maskBorder().hasImage(); }
 inline bool RenderStyle::hasInset() const { return !Style::isZero(insetBox()); }
 inline bool RenderStyle::hasOffsetPath() const { return !WTF::holdsAlternative<CSS::Keyword::None>(m_nonInheritedData->rareData->offsetPath); }
-inline bool RenderStyle::hasOpacity() const { return m_nonInheritedData->miscData->hasOpacity(); }
+inline bool RenderStyle::hasOpacity() const { return !opacity().isOpaque(); }
 inline bool RenderStyle::hasOutOfFlowPosition() const { return position() == PositionType::Absolute || position() == PositionType::Fixed; }
 inline bool RenderStyle::hasOutline() const { return outlineStyle() != OutlineStyle::None && outlineWidth().isPositive(); }
 inline bool RenderStyle::hasOutlineInVisualOverflow() const { return hasOutline() && outlineSize() > 0; }
@@ -324,7 +324,6 @@ inline bool RenderStyle::hasViewportConstrainedPosition() const { return positio
 inline bool RenderStyle::hasVisibleBorder() const { return border().hasVisibleBorder(); }
 inline bool RenderStyle::hasVisibleBorderDecoration() const { return hasVisibleBorder() || hasBorderImage(); }
 inline bool RenderStyle::hasVisitedLinkAutoCaretColor() const { return m_rareInheritedData->hasVisitedLinkAutoCaretColor; }
-inline bool RenderStyle::hasZeroOpacity() const { return m_nonInheritedData->miscData->hasZeroOpacity(); }
 inline const Style::PreferredSize& RenderStyle::height() const { return m_nonInheritedData->boxData->height(); }
 inline Style::HyphenateLimitEdge RenderStyle::hyphenateLimitAfter() const { return m_rareInheritedData->hyphenateLimitAfter; }
 inline Style::HyphenateLimitEdge RenderStyle::hyphenateLimitBefore() const { return m_rareInheritedData->hyphenateLimitBefore; }
@@ -453,6 +452,7 @@ constexpr Style::OffsetRotate RenderStyle::initialOffsetRotate() { return CSS::K
 constexpr OverflowAnchor RenderStyle::initialOverflowAnchor() { return OverflowAnchor::Auto; }
 inline OverflowContinue RenderStyle::initialOverflowContinue() { return OverflowContinue::Auto; }
 constexpr Style::Length<> RenderStyle::initialOutlineOffset() { return 0_css_px; }
+constexpr Style::Opacity RenderStyle::initialOpacity() { return 1_css_number; }
 constexpr OutlineStyle RenderStyle::initialOutlineStyle() { return OutlineStyle::None; }
 constexpr Style::LineWidth RenderStyle::initialOutlineWidth() { return CSS::Keyword::Medium { }; }
 constexpr OverflowWrap RenderStyle::initialOverflowWrap() { return OverflowWrap::Normal; }
@@ -665,7 +665,7 @@ inline const Style::OffsetDistance& RenderStyle::offsetDistance() const { return
 inline const Style::OffsetPath& RenderStyle::offsetPath() const { return m_nonInheritedData->rareData->offsetPath; }
 inline const Style::OffsetPosition& RenderStyle::offsetPosition() const { return m_nonInheritedData->rareData->offsetPosition; }
 inline const Style::OffsetRotate& RenderStyle::offsetRotate() const { return m_nonInheritedData->rareData->offsetRotate; }
-inline float RenderStyle::opacity() const { return m_nonInheritedData->miscData->opacity; }
+inline Style::Opacity RenderStyle::opacity() const { return m_nonInheritedData->miscData->opacity; }
 inline int RenderStyle::order() const { return m_nonInheritedData->miscData->order; }
 inline unsigned short RenderStyle::orphans() const { return m_rareInheritedData->orphans; }
 inline const OutlineValue& RenderStyle::outline() const { return m_nonInheritedData->backgroundData->outline; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -241,6 +241,7 @@ inline void RenderStyle::setOffsetDistance(Style::OffsetDistance&& distance) { S
 inline void RenderStyle::setOffsetPath(Style::OffsetPath&& path) { SET_NESTED(m_nonInheritedData, rareData, offsetPath, WTFMove(path)); }
 inline void RenderStyle::setOffsetPosition(Style::OffsetPosition&& position) { SET_NESTED(m_nonInheritedData, rareData, offsetPosition, WTFMove(position)); }
 inline void RenderStyle::setOffsetRotate(Style::OffsetRotate&& rotate) { SET_NESTED(m_nonInheritedData, rareData, offsetRotate, WTFMove(rotate)); }
+inline void RenderStyle::setOpacity(Style::Opacity opacity) { SET_NESTED(m_nonInheritedData, miscData, opacity, opacity); }
 inline void RenderStyle::setOrder(int o) { SET_NESTED(m_nonInheritedData, miscData, order, o); }
 inline void RenderStyle::setOutlineColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_color, WTFMove(color)); }
 inline void RenderStyle::setOutlineOffset(Style::Length<> offset) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_offset, offset); }
@@ -582,12 +583,6 @@ inline void RenderStyle::setLogicalMaxHeight(Style::MaximumSize&& height)
         setMaxHeight(WTFMove(height));
     else
         setMaxWidth(WTFMove(height));
-}
-
-inline void RenderStyle::setOpacity(float opacity)
-{
-    float clampedOpacity = clampTo(opacity, 0.f, 1.f);
-    SET_NESTED(m_nonInheritedData, miscData, opacity, clampedOpacity);
 }
 
 inline void RenderStyle::setOrphans(unsigned short count)

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -77,15 +77,15 @@ public:
     static TextAnchor initialTextAnchor() { return TextAnchor::Start; }
     static GlyphOrientation initialGlyphOrientationHorizontal() { return GlyphOrientation::Degrees0; }
     static GlyphOrientation initialGlyphOrientationVertical() { return GlyphOrientation::Auto; }
-    static float initialFillOpacity() { return 1; }
+    static constexpr Style::Opacity initialFillOpacity();
     static Style::SVGPaint initialFill() { return Style::SVGPaint { Style::SVGPaintType::RGBColor, Style::URL::none(), Color::black }; }
-    static float initialStrokeOpacity() { return 1; }
+    static constexpr Style::Opacity initialStrokeOpacity();
     static Style::SVGPaint initialStroke() { return Style::SVGPaint { Style::SVGPaintType::None, Style::URL::none(), Color { } }; }
     static inline Style::SVGStrokeDasharray initialStrokeDashArray();
     static inline Style::SVGStrokeDashoffset initialStrokeDashOffset();
-    static float initialStopOpacity() { return 1; }
+    static constexpr Style::Opacity initialStopOpacity();
     static Style::Color initialStopColor() { return Color::black; }
-    static float initialFloodOpacity() { return 1; }
+    static constexpr Style::Opacity initialFloodOpacity();
     static Style::Color initialFloodColor() { return Color::black; }
     static Style::Color initialLightingColor() { return Color::white; }
     static Style::URL initialMarkerStartResource() { return Style::URL::none(); }
@@ -116,18 +116,18 @@ public:
     void setX(Style::SVGCoordinateComponent&&);
     void setY(Style::SVGCoordinateComponent&&);
     void setD(RefPtr<StylePathData>&&);
-    void setFillOpacity(float);
+    void setFillOpacity(Style::Opacity);
     void setFill(Style::SVGPaint&&);
     void setVisitedLinkFill(Style::SVGPaint&&);
-    void setStrokeOpacity(float);
+    void setStrokeOpacity(Style::Opacity);
     void setStroke(Style::SVGPaint&&);
     void setVisitedLinkStroke(Style::SVGPaint&&);
 
     void setStrokeDashArray(Style::SVGStrokeDasharray&&);
     void setStrokeDashOffset(Style::SVGStrokeDashoffset&&);
-    void setStopOpacity(float);
+    void setStopOpacity(Style::Opacity);
     void setStopColor(Style::Color&&);
-    void setFloodOpacity(float);
+    void setFloodOpacity(Style::Opacity);
     void setFloodColor(Style::Color&&);
     void setLightingColor(Style::Color&&);
     void setBaselineShift(Style::SVGBaselineShift&&);
@@ -151,14 +151,14 @@ public:
     GlyphOrientation glyphOrientationHorizontal() const { return static_cast<GlyphOrientation>(m_inheritedFlags.glyphOrientationHorizontal); }
     GlyphOrientation glyphOrientationVertical() const { return static_cast<GlyphOrientation>(m_inheritedFlags.glyphOrientationVertical); }
     const Style::SVGPaint& fill() const { return m_fillData->paint; }
-    float fillOpacity() const { return m_fillData->opacity; }
+    Style::Opacity fillOpacity() const { return m_fillData->opacity; }
     const Style::SVGPaint& stroke() const { return m_strokeData->paint; }
-    float strokeOpacity() const { return m_strokeData->opacity; }
+    Style::Opacity strokeOpacity() const { return m_strokeData->opacity; }
     const Style::SVGStrokeDasharray& strokeDashArray() const { return m_strokeData->dashArray; }
     const Style::SVGStrokeDashoffset& strokeDashOffset() const { return m_strokeData->dashOffset; }
-    float stopOpacity() const { return m_stopData->opacity; }
+    Style::Opacity stopOpacity() const { return m_stopData->opacity; }
     const Style::Color& stopColor() const { return m_stopData->color; }
-    float floodOpacity() const { return m_miscData->floodOpacity; }
+    Style::Opacity floodOpacity() const { return m_miscData->floodOpacity; }
     const Style::Color& floodColor() const { return m_miscData->floodColor; }
     const Style::Color& lightingColor() const { return m_miscData->lightingColor; }
     const Style::SVGBaselineShift& baselineShift() const { return m_miscData->baselineShift; }
@@ -250,11 +250,11 @@ inline const Style::SVGBaselineShift& RenderStyle::baselineShift() const { retur
 inline const Style::SVGCenterCoordinateComponent& RenderStyle::cx() const { return svgStyle().cx(); }
 inline const Style::SVGCenterCoordinateComponent& RenderStyle::cy() const { return svgStyle().cy(); }
 inline StylePathData* RenderStyle::d() const { return svgStyle().d(); }
-inline float RenderStyle::fillOpacity() const { return svgStyle().fillOpacity(); }
+inline Style::Opacity RenderStyle::fillOpacity() const { return svgStyle().fillOpacity(); }
 inline const Style::SVGPaint& RenderStyle::fill() const { return svgStyle().fill(); }
 inline const Style::SVGPaint& RenderStyle::visitedLinkFill() const { return svgStyle().visitedLinkFill(); }
 inline const Style::Color& RenderStyle::floodColor() const { return svgStyle().floodColor(); }
-inline float RenderStyle::floodOpacity() const { return svgStyle().floodOpacity(); }
+inline Style::Opacity RenderStyle::floodOpacity() const { return svgStyle().floodOpacity(); }
 inline bool RenderStyle::hasExplicitlySetStrokeWidth() const { return m_rareInheritedData->hasSetStrokeWidth; }
 inline bool RenderStyle::hasVisibleStroke() const { return svgStyle().hasStroke() && !strokeWidth().isZero(); }
 inline const Style::Color& RenderStyle::lightingColor() const { return svgStyle().lightingColor(); }
@@ -265,29 +265,29 @@ inline void RenderStyle::setBaselineShift(Style::SVGBaselineShift&& baselineShif
 inline void RenderStyle::setCx(Style::SVGCenterCoordinateComponent&& cx) { accessSVGStyle().setCx(WTFMove(cx)); }
 inline void RenderStyle::setCy(Style::SVGCenterCoordinateComponent&& cy) { accessSVGStyle().setCy(WTFMove(cy)); }
 inline void RenderStyle::setD(RefPtr<StylePathData>&& d) { accessSVGStyle().setD(WTFMove(d)); }
-inline void RenderStyle::setFillOpacity(float f) { accessSVGStyle().setFillOpacity(f); }
+inline void RenderStyle::setFillOpacity(Style::Opacity opacity) { accessSVGStyle().setFillOpacity(opacity); }
 inline void RenderStyle::setFill(Style::SVGPaint&& paint) { accessSVGStyle().setFill(WTFMove(paint)); }
 inline void RenderStyle::setVisitedLinkFill(Style::SVGPaint&& paint) { accessSVGStyle().setVisitedLinkFill(WTFMove(paint)); }
 inline void RenderStyle::setFloodColor(Style::Color&& c) { accessSVGStyle().setFloodColor(WTFMove(c)); }
-inline void RenderStyle::setFloodOpacity(float f) { accessSVGStyle().setFloodOpacity(f); }
+inline void RenderStyle::setFloodOpacity(Style::Opacity opacity) { accessSVGStyle().setFloodOpacity(opacity); }
 inline void RenderStyle::setLightingColor(Style::Color&& c) { accessSVGStyle().setLightingColor(WTFMove(c)); }
 inline void RenderStyle::setR(Style::SVGRadius&& r) { accessSVGStyle().setR(WTFMove(r)); }
 inline void RenderStyle::setRx(Style::SVGRadiusComponent&& rx) { accessSVGStyle().setRx(WTFMove(rx)); }
 inline void RenderStyle::setRy(Style::SVGRadiusComponent&& ry) { accessSVGStyle().setRy(WTFMove(ry)); }
 inline void RenderStyle::setStopColor(Style::Color&& c) { accessSVGStyle().setStopColor(WTFMove(c)); }
-inline void RenderStyle::setStopOpacity(float f) { accessSVGStyle().setStopOpacity(f); }
+inline void RenderStyle::setStopOpacity(Style::Opacity opacity) { accessSVGStyle().setStopOpacity(opacity); }
 inline void RenderStyle::setStrokeDashArray(Style::SVGStrokeDasharray&& array) { accessSVGStyle().setStrokeDashArray(WTFMove(array)); }
 inline void RenderStyle::setStrokeDashOffset(Style::SVGStrokeDashoffset&& offset) { accessSVGStyle().setStrokeDashOffset(WTFMove(offset)); }
-inline void RenderStyle::setStrokeOpacity(float f) { accessSVGStyle().setStrokeOpacity(f); }
+inline void RenderStyle::setStrokeOpacity(Style::Opacity opacity) { accessSVGStyle().setStrokeOpacity(opacity); }
 inline void RenderStyle::setStroke(Style::SVGPaint&& paint) { accessSVGStyle().setStroke(WTFMove(paint)); }
 inline void RenderStyle::setVisitedLinkStroke(Style::SVGPaint&& paint) { accessSVGStyle().setVisitedLinkStroke(WTFMove(paint)); }
 inline void RenderStyle::setX(Style::SVGCoordinateComponent&& x) { accessSVGStyle().setX(WTFMove(x)); }
 inline void RenderStyle::setY(Style::SVGCoordinateComponent&& y) { accessSVGStyle().setY(WTFMove(y)); }
 inline const Style::Color& RenderStyle::stopColor() const { return svgStyle().stopColor(); }
-inline float RenderStyle::stopOpacity() const { return svgStyle().stopOpacity(); }
+inline Style::Opacity RenderStyle::stopOpacity() const { return svgStyle().stopOpacity(); }
 inline const Style::SVGStrokeDasharray& RenderStyle::strokeDashArray() const { return svgStyle().strokeDashArray(); }
 inline const Style::SVGStrokeDashoffset& RenderStyle::strokeDashOffset() const { return svgStyle().strokeDashOffset(); }
-inline float RenderStyle::strokeOpacity() const { return svgStyle().strokeOpacity(); }
+inline Style::Opacity RenderStyle::strokeOpacity() const { return svgStyle().strokeOpacity(); }
 inline const Style::SVGPaint& RenderStyle::stroke() const { return svgStyle().stroke(); }
 inline const Style::SVGPaint& RenderStyle::visitedLinkStroke() const { return svgStyle().visitedLinkStroke(); }
 inline const Style::StrokeWidth& RenderStyle::strokeWidth() const { return m_rareInheritedData->strokeWidth; }
@@ -303,9 +303,17 @@ inline Style::SVGCoordinateComponent RenderStyle::initialX() { return 0_css_px; 
 inline Style::SVGCoordinateComponent RenderStyle::initialY() { return 0_css_px; }
 inline Style::SVGStrokeDasharray RenderStyle::initialStrokeDashArray() { return CSS::Keyword::None { }; }
 inline Style::SVGStrokeDashoffset RenderStyle::initialStrokeDashOffset() { return 0_css_px; }
+constexpr Style::Opacity RenderStyle::initialFillOpacity() { return 1_css_number; }
+constexpr Style::Opacity RenderStyle::initialStrokeOpacity() { return 1_css_number; }
+constexpr Style::Opacity RenderStyle::initialStopOpacity() { return 1_css_number; }
+constexpr Style::Opacity RenderStyle::initialFloodOpacity() { return 1_css_number; }
 
 inline Style::SVGStrokeDasharray SVGRenderStyle::initialStrokeDashArray() { return RenderStyle::initialStrokeDashArray(); }
 inline Style::SVGStrokeDashoffset SVGRenderStyle::initialStrokeDashOffset() { return RenderStyle::initialStrokeDashOffset(); }
+constexpr Style::Opacity SVGRenderStyle::initialFillOpacity() { return RenderStyle::initialFillOpacity(); }
+constexpr Style::Opacity SVGRenderStyle::initialStrokeOpacity() { return RenderStyle::initialStrokeOpacity(); }
+constexpr Style::Opacity SVGRenderStyle::initialStopOpacity() { return RenderStyle::initialStopOpacity(); }
+constexpr Style::Opacity SVGRenderStyle::initialFloodOpacity() { return RenderStyle::initialFloodOpacity(); }
 
 inline void SVGRenderStyle::setCx(Style::SVGCenterCoordinateComponent&& length)
 {
@@ -355,11 +363,10 @@ inline void SVGRenderStyle::setD(RefPtr<StylePathData>&& d)
         m_layoutData.access().d = WTFMove(d);
 }
 
-inline void SVGRenderStyle::setFillOpacity(float opacity)
+inline void SVGRenderStyle::setFillOpacity(Style::Opacity opacity)
 {
-    auto clampedOpacity = clampTo<float>(opacity, 0.f, 1.f);
-    if (!(m_fillData->opacity == clampedOpacity))
-        m_fillData.access().opacity = clampedOpacity;
+    if (!(m_fillData->opacity == opacity))
+        m_fillData.access().opacity = opacity;
 }
 
 inline void SVGRenderStyle::setFill(Style::SVGPaint&& paint)
@@ -374,11 +381,10 @@ inline void SVGRenderStyle::setVisitedLinkFill(Style::SVGPaint&& paint)
         m_fillData.access().visitedLinkPaint = WTFMove(paint);
 }
 
-inline void SVGRenderStyle::setStrokeOpacity(float opacity)
+inline void SVGRenderStyle::setStrokeOpacity(Style::Opacity opacity)
 {
-    auto clampedOpacity = clampTo<float>(opacity, 0.f, 1.f);
-    if (!(m_strokeData->opacity == clampedOpacity))
-        m_strokeData.access().opacity = clampedOpacity;
+    if (!(m_strokeData->opacity == opacity))
+        m_strokeData.access().opacity = opacity;
 }
 
 inline void SVGRenderStyle::setStroke(Style::SVGPaint&& paint)
@@ -405,11 +411,10 @@ inline void SVGRenderStyle::setStrokeDashOffset(Style::SVGStrokeDashoffset&& off
         m_strokeData.access().dashOffset = WTFMove(offset);
 }
 
-inline void SVGRenderStyle::setStopOpacity(float opacity)
+inline void SVGRenderStyle::setStopOpacity(Style::Opacity opacity)
 {
-    auto clampedOpacity = clampTo<float>(opacity, 0.f, 1.f);
-    if (!(m_stopData->opacity == clampedOpacity))
-        m_stopData.access().opacity = clampedOpacity;
+    if (!(m_stopData->opacity == opacity))
+        m_stopData.access().opacity = opacity;
 }
 
 inline void SVGRenderStyle::setStopColor(Style::Color&& color)
@@ -418,11 +423,10 @@ inline void SVGRenderStyle::setStopColor(Style::Color&& color)
         m_stopData.access().color = WTFMove(color);
 }
 
-inline void SVGRenderStyle::setFloodOpacity(float opacity)
+inline void SVGRenderStyle::setFloodOpacity(Style::Opacity opacity)
 {
-    auto clampedOpacity = clampTo<float>(opacity, 0.f, 1.f);
-    if (!(m_miscData->floodOpacity == clampedOpacity))
-        m_miscData.access().floodOpacity = clampedOpacity;
+    if (!(m_miscData->floodOpacity == opacity))
+        m_miscData.access().floodOpacity = opacity;
 }
 
 inline void SVGRenderStyle::setFloodColor(Style::Color&& color)

--- a/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyleDefs.h
@@ -33,6 +33,7 @@
 #include "SVGLengthValue.h"
 #include "StyleBoxShadow.h"
 #include "StyleColor.h"
+#include "StyleOpacity.h"
 #include "StylePathData.h"
 #include "StyleSVGBaselineShift.h"
 #include "StyleSVGCenterCoordinateComponent.h"
@@ -148,7 +149,7 @@ public:
     void dumpDifferences(TextStream&, const StyleFillData&) const;
 #endif
 
-    float opacity;
+    Style::Opacity opacity;
     Style::SVGPaint paint;
     Style::SVGPaint visitedLinkPaint;
 
@@ -170,7 +171,7 @@ public:
     void dumpDifferences(TextStream&, const StyleStrokeData&) const;
 #endif
 
-    float opacity;
+    Style::Opacity opacity;
     Style::SVGPaint paint;
     Style::SVGPaint visitedLinkPaint;
     Style::SVGStrokeDashoffset dashOffset;
@@ -194,7 +195,7 @@ public:
     void dumpDifferences(TextStream&, const StyleStopData&) const;
 #endif
 
-    float opacity;
+    Style::Opacity opacity;
     Style::Color color;
 
 private:
@@ -216,7 +217,7 @@ public:
     void dumpDifferences(TextStream&, const StyleMiscData&) const;
 #endif
 
-    float floodOpacity;
+    Style::Opacity floodOpacity;
     Style::Color floodColor;
     Style::Color lightingColor;
 

--- a/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleMiscNonInheritedData.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +33,7 @@
 #include "StyleContent.h"
 #include "StyleContentAlignmentData.h"
 #include "StyleObjectPosition.h"
+#include "StyleOpacity.h"
 #include "StyleSelfAlignmentData.h"
 #include <memory>
 #include <wtf/DataRef.h>
@@ -69,12 +71,10 @@ public:
     void dumpDifferences(TextStream&, const StyleMiscNonInheritedData&) const;
 #endif
 
-    bool hasOpacity() const { return opacity < 1; }
-    bool hasZeroOpacity() const { return !opacity; }
     bool hasFilters() const;
 
     // This is here to pack in with m_refCount.
-    float opacity;
+    Style::Opacity opacity;
 
     DataRef<StyleDeprecatedFlexibleBoxData> deprecatedFlexibleBox; // Flexible box properties
     DataRef<StyleFlexibleBoxData> flexibleBox;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -96,7 +96,7 @@ bool RenderSVGResourceGradient::prepareFillOperation(GraphicsContext& context, c
         return false;
 
     Ref svgStyle = style.svgStyle();
-    context.setAlpha(svgStyle->fillOpacity());
+    context.setAlpha(svgStyle->fillOpacity().value.value);
     context.setFillRule(svgStyle->fillRule());
     context.setFillGradient(m_gradient.copyRef().releaseNonNull(), userspaceTransform);
     return true;
@@ -114,7 +114,7 @@ bool RenderSVGResourceGradient::prepareStrokeOperation(GraphicsContext& context,
             userspaceTransform = shape->nonScalingStrokeTransform() * userspaceTransform;
     }
 
-    context.setAlpha(svgStyle->strokeOpacity());
+    context.setAlpha(svgStyle->strokeOpacity().value.value);
     SVGRenderSupport::applyStrokeStyleToContext(context, style, targetRenderer);
     context.setStrokeGradient(m_gradient.copyRef().releaseNonNull(), userspaceTransform);
     return true;

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -137,7 +137,7 @@ bool RenderSVGResourcePattern::prepareFillOperation(GraphicsContext& context, co
         return false;
 
     const auto& svgStyle = style.svgStyle();
-    context.setAlpha(svgStyle.fillOpacity());
+    context.setAlpha(svgStyle.fillOpacity().value.value);
     context.setFillRule(svgStyle.fillRule());
     context.setFillPattern(*pattern);
     return true;
@@ -151,7 +151,7 @@ bool RenderSVGResourcePattern::prepareStrokeOperation(GraphicsContext& context, 
 
     const auto& svgStyle = style.svgStyle();
 
-    context.setAlpha(svgStyle.strokeOpacity());
+    context.setAlpha(svgStyle.strokeOpacity().value.value);
     SVGRenderSupport::applyStrokeStyleToContext(context, style, targetRenderer);
     if (svgStyle.vectorEffect() == VectorEffect::NonScalingStroke) {
         if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(targetRenderer))

--- a/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
@@ -129,7 +129,7 @@ private:
             m_context.setAlpha(1);
             m_context.setFillRule(svgStyle->clipRule());
         } else {
-            m_context.setAlpha(svgStyle->fillOpacity());
+            m_context.setAlpha(svgStyle->fillOpacity().value.value);
             m_context.setFillRule(svgStyle->fillRule());
         }
 
@@ -138,7 +138,7 @@ private:
 
     inline void prepareStrokeOperation(const RenderLayerModelObject& renderer, const RenderStyle& style, const Color& strokeColor) const
     {
-        m_context.setAlpha(style.svgStyle().strokeOpacity());
+        m_context.setAlpha(style.svgStyle().strokeOpacity().value.value);
         m_context.setStrokeColor(style.colorByApplyingColorFilter(strokeColor));
         SVGRenderSupport::applyStrokeStyleToContext(m_context, style, renderer);
     }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -527,7 +527,7 @@ void SVGRenderSupport::styleChanged(RenderElement& renderer, const RenderStyle* 
 
 bool SVGRenderSupport::isolatesBlending(const RenderStyle& style)
 {
-    return style.hasPositionedMask() || style.hasFilter() || style.hasBlendMode() || style.opacity() < 1.0f;
+    return style.hasPositionedMask() || style.hasFilter() || style.hasBlendMode() || !style.opacity().isOpaque();
 }
 
 void SVGRenderSupport::updateMaskedAncestorShouldIsolateBlending(const RenderElement& renderer)

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -191,7 +191,7 @@ static void writeSVGFillPaintingResource(TextStream& ts, const RenderElement& re
     writeSVGPaintingResource(ts, fillPaintingResource);
 
     const auto& svgStyle = renderer.style().svgStyle();
-    writeIfNotDefault(ts, "opacity"_s, svgStyle.fillOpacity(), 1.0f);
+    writeIfNotDefault(ts, "opacity"_s, svgStyle.fillOpacity().value.value, 1.0f);
     writeIfNotDefault(ts, "fill rule"_s, svgStyle.fillRule(), WindRule::NonZero);
     ts << "}]"_s;
 }
@@ -212,7 +212,7 @@ static void writeSVGStrokePaintingResource(TextStream& ts, const RenderElement& 
         return lengthContext.valueForLength(length);
     });
 
-    writeIfNotDefault(ts, "opacity"_s, svgStyle.strokeOpacity(), 1.0f);
+    writeIfNotDefault(ts, "opacity"_s, svgStyle.strokeOpacity().value.value, 1.0f);
     writeIfNotDefault(ts, "stroke width"_s, strokeWidth, 1.0);
     writeIfNotDefault(ts, "miter limit"_s, style.strokeMiterLimit(), 4.0f);
     writeIfNotDefault(ts, "line cap"_s, style.capStyle(), LineCap::Butt);
@@ -237,7 +237,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
     if (!renderer.localTransform().isIdentity())
         writeNameValuePair(ts, "transform"_s, renderer.localTransform());
     writeIfNotDefault(ts, "image rendering"_s, style.imageRendering(), RenderStyle::initialImageRendering());
-    writeIfNotDefault(ts, "opacity"_s, style.opacity(), RenderStyle::initialOpacity());
+    writeIfNotDefault(ts, "opacity"_s, style.opacity().value.value, 1.0f);
 
     if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer)) {
         Color fallbackColor;

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -110,7 +110,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
     // Setup transparency layers before setting up SVG resources!
     bool isRenderingMask = isRenderingMaskImage(*m_renderer);
     // RenderLayer takes care of root opacity.
-    float opacity = (renderer.isLegacyRenderSVGRoot() || isRenderingMask) ? 1 : style.opacity();
+    float opacity = (renderer.isLegacyRenderSVGRoot() || isRenderingMask) ? 1 : style.opacity().value.value;
     bool hasBlendMode = style.hasBlendMode();
     bool hasIsolation = style.hasIsolation();
     bool isolateMaskForBlending = false;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -136,13 +136,13 @@ static inline void applyGradientResource(RenderElement& renderer, const RenderSt
     auto userspaceTransform = gradientData.userspaceTransform;
 
     if (resourceMode.contains(RenderSVGResourceMode::ApplyToFill)) {
-        context.setAlpha(svgStyle.fillOpacity());
+        context.setAlpha(svgStyle.fillOpacity().value.value);
         context.setFillGradient(*gradientData.gradient, userspaceTransform);
         context.setFillRule(svgStyle.fillRule());
     } else if (resourceMode.contains(RenderSVGResourceMode::ApplyToStroke)) {
         if (svgStyle.vectorEffect() == VectorEffect::NonScalingStroke)
             userspaceTransform = LegacyRenderSVGResourceContainer::transformOnNonScalingStroke(&renderer, gradientData.userspaceTransform);
-        context.setAlpha(svgStyle.strokeOpacity());
+        context.setAlpha(svgStyle.strokeOpacity().value.value);
         context.setStrokeGradient(*gradientData.gradient, userspaceTransform);
         SVGRenderSupport::applyStrokeStyleToContext(context, style, renderer);
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -182,13 +182,13 @@ auto LegacyRenderSVGResourcePattern::applyResource(RenderElement& renderer, cons
     Ref svgStyle = style.svgStyle();
 
     if (resourceMode.contains(RenderSVGResourceMode::ApplyToFill)) {
-        context->setAlpha(svgStyle->fillOpacity());
+        context->setAlpha(svgStyle->fillOpacity().value.value);
         context->setFillPattern(*patternData->pattern);
         context->setFillRule(svgStyle->fillRule());
     } else if (resourceMode.contains(RenderSVGResourceMode::ApplyToStroke)) {
         if (svgStyle->vectorEffect() == VectorEffect::NonScalingStroke)
             patternData->pattern->setPatternSpaceTransform(transformOnNonScalingStroke(&renderer, patternData->transform));
-        context->setAlpha(svgStyle->strokeOpacity());
+        context->setAlpha(svgStyle->strokeOpacity().value.value);
         context->setStrokePattern(*patternData->pattern);
         SVGRenderSupport::applyStrokeStyleToContext(*context, style, renderer);
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp
@@ -49,7 +49,7 @@ auto LegacyRenderSVGResourceSolidColor::applyResource(RenderElement& renderer, c
 
     if (resourceMode.contains(RenderSVGResourceMode::ApplyToFill)) {
         if (!isRenderingMask)
-            context->setAlpha(svgStyle.fillOpacity());
+            context->setAlpha(svgStyle.fillOpacity().value.value);
         else
             context->setAlpha(1);
         context->setFillColor(style.colorByApplyingColorFilter(m_color));
@@ -63,7 +63,7 @@ auto LegacyRenderSVGResourceSolidColor::applyResource(RenderElement& renderer, c
     } else if (resourceMode.contains(RenderSVGResourceMode::ApplyToStroke)) {
         // When rendering the mask for a LegacyRenderSVGResourceClipper, the stroke code path is never hit.
         ASSERT(!isRenderingMask);
-        context->setAlpha(svgStyle.strokeOpacity());
+        context->setAlpha(svgStyle.strokeOpacity().value.value);
         context->setStrokeColor(style.colorByApplyingColorFilter(m_color));
 
         SVGRenderSupport::applyStrokeStyleToContext(*context, style, renderer);

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -788,7 +788,7 @@ static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingB
         auto shouldRepaint = [&] {
             if (!renderElement->everHadLayout())
                 return false;
-            if (!renderElement->style().opacity())
+            if (renderElement->style().opacity().isTransparent())
                 return false;
             if (renderElement->isOutOfFlowPositioned())
                 return destroyRootRenderer != renderElement->containingBlock() || !destroyRootRenderer->hasNonVisibleOverflow();

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -179,7 +179,6 @@ public:
     static FontFeatureSettings convertFontFeatureSettings(BuilderState&, const CSSValue&);
     static FontVariationSettings convertFontVariationSettings(BuilderState&, const CSSValue&);
     static PaintOrder convertPaintOrder(BuilderState&, const CSSValue&);
-    static float convertOpacity(BuilderState&, const CSSValue&);
     static URL convertSVGURIReference(BuilderState&, const CSSValue&);
     static StyleSelfAlignmentData convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue&);
     static StyleContentAlignmentData convertContentAlignmentData(BuilderState&, const CSSValue&);
@@ -972,16 +971,6 @@ inline PaintOrder BuilderConverter::convertPaintOrder(BuilderState& builderState
         ASSERT_NOT_REACHED();
         return PaintOrder::Normal;
     }
-}
-
-inline float BuilderConverter::convertOpacity(BuilderState& builderState, const CSSValue& value)
-{
-    auto* primitiveValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
-    if (!primitiveValue)
-        return { };
-
-    float opacity = primitiveValue->valueDividingBy100IfPercentage(builderState.cssToLengthConversionData());
-    return std::max(0.0f, std::min(1.0f, opacity));
 }
 
 inline URL BuilderConverter::convertSVGURIReference(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleExtractorConverter.h
+++ b/Source/WebCore/style/StyleExtractorConverter.h
@@ -160,7 +160,6 @@ public:
 
     // MARK: Shared conversions
 
-    static Ref<CSSValue> convertOpacity(ExtractorState&, float);
     static Ref<CSSValue> convertImageOrNone(ExtractorState&, const StyleImage*);
     static Ref<CSSValue> convertGlyphOrientation(ExtractorState&, GlyphOrientation);
     static Ref<CSSValue> convertGlyphOrientationOrAuto(ExtractorState&, GlyphOrientation);
@@ -509,11 +508,6 @@ inline Ref<CSSValue> ExtractorConverter::convertTransformOperation(const RenderS
 }
 
 // MARK: - Shared conversions
-
-inline Ref<CSSValue> ExtractorConverter::convertOpacity(ExtractorState& state, float opacity)
-{
-    return convert(state, opacity);
-}
 
 inline Ref<CSSValue> ExtractorConverter::convertImageOrNone(ExtractorState& state, const StyleImage* image)
 {

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -81,7 +81,6 @@ public:
 
     // MARK: Shared serializations
 
-    static void serializeOpacity(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, float);
     static void serializeImageOrNone(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, const StyleImage*);
     static void serializeGlyphOrientation(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GlyphOrientation);
     static void serializeGlyphOrientationOrAuto(ExtractorState&, StringBuilder&, const CSS::SerializationContext&, GlyphOrientation);
@@ -567,11 +566,6 @@ inline void ExtractorSerializer::serializeTransformOperation(const RenderStyle& 
 }
 
 // MARK: - Shared serializations
-
-inline void ExtractorSerializer::serializeOpacity(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, float opacity)
-{
-    serialize(state, builder, context, opacity);
-}
 
 inline void ExtractorSerializer::serializeImageOrNone(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StyleImage* image)
 {

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -210,7 +210,7 @@ bool Styleable::mayHaveNonZeroOpacity() const
     if (!renderer)
         return false;
 
-    if (renderer->style().opacity() != 0.0f)
+    if (!renderer->style().opacity().isZero())
         return true;
 
     if (renderer->style().willChange() && renderer->style().willChange()->containsProperty(CSSPropertyOpacity))

--- a/Source/WebCore/style/values/color/StyleOpacity.cpp
+++ b/Source/WebCore/style/values/color/StyleOpacity.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleOpacity.h"
+
+#include "CSSPrimitiveValue.h"
+#include "StyleBuilderChecking.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Conversion
+
+auto CSSValueConversion<Opacity>::operator()(BuilderState& state, const CSSValue& value) -> Opacity
+{
+    RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
+    if (!primitiveValue)
+        return 1.0f;
+
+    auto opacity = primitiveValue->valueDividingBy100IfPercentage<float>(state.cssToLengthConversionData());
+    return CSS::clampToRange<Opacity::Number::range>(opacity);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleOpacity.h
+++ b/Source/WebCore/style/values/color/StyleOpacity.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumeric.h"
+#include "StyleValueTypes.h"
+
+namespace WebCore {
+namespace Style {
+
+// <opacity-value> = <number [0,1]@(allow-both-at-parse)> | <percentage [0,100]@(allow-both-at-parse, converted-to-number)>
+// https://drafts.csswg.org/css-color-4/#typedef-opacity-opacity-value
+struct Opacity {
+    using Number = Style::Number<CSS::ClosedUnitRange, float>;
+
+    Number value;
+
+    constexpr Opacity(Number number)
+        : value { number }
+    {
+    }
+
+    constexpr Opacity(float literal)
+        : value { literal }
+    {
+    }
+
+    constexpr Opacity(CSS::ValueLiteral<CSS::NumberUnit::Number> literal)
+        : value { literal }
+    {
+    }
+
+    constexpr bool isZero() const { return value == 0; }
+
+    constexpr bool isTransparent() const { return value == 0; }
+    constexpr bool isOpaque() const { return value == 1; }
+
+    constexpr bool operator==(const Opacity&) const = default;
+    constexpr auto operator<=>(const Opacity&) const = default;
+};
+DEFINE_TYPE_WRAPPER_GET(Opacity, value);
+
+// MARK: - Conversion
+
+template<> struct CSSValueConversion<Opacity> { auto operator()(BuilderState&, const CSSValue&) -> Opacity; };
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_TUPLE_LIKE_CONFORMANCE_FOR_TYPE_WRAPPER(WebCore::Style::Opacity)

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -130,7 +130,7 @@ bool SVGFEDropShadowElement::setFilterEffectAttribute(FilterEffect& filterEffect
         return effect.setShadowColor(style.colorResolvingCurrentColor(style.svgStyle().floodColor()));
     }
     case AttributeNames::flood_opacityAttr:
-        return effect.setShadowOpacity(renderer()->style().svgStyle().floodOpacity());
+        return effect.setShadowOpacity(renderer()->style().svgStyle().floodOpacity().value.value);
     default:
         break;
     }
@@ -163,7 +163,7 @@ RefPtr<FilterEffect> SVGFEDropShadowElement::createFilterEffect(const FilterEffe
     const SVGRenderStyle& svgStyle = style.svgStyle();
     
     Color color = style.colorWithColorFilter(svgStyle.floodColor());
-    float opacity = svgStyle.floodOpacity();
+    float opacity = svgStyle.floodOpacity().value.value;
 
     return FEDropShadow::create(stdDeviationX(), stdDeviationY(), dx(), dy(), color, opacity);
 }

--- a/Source/WebCore/svg/SVGFEFloodElement.cpp
+++ b/Source/WebCore/svg/SVGFEFloodElement.cpp
@@ -56,7 +56,7 @@ bool SVGFEFloodElement::setFilterEffectAttribute(FilterEffect& effect, const Qua
     if (attrName == SVGNames::flood_colorAttr)
         return feFlood.setFloodColor(style.colorResolvingCurrentColor(style.svgStyle().floodColor()));
     if (attrName == SVGNames::flood_opacityAttr)
-        return feFlood.setFloodOpacity(style.svgStyle().floodOpacity());
+        return feFlood.setFloodOpacity(style.svgStyle().floodOpacity().value.value);
 
     ASSERT_NOT_REACHED();
     return false;
@@ -72,7 +72,7 @@ RefPtr<FilterEffect> SVGFEFloodElement::createFilterEffect(const FilterEffectVec
     auto& svgStyle = style.svgStyle();
 
     auto color = style.colorWithColorFilter(svgStyle.floodColor());
-    float opacity = svgStyle.floodOpacity();
+    float opacity = svgStyle.floodOpacity().value.value;
 
     return FEFlood::create(color, opacity);
 }

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -97,7 +97,7 @@ Color SVGStopElement::stopColorIncludingOpacity() const
     Ref svgStyle = style.svgStyle();
     auto stopColor = style.colorResolvingCurrentColor(svgStyle->stopColor());
 
-    return stopColor.colorWithAlphaMultipliedBy(svgStyle->stopOpacity());
+    return stopColor.colorWithAlphaMultipliedBy(svgStyle->stopOpacity().value.value);
 }
 
 }


### PR DESCRIPTION
#### edd39f21a416e850c451a44e6dbba7b62bd34bbd
<pre>
[Style] Convert opacity properties to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296750">https://bugs.webkit.org/show_bug.cgi?id=296750</a>

Reviewed by Darin Adler.

Converts the opacity properties, `opacity`, `fill-opacity`, `stroke-opacity`,
`flood-opacity` and `stop-opacity` to use strong style types.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/page/ElementTargetingController.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/rendering/RenderElementInlines.h:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
* Source/WebCore/rendering/RenderScrollbar.cpp:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
* Source/WebCore/rendering/RenderView.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyleDefs.h:
* Source/WebCore/rendering/style/StyleMiscNonInheritedData.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
* Source/WebCore/rendering/svg/SVGPaintServerHandling.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.cpp:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
* Source/WebCore/style/StyleBuilderConverter.h:
* Source/WebCore/style/StyleExtractorConverter.h:
* Source/WebCore/style/StyleExtractorSerializer.h:
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/style/values/color/StyleOpacity.cpp: Added.
* Source/WebCore/style/values/color/StyleOpacity.h: Added.
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
* Source/WebCore/svg/SVGFEFloodElement.cpp:
* Source/WebCore/svg/SVGStopElement.cpp:

Canonical link: <a href="https://commits.webkit.org/298130@main">https://commits.webkit.org/298130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9de6d5fb35c941234886d03d963c63f3551411c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114267 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102633 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67237 "Found 2 new API test failures: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close, /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123644 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95671 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24341 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46669 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->