### PR TITLE
[Style] Convert widows and orphans to strong style types

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -256,13 +256,12 @@ template<typename TargetType, typename SourceType>
           &&   std::unsigned_integral<TargetType>
           &&   std::signed_integral<SourceType>
           &&   sizeof(SourceType) > sizeof(TargetType))
-constexpr TargetType clampTo(SourceType value)
+constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
 {
-    if (value < 0)
-        return 0;
-    TargetType max = std::numeric_limits<TargetType>::max();
     if (value >= static_cast<SourceType>(max))
         return max;
+    if (value <= static_cast<SourceType>(min))
+        return min;
     return static_cast<TargetType>(value);
 }
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -204,6 +204,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/style/values/backgrounds"
     "${WEBCORE_DIR}/style/values/borders"
     "${WEBCORE_DIR}/style/values/box"
+    "${WEBCORE_DIR}/style/values/break"
     "${WEBCORE_DIR}/style/values/color-adjust"
     "${WEBCORE_DIR}/style/values/color"
     "${WEBCORE_DIR}/style/values/contain"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2775,6 +2775,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/box/StyleMargin.h
     style/values/box/StylePadding.h
 
+    style/values/break/StyleOrphans.h
+    style/values/break/StyleWidows.h
+
     style/values/color/StyleColor.h
     style/values/color/StyleColorOptions.h
     style/values/color/StyleCurrentColor.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3148,6 +3148,8 @@ style/values/backgrounds/StyleLineWidth.cpp
 style/values/borders/StyleBorderRadius.cpp
 style/values/borders/StyleBoxShadow.cpp
 style/values/borders/StyleCornerShapeValue.cpp
+style/values/break/StyleOrphans.cpp
+style/values/break/StyleWidows.cpp
 style/values/color-adjust/StyleColorScheme.cpp
 style/values/color/StyleColor.cpp
 style/values/color/StyleColorLayers.cpp

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6571,13 +6571,15 @@
             "inherited": true,
             "initial": "2",
             "codegen-properties": {
-                "animation-wrapper": "PositiveWrapper<unsigned short>",
-                "auto-functions": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<Orphans>",
                 "parser-grammar": "<integer [1,inf]>"
             },
             "specification": {
-                "category": "css-22",
-                "url": "https://www.w3.org/TR/CSS22/page.html#propdef-orphans"
+                "category": "css-break",
+                "url": "https://drafts.csswg.org/css-break/#propdef-orphans",
+                "obsolete-category": "css-22",
+                "obsolete-url": "https://www.w3.org/TR/CSS22/page.html#propdef-orphans"
             }
         },
         "outline": {
@@ -8308,13 +8310,15 @@
             "inherited": true,
             "initial": "2",
             "codegen-properties": {
-                "animation-wrapper": "PositiveWrapper<unsigned short>",
-                "auto-functions": true,
+                "animation-wrapper": "StyleTypeWrapper",
+                "style-converter": "StyleType<Widows>",
                 "parser-grammar": "<integer [1,inf]>"
             },
             "specification": {
-                "category": "css-22",
-                "url": "https://www.w3.org/TR/CSS22/page.html#propdef-orphans"
+                "category": "css-break",
+                "url": "https://drafts.csswg.org/css-break/#propdef-widows",
+                "obsolete-category": "css-22",
+                "obsolete-url": "https://www.w3.org/TR/CSS22/page.html#propdef-widows"
             }
         },
         "width": {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -92,8 +92,8 @@ std::pair<Vector<LineAdjustment>, std::optional<LayoutRestartLine>> computeAdjus
     std::optional<size_t> previousPageBreakIndex;
     std::optional<LayoutRestartLine> layoutRestartLine;
 
-    size_t widows = flow.style().hasAutoWidows() ? 0 : flow.style().widows();
-    size_t orphans = flow.style().orphans();
+    size_t widows = flow.style().widows().tryValue().value_or(0).value;
+    size_t orphans = flow.style().orphans().tryValue().value_or(2).value;
 
     auto accumulatedOffset = 0_lu;
     for (size_t lineIndex = 0; lineIndex < lineCount;) {

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1969,7 +1969,7 @@ static inline LayoutUnit calculateMinimumPageHeight(const RenderStyle& renderSty
 {
     // We may require a certain minimum number of lines per page in order to satisfy
     // orphans and widows, and that may affect the minimum page height.
-    unsigned lineCount = std::max<unsigned>(renderStyle.hasAutoOrphans() ? 1 : renderStyle.orphans(), renderStyle.hasAutoWidows() ? 1 : renderStyle.widows());
+    unsigned lineCount = std::max<unsigned>(renderStyle.orphans().tryValue().value_or(1).value, renderStyle.widows().tryValue().value_or(1).value);
     if (lineCount > 1) {
         auto line = lastLine;
         for (unsigned i = 1; i < lineCount && line->previous(); i++)
@@ -2104,7 +2104,8 @@ RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustment
         setPageBreak(logicalOffset, lineHeight - remainingLogicalHeight);
 
         bool avoidFirstLinePageBreak = lineBox->isFirst() && totalLogicalHeight < pageLogicalHeightAtNewOffset && !floatMinimumBottom;
-        bool affectedByOrphans = !style().hasAutoOrphans() && style().orphans() >= lineNumber;
+        auto orphansValue = style().orphans().tryValue();
+        bool affectedByOrphans = orphansValue && orphansValue->value >= lineNumber;
 
         if ((avoidFirstLinePageBreak || affectedByOrphans) && !isOutOfFlowPositioned() && !isRenderTableCell()) {
             if (needsAppleMailPaginationQuirk(*this))

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2100,9 +2100,9 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyWordSpacing);
         if (first.miterLimit != second.miterLimit)
             changingProperties.m_properties.set(CSSPropertyStrokeMiterlimit);
-        if (first.widows != second.widows || first.hasAutoWidows != second.hasAutoWidows)
+        if (first.widows != second.widows)
             changingProperties.m_properties.set(CSSPropertyWidows);
-        if (first.orphans != second.orphans || first.hasAutoOrphans != second.hasAutoOrphans)
+        if (first.orphans != second.orphans)
             changingProperties.m_properties.set(CSSPropertyOrphans);
         if (first.wordBreak != second.wordBreak)
             changingProperties.m_properties.set(CSSPropertyWordBreak);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -314,6 +314,7 @@ struct OffsetPath;
 struct OffsetPosition;
 struct OffsetRotate;
 struct Opacity;
+struct Orphans;
 struct PaddingEdge;
 struct Perspective;
 struct Position;
@@ -359,6 +360,7 @@ struct ViewTransitionClasses;
 struct ViewTransitionName;
 struct WebkitLineGrid;
 struct WebkitTextStrokeWidth;
+struct Widows;
 
 enum class Change : uint8_t;
 enum class GridTrackSizingDirection : bool;
@@ -852,10 +854,8 @@ public:
     InsideLink insideLink() const { return static_cast<InsideLink>(m_inheritedFlags.insideLink); }
     bool isLink() const { return m_nonInheritedFlags.isLink; }
 
-    inline unsigned short widows() const;
-    inline unsigned short orphans() const;
-    inline bool hasAutoWidows() const;
-    inline bool hasAutoOrphans() const;
+    inline Style::Widows widows() const;
+    inline Style::Orphans orphans() const;
 
     inline BreakInside breakInside() const;
     inline BreakBetween breakBefore() const;
@@ -1511,11 +1511,8 @@ public:
     inline void setUsedZIndex(int);
     inline void setHasAutoUsedZIndex();
 
-    inline void setHasAutoWidows();
-    inline void setWidows(unsigned short);
-
-    inline void setHasAutoOrphans();
-    inline void setOrphans(unsigned short);
+    inline void setWidows(Style::Widows);
+    inline void setOrphans(Style::Orphans);
 
     inline void setOutlineOffset(Style::Length<>);
     inline void setTextShadow(Style::TextShadows&&);
@@ -2025,8 +2022,8 @@ public:
     static TextEdge initialTextBoxEdge();
     static TextEdge initialLineFitEdge();
     static constexpr LengthType zeroLength();
-    static unsigned short initialWidows() { return 2; }
-    static unsigned short initialOrphans() { return 2; }
+    static constexpr Style::Widows initialWidows();
+    static constexpr Style::Orphans initialOrphans();
     // Returning -100% percent here means the line-height is not set.
     static inline Length initialLineHeight();
     static constexpr TextAlignMode initialTextAlign();

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -267,11 +267,9 @@ inline bool RenderStyle::hasAutoColumnCount() const { return m_nonInheritedData-
 inline bool RenderStyle::hasAutoColumnWidth() const { return m_nonInheritedData->miscData->multiCol->autoWidth; }
 inline bool RenderStyle::hasAutoLeftAndRight() const { return left().isAuto() && right().isAuto(); }
 inline bool RenderStyle::hasAutoLengthContainIntrinsicSize() const { return containIntrinsicWidth().hasAuto() || containIntrinsicHeight().hasAuto(); }
-inline bool RenderStyle::hasAutoOrphans() const { return m_rareInheritedData->hasAutoOrphans; }
 inline bool RenderStyle::hasAutoSpecifiedZIndex() const { return m_nonInheritedData->boxData->hasAutoSpecifiedZIndex(); }
 inline bool RenderStyle::hasAutoTopAndBottom() const { return top().isAuto() && bottom().isAuto(); }
 inline bool RenderStyle::hasAutoUsedZIndex() const { return m_nonInheritedData->boxData->hasAutoUsedZIndex(); }
-inline bool RenderStyle::hasAutoWidows() const { return m_rareInheritedData->hasAutoWidows; }
 inline bool RenderStyle::hasBackground() const { return visitedDependentColor(CSSPropertyBackgroundColor).isVisible() || hasBackgroundImage(); }
 inline bool RenderStyle::hasBackgroundImage() const { return backgroundLayers().hasImage(); }
 inline bool RenderStyle::hasBlendMode() const { return blendMode() != BlendMode::Normal; }
@@ -454,6 +452,7 @@ inline Style::OffsetDistance RenderStyle::initialOffsetDistance() { return 0_css
 inline Style::OffsetPath RenderStyle::initialOffsetPath() { return CSS::Keyword::None { }; }
 inline Style::OffsetPosition RenderStyle::initialOffsetPosition() { return CSS::Keyword::Normal { }; }
 constexpr Style::OffsetRotate RenderStyle::initialOffsetRotate() { return CSS::Keyword::Auto { }; }
+constexpr Style::Orphans RenderStyle::initialOrphans() { return CSS::Keyword::Auto { }; }
 constexpr OverflowAnchor RenderStyle::initialOverflowAnchor() { return OverflowAnchor::Auto; }
 inline OverflowContinue RenderStyle::initialOverflowContinue() { return OverflowContinue::Auto; }
 constexpr Style::Length<> RenderStyle::initialOutlineOffset() { return 0_css_px; }
@@ -558,6 +557,7 @@ inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { retu
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
 inline const NameScope RenderStyle::initialTimelineScope() { return { }; }
 constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
+constexpr Style::Widows RenderStyle::initialWidows() { return CSS::Keyword::Auto { }; }
 constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
 inline Length RenderStyle::initialLetterSpacing() { return zeroLength(); }
 inline Length RenderStyle::initialWordSpacing() { return zeroLength(); }
@@ -673,7 +673,7 @@ inline const Style::OffsetPosition& RenderStyle::offsetPosition() const { return
 inline const Style::OffsetRotate& RenderStyle::offsetRotate() const { return m_nonInheritedData->rareData->offsetRotate; }
 inline Style::Opacity RenderStyle::opacity() const { return m_nonInheritedData->miscData->opacity; }
 inline int RenderStyle::order() const { return m_nonInheritedData->miscData->order; }
-inline unsigned short RenderStyle::orphans() const { return m_rareInheritedData->orphans; }
+inline Style::Orphans RenderStyle::orphans() const { return m_rareInheritedData->orphans; }
 inline const OutlineValue& RenderStyle::outline() const { return m_nonInheritedData->backgroundData->outline; }
 inline const Style::Color& RenderStyle::outlineColor() const { return outline().color(); }
 inline OutlineStyle RenderStyle::outlineStyle() const { return outline().style(); }
@@ -806,7 +806,7 @@ inline const Style::Color& RenderStyle::visitedLinkTextDecorationColor() const {
 inline const Style::Color& RenderStyle::visitedLinkTextEmphasisColor() const { return m_rareInheritedData->visitedLinkTextEmphasisColor; }
 inline const Style::Color& RenderStyle::visitedLinkTextFillColor() const { return m_rareInheritedData->visitedLinkTextFillColor; }
 inline const Style::Color& RenderStyle::visitedLinkTextStrokeColor() const { return m_rareInheritedData->visitedLinkTextStrokeColor; }
-inline unsigned short RenderStyle::widows() const { return m_rareInheritedData->widows; }
+inline Style::Widows RenderStyle::widows() const { return m_rareInheritedData->widows; }
 inline const Style::PreferredSize& RenderStyle::width() const { return m_nonInheritedData->boxData->width(); }
 inline WillChangeData* RenderStyle::willChange() const { return m_nonInheritedData->rareData->willChange.get(); }
 inline bool RenderStyle::willChangeCreatesStackingContext() const { return willChange() && willChange()->canCreateStackingContext(); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -171,10 +171,8 @@ inline void RenderStyle::setHasAutoAccentColor() { SET_PAIR(m_rareInheritedData,
 inline void RenderStyle::setHasAutoCaretColor() { SET_PAIR(m_rareInheritedData, hasAutoCaretColor, true, caretColor, Style::Color::currentColor()); }
 inline void RenderStyle::setHasAutoColumnCount() { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, miscData, multiCol, autoCount, true, count, initialColumnCount()); }
 inline void RenderStyle::setHasAutoColumnWidth() { SET_DOUBLY_NESTED_PAIR(m_nonInheritedData, miscData, multiCol, autoWidth, true, width, 0); }
-inline void RenderStyle::setHasAutoOrphans() { SET_PAIR(m_rareInheritedData, hasAutoOrphans, true, orphans, initialOrphans()); }
 inline void RenderStyle::setHasAutoSpecifiedZIndex() { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoSpecifiedZIndex, true, m_specifiedZIndex, 0); }
 inline void RenderStyle::setHasAutoUsedZIndex() { SET_NESTED_PAIR(m_nonInheritedData, boxData, m_hasAutoUsedZIndex, true, m_usedZIndex, 0); }
-inline void RenderStyle::setHasAutoWidows() { SET_PAIR(m_rareInheritedData, hasAutoWidows, true, widows, initialWidows()); }
 inline void RenderStyle::setHasDisplayAffectedByAnimations() { SET_NESTED(m_nonInheritedData, miscData, hasDisplayAffectedByAnimations, true); }
 inline void RenderStyle::setHasExplicitlySetBorderBottomLeftRadius(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetBorderBottomLeftRadius, value); }
 inline void RenderStyle::setHasExplicitlySetBorderBottomRightRadius(bool value) { SET_NESTED(m_nonInheritedData, surroundData, hasExplicitlySetBorderBottomRightRadius, value); }
@@ -243,6 +241,7 @@ inline void RenderStyle::setOffsetPosition(Style::OffsetPosition&& position) { S
 inline void RenderStyle::setOffsetRotate(Style::OffsetRotate&& rotate) { SET_NESTED(m_nonInheritedData, rareData, offsetRotate, WTFMove(rotate)); }
 inline void RenderStyle::setOpacity(Style::Opacity opacity) { SET_NESTED(m_nonInheritedData, miscData, opacity, opacity); }
 inline void RenderStyle::setOrder(int o) { SET_NESTED(m_nonInheritedData, miscData, order, o); }
+inline void RenderStyle::setOrphans(Style::Orphans orphans) { SET(m_rareInheritedData, orphans, orphans); }
 inline void RenderStyle::setOutlineColor(Style::Color&& color) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_color, WTFMove(color)); }
 inline void RenderStyle::setOutlineOffset(Style::Length<> offset) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_offset, offset); }
 inline void RenderStyle::setOutlineStyle(OutlineStyle style) { SET_NESTED(m_nonInheritedData, backgroundData, outline.m_style, static_cast<unsigned>(style)); }
@@ -287,6 +286,7 @@ inline void RenderStyle::setTimelineScope(const NameScope& scope) { SET_NESTED(m
 inline void RenderStyle::setScrollbarColor(Style::ScrollbarColor&& color) { SET(m_rareInheritedData, scrollbarColor, WTFMove(color)); }
 inline void RenderStyle::setScrollbarGutter(Style::ScrollbarGutter&& gutter) { SET_NESTED(m_nonInheritedData, rareData, scrollbarGutter, WTFMove(gutter)); }
 inline void RenderStyle::setScrollbarWidth(ScrollbarWidth width) { SET_NESTED(m_nonInheritedData, rareData, scrollbarWidth, static_cast<unsigned>(width)); }
+inline void RenderStyle::setShapeImageThreshold(Style::ShapeImageThreshold shapeImageThreshold) { SET_NESTED(m_nonInheritedData, rareData, shapeImageThreshold, shapeImageThreshold); }
 inline void RenderStyle::setShapeMargin(Style::ShapeMargin&& shapeMargin) { SET_NESTED(m_nonInheritedData, rareData, shapeMargin, WTFMove(shapeMargin)); }
 inline void RenderStyle::setShapeOutside(Style::ShapeOutside&& shapeOutside) { SET_NESTED(m_nonInheritedData, rareData, shapeOutside, WTFMove(shapeOutside)); }
 inline void RenderStyle::setUsedContentVisibility(ContentVisibility usedContentVisibility) { SET(m_rareInheritedData, usedContentVisibility, static_cast<unsigned>(usedContentVisibility)); }
@@ -356,6 +356,7 @@ inline void RenderStyle::setVisitedLinkTextDecorationColor(Style::Color&& value)
 inline void RenderStyle::setVisitedLinkTextEmphasisColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkTextEmphasisColor, WTFMove(value)); }
 inline void RenderStyle::setVisitedLinkTextFillColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkTextFillColor, WTFMove(value)); }
 inline void RenderStyle::setVisitedLinkTextStrokeColor(Style::Color&& value) { SET(m_rareInheritedData, visitedLinkTextStrokeColor, WTFMove(value)); }
+inline void RenderStyle::setWidows(Style::Widows widows) { SET(m_rareInheritedData, widows, widows); }
 inline void RenderStyle::setWidth(Style::PreferredSize&& length) { SET_NESTED(m_nonInheritedData, boxData, m_width, WTFMove(length)); }
 inline void RenderStyle::setWordBreak(WordBreak rule) { SET(m_rareInheritedData, wordBreak, static_cast<unsigned>(rule)); }
 
@@ -585,30 +586,12 @@ inline void RenderStyle::setLogicalMaxHeight(Style::MaximumSize&& height)
         setMaxWidth(WTFMove(height));
 }
 
-inline void RenderStyle::setOrphans(unsigned short count)
-{
-    unsigned short clampedCount = std::max<unsigned short>(count, 1);
-    SET_PAIR(m_rareInheritedData, orphans, clampedCount, hasAutoOrphans, false);
-}
-
-inline void RenderStyle::setShapeImageThreshold(Style::ShapeImageThreshold shapeImageThreshold)
-{
-    auto clampedShapeImageThreshold = Style::ShapeImageThreshold { clampTo(shapeImageThreshold.value, 0.0f, 1.0f) };
-    SET_NESTED(m_nonInheritedData, rareData, shapeImageThreshold, clampedShapeImageThreshold);
-}
-
 inline bool RenderStyle::setTextOrientation(TextOrientation textOrientation)
 {
     if (writingMode().computedTextOrientation() == textOrientation)
         return false;
     m_inheritedFlags.writingMode.setTextOrientation(textOrientation);
     return true;
-}
-
-inline void RenderStyle::setWidows(unsigned short count)
-{
-    auto clampedCount = std::max<unsigned short>(count, 1);
-    SET_PAIR(m_rareInheritedData, widows, clampedCount, hasAutoWidows, false);
 }
 
 inline bool RenderStyle::setWritingMode(StyleWritingMode mode)

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -100,8 +100,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , customProperties(Style::CustomPropertyData::create())
     , widows(RenderStyle::initialWidows())
     , orphans(RenderStyle::initialOrphans())
-    , hasAutoWidows(true)
-    , hasAutoOrphans(true)
     , textSecurity(static_cast<unsigned>(RenderStyle::initialTextSecurity()))
     , userModify(static_cast<unsigned>(UserModify::ReadOnly))
     , wordBreak(static_cast<unsigned>(RenderStyle::initialWordBreak()))
@@ -203,8 +201,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , customProperties(o.customProperties)
     , widows(o.widows)
     , orphans(o.orphans)
-    , hasAutoWidows(o.hasAutoWidows)
-    , hasAutoOrphans(o.hasAutoOrphans)
     , textSecurity(o.textSecurity)
     , userModify(o.userModify)
     , wordBreak(o.wordBreak)
@@ -319,8 +315,6 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && miterLimit == o.miterLimit
         && widows == o.widows
         && orphans == o.orphans
-        && hasAutoWidows == o.hasAutoWidows
-        && hasAutoOrphans == o.hasAutoOrphans
         && textSecurity == o.textSecurity
         && userModify == o.userModify
         && wordBreak == o.wordBreak
@@ -445,8 +439,6 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
 
     LOG_IF_DIFFERENT(widows);
     LOG_IF_DIFFERENT(orphans);
-    LOG_IF_DIFFERENT(hasAutoWidows);
-    LOG_IF_DIFFERENT(hasAutoOrphans);
 
     LOG_IF_DIFFERENT_WITH_CAST(TextSecurity, textSecurity);
     LOG_IF_DIFFERENT_WITH_CAST(UserModify, userModify);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -37,6 +37,7 @@
 #include "StyleHyphenateLimitEdge.h"
 #include "StyleHyphenateLimitLines.h"
 #include "StyleListStyleType.h"
+#include "StyleOrphans.h"
 #include "StyleQuotes.h"
 #include "StyleScrollbarColor.h"
 #include "StyleStrokeMiterlimit.h"
@@ -50,6 +51,7 @@
 #include "StyleWebKitOverflowScrolling.h"
 #include "StyleWebKitTextStrokeWidth.h"
 #include "StyleWebKitTouchCallout.h"
+#include "StyleWidows.h"
 #include "TabSize.h"
 #include "TouchAction.h"
 #include <wtf/DataRef.h>
@@ -139,10 +141,8 @@ public:
 
     DataRef<Style::CustomPropertyData> customProperties;
 
-    unsigned short widows;
-    unsigned short orphans;
-    PREFERRED_TYPE(bool) unsigned hasAutoWidows : 1;
-    PREFERRED_TYPE(bool) unsigned hasAutoOrphans : 1;
+    Style::Widows widows;
+    Style::Orphans orphans;
 
     PREFERRED_TYPE(TextSecurity) unsigned textSecurity : 2;
     PREFERRED_TYPE(UserModify) unsigned userModify : 2;

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -297,22 +297,6 @@ private:
     ValueRange m_valueRange;
 };
 
-template<typename T>
-class PositiveWrapper final : public Wrapper<T> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PositiveWrapper, Animation);
-public:
-    PositiveWrapper(CSSPropertyID property, T (RenderStyle::*getter)() const, void (RenderStyle::*setter)(T))
-        : Wrapper<T>(property, getter, setter)
-    {
-    }
-
-    void interpolate(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const Context& context) const final
-    {
-        auto blendedValue = blendFunc(this->value(from), this->value(to), context);
-        (destination.*this->m_setter)(blendedValue > 1 ? blendedValue : 1);
-    }
-};
-
 class LengthWrapper : public WrapperWithGetter<const WebCore::Length&> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LengthWrapper, Animation);
 public:

--- a/Source/WebCore/style/values/break/StyleOrphans.cpp
+++ b/Source/WebCore/style/values/break/StyleOrphans.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleOrphans.h"
+
+#include "AnimationUtilities.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Blending
+
+auto Blending<Orphans>::blend(const Orphans& a, const Orphans& b, const BlendingContext& context) -> Orphans
+{
+    return Style::blend(a.tryValue().value_or(2), b.tryValue().value_or(2), context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/break/StyleOrphans.h
+++ b/Source/WebCore/style/values/break/StyleOrphans.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumeric.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'orphans'> = <integer [1,∞]>
+// https://drafts.csswg.org/css-break/#propdef-orphans
+// FIXME: `orphans` should not support `auto`. It doesn't allow parsing `auto`.
+struct Orphans : ValueOrKeyword<Integer<CSS::Range{1,CSS::Range::infinity}, unsigned short>, CSS::Keyword::Auto> {
+    using Base::Base;
+    using Integer = typename Base::Value;
+
+    bool isAuto() const { return isKeyword(); }
+    bool isInteger() const { return isValue(); }
+    std::optional<Integer> tryInteger() const { return tryValue(); }
+};
+
+// MARK: - Blending
+
+template<> struct Blending<Orphans> {
+    auto blend(const Orphans&, const Orphans&, const BlendingContext&) -> Orphans;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Orphans)

--- a/Source/WebCore/style/values/break/StyleWidows.cpp
+++ b/Source/WebCore/style/values/break/StyleWidows.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleWidows.h"
+
+#include "AnimationUtilities.h"
+#include "StylePrimitiveNumericTypes+Blending.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Blending
+
+auto Blending<Widows>::blend(const Widows& a, const Widows& b, const BlendingContext& context) -> Widows
+{
+    return Style::blend(a.tryValue().value_or(2), b.tryValue().value_or(2), context);
+}
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/break/StyleWidows.h
+++ b/Source/WebCore/style/values/break/StyleWidows.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePrimitiveNumeric.h"
+
+namespace WebCore {
+namespace Style {
+
+// <'widows'> = <integer [1,∞]>
+// https://drafts.csswg.org/css-break/#propdef-orphans
+// FIXME: `widows` should not support `auto`. It doesn't allow parsing `auto`.
+struct Widows : ValueOrKeyword<Integer<CSS::Range{1,CSS::Range::infinity}, unsigned short>, CSS::Keyword::Auto> {
+    using Base::Base;
+    using Integer = typename Base::Value;
+
+    bool isAuto() const { return isKeyword(); }
+    bool isInteger() const { return isValue(); }
+    std::optional<Integer> tryInteger() const { return tryValue(); }
+};
+
+// MARK: - Blending
+
+template<> struct Blending<Widows> {
+    auto blend(const Widows&, const Widows&, const BlendingContext&) -> Widows;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+DEFINE_VARIANT_LIKE_CONFORMANCE(WebCore::Style::Widows)

--- a/Source/WebCore/style/values/color/StyleOpacity.cpp
+++ b/Source/WebCore/style/values/color/StyleOpacity.cpp
@@ -42,7 +42,7 @@ auto CSSValueConversion<Opacity>::operator()(BuilderState& state, const CSSValue
         return 1.0f;
 
     auto opacity = primitiveValue->valueDividingBy100IfPercentage<float>(state.cssToLengthConversionData());
-    return CSS::clampToRange<Opacity::Number::range>(opacity);
+    return CSS::clampToRange<Opacity::Number::range, Opacity::Number::ResolvedValueType>(opacity);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h
@@ -51,7 +51,7 @@ template<Numeric StyleType> struct Blending<StyleType> {
         // that concept, and the `WebCore::Length` code path did clamping in the same fashion.
         // https://drafts.csswg.org/css-values/#combining-range
 
-        return StyleType { CSS::clampToRange<StyleType::range>(WebCore::blend(from.value, to.value, context)) };
+        return StyleType { CSS::clampToRange<StyleType::range, typename StyleType::ResolvedValueType>(WebCore::blend(from.value, to.value, context)) };
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -39,14 +39,14 @@ template<auto R, typename V> struct CSSValueConversion<Integer<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Integer<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Integer<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_integer;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -54,14 +54,14 @@ template<auto R, typename V> struct CSSValueConversion<Number<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Number<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Number<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_number;
-        return { protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsNumber<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -69,14 +69,14 @@ template<auto R, typename V> struct CSSValueConversion<Percentage<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Percentage<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Percentage<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_percentage;
-        return { protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -84,14 +84,14 @@ template<auto R, typename V> struct CSSValueConversion<Angle<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Angle<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Angle<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_deg;
-        return { protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsAngle<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -102,7 +102,7 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
         auto conversionData = builderState.useSVGZoomRulesForLength()
             ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
             : builderState.cssToLengthConversionData();
-        return { protectedValue->resolveAsLength<V>(conversionData) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Length<R, V>
     {
@@ -112,7 +112,7 @@ template<auto R, typename V> struct CSSValueConversion<Length<R, V>> {
         auto conversionData = builderState.useSVGZoomRulesForLength()
             ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
             : builderState.cssToLengthConversionData();
-        return { protectedValue->resolveAsLength<V>(conversionData) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
 };
 
@@ -120,14 +120,14 @@ template<auto R, typename V> struct CSSValueConversion<Time<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Time<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Time<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_s;
-        return { protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsTime<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -135,14 +135,14 @@ template<auto R, typename V> struct CSSValueConversion<Resolution<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Resolution<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Resolution<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_dppx;
-        return { protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsResolution<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -150,14 +150,14 @@ template<auto R, typename V> struct CSSValueConversion<Flex<R, V>> {
     auto operator()(BuilderState& builderState, const CSSPrimitiveValue& value) -> Flex<R, V>
     {
         Ref protectedValue = value;
-        return { protectedValue->resolveAsFlex<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsFlex<V>(builderState.cssToLengthConversionData())) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> Flex<R, V>
     {
         RefPtr protectedValue = requiredDowncast<CSSPrimitiveValue>(builderState, value);
         if (!protectedValue)
             return 0_css_fr;
-        return { protectedValue->resolveAsFlex<V>(builderState.cssToLengthConversionData()) };
+        return { CSS::clampToRange<R, V>(protectedValue->resolveAsFlex<V>(builderState.cssToLengthConversionData())) };
     }
 };
 
@@ -169,10 +169,10 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
             ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
             : builderState.cssToLengthConversionData();
         if (protectedValue->isPercentage())
-            return typename LengthPercentage<R, V>::Percentage { protectedValue->resolveAsPercentage<V>(conversionData) };
+            return typename LengthPercentage<R, V>::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
         if (protectedValue->isCalculatedPercentageWithLength())
             return typename LengthPercentage<R, V>::Calc { protectedValue->protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
-        return typename LengthPercentage<R, V>::Dimension { protectedValue->resolveAsLength<V>(conversionData) };
+        return typename LengthPercentage<R, V>::Dimension { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> LengthPercentage<R, V>
     {
@@ -183,10 +183,10 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
             ? builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f)
             : builderState.cssToLengthConversionData();
         if (protectedValue->isPercentage())
-            return typename LengthPercentage<R, V>::Percentage { protectedValue->resolveAsPercentage<V>(conversionData) };
+            return typename LengthPercentage<R, V>::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
         if (protectedValue->isCalculatedPercentageWithLength())
             return typename LengthPercentage<R, V>::Calc { protectedValue->protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
-        return typename LengthPercentage<R, V>::Dimension { protectedValue->resolveAsLength<V>(conversionData) };
+        return typename LengthPercentage<R, V>::Dimension { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
 };
 


### PR DESCRIPTION
#### cc58756c6140ddc18fa899b1b4049ade7d68f3c2
<pre>
[Style] Convert widows and orphans to strong style types
<a href="https://bugs.webkit.org/show_bug.cgi?id=296767">https://bugs.webkit.org/show_bug.cgi?id=296767</a>

Reviewed by Darin Adler.

Converts the `widows` and `orphans` properties to use strong styles.

The current implementation of `widows` and `orphans` is a bit bizarre.
Both properties have an &quot;is auto&quot; bit in RenderStyle, which gets set
as the initial value, despite neither allowing `auto` as a value at
parse time. This leads to the computed style not being parseable.
This change does not attempt to fix this.

To ensure correct numeric clamping, instead of clamping when setting
on RenderStyle, we utilize the range template parameter and clamp enforce
the clamp when converting from CSSValue, ensuring the value is never
invalid. This allows us to also remove now unnecessary clamping for
the `shape-image-threshold` property.

* Source/WTF/wtf/MathExtras.h:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/values/break/StyleOrphans.cpp: Added.
* Source/WebCore/style/values/break/StyleOrphans.h: Added.
* Source/WebCore/style/values/break/StyleWidows.cpp: Added.
* Source/WebCore/style/values/break/StyleWidows.h: Added.
* Source/WebCore/style/values/color/StyleOpacity.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:

Canonical link: <a href="https://commits.webkit.org/298403@main">https://commits.webkit.org/298403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/552d4928422715bd641f45bfeebe74cf3b636419

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115414 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65156 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107619 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124668 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113953 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31730 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99789 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41491 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19347 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47789 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139051 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41735 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139051 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->