### PR TITLE
Safer Cpp: add virtual destructors to base classes

### DIFF
--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -166,7 +166,7 @@ class WatchpointSet : public ThreadSafeRefCounted<WatchpointSet> {
 public:
     // FIXME: In many cases, it would be amazing if this *did* fire the watchpoints. I suspect that
     // this might be hard to get right, but still, it might be awesome.
-    JS_EXPORT_PRIVATE ~WatchpointSet(); // Note that this will not fire any of the watchpoints; if you need to know when a WatchpointSet dies then you need a separate mechanism for this.
+    JS_EXPORT_PRIVATE virtual ~WatchpointSet(); // Note that this will not fire any of the watchpoints; if you need to know when a WatchpointSet dies then you need a separate mechanism for this.
 
     static Ref<WatchpointSet> create(WatchpointState state)
     {

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -59,6 +59,7 @@ public:
     using Base = JITStubRoutine;
     friend class JITStubRoutine;
     GCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, JSCell* owner, bool isCodeImmutable);
+    ~GCAwareJITStubRoutine() = default;
 
     static Ref<JITStubRoutine> create(VM& vm, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner, bool isCodeImmutable)
     {

--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -80,6 +80,8 @@ public:
         , m_type(type)
     {
     }
+
+    virtual ~JITStubRoutine() = default;
     
     // Use this if you want to pass a CodePtr to someone who insists on taking
     // a RefPtr<JITStubRoutine>.

--- a/Source/JavaScriptCore/jit/Snippet.h
+++ b/Source/JavaScriptCore/jit/Snippet.h
@@ -62,6 +62,8 @@ public:
     uint8_t numGPScratchRegisters { 0 };
     uint8_t numFPScratchRegisters { 0 };
 
+    virtual ~Snippet() = default;
+
 protected:
     Snippet() = default;
 

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -136,7 +136,7 @@ public:
     bool isGrowableShared() const { return m_isGrowableShared; }
     bool isAutoLength() const { return m_isAutoLength; }
 
-    inline ~ArrayBufferView();
+    virtual inline ~ArrayBufferView();
 
     // Helper to verify byte offset is size aligned.
     static bool verifyByteOffsetAlignment(size_t byteOffset, size_t elementSize)

--- a/Source/JavaScriptCore/runtime/NativeCallee.h
+++ b/Source/JavaScriptCore/runtime/NativeCallee.h
@@ -49,6 +49,7 @@ public:
     void dump(PrintStream&) const;
 
     JS_EXPORT_PRIVATE void operator delete(NativeCallee*, std::destroying_delete_t);
+    JS_EXPORT_PRIVATE virtual ~NativeCallee() = default;
 
 protected:
     JS_EXPORT_PRIVATE NativeCallee(Category, ImplementationVisibility);


### PR DESCRIPTION
#### 57e85e6e2817083da455c212849d5ec65a2a0ca1
<pre>
Safer Cpp: add virtual destructors to base classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=296764">https://bugs.webkit.org/show_bug.cgi?id=296764</a>
<a href="https://rdar.apple.com/157239984">rdar://157239984</a>

Reviewed by NOBODY (OOPS!).

This patch adds a virtual destructor to a few classes that are used as base classes.

* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
* Source/JavaScriptCore/jit/JITStubRoutine.h:
* Source/JavaScriptCore/jit/Snippet.h:
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
* Source/JavaScriptCore/runtime/NativeCallee.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e85e6e2817083da455c212849d5ec65a2a0ca1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120428 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/64990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42570 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86835 "Found 15 new test failures: imported/w3c/web-platform-tests/wasm/core/f32.wast.js.html imported/w3c/web-platform-tests/wasm/core/f32_cmp.wast.js.html imported/w3c/web-platform-tests/wasm/core/f64.wast.js.html imported/w3c/web-platform-tests/wasm/core/f64_cmp.wast.js.html imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html imported/w3c/web-platform-tests/wasm/core/float_memory.wast.js.html imported/w3c/web-platform-tests/wasm/core/memory_copy.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_const.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f32x4_arith.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f32x4_cmp.wast.js.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/64990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64119 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106663 "Found 56 new JSC stress test failures: wasm.yaml/wasm/function-tests/context-switch.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-bbq, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-omg, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-simd, wasm.yaml/wasm/function-tests/memory-reuse.js.default-wasm, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-bbq, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-eager ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96958 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20867 "Found 2 new test failures: imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123639 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/112825 "Found 55 new JSC stress test failures: wasm.yaml/wasm/function-tests/context-switch.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-bbq, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-omg, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-simd, wasm.yaml/wasm/function-tests/memory-reuse.js.default-wasm, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-aggressive-inline, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-bbq, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-bbq-no-consts, wasm.yaml/wasm/function-tests/memory-reuse.js.wasm-collect-continuously ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41280 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30781 "Found 60 new test failures: accessibility/mac/basic-embed-pdf-accessibility.html fast/parser/entities-in-html.html http/tests/security/cookie-module-propagate.html http/tests/webgpu/webgpu/shader/validation/parse/blankspace.html http/wpt/cache-storage/cache-in-stopped-context.html http/wpt/mediarecorder/MediaRecorder-dataavailable.html http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https.html imported/w3c/web-platform-tests/content-security-policy/worker-src/service-worker-src-child-fallback.https.sub.html imported/w3c/web-platform-tests/fetch/api/abort/general.any.html imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95666 "Found 11 new test failures: imported/w3c/web-platform-tests/wasm/core/address.wast.js.html imported/w3c/web-platform-tests/wasm/core/f32.wast.js.html imported/w3c/web-platform-tests/wasm/core/f64.wast.js.html imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html imported/w3c/web-platform-tests/wasm/core/float_memory.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_const.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f32x4_cmp.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f32x4_pmin_pmax.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f64x2_cmp.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_f64x2_pmin_pmax.wast.js.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95449 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40590 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18423 "Found 2 new test failures: imported/w3c/web-platform-tests/wasm/core/simd/simd_load_extend.wast.js.html imported/w3c/web-platform-tests/wasm/core/simd/simd_load_zero.wast.js.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46664 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137022 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40757 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36672 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->