### PR TITLE
WebVTT wpt should use ::cue instead of ::cue(*)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -604,9 +604,6 @@ imported/w3c/web-platform-tests/x-frame-options/multiple.html [ DumpJSConsoleLog
 imported/w3c/web-platform-tests/x-frame-options/sameorigin.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window.html [ DumpJSConsoleLogInStdErr ]
 
-# We need to fix our WebVTT implementation to pass most of the WebVTT rendering WPT (https://bugs.webkit.org/show_bug.cgi?id=277975).
-imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
-
 webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.lang.dynamic.html [ ImageOnlyFailure ]
 webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.lang.html [ ImageOnlyFailure ]
 webkit.org/b/285993 imported/w3c/web-platform-tests/html/canvas/element/manual/text/canvas.2d.lang.inherit.disconnected.canvas.html [ ImageOnlyFailure ]
@@ -622,6 +619,9 @@ webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.transferred.direction.inherit.html [ ImageOnlyFailure ]
 webkit.org/b/290522 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/text/canvas.2d.offscreen.worker.direction.inherit.html [ ImageOnlyFailure ]
 
+# We need to fix our WebVTT implementation to pass most of the WebVTT rendering WPT (https://bugs.webkit.org/show_bug.cgi?id=277975).
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video [ ImageOnlyFailure ]
+
 # These are the WebVTT rendering WPT we are already passing.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_remove_cue_while_paused.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_cascade_priority.html [ Pass ]
@@ -632,6 +632,14 @@ imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-mode
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_urls.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/media_height_19.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html [ Pass ]
+imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html [ Pass ]
 
 # These WebVTT rendering WPT are flaky.
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/evil/non-standard-pseudo-elements.html [ ImageOnlyFailure Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, line:50% should be vertically centered</title>
+<title>WebVTT rendering, line:50%: top edge should be vertically centered</title>
 <link rel="match" href="line_50_percent-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), background properties</title>
+<title>Reference for WebVTT rendering, ::cue, background properties</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), background properties</title>
+<title>Reference for WebVTT rendering, ::cue, background properties</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), background properties</title>
+<title>WebVTT rendering, ::cue, background properties</title>
 <link rel="match" href="background_properties-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     background-color: #0f0;
     background-image: url('../../media/background.gif');

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), background shorthand</title>
+<title>Reference for WebVTT rendering, ::cue, background shorthand</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), background shorthand</title>
+<title>Reference for WebVTT rendering, ::cue, background shorthand</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), background shorthand</title>
+<title>WebVTT rendering, ::cue, background shorthand</title>
 <link rel="match" href="background_shorthand-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     background: #0f0 url('../../media/background.gif') repeat-x top left;
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), background shorthand, background image URL with relative path from CSS file</title>
+<title>Reference for WebVTT rendering, ::cue, background shorthand, background image URL with relative path from CSS file</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), background shorthand, background image URL with relative path from CSS file</title>
+<title>Reference for WebVTT rendering, ::cue, background shorthand, background image URL with relative path from CSS file</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), background shorthand, background image URL with relative path from CSS file</title>
+<title>WebVTT rendering, ::cue, background shorthand, background image URL with relative path from CSS file</title>
 <link rel="match" href="background_shorthand_css_relative_url-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     background: #0f0 url('../../media/background.gif') repeat-x top left;
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), color: #60ff60</title>
+<title>Reference for WebVTT rendering, ::cue, color: #60ff60</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), color: #60ff60</title>
+<title>Reference for WebVTT rendering, ::cue, color: #60ff60</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), color: #60ff60</title>
+<title>WebVTT rendering, ::cue, color: #60ff60</title>
 <link rel="match" href="color_hex-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     color: #60ff60;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), color: hsla()</title>
+<title>Reference for WebVTT rendering, ::cue, color: hsla()</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), color: hsla()</title>
+<title>Reference for WebVTT rendering, ::cue, color: hsla()</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), color: hsla()</title>
+<title>WebVTT rendering, ::cue, color: hsla()</title>
 <link rel="match" href="color_hsla-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     color: hsla(100,100%,50%,0.5);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), color: rgba()</title>
+<title>Reference for WebVTT rendering, ::cue, color: rgba()</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), color: rgba()</title>
+<title>Reference for WebVTT rendering, ::cue, color: rgba()</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), color: rgba()</title>
+<title>WebVTT rendering, ::cue, color: rgba()</title>
 <link rel="match" href="color_rgba-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     color: rgba(128,255,128,0.5);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), font properties</title>
+<title>Reference for WebVTT rendering, ::cue, font properties</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), font properties</title>
+<title>Reference for WebVTT rendering, ::cue, font properties</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), font properties</title>
+<title>WebVTT rendering, ::cue, font properties</title>
 <link rel="match" href="font_properties-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-style: italic;
     font-variant: small-caps;
     font-weight: bold;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), font shorthand</title>
+<title>Reference for WebVTT rendering, ::cue, font shorthand</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), font shorthand</title>
+<title>Reference for WebVTT rendering, ::cue, font shorthand</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), font shorthand</title>
+<title>WebVTT rendering, ::cue, font shorthand</title>
 <link rel="match" href="font_shorthand-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font: italic small-caps bold 9px/18px sans-serif;
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(*), css properties with value inherit should inherit from media element</title>
+<title>Reference for WebVTT rendering, ::cue, css properties with value inherit should inherit from media element</title>
 <style>
 .video {
     position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(*), css properties with value inherit should inherit from media element</title>
+<title>Reference for WebVTT rendering, ::cue, css properties with value inherit should inherit from media element</title>
 <style>
 .video {
     position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(*), css properties with value inherit should inherit from media element</title>
+<title>WebVTT rendering, ::cue, css properties with value inherit should inherit from media element</title>
 <link rel="match" href="inherit_values_from_media_element-ref.html">
 <style>
 video {
@@ -12,7 +12,7 @@ video {
     background: #0f0 url('../../media/background.gif') repeat-x top left;
     outline: solid #00f 2px;
 }
-::cue(*) {
+::cue {
     white-space: inherit;
     font: inherit;
     color: inherit;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), properties that should not affect the cue</title>
+<title>Reference for WebVTT rendering, ::cue, properties that should not affect the cue</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), properties that should not affect the cue</title>
+<title>Reference for WebVTT rendering, ::cue, properties that should not affect the cue</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), properties that should not affect the cue</title>
+<title>WebVTT rendering, ::cue, properties that should not affect the cue</title>
 <link rel="match" href="not_allowed_properties-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     border: 2px solid red;
     border-radius: 5px;
     bottom: 300px;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), outline properties</title>
+<title>Reference for WebVTT rendering, ::cue, outline properties</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), outline properties</title>
+<title>Reference for WebVTT rendering, ::cue, outline properties</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), outline properties</title>
+<title>WebVTT rendering, ::cue, outline properties</title>
 <link rel="match" href="outline_properties-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     outline-style: solid;
     outline-color: #00f;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), outline shorthand</title>
+<title>Reference for WebVTT rendering, ::cue, outline shorthand</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), outline shorthand</title>
+<title>Reference for WebVTT rendering, ::cue, outline shorthand</title>
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), outline shorthand</title>
+<title>WebVTT rendering, ::cue, outline shorthand</title>
 <link rel="match" href="outline_shorthand-ref.html">
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: Ahem, sans-serif;
     outline: solid #00f 2px;
     color: green;

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: line-through</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: line-through</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: line-through</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: line-through</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), text-decoration: line-through</title>
+<title>WebVTT rendering, ::cue, text-decoration: line-through</title>
 <link rel="match" href="text-decoration_line-through-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: sans-serif;
     text-decoration: line-through;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: overline</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: overline</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: overline</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: overline</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), text-decoration: overline</title>
+<title>WebVTT rendering, ::cue, text-decoration: overline</title>
 <link rel="match" href="text-decoration_overline-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: sans-serif;
     text-decoration: overline;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: overline underline line-through</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: overline underline line-through</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: overline underline line-through</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: overline underline line-through</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), text-decoration: overline underline line-through</title>
+<title>WebVTT rendering, ::cue, text-decoration: overline underline line-through</title>
 <link rel="match" href="text-decoration_overline_underline_line-through-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: sans-serif;
     text-decoration: overline underline line-through;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: underline</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: underline</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-decoration: underline</title>
+<title>Reference for WebVTT rendering, ::cue, text-decoration: underline</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), text-decoration: underline</title>
+<title>WebVTT rendering, ::cue, text-decoration: underline</title>
 <link rel="match" href="text-decoration_underline-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: sans-serif;
     text-decoration: underline;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-shadow</title>
+<title>Reference for WebVTT rendering, ::cue, text-shadow</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), text-shadow</title>
+<title>Reference for WebVTT rendering, ::cue, text-shadow</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), text-shadow</title>
+<title>WebVTT rendering, ::cue, text-shadow</title>
 <link rel="match" href="text-shadow-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     font-family: sans-serif;
     text-shadow: 0px 0px 5px #0f0;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: normal (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: normal (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: normal (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: normal (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), white-space: normal (cue that wraps)</title>
+<title>WebVTT rendering, ::cue, white-space: normal (cue that wraps)</title>
 <link rel="match" href="white-space_normal_wrapped-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     white-space: normal
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: nowrap (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: nowrap (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: nowrap (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: nowrap (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), white-space: nowrap (cue that wraps)</title>
+<title>WebVTT rendering, ::cue, white-space: nowrap (cue that wraps)</title>
 <link rel="match" href="white-space_nowrap_wrapped-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     white-space: nowrap
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre-line (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre-line (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre-line (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre-line (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), white-space: pre-line (cue that wraps)</title>
+<title>WebVTT rendering, ::cue, white-space: pre-line (cue that wraps)</title>
 <link rel="match" href="white-space_pre-line_wrapped-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     white-space: pre-line
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre-wrap (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre-wrap (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre-wrap (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre-wrap (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), white-space: pre-wrap (cue that wraps)</title>
+<title>WebVTT rendering, ::cue, white-space: pre-wrap (cue that wraps)</title>
 <link rel="match" href="white-space_pre-wrap_wrapped-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     white-space: pre-wrap
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), white-space: pre</title>
+<title>WebVTT rendering, ::cue, white-space: pre</title>
 <link rel="match" href="white-space_pre-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     white-space: pre
 }
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Reference for WebVTT rendering, ::cue(), white-space: pre (cue that wraps)</title>
+<title>Reference for WebVTT rendering, ::cue, white-space: pre (cue that wraps)</title>
 <style>
 html { overflow:hidden }
 body { margin:0 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html class="reftest-wait">
-<title>WebVTT rendering, ::cue(), white-space: pre (cue that wraps)</title>
+<title>WebVTT rendering, ::cue, white-space: pre (cue that wraps)</title>
 <link rel="match" href="white-space_pre_wrapped-ref.html">
 <style>
 html { overflow:hidden }
 body { margin:0 }
-::cue(*) {
+::cue {
     white-space: pre
 }
 </style>


### PR DESCRIPTION
#### d1d64f87d594aa8d57081ce1386e0fc4f782f5b9
<pre>
WebVTT wpt should use ::cue instead of ::cue(*)
<a href="https://bugs.webkit.org/show_bug.cgi?id=296756">https://bugs.webkit.org/show_bug.cgi?id=296756</a>
<a href="https://rdar.apple.com/136808926">rdar://136808926</a>

Reviewed by NOBODY (OOPS!).

These tests use the selector ::cue(*) to attempt to style the cue, but ::cue(*) only targets internal
nodes within the cue (like &lt;rt&gt;, &lt;c&gt;,&lt;b&gt;, etc.), not plain text. And the .vtt files used in these
tests only have cues with just plain text. Based on the ref files for these tests it appears the
intention is to have the style apply to the cues, so we should replace ::cue(*) with ::cue in these
tests.

And in the future we should write a test that tests the functionality of ::cue(*).

* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/background_shorthand_css_relative_url.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hex.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_hsla.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/color_rgba.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/font_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/inherit_values_from_media_element.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_properties.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/outline_shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_overline_underline_line-through.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-decoration_underline.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/text-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-line_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre-wrap_wrapped.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre_wrapped.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1d64f87d594aa8d57081ce1386e0fc4f782f5b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/64969 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42543 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86812 "Found 3 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_normal_wrapped.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_nowrap_wrapped.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/white-space_pre.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41757 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117183 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27560 "Exiting early after 10 failures. 38 tests run. 1 new passes 5 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67202 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26741 "Exiting early after 10 failures. 18 tests run. 5 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20721 "Exiting early after 10 failures. 67 tests run. 1 new passes 3 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64094 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123617 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41253 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30760 "Exiting early after 10 failures. 304 tests run. 1 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95645 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/selectors/cue_function/not_allowed_properties.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95428 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40568 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41133 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->