### PR TITLE
Safer Cpp: fix unsafe lambda capture of this pointer in AXIsolatedObject

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -408,8 +408,8 @@ void AXIsolatedObject::setIsExpanded(bool value)
 
 bool AXIsolatedObject::performDismissAction()
 {
-    return Accessibility::retrieveValueFromMainThread<bool>([this] () -> bool {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<bool>([weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->performDismissAction();
         return false;
     });
@@ -445,8 +445,8 @@ void AXIsolatedObject::scrollToGlobalPoint(IntPoint&& point) const
 
 bool AXIsolatedObject::setValue(float value)
 {
-    return Accessibility::retrieveValueFromMainThread<bool>([&value, this] () -> bool {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<bool>([&value, weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->setValue(value);
         return false;
     });
@@ -461,8 +461,8 @@ void AXIsolatedObject::setValueIgnoringResult(float value)
 
 bool AXIsolatedObject::setValue(const String& value)
 {
-    return Accessibility::retrieveValueFromMainThread<bool>([&value, this] () -> bool {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<bool>([&value, weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->setValue(value);
         return false;
     });
@@ -513,8 +513,8 @@ String AXIsolatedObject::selectedText() const
         return selectedTextMarkerRange().toString();
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<String>([weakThis = WeakPtr { *this }] () -> String {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->selectedText().isolatedCopy();
         return { };
     });
@@ -554,8 +554,8 @@ SRGBA<uint8_t> AXIsolatedObject::colorValue() const
 
 AXIsolatedObject* AXIsolatedObject::accessibilityHitTest(const IntPoint& point) const
 {
-    auto axID = Accessibility::retrieveValueFromMainThread<std::optional<AXID>>([&point, this] () -> std::optional<AXID> {
-        if (RefPtr object = associatedAXObject()) {
+    auto axID = Accessibility::retrieveValueFromMainThread<std::optional<AXID>>([&point, weakThis = WeakPtr { *this }] () -> std::optional<AXID> {
+        if (RefPtr object = weakThis->associatedAXObject()) {
             object->updateChildrenIfNecessary();
             if (auto* axObject = object->accessibilityHitTest(point))
                 return axObject->objectID();
@@ -888,8 +888,8 @@ T AXIsolatedObject::getOrRetrievePropertyValue(AXProperty property)
     if (std::optional value = optionalAttributeValue<T>(property))
         return *value;
 
-    Accessibility::performFunctionOnMainThreadAndWait([&property, this] () {
-        RefPtr axObject = associatedAXObject();
+    Accessibility::performFunctionOnMainThreadAndWait([&property, weakThis = WeakPtr { *this }] () {
+        RefPtr axObject = weakThis->associatedAXObject();
         if (!axObject)
             return;
 
@@ -906,7 +906,7 @@ T AXIsolatedObject::getOrRetrievePropertyValue(AXProperty property)
         }
 
         // Cache value so that there is no need to access the main thread in subsequent calls.
-        setPropertyInVector(property, WTFMove(value));
+        weakThis->setPropertyInVector(property, WTFMove(value));
     });
 
     return propertyValue<T>(property);
@@ -987,8 +987,8 @@ int AXIsolatedObject::indexForVisiblePosition(const VisiblePosition&) const
 
 Vector<SimpleRange> AXIsolatedObject::findTextRanges(const AccessibilitySearchTextCriteria& criteria) const
 {
-    return Accessibility::retrieveValueFromMainThread<Vector<SimpleRange>>([&criteria, this] () -> Vector<SimpleRange> {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<Vector<SimpleRange>>([&criteria, weakThis = WeakPtr { *this }] () -> Vector<SimpleRange> {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->findTextRanges(criteria);
         return { };
     });
@@ -996,8 +996,8 @@ Vector<SimpleRange> AXIsolatedObject::findTextRanges(const AccessibilitySearchTe
 
 Vector<String> AXIsolatedObject::performTextOperation(const AccessibilityTextOperation& textOperation)
 {
-    return Accessibility::retrieveValueFromMainThread<Vector<String>>([&textOperation, this] () -> Vector<String> {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<Vector<String>>([&textOperation, weakThis = WeakPtr { *this }] () -> Vector<String> {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->performTextOperation(textOperation);
         return Vector<String>();
     });
@@ -1031,8 +1031,8 @@ LayoutRect AXIsolatedObject::elementRect() const
     ASSERT(_AXGetClientForCurrentRequestUntrusted() != kAXClientTypeVoiceOver);
 #endif
 
-    return Accessibility::retrieveValueFromMainThread<LayoutRect>([&, this] () -> LayoutRect {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<LayoutRect>([&, weakThis = WeakPtr { *this }] () -> LayoutRect {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->elementRect();
         return { };
     });
@@ -1073,8 +1073,8 @@ FloatRect AXIsolatedObject::relativeFrame() const
     // Mock objects and SVG objects need use the main thread since they do not have render nodes and are not painted with layers, respectively.
     // FIXME: Remove isNonLayerSVGObject when LBSE is enabled & SVG frames are cached.
     if (!AXObjectCache::shouldServeInitialCachedFrame() || isNonLayerSVGObject()) {
-        return Accessibility::retrieveValueFromMainThread<FloatRect>([this] () -> FloatRect {
-            if (RefPtr axObject = associatedAXObject())
+        return Accessibility::retrieveValueFromMainThread<FloatRect>([weakThis = WeakPtr { *this }] () -> FloatRect {
+            if (RefPtr axObject = weakThis->associatedAXObject())
                 return axObject->relativeFrame();
             return { };
         });
@@ -1146,8 +1146,8 @@ FloatRect AXIsolatedObject::convertFrameToSpace(const FloatRect& rect, Accessibi
         }
     }
 
-    return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, this] () -> FloatRect {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<FloatRect>([&rect, &space, weakThis = WeakPtr { *this }] () -> FloatRect {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->convertFrameToSpace(rect, space);
         return { };
     });
@@ -1155,8 +1155,8 @@ FloatRect AXIsolatedObject::convertFrameToSpace(const FloatRect& rect, Accessibi
 
 bool AXIsolatedObject::replaceTextInRange(const String& replacementText, const CharacterRange& textRange)
 {
-    return Accessibility::retrieveValueFromMainThread<bool>([text = replacementText.isolatedCopy(), &textRange, this] () -> bool {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<bool>([text = replacementText.isolatedCopy(), &textRange, weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->replaceTextInRange(text, textRange);
         return false;
     });
@@ -1235,8 +1235,8 @@ int AXIsolatedObject::insertionPointLineNumber() const
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<int>([this] () -> int {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<int>([weakThis = WeakPtr { *this }] () -> int {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->insertionPointLineNumber();
         return -1;
     });
@@ -1247,8 +1247,8 @@ String AXIsolatedObject::identifierAttribute() const
 #if !LOG_DISABLED
     return stringAttributeValue(AXProperty::IdentifierAttribute);
 #else
-    return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<String>([weakThis = WeakPtr { *this }] () -> String {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->identifierAttribute().isolatedCopy();
         return { };
     });
@@ -1262,8 +1262,8 @@ CharacterRange AXIsolatedObject::doAXRangeForLine(unsigned lineIndex) const
         return AXTextMarker { *this, 0 }.characterRangeForLine(lineIndex);
 #endif
 
-    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&lineIndex, this] () -> CharacterRange {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&lineIndex, weakThis = WeakPtr { *this }] () -> CharacterRange {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXRangeForLine(lineIndex);
         return { };
     });
@@ -1276,8 +1276,8 @@ String AXIsolatedObject::doAXStringForRange(const CharacterRange& range) const
         return textMarkerRange().toString().substring(range.location, range.length);
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
-    return Accessibility::retrieveValueFromMainThread<String>([&range, this] () -> String {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<String>([&range, weakThis = WeakPtr { *this }] () -> String {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXStringForRange(range).isolatedCopy();
         return { };
     });
@@ -1285,8 +1285,8 @@ String AXIsolatedObject::doAXStringForRange(const CharacterRange& range) const
 
 CharacterRange AXIsolatedObject::characterRangeForPoint(const IntPoint& point) const
 {
-    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&point, this] () -> CharacterRange {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&point, weakThis = WeakPtr { *this }] () -> CharacterRange {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->characterRangeForPoint(point);
         return { };
     });
@@ -1294,8 +1294,8 @@ CharacterRange AXIsolatedObject::characterRangeForPoint(const IntPoint& point) c
 
 CharacterRange AXIsolatedObject::doAXRangeForIndex(unsigned index) const
 {
-    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&index, this] () -> CharacterRange {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&index, weakThis = WeakPtr { *this }] () -> CharacterRange {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXRangeForIndex(index);
         return { };
     });
@@ -1303,8 +1303,8 @@ CharacterRange AXIsolatedObject::doAXRangeForIndex(unsigned index) const
 
 CharacterRange AXIsolatedObject::doAXStyleRangeForIndex(unsigned index) const
 {
-    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&index, this] () -> CharacterRange {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<CharacterRange>([&index, weakThis = WeakPtr { *this }] () -> CharacterRange {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXStyleRangeForIndex(index);
         return { };
     });
@@ -1312,8 +1312,8 @@ CharacterRange AXIsolatedObject::doAXStyleRangeForIndex(unsigned index) const
 
 IntRect AXIsolatedObject::doAXBoundsForRange(const CharacterRange& axRange) const
 {
-    return Accessibility::retrieveValueFromMainThread<IntRect>([&axRange, this] () -> IntRect {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<IntRect>([&axRange, weakThis = WeakPtr { *this }] () -> IntRect {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXBoundsForRange(axRange);
         return { };
     });
@@ -1321,8 +1321,8 @@ IntRect AXIsolatedObject::doAXBoundsForRange(const CharacterRange& axRange) cons
 
 IntRect AXIsolatedObject::doAXBoundsForRangeUsingCharacterOffset(const CharacterRange& axRange) const
 {
-    return Accessibility::retrieveValueFromMainThread<IntRect>([&axRange, this] () -> IntRect {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<IntRect>([&axRange, weakThis = WeakPtr { *this }] () -> IntRect {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXBoundsForRangeUsingCharacterOffset(axRange);
         return { };
     });
@@ -1336,8 +1336,8 @@ unsigned AXIsolatedObject::doAXLineForIndex(unsigned index)
         return AXTextMarker { *this, 0 }.lineNumberForIndex(index);
 #endif
 
-    return Accessibility::retrieveValueFromMainThread<unsigned>([&index, this] () -> unsigned {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<unsigned>([&index, weakThis = WeakPtr { *this }] () -> unsigned {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->doAXLineForIndex(index);
         return 0;
     });
@@ -1362,8 +1362,8 @@ void AXIsolatedObject::setSelectedVisiblePositionRange(const VisiblePositionRang
 #if PLATFORM(COCOA) && ENABLE(MODEL_ELEMENT)
 Vector<RetainPtr<id>> AXIsolatedObject::modelElementChildren()
 {
-    return Accessibility::retrieveValueFromMainThread<Vector<RetainPtr<id>>>([this] () -> Vector<RetainPtr<id>> {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<Vector<RetainPtr<id>>>([weakThis = WeakPtr { *this }] () -> Vector<RetainPtr<id>> {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->modelElementChildren();
         return { };
     });
@@ -1454,8 +1454,8 @@ bool AXIsolatedObject::isNonNativeTextControl() const
 
 bool AXIsolatedObject::isOnScreen() const
 {
-    return Accessibility::retrieveValueFromMainThread<bool>([this] () -> bool {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<bool>([weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->isOnScreen();
         return false;
     });
@@ -1483,8 +1483,8 @@ bool AXIsolatedObject::isSelectedOptionActive() const
 
 Vector<AXTextMarkerRange> AXIsolatedObject::misspellingRanges() const
 {
-    return Accessibility::retrieveValueFromMainThread<Vector<AXTextMarkerRange>>([this] () -> Vector<AXTextMarkerRange> {
-        if (RefPtr axObject = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<Vector<AXTextMarkerRange>>([weakThis = WeakPtr { *this }] () -> Vector<AXTextMarkerRange> {
+        if (RefPtr axObject = weakThis->associatedAXObject())
             return axObject->misspellingRanges();
         return { };
     });
@@ -1515,8 +1515,8 @@ bool AXIsolatedObject::hasSameFont(AXCoreObject& otherObject)
     if (!is<AXIsolatedObject>(otherObject))
         return false;
 
-    return Accessibility::retrieveValueFromMainThread<bool>([&otherObject, this] () -> bool {
-        if (RefPtr axObject = associatedAXObject()) {
+    return Accessibility::retrieveValueFromMainThread<bool>([&otherObject, weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject()) {
             if (RefPtr axOtherObject = downcast<AXIsolatedObject>(otherObject).associatedAXObject())
                 return axObject->hasSameFont(*axOtherObject);
         }
@@ -1540,8 +1540,8 @@ bool AXIsolatedObject::hasSameFontColor(AXCoreObject& otherObject)
     if (!is<AXIsolatedObject>(otherObject))
         return false;
 
-    return Accessibility::retrieveValueFromMainThread<bool>([&otherObject, this] () -> bool {
-        if (RefPtr axObject = associatedAXObject()) {
+    return Accessibility::retrieveValueFromMainThread<bool>([&otherObject, weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject()) {
             if (RefPtr axOtherObject = downcast<AXIsolatedObject>(otherObject).associatedAXObject())
                 return axObject->hasSameFontColor(*axOtherObject);
         }
@@ -1565,8 +1565,8 @@ bool AXIsolatedObject::hasSameStyle(AXCoreObject& otherObject)
     if (!is<AXIsolatedObject>(otherObject))
         return false;
 
-    return Accessibility::retrieveValueFromMainThread<bool>([&otherObject, this] () -> bool {
-        if (RefPtr axObject = associatedAXObject()) {
+    return Accessibility::retrieveValueFromMainThread<bool>([&otherObject, weakThis = WeakPtr { *this }] () -> bool {
+        if (RefPtr axObject = weakThis->associatedAXObject()) {
             if (RefPtr axOtherObject = downcast<AXIsolatedObject>(otherObject).associatedAXObject())
                 return axObject->hasSameStyle(*axOtherObject);
         }
@@ -1594,8 +1594,8 @@ AXTextMarkerRange AXIsolatedObject::textInputMarkedTextMarkerRange() const
 // Re-visit if ITM expands to more platforms, or if AX clients need to start using this.
 String AXIsolatedObject::linkRelValue() const
 {
-    return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
-        if (RefPtr object = associatedAXObject())
+    return Accessibility::retrieveValueFromMainThread<String>([weakThis = WeakPtr { *this }] () -> String {
+        if (RefPtr object = weakThis->associatedAXObject())
             return object->linkRelValue().isolatedCopy();
         return { };
     });


### PR DESCRIPTION
#### 967b3ea96b35331fa860f2cdc1c5c4892c41fcce
<pre>
fix unsafe lambda capture of this pointer in AXIsolatedObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=296762">https://bugs.webkit.org/show_bug.cgi?id=296762</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

I converted the captured raw this pointer to a WeakPtr

* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::performDismissAction):
(WebCore::AXIsolatedObject::setValue):
(WebCore::AXIsolatedObject::selectedText const):
(WebCore::AXIsolatedObject::accessibilityHitTest const):
(WebCore::AXIsolatedObject::getOrRetrievePropertyValue):
(WebCore::AXIsolatedObject::findTextRanges const):
(WebCore::AXIsolatedObject::performTextOperation):
(WebCore::AXIsolatedObject::elementRect const):
(WebCore::AXIsolatedObject::relativeFrame const):
(WebCore::AXIsolatedObject::convertFrameToSpace const):
(WebCore::AXIsolatedObject::replaceTextInRange):
(WebCore::AXIsolatedObject::insertionPointLineNumber const):
(WebCore::AXIsolatedObject::identifierAttribute const):
(WebCore::AXIsolatedObject::doAXRangeForLine const):
(WebCore::AXIsolatedObject::doAXStringForRange const):
(WebCore::AXIsolatedObject::characterRangeForPoint const):
(WebCore::AXIsolatedObject::doAXRangeForIndex const):
(WebCore::AXIsolatedObject::doAXStyleRangeForIndex const):
(WebCore::AXIsolatedObject::doAXBoundsForRange const):
(WebCore::AXIsolatedObject::doAXBoundsForRangeUsingCharacterOffset const):
(WebCore::AXIsolatedObject::doAXLineForIndex):
(WebCore::AXIsolatedObject::modelElementChildren):
(WebCore::AXIsolatedObject::isOnScreen const):
(WebCore::AXIsolatedObject::misspellingRanges const):
(WebCore::AXIsolatedObject::hasSameFont):
(WebCore::AXIsolatedObject::hasSameFontColor):
(WebCore::AXIsolatedObject::hasSameStyle):
(WebCore::AXIsolatedObject::linkRelValue const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/967b3ea96b35331fa860f2cdc1c5c4892c41fcce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/33995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120414 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20735 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64106 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95654 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95437 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40580 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18408 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46655 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->