### PR TITLE
Make BaselineSynthesisEdge and FontBaseline enum classes

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -119,7 +119,7 @@ private:
     InlineRect m_logicalRect;
     OptionSet<InlineLevelBox::Type> m_boxTypes;
 
-    FontBaseline m_baselineType { AlphabeticBaseline };
+    FontBaseline m_baselineType { FontBaseline::Alphabetic };
     InlineLevelBox m_rootInlineBox;
     InlineLevelBoxList m_nonRootInlineLevelBoxList;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -99,7 +99,7 @@ TextUtil::FallbackFontList LineBoxBuilder::collectFallbackFonts(const InlineLeve
     return fallbackFonts;
 }
 
-static InlineLevelBox::AscentAndDescent primaryFontMetricsForInlineBox(const InlineLevelBox& inlineBox, FontBaseline fontBaseline = AlphabeticBaseline)
+static InlineLevelBox::AscentAndDescent primaryFontMetricsForInlineBox(const InlineLevelBox& inlineBox, FontBaseline fontBaseline = FontBaseline::Alphabetic)
 {
     ASSERT(inlineBox.isInlineBox());
     auto& fontMetrics = inlineBox.primarymetricsOfPrimaryFont();
@@ -133,10 +133,10 @@ static InlineLevelBox::AscentAndDescent layoutBoundstWithEdgeAdjustmentForInline
         case TextEdgeType::ExHeight:
             return roundf(fontMetrics.xHeight().value_or(0.f));
         case TextEdgeType::CJKIdeographic:
-            return fontMetrics.intAscent(IdeographicBaseline);
+            return fontMetrics.intAscent(FontBaseline::Ideographic);
         case TextEdgeType::CJKIdeographicInk:
             ASSERT_NOT_IMPLEMENTED_YET();
-            return fontMetrics.intAscent(IdeographicBaseline);
+            return fontMetrics.intAscent(FontBaseline::Ideographic);
         default:
             ASSERT_NOT_REACHED();
             return fontMetrics.intAscent(fontBaseline);
@@ -151,10 +151,10 @@ static InlineLevelBox::AscentAndDescent layoutBoundstWithEdgeAdjustmentForInline
         case TextEdgeType::Alphabetic:
             return 0.f;
         case TextEdgeType::CJKIdeographic:
-            return fontMetrics.intDescent(IdeographicBaseline);
+            return fontMetrics.intDescent(FontBaseline::Ideographic);
         case TextEdgeType::CJKIdeographicInk:
             ASSERT_NOT_IMPLEMENTED_YET();
-            return fontMetrics.intDescent(IdeographicBaseline);
+            return fontMetrics.intDescent(FontBaseline::Ideographic);
         default:
             ASSERT_NOT_REACHED();
             return fontMetrics.intDescent(fontBaseline);
@@ -182,10 +182,10 @@ static InlineLevelBox::AscentAndDescent textBoxAdjustedInlineBoxHeight(const Inl
         case TextEdgeType::ExHeight:
             return roundf(fontMetrics.xHeight().value_or(0.f));
         case TextEdgeType::CJKIdeographic:
-            return fontMetrics.intAscent(IdeographicBaseline);
+            return fontMetrics.intAscent(FontBaseline::Ideographic);
         case TextEdgeType::CJKIdeographicInk:
             ASSERT_NOT_IMPLEMENTED_YET();
-            return fontMetrics.intAscent(IdeographicBaseline);
+            return fontMetrics.intAscent(FontBaseline::Ideographic);
         default:
             ASSERT_NOT_REACHED();
             return fontMetrics.intAscent(fontBaseline);
@@ -201,10 +201,10 @@ static InlineLevelBox::AscentAndDescent textBoxAdjustedInlineBoxHeight(const Inl
         case TextEdgeType::Alphabetic:
             return 0.f;
         case TextEdgeType::CJKIdeographic:
-            return fontMetrics.intDescent(IdeographicBaseline);
+            return fontMetrics.intDescent(FontBaseline::Ideographic);
         case TextEdgeType::CJKIdeographicInk:
             ASSERT_NOT_IMPLEMENTED_YET();
-            return fontMetrics.intDescent(IdeographicBaseline);
+            return fontMetrics.intDescent(FontBaseline::Ideographic);
         default:
             ASSERT_NOT_REACHED();
             return fontMetrics.intDescent(fontBaseline);
@@ -334,7 +334,7 @@ void LineBoxBuilder::setVerticalPropertiesForInlineLevelBox(const LineBox& lineB
         auto& listMarkerBoxGeometry = formattingContext().geometryForBox(layoutBox);
         auto marginBoxHeight = listMarkerBoxGeometry.marginBoxHeight();
 
-        if (lineBox.baselineType() == IdeographicBaseline) {
+        if (lineBox.baselineType() == FontBaseline::Ideographic) {
             // FIXME: We should rely on the integration baseline.
             setVerticalProperties(primaryFontMetricsForInlineBox(lineBox.parentInlineBox(inlineLevelBox), lineBox.baselineType()));
             inlineLevelBox.setLogicalHeight(marginBoxHeight);
@@ -411,7 +411,7 @@ void LineBoxBuilder::constructInlineLevelBoxes(LineBox& lineBox)
             if (auto fallbackFonts = collectFallbackFonts(parentInlineBox, run, style); !fallbackFonts.isEmptyIgnoringNullReferences()) {
                 // Adjust non-empty inline box height when glyphs from the non-primary font stretch the box.
                 if (parentInlineBox.isPreferredLineHeightFontMetricsBased()) {
-                    auto enclosingAscentAndDescent = enclosingAscentDescentWithFallbackFonts(parentInlineBox, fallbackFonts, AlphabeticBaseline);
+                    auto enclosingAscentAndDescent = enclosingAscentDescentWithFallbackFonts(parentInlineBox, fallbackFonts, FontBaseline::Alphabetic);
                     auto layoutBounds = parentInlineBox.layoutBounds();
                     parentInlineBox.setLayoutBounds({ std::max(layoutBounds.ascent, enclosingAscentAndDescent.ascent), std::max(layoutBounds.descent, enclosingAscentAndDescent.descent) });
                 }
@@ -585,7 +585,7 @@ void LineBoxBuilder::adjustInlineBoxHeightsForLineBoxContainIfApplicable(LineBox
             auto ascentAndDescent = TextUtil::enclosingGlyphBoundsForText(StringView(textBox.content()).substring(textContent->start, textContent->length), style, textBox.shouldUseSimpleGlyphOverflowCodePath() ? TextUtil::ShouldUseSimpleGlyphOverflowCodePath::Yes : TextUtil::ShouldUseSimpleGlyphOverflowCodePath::No);
 
             initialLetterDescent = ascentAndDescent.descent;
-            if (lineBox.baselineType() != AlphabeticBaseline)
+            if (lineBox.baselineType() != FontBaseline::Alphabetic)
                 initialLetterAscent = -ascentAndDescent.ascent;
             break;
         }
@@ -635,7 +635,7 @@ void LineBoxBuilder::adjustIdeographicBaselineIfApplicable(LineBox& lineBox)
     if (!lineNeedsIdeographicBaseline())
         return;
 
-    lineBox.setBaselineType(IdeographicBaseline);
+    lineBox.setBaselineType(FontBaseline::Ideographic);
 
     auto adjustLayoutBoundsWithIdeographicBaseline = [&] (auto& inlineLevelBox) {
         auto initiatesLayoutBoundsChange = inlineLevelBox.isInlineBox() || inlineLevelBox.isAtomicInlineBox() || inlineLevelBox.isLineBreakBox();
@@ -655,7 +655,7 @@ void LineBoxBuilder::adjustIdeographicBaselineIfApplicable(LineBox& lineBox)
         auto needsFontFallbackAdjustment = inlineLevelBox.isInlineBox();
         if (needsFontFallbackAdjustment) {
             if (auto fallbackFonts = m_fallbackFontsForInlineBoxes.get(&inlineLevelBox); !fallbackFonts.isEmptyIgnoringNullReferences() && inlineLevelBox.isPreferredLineHeightFontMetricsBased()) {
-                auto enclosingAscentAndDescent = enclosingAscentDescentWithFallbackFonts(inlineLevelBox, fallbackFonts, IdeographicBaseline);
+                auto enclosingAscentAndDescent = enclosingAscentDescentWithFallbackFonts(inlineLevelBox, fallbackFonts, FontBaseline::Ideographic);
                 auto layoutBounds = inlineLevelBox.layoutBounds();
                 inlineLevelBox.setLayoutBounds({ std::max(layoutBounds.ascent, enclosingAscentAndDescent.ascent), std::max(layoutBounds.descent, enclosingAscentAndDescent.descent) });
             }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
@@ -131,7 +131,7 @@ private:
     float m_contentLogicalLeft { 0.f };
     float m_contentLogicalLeftIgnoringInlineDirection { 0.f };
     float m_contentLogicalWidth { 0.f };
-    FontBaseline m_baselineType { AlphabeticBaseline };
+    FontBaseline m_baselineType { FontBaseline::Alphabetic };
     bool m_isLeftToRightDirection : 1 { true };
     bool m_isHorizontal : 1 { true };
     bool m_isFirstAfterPageBreak : 1 { false };

--- a/Source/WebCore/platform/graphics/FontBaseline.h
+++ b/Source/WebCore/platform/graphics/FontBaseline.h
@@ -28,9 +28,9 @@
 
 namespace WebCore {
 
-enum FontBaseline { AlphabeticBaseline, IdeographicBaseline, CentralBaseline };
+enum class FontBaseline : uint8_t { Alphabetic, Ideographic, Central };
 
-enum BaselineSynthesisEdge { ContentBox, BorderBox, MarginBox };
+enum class BaselineSynthesisEdge : uint8_t { ContentBox, BorderBox, MarginBox };
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/FontMetrics.h
+++ b/Source/WebCore/platform/graphics/FontMetrics.h
@@ -33,24 +33,24 @@ public:
     unsigned unitsPerEm() const { return m_unitsPerEm; }
     void setUnitsPerEm(unsigned unitsPerEm) { m_unitsPerEm = unitsPerEm; }
 
-    float height(FontBaseline baselineType = AlphabeticBaseline) const
+    float height(FontBaseline baselineType = FontBaseline::Alphabetic) const
     {
         return ascent(baselineType) + descent(baselineType);
     }
-    int intHeight(FontBaseline baselineType = AlphabeticBaseline) const
+    int intHeight(FontBaseline baselineType = FontBaseline::Alphabetic) const
     {
         return intAscent(baselineType) + intDescent(baselineType);
     }
 
-    float ascent(FontBaseline baselineType = AlphabeticBaseline) const
+    float ascent(FontBaseline baselineType = FontBaseline::Alphabetic) const
     {
-        if (baselineType == AlphabeticBaseline)
+        if (baselineType == FontBaseline::Alphabetic)
             return m_ascent.value_or(0.f);
         return height() / 2;
     }
-    int intAscent(FontBaseline baselineType = AlphabeticBaseline) const
+    int intAscent(FontBaseline baselineType = FontBaseline::Alphabetic) const
     {
-        if (baselineType == AlphabeticBaseline)
+        if (baselineType == FontBaseline::Alphabetic)
             return m_intAscent;
         return intHeight() - intHeight() / 2;
     }
@@ -60,15 +60,15 @@ public:
         m_intAscent = std::max(static_cast<int>(lroundf(ascent)), 0);
     }
 
-    float descent(FontBaseline baselineType = AlphabeticBaseline) const
+    float descent(FontBaseline baselineType = FontBaseline::Alphabetic) const
     {
-        if (baselineType == AlphabeticBaseline)
+        if (baselineType == FontBaseline::Alphabetic)
             return m_descent.value_or(0.f);
         return height() / 2;
     }
-    int intDescent(FontBaseline baselineType = AlphabeticBaseline) const
+    int intDescent(FontBaseline baselineType = FontBaseline::Alphabetic) const
     {
-        if (baselineType == AlphabeticBaseline)
+        if (baselineType == FontBaseline::Alphabetic)
             return m_intDescent;
         return intHeight() / 2;
     }

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorder.cpp
@@ -347,7 +347,7 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
     if (font->platformData().orientation() == FontOrientation::Vertical) {
         Vector<CGSize, 256> translations(glyphs.size());
         CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
-        auto ascentDelta = font->fontMetrics().ascent(IdeographicBaseline) - font->fontMetrics().ascent();
+        auto ascentDelta = font->fontMetrics().ascent(FontBaseline::Ideographic) - font->fontMetrics().ascent();
         advances = computeVerticalAdvancesFromPositions(translations.span(), positions, ascentDelta, textMatrix);
     } else
         advances = computeHorizontalAdvancesFromPositions(positions, textMatrix);

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -277,7 +277,7 @@ static void showGlyphsWithAdvances(const FloatPoint& point, const Font& font, CG
         RetainPtr ctFont = platformData.ctFont();
         CTFontGetVerticalTranslationsForGlyphs(ctFont.get(), glyphs.data(), translations.mutableSpan().data(), glyphs.size());
 
-        auto ascentDelta = font.fontMetrics().ascent(IdeographicBaseline) - font.fontMetrics().ascent();
+        auto ascentDelta = font.fontMetrics().ascent(FontBaseline::Ideographic) - font.fontMetrics().ascent();
         fillVectorWithVerticalGlyphPositions(positions, translations, advances, point, ascentDelta, CGContextGetTextMatrix(context));
         CTFontDrawGlyphs(ctFont.get(), glyphs.data(), positions.span().data(), glyphs.size(), context);
     } else {

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.h
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.h
@@ -152,7 +152,7 @@ protected:
     // The following members are only used by RootInlineBox but moved here to keep the bits packed.
 
     // Whether or not this line uses alphabetic or ideographic baselines by default.
-    unsigned m_baselineType : 1 { AlphabeticBaseline }; // FontBaseline
+    unsigned m_baselineType : 1 { enumToUnderlyingType(FontBaseline::Alphabetic) }; // FontBaseline
 
     unsigned m_lineBreakBidiStatusEor : 5; // UCharDirection
     unsigned m_lineBreakBidiStatusLastStrong : 5; // UCharDirection

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5380,15 +5380,15 @@ LayoutUnit synthesizedBaseline(const RenderBox& box, const RenderStyle& parentSt
     auto parentWritingMode = parentStyle.writingMode();
     // https://drafts.csswg.org/css-inline-3/#alignment-baseline-property
     // https://drafts.csswg.org/css-inline-3/#dominant-baseline-property
-    auto baselineType = parentWritingMode.prefersCentralBaseline() ? FontBaseline::CentralBaseline : FontBaseline::AlphabeticBaseline;
+    auto baselineType = parentWritingMode.prefersCentralBaseline() ? FontBaseline::Central : FontBaseline::Alphabetic;
 
     auto boxSize = direction == HorizontalLine ? box.height() : box.width();
-    if (edge == ContentBox)
+    if (edge == BaselineSynthesisEdge::ContentBox)
         boxSize -= direction == HorizontalLine ? box.verticalBorderAndPaddingExtent() : box.horizontalBorderAndPaddingExtent();
-    else if (edge == MarginBox)
+    else if (edge == BaselineSynthesisEdge::MarginBox)
         boxSize += direction == HorizontalLine ? box.verticalMarginExtent() : box.horizontalMarginExtent();
     
-    if (baselineType == FontBaseline::AlphabeticBaseline) {
+    if (baselineType == FontBaseline::Alphabetic) {
         auto shouldTreatAsHorizontal = direction == HorizontalLine
             || (parentWritingMode.isSidewaysOrientation() && parentWritingMode.computedWritingMode() == StyleWritingMode::VerticalRl);
         return shouldTreatAsHorizontal ? boxSize : LayoutUnit();

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -283,7 +283,7 @@ std::optional<LayoutUnit> RenderFlexibleBox::firstLineBaseline() const
         // FIXME: We should pass |direction| into firstLineBoxBaseline and stop bailing out if we're a writing mode root.
         // This would also fix some cases where the flexbox is orthogonal to its container.
         LineDirectionMode direction = isHorizontalWritingMode() ? HorizontalLine : VerticalLine;
-        return synthesizedBaseline(*baselineFlexItem, style(), direction, BorderBox) + baselineFlexItem->logicalTop();
+        return synthesizedBaseline(*baselineFlexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + baselineFlexItem->logicalTop();
     }
 
     return LayoutUnit { (baseline.value() + baselineFlexItem->logicalTop()).toInt() };
@@ -308,7 +308,7 @@ std::optional <LayoutUnit> RenderFlexibleBox::lastLineBaseline() const
         // FIXME: We should pass |direction| into firstLineBoxBaseline and stop bailing out if we're a writing mode root.
         // This would also fix some cases where the flexbox is orthogonal to its container.
         LineDirectionMode direction = isHorizontalWritingMode() ? HorizontalLine : VerticalLine;
-        return synthesizedBaseline(*baselineFlexItem, style(), direction, BorderBox) + baselineFlexItem->logicalTop();
+        return synthesizedBaseline(*baselineFlexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + baselineFlexItem->logicalTop();
     }
 
     return LayoutUnit { (baseline.value() + baselineFlexItem->logicalTop()).toInt() };
@@ -1602,10 +1602,10 @@ LayoutUnit RenderFlexibleBox::marginBoxAscentForFlexItem(const RenderBox& flexIt
     auto direction = isHorizontalFlow ? HorizontalLine : VerticalLine;
 
     if (!mainAxisIsFlexItemInlineAxis(flexItem))
-        return synthesizedBaseline(flexItem, style(), direction, BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+        return synthesizedBaseline(flexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
     auto ascent = alignmentForFlexItem(flexItem) == ItemPosition::LastBaseline ? flexItem.lastLineBaseline() : flexItem.firstLineBaseline();
     if (!ascent)
-        return synthesizedBaseline(flexItem, style(), direction, BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+        return synthesizedBaseline(flexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
 
     if (!flexItem.writingMode().isBlockMatchingAny(writingMode())) {
         // Baseline from flex item with opposite block direction needs to be resolved as if flex item had the same block direction.

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2015,7 +2015,7 @@ std::optional<LayoutUnit> RenderGrid::firstLineBaseline() const
         // FIXME: We should pass |direction| into firstLineBaseline and stop bailing out if we're a writing
         // mode root. This would also fix some cases where the grid is orthogonal to its container.
         LineDirectionMode direction = isHorizontalWritingMode() ? HorizontalLine : VerticalLine;
-        return synthesizedBaseline(*baselineGridItem, style(), direction, BorderBox) + logicalTopForChild(*baselineGridItem);
+        return synthesizedBaseline(*baselineGridItem, style(), direction, BaselineSynthesisEdge::BorderBox) + logicalTopForChild(*baselineGridItem);
     }
     return baseline.value() + baselineGridItem->logicalTop().toInt();
 }
@@ -2032,7 +2032,7 @@ std::optional<LayoutUnit> RenderGrid::lastLineBaseline() const
     auto baseline = GridLayoutFunctions::isOrthogonalGridItem(*this, *baselineGridItem) ? std::nullopt : baselineGridItem->lastLineBaseline();
     if (!baseline) {
         LineDirectionMode direction = isHorizontalWritingMode() ? HorizontalLine : VerticalLine;
-        return synthesizedBaseline(*baselineGridItem, style(), direction, BorderBox) + logicalTopForChild(*baselineGridItem);
+        return synthesizedBaseline(*baselineGridItem, style(), direction, BaselineSynthesisEdge::BorderBox) + logicalTopForChild(*baselineGridItem);
 
     }
 


### PR DESCRIPTION
#### 955ce7dd056b6d1e05cfd70742d4d4da0f962fb5
<pre>
Make BaselineSynthesisEdge and FontBaseline enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=296757">https://bugs.webkit.org/show_bug.cgi?id=296757</a>
<a href="https://rdar.apple.com/157231084">rdar://157231084</a>

Reviewed by Ryan Reno.

These are just enums currently but we should make them into strongly
typed enum classes.

Canonical link: <a href="https://commits.webkit.org/298111@main">https://commits.webkit.org/298111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38c48b420164678c16a6d5bc9c7876be2ae04136

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102638 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67243 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64132 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123652 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95457 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/24327 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18436 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18313 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41173 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46679 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->