### PR TITLE
Implement User-Agent Client Hints - navigator.userAgentData

### DIFF
--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -448,19 +448,10 @@ int Navigator::maxTouchPoints() const
     return 0;
 }
 
-void Navigator::initializeNavigatorUAData() const
-{
-    if (m_navigatorUAData)
-        return;
-
-    // FIXME(296489): populate the data structure
-    return;
-}
-
 NavigatorUAData& Navigator::userAgentData() const
 {
     if (!m_navigatorUAData)
-        initializeNavigatorUAData();
+        m_navigatorUAData = NavigatorUAData::create();
 
     return *m_navigatorUAData;
 };

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -86,7 +86,6 @@ private:
     explicit Navigator(ScriptExecutionContext*, LocalDOMWindow&);
 
     void initializePluginAndMimeTypeArrays();
-    void initializeNavigatorUAData() const;
 
     mutable RefPtr<ShareDataReader> m_loader;
     mutable bool m_hasPendingShare { false };

--- a/Source/WebCore/page/NavigatorUAData.h
+++ b/Source/WebCore/page/NavigatorUAData.h
@@ -29,6 +29,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "NavigatorUABrandVersion.h"
 #include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 struct NavigatorUABrandVersion;
@@ -40,17 +41,16 @@ public:
     static Ref<NavigatorUAData> create();
     const Vector<NavigatorUABrandVersion>& brands() const;
     bool mobile() const;
-    const String& platform() const;
+    String platform() const;
     UALowEntropyJSON toJSON() const;
 
-    using ValuesPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<UADataValues>>>;
+    using ValuesPromise = DOMPromiseDeferred<IDLDictionary<UADataValues>>;
     void getHighEntropyValues(const Vector<String>& hints, ValuesPromise&&) const;
     ~NavigatorUAData();
 
 private:
     NavigatorUAData();
-
-    const Vector<NavigatorUABrandVersion> m_brands = { };
-    const String m_platform = ""_s;
+    static String createArbitraryVersion();
+    static String createArbitraryBrand();
 };
 }

--- a/Source/WebCore/page/UADataValues.h
+++ b/Source/WebCore/page/UADataValues.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "NavigatorUABrandVersion.h"
+#include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-struct UADataValues {
+struct UADataValues : RefCounted<UADataValues> {
     String architecture;
     String bitness;
     Vector<NavigatorUABrandVersion> brands;
@@ -42,5 +43,14 @@ struct UADataValues {
     String platformVersion;
     String uaFullVersion;
     bool wow64;
+
+    static Ref<UADataValues> create(const Vector<NavigatorUABrandVersion>& brands, bool mobile, const String& platform)
+    {
+        return adoptRef(*new UADataValues(brands, mobile, platform));
+    }
+
+private:
+    UADataValues(const Vector<NavigatorUABrandVersion>& brands, bool mobile, const String& platform)
+        : brands(brands), mobile(mobile), platform(platform) { }
 };
 }

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -110,19 +110,10 @@ void WorkerNavigator::clearAppBadge(Ref<DeferredPromise>&& promise)
     setAppBadge(0, WTFMove(promise));
 }
 
-void WorkerNavigator::initializeNavigatorUAData() const
-{
-    if (m_navigatorUAData)
-        return;
-
-    // FIXME(296489): populate the data structure
-    return;
-}
-
 NavigatorUAData& WorkerNavigator::userAgentData() const
 {
     if (!m_navigatorUAData)
-        initializeNavigatorUAData();
+        m_navigatorUAData = NavigatorUAData::create();
 
     return *m_navigatorUAData;
 };

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -56,8 +56,6 @@ public:
 private:
     explicit WorkerNavigator(ScriptExecutionContext&, const String&, bool isOnline);
 
-    void initializeNavigatorUAData() const;
-
     mutable RefPtr<NavigatorUAData> m_navigatorUAData;
     String m_userAgent;
     bool m_isOnline;


### PR DESCRIPTION
#### 5bfcbdd6b8303a9df35caa888c268c9fe3710568
<pre>
Implement User-Agent Client Hints - navigator.userAgentData
<a href="https://bugs.webkit.org/show_bug.cgi?id=241749">https://bugs.webkit.org/show_bug.cgi?id=241749</a>
<a href="https://rdar.apple.com/95454627">rdar://95454627</a>

Reviewed by Brent Fulgham.

This patch populates the userAgentData data structure to be used for quirking. It follows this spec:
<a href="https://wicg.github.io/ua-client-hints/#getHighEntropyValues">https://wicg.github.io/ua-client-hints/#getHighEntropyValues</a>

Sensitive information is denied such as model and formFactors.

* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::userAgentData const):
(WebCore::Navigator::initializeNavigatorUAData const): Deleted.
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/NavigatorUAData.cpp:
(WebCore::NavigatorUAData::brands const):
(WebCore::NavigatorUAData::mobile const):
(WebCore::NavigatorUAData::platform const):
(WebCore::NavigatorUAData::toJSON const):
(WebCore::NavigatorUAData::getHighEntropyValues const):
(WebCore::NavigatorUAData::createArbitraryVersion):
(WebCore::NavigatorUAData::createArbitraryBrand):
* Source/WebCore/page/NavigatorUAData.h:
* Source/WebCore/page/UADataValues.h:
(WebCore::UADataValues::create):
(WebCore::UADataValues::UADataValues):
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::userAgentData const):
(WebCore::WorkerNavigator::initializeNavigatorUAData const): Deleted.
* Source/WebCore/page/WorkerNavigator.h:

Canonical link: <a href="https://commits.webkit.org/298242@main">https://commits.webkit.org/298242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d78c3e19ab7e6bb9fe485e1028fc56fb2d5dfc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87135 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42039 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67523 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64473 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41642 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31096 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42019 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99128 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95730 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18734 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37741 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47032 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41106 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->