### PR TITLE
EditingStyle: prefer enum class for multiple enums

### DIFF
--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -906,7 +906,7 @@ bool ApplyStyleCommand::removeInlineStyleFromElement(EditingStyle& style, HTMLEl
         if (mode == InlineStyleRemovalMode::None)
             return true;
         if (extractedStyle)
-            extractedStyle->mergeInlineStyleOfElement(element, EditingStyle::OverrideValues);
+            extractedStyle->mergeInlineStyleOfElement(element, EditingStyle::CSSPropertyOverrideMode::OverrideValues);
         removeNodePreservingChildren(element);
         return true;
     }
@@ -944,14 +944,14 @@ bool ApplyStyleCommand::removeImplicitlyStyledElement(EditingStyle& style, HTMLE
     }
 
     ASSERT(mode == InlineStyleRemovalMode::IfNeeded || mode == InlineStyleRemovalMode::Always);
-    if (style.conflictsWithImplicitStyleOfElement(element, extractedStyle, mode == InlineStyleRemovalMode::Always ? EditingStyle::ExtractMatchingStyle : EditingStyle::DoNotExtractMatchingStyle)) {
+    if (style.conflictsWithImplicitStyleOfElement(element, extractedStyle, mode == InlineStyleRemovalMode::Always ? EditingStyle::ShouldExtractMatchingStyle::Yes : EditingStyle::ShouldExtractMatchingStyle::No)) {
         replaceWithSpanOrRemoveIfWithoutAttributes(element);
         return true;
     }
 
     // unicode-bidi and direction are pushed down separately so don't push down with other styles
     Vector<QualifiedName> attributes;
-    if (!style.extractConflictingImplicitStyleOfAttributes(element, extractedStyle ? EditingStyle::PreserveWritingDirection : EditingStyle::DoNotPreserveWritingDirection, extractedStyle, attributes, mode == InlineStyleRemovalMode::Always ? EditingStyle::ExtractMatchingStyle : EditingStyle::DoNotExtractMatchingStyle))
+    if (!style.extractConflictingImplicitStyleOfAttributes(element, extractedStyle ? EditingStyle::ShouldPreserveWritingDirection::Yes : EditingStyle::ShouldPreserveWritingDirection::No, extractedStyle, attributes, mode == InlineStyleRemovalMode::Always ? EditingStyle::ShouldExtractMatchingStyle::Yes : EditingStyle::ShouldExtractMatchingStyle::No))
         return false;
 
     for (auto& attribute : attributes)
@@ -1014,7 +1014,7 @@ void ApplyStyleCommand::applyInlineStyleToPushDown(Node& node, EditingStyle* sty
     RefPtr newInlineStyle = style;
     if (auto* htmlElement = dynamicDowncast<HTMLElement>(node); htmlElement && htmlElement->inlineStyle()) {
         newInlineStyle = style->copy();
-        newInlineStyle->mergeInlineStyleOfElement(*htmlElement, EditingStyle::OverrideValues);
+        newInlineStyle->mergeInlineStyleOfElement(*htmlElement, EditingStyle::CSSPropertyOverrideMode::OverrideValues);
     }
 
     // Since addInlineStyleIfNeeded can't add styles to block-flow render objects, add style attribute instead.

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -195,7 +195,7 @@ template<typename T> CSSValueID identifierForStyleProperty(T& style, CSSProperty
 }
 
 template<typename T> Ref<MutableStyleProperties> getPropertiesNotIn(StyleProperties& styleWithRedundantProperties, T& baseStyle);
-enum LegacyFontSizeMode { AlwaysUseLegacyFontSize, UseLegacyFontSizeOnlyIfPixelValuesMatch };
+enum class LegacyFontSizeMode : bool { AlwaysUseLegacyFontSize, UseLegacyFontSizeOnlyIfPixelValuesMatch };
 static int legacyFontSizeFromCSSValue(Document&, CSSPrimitiveValue*, bool shouldUseFixedFontDefaultSize, LegacyFontSizeMode);
 static bool hasTransparentBackgroundColor(StyleProperties*);
 static RefPtr<CSSValue> backgroundColorInEffect(Node*);
@@ -692,7 +692,7 @@ void EditingStyle::setStyle(RefPtr<MutableStyleProperties>&& style)
 
 void EditingStyle::overrideWithStyle(const StyleProperties& style)
 {
-    return mergeStyle(&style, OverrideValues);
+    return mergeStyle(&style, CSSPropertyOverrideMode::OverrideValues);
 }
 
 static void applyTextDecorationChangeToValueList(CSSValueListBuilder& valueList, TextDecorationChange change, Ref<CSSPrimitiveValue>&& value)
@@ -711,11 +711,11 @@ static void applyTextDecorationChangeToValueList(CSSValueListBuilder& valueList,
 
 void EditingStyle::overrideTypingStyleAt(const EditingStyle& style, const Position& position)
 {
-    mergeStyle(style.m_mutableStyle.get(), OverrideValues);
+    mergeStyle(style.m_mutableStyle.get(), CSSPropertyOverrideMode::OverrideValues);
 
     m_fontSizeDelta += style.m_fontSizeDelta;
 
-    prepareToApplyAt(position, EditingStyle::PreserveWritingDirection);
+    prepareToApplyAt(position, EditingStyle::ShouldPreserveWritingDirection::Yes);
 
     auto underlineChange = style.underlineChange();
     auto strikeThroughChange = style.strikeThroughChange();
@@ -872,7 +872,7 @@ TriState EditingStyle::triStateOfStyle(EditingStyle* style) const
 {
     if (!style || !style->m_mutableStyle)
         return TriState::False;
-    return triStateOfStyle(*style->m_mutableStyle.copyRef(), DoNotIgnoreTextOnlyProperties);
+    return triStateOfStyle(*style->m_mutableStyle.copyRef(), ShouldIgnoreTextOnlyProperties::No);
 }
 
 template<typename T>
@@ -884,7 +884,7 @@ TriState EditingStyle::triStateOfStyle(T& styleToCompare, ShouldIgnoreTextOnlyPr
 
     auto difference = getPropertiesNotIn(*mutableStyle, styleToCompare);
 
-    if (shouldIgnoreTextOnlyProperties == IgnoreTextOnlyProperties)
+    if (shouldIgnoreTextOnlyProperties == ShouldIgnoreTextOnlyProperties::Yes)
         difference->removeProperties(textOnlyProperties);
 
     if (difference->isEmpty())
@@ -908,7 +908,7 @@ TriState EditingStyle::triStateOfStyle(const VisibleSelection& selection) const
     for (RefPtr node = selection.start().deprecatedNode(); node; node = NodeTraversal::next(*node)) {
         if (node->renderer() && node->hasEditableStyle()) {
             Style::Extractor computedStyle(node.get());
-            TriState nodeState = triStateOfStyle(computedStyle, node->isTextNode() ? EditingStyle::DoNotIgnoreTextOnlyProperties : EditingStyle::IgnoreTextOnlyProperties);
+            TriState nodeState = triStateOfStyle(computedStyle, node->isTextNode() ? EditingStyle::ShouldIgnoreTextOnlyProperties::No : EditingStyle::ShouldIgnoreTextOnlyProperties::Yes);
             if (nodeIsStart) {
                 state = nodeState;
                 nodeIsStart = false;
@@ -1051,7 +1051,7 @@ bool EditingStyle::conflictsWithImplicitStyleOfElement(HTMLElement& element, Edi
 
     for (auto& equivalent : htmlElementEquivalents()) {
         if (equivalent->matches(element) && equivalent->propertyExistsInStyle(*this)
-            && (shouldExtractMatchingStyle == ExtractMatchingStyle || !equivalent->valueIsPresentInStyle(element, *this))) {
+            && (shouldExtractMatchingStyle == ShouldExtractMatchingStyle::Yes || !equivalent->valueIsPresentInStyle(element, *this))) {
             if (extractedStyle)
                 equivalent->addToStyle(&element, extractedStyle);
             return true;
@@ -1092,18 +1092,18 @@ bool EditingStyle::extractConflictingImplicitStyleOfAttributes(HTMLElement& elem
     EditingStyle* extractedStyle, Vector<QualifiedName>& conflictingAttributes, ShouldExtractMatchingStyle shouldExtractMatchingStyle) const
 {
     // HTMLAttributeEquivalent::addToStyle doesn't support unicode-bidi and direction properties
-    ASSERT(!extractedStyle || shouldPreserveWritingDirection == PreserveWritingDirection);
+    ASSERT(!extractedStyle || shouldPreserveWritingDirection == ShouldPreserveWritingDirection::Yes);
     if (!m_mutableStyle)
         return false;
 
     bool removed = false;
     for (auto& equivalent : htmlAttributeEquivalents()) {
         // unicode-bidi and direction are pushed down separately so don't push down with other styles.
-        if (shouldPreserveWritingDirection == PreserveWritingDirection && equivalent->attributeName() == HTMLNames::dirAttr)
+        if (shouldPreserveWritingDirection == ShouldPreserveWritingDirection::Yes && equivalent->attributeName() == HTMLNames::dirAttr)
             continue;
 
         if (!equivalent->matches(element) || !equivalent->propertyExistsInStyle(*this)
-            || (shouldExtractMatchingStyle == DoNotExtractMatchingStyle && equivalent->valueIsPresentInStyle(element, *this)))
+            || (shouldExtractMatchingStyle == ShouldExtractMatchingStyle::No && equivalent->valueIsPresentInStyle(element, *this)))
             continue;
 
         if (extractedStyle)
@@ -1197,7 +1197,7 @@ void EditingStyle::prepareToApplyAt(const Position& position, ShouldPreserveWrit
 
     std::optional<CSSValueID> unicodeBidi;
     std::optional<CSSValueID> direction;
-    if (shouldPreserveWritingDirection == PreserveWritingDirection) {
+    if (shouldPreserveWritingDirection == ShouldPreserveWritingDirection::Yes) {
         unicodeBidi = mutableStyle->propertyAsValueID(CSSPropertyUnicodeBidi);
         direction = mutableStyle->propertyAsValueID(CSSPropertyDirection);
     }
@@ -1235,7 +1235,7 @@ void EditingStyle::mergeTypingStyle(Document& document)
     if (!typingStyle || typingStyle == this)
         return;
 
-    mergeStyle(typingStyle->protectedStyle().get(), OverrideValues);
+    mergeStyle(typingStyle->protectedStyle().get(), CSSPropertyOverrideMode::OverrideValues);
 }
 
 void EditingStyle::mergeInlineStyleOfElement(StyledElement& element, CSSPropertyOverrideMode mode, PropertiesToInclude propertiesToInclude)
@@ -1266,7 +1266,7 @@ static inline bool elementMatchesAndPropertyIsNotInInlineStyleDecl(const HTMLEle
 {
     if (!equivalent.matches(element))
         return false;
-    if (mode != EditingStyle::OverrideValues && equivalent.propertyExistsInStyle(style))
+    if (mode != EditingStyle::CSSPropertyOverrideMode::OverrideValues && equivalent.propertyExistsInStyle(style))
         return false;
 
     return !element.inlineStyle() || !equivalent.propertyExistsInStyle(EditingStyle::create(element.protectedInlineStyle().get()).get());
@@ -1334,7 +1334,7 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
     // When not annotating for interchange, we only preserve inline style declarations.
     for (RefPtr node = context; node && !node->isDocumentNode(); node = node->parentNode()) {
         if (auto* element = dynamicDowncast<StyledElement>(*node); element && !isMailBlockquote(*element))
-            wrappingStyle->mergeInlineAndImplicitStyleOfElement(*element, DoNotOverrideValues, PropertiesToInclude::EditingPropertiesInEffect, standardFontFamilySerializationMode);
+            wrappingStyle->mergeInlineAndImplicitStyleOfElement(*element, CSSPropertyOverrideMode::DoNotOverrideValues, PropertiesToInclude::EditingPropertiesInEffect, standardFontFamilySerializationMode);
     }
 
     return wrappingStyle;
@@ -1376,7 +1376,7 @@ void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideM
             }
         }
 
-        if (mode == OverrideValues || (mode == DoNotOverrideValues && !value))
+        if (mode == CSSPropertyOverrideMode::OverrideValues || (mode == CSSPropertyOverrideMode::DoNotOverrideValues && !value))
             m_mutableStyle->setProperty(property.id(), property.protectedValue(), property.isImportant() ? IsImportant::Yes : IsImportant::No);
     }
 
@@ -1603,7 +1603,7 @@ int EditingStyle::legacyFontSize(Document& document) const
     RefPtr cssValue = dynamicDowncast<CSSPrimitiveValue>(m_mutableStyle->getPropertyCSSValue(CSSPropertyFontSize));
     if (!cssValue)
         return 0;
-    return legacyFontSizeFromCSSValue(document, cssValue.get(), m_shouldUseFixedDefaultFontSize, AlwaysUseLegacyFontSize);
+    return legacyFontSizeFromCSSValue(document, cssValue.get(), m_shouldUseFixedDefaultFontSize, LegacyFontSizeMode::AlwaysUseLegacyFontSize);
 }
 
 bool EditingStyle::hasStyle(CSSPropertyID propertyID, const String& value)
@@ -1971,7 +1971,7 @@ void StyleChange::extractTextStyles(Document& document, MutableStyleProperties& 
         auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*fontSize);
         if (!primitiveValue)
             style.removeProperty(CSSPropertyFontSize); // Can't make sense of the number. Put no font size.
-        else if (int legacyFontSize = legacyFontSizeFromCSSValue(document, primitiveValue, shouldUseFixedFontDefaultSize, UseLegacyFontSizeOnlyIfPixelValuesMatch)) {
+        else if (int legacyFontSize = legacyFontSizeFromCSSValue(document, primitiveValue, shouldUseFixedFontDefaultSize, LegacyFontSizeMode::UseLegacyFontSizeOnlyIfPixelValuesMatch)) {
             m_applyFontSize = AtomString::number(legacyFontSize);
             style.removeProperty(CSSPropertyFontSize);
         }
@@ -2038,7 +2038,7 @@ int legacyFontSizeFromCSSValue(Document& document, CSSPrimitiveValue* value, boo
         int legacyFontSize = Style::legacyFontSizeForPixelSize(pixelFontSize, shouldUseFixedFontDefaultSize, document);
         // Use legacy font size only if pixel value matches exactly to that of legacy font size.
         int cssPrimitiveEquivalent = legacyFontSize - 1 + CSSValueXSmall;
-        if (mode == AlwaysUseLegacyFontSize || Style::fontSizeForKeyword(cssPrimitiveEquivalent, shouldUseFixedFontDefaultSize, document) == pixelFontSize)
+        if (mode == LegacyFontSizeMode::AlwaysUseLegacyFontSize || Style::fontSizeForKeyword(cssPrimitiveEquivalent, shouldUseFixedFontDefaultSize, document) == pixelFontSize)
             return legacyFontSize;
 
         return 0;

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -57,7 +57,7 @@ class StyleProperties;
 class StyledElement;
 class VisibleSelection;
 
-enum class TextDecorationChange { None, Add, Remove };
+enum class TextDecorationChange : uint8_t { None, Add, Remove };
 
 // FIXME: "Keep" should be "Resolve" instead and resolve all generic font family names.
 enum class StandardFontFamilySerializationMode : uint8_t { Keep, Strip };
@@ -65,10 +65,10 @@ enum class StandardFontFamilySerializationMode : uint8_t { Keep, Strip };
 class EditingStyle : public RefCounted<EditingStyle> {
 public:
 
-    enum class PropertiesToInclude { AllProperties, OnlyEditingInheritableProperties, EditingPropertiesInEffect, PostLayoutProperties };
+    enum class PropertiesToInclude : uint8_t { AllProperties, OnlyEditingInheritableProperties, EditingPropertiesInEffect, PostLayoutProperties };
 
-    enum ShouldPreserveWritingDirection { PreserveWritingDirection, DoNotPreserveWritingDirection };
-    enum ShouldExtractMatchingStyle { ExtractMatchingStyle, DoNotExtractMatchingStyle };
+    enum class ShouldPreserveWritingDirection : bool { No, Yes };
+    enum class ShouldExtractMatchingStyle : bool { No, Yes };
     static float NoFontDelta;
 
     static Ref<EditingStyle> create()
@@ -125,7 +125,7 @@ public:
     void removeStyleConflictingWithStyleOfNode(Node&);
     template<typename T> void removeEquivalentProperties(T&);
     void collapseTextDecorationProperties();
-    enum ShouldIgnoreTextOnlyProperties { IgnoreTextOnlyProperties, DoNotIgnoreTextOnlyProperties };
+    enum class ShouldIgnoreTextOnlyProperties : bool { No, Yes };
     TriState triStateOfStyle(EditingStyle*) const;
     TriState triStateOfStyle(const VisibleSelection&) const;
     bool conflictsWithInlineStyleOfElement(StyledElement& element) const { return conflictsWithInlineStyleOfElement(element, nullptr, nullptr); }
@@ -133,16 +133,16 @@ public:
     {
         return conflictsWithInlineStyleOfElement(element, &newInlineStyle, extractedStyle);
     }
-    bool conflictsWithImplicitStyleOfElement(HTMLElement&, EditingStyle* extractedStyle = nullptr, ShouldExtractMatchingStyle = DoNotExtractMatchingStyle) const;
+    bool conflictsWithImplicitStyleOfElement(HTMLElement&, EditingStyle* extractedStyle = nullptr, ShouldExtractMatchingStyle = ShouldExtractMatchingStyle::No) const;
     bool conflictsWithImplicitStyleOfAttributes(HTMLElement&) const;
     bool extractConflictingImplicitStyleOfAttributes(HTMLElement&, ShouldPreserveWritingDirection, EditingStyle* extractedStyle, Vector<QualifiedName>& conflictingAttributes, ShouldExtractMatchingStyle) const;
     bool styleIsPresentInComputedStyleOfNode(Node&) const;
 
     static bool elementIsStyledSpanOrHTMLEquivalent(const HTMLElement&);
 
-    void prepareToApplyAt(const Position&, ShouldPreserveWritingDirection = DoNotPreserveWritingDirection);
+    void prepareToApplyAt(const Position&, ShouldPreserveWritingDirection = ShouldPreserveWritingDirection::No);
     void mergeTypingStyle(Document&);
-    enum CSSPropertyOverrideMode { OverrideValues, DoNotOverrideValues };
+    enum class CSSPropertyOverrideMode : bool { DoNotOverrideValues, OverrideValues };
     void mergeInlineStyleOfElement(StyledElement&, CSSPropertyOverrideMode, PropertiesToInclude = PropertiesToInclude::AllProperties);
     static Ref<EditingStyle> wrappingStyleForSerialization(Node& context, bool shouldAnnotate, StandardFontFamilySerializationMode);
     void mergeStyleFromRules(StyledElement&);

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -243,7 +243,7 @@ void InsertTextCommand::doApply()
 #endif
 
     if (typingStyle) {
-        typingStyle->prepareToApplyAt(endPosition, EditingStyle::PreserveWritingDirection);
+        typingStyle->prepareToApplyAt(endPosition, EditingStyle::ShouldPreserveWritingDirection::Yes);
         if (!typingStyle->isEmpty())
             applyStyle(typingStyle.get());
     }

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -698,7 +698,7 @@ void ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline(Insert
                     node = replaceElementWithSpanPreservingChildrenAndAttributes(*htmlElement);
                     element = downcast<StyledElement>(node.get());
                     insertedNodes.didReplaceNode(htmlElement.get(), node.get());
-                } else if (newInlineStyle->extractConflictingImplicitStyleOfAttributes(*htmlElement, EditingStyle::PreserveWritingDirection, nullptr, attributes, EditingStyle::DoNotExtractMatchingStyle)) {
+                } else if (newInlineStyle->extractConflictingImplicitStyleOfAttributes(*htmlElement, EditingStyle::ShouldPreserveWritingDirection::Yes, nullptr, attributes, EditingStyle::ShouldExtractMatchingStyle::No)) {
                     // e.g. <font size="3" style="font-size: 20px;"> is converted to <font style="font-size: 20px;">
                     for (auto& attribute : attributes)
                         removeNodeAttribute(*element, attribute);


### PR DESCRIPTION
#### e5c84e770a0e4eac1774a64b99b34297288bf24a
<pre>
EditingStyle: prefer enum class for multiple enums
<a href="https://rdar.apple.com/157253470">rdar://157253470</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296774">https://bugs.webkit.org/show_bug.cgi?id=296774</a>

Reviewed by Sammy Gill.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::removeInlineStyleFromElement):
(WebCore::ApplyStyleCommand::removeImplicitlyStyledElement):
(WebCore::ApplyStyleCommand::applyInlineStyleToPushDown):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::overrideWithStyle):
(WebCore::EditingStyle::overrideTypingStyleAt):
(WebCore::EditingStyle::triStateOfStyle const):
(WebCore::EditingStyle::conflictsWithImplicitStyleOfElement const):
(WebCore::EditingStyle::extractConflictingImplicitStyleOfAttributes const):
(WebCore::EditingStyle::prepareToApplyAt):
(WebCore::EditingStyle::mergeTypingStyle):
(WebCore::elementMatchesAndPropertyIsNotInInlineStyleDecl):
(WebCore::EditingStyle::wrappingStyleForSerialization):
(WebCore::EditingStyle::mergeStyle):
(WebCore::EditingStyle::legacyFontSize const):
(WebCore::StyleChange::extractTextStyles):
(WebCore::legacyFontSizeFromCSSValue):
* Source/WebCore/editing/EditingStyle.h:
(): Deleted.
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::doApply):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline):

Canonical link: <a href="https://commits.webkit.org/298122@main">https://commits.webkit.org/298122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39c7b1260c46d3f1239eacd589816af232a76dfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67275 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123700 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95705 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95489 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18473 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46728 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->