### PR TITLE
REGRESSION(275091@main): Darker output with SVG feComponentTransfer

### DIFF
--- a/LayoutTests/svg/filters/feComponentTransfer-gamma-expected.html
+++ b/LayoutTests/svg/filters/feComponentTransfer-gamma-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<style>
+    .box {
+        width: 200px;
+        height: 200px;
+        background-color: rgb(193, 193, 193);
+    }
+</style>
+
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/svg/filters/feComponentTransfer-gamma.html
+++ b/LayoutTests/svg/filters/feComponentTransfer-gamma.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<style>
+    .box {
+        width: 200px;
+        height: 200px;
+        filter: url('#gamma-filter');
+        background-color: rgb(1 1 1);
+    }
+</style>
+
+<body>
+    <div class="box"></div>
+    <svg class="gamma-svg">
+        <filter id="gamma-filter">
+            <feComponentTransfer color-interpolation-filters="sRGB">
+                <feFuncR type="gamma" exponent="0.05"></feFuncR>
+                <feFuncG type="gamma" exponent="0.05"></feFuncG>
+                <feFuncB type="gamma" exponent="0.05"></feFuncB>
+            </feComponentTransfer>
+        </filter>
+    </svg>
+</body>
+</html>

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -86,7 +86,12 @@ static std::optional<std::tuple<SVGFilterEffectGraph, FilterEffectGeometryMap>> 
     if (filterElement.countChildNodes() > maxCountChildNodes)
         return std::nullopt;
 
+#if USE(CAIRO)
     const auto colorSpace = filterElement.colorInterpolation() == ColorInterpolation::LinearRGB ? DestinationColorSpace::LinearSRGB() : DestinationColorSpace::SRGB();
+#else
+    const auto colorSpace = DestinationColorSpace::SRGB();
+#endif
+
     SVGFilterEffectGraph graph(SourceGraphic::create(colorSpace), SourceAlpha::create(colorSpace));
     FilterEffectGeometryMap effectGeometryMap;
 


### PR DESCRIPTION
#### 1c0dff3c8c02031702252129caf96dccdc05cf60
<pre>
REGRESSION(275091@main): Darker output with SVG feComponentTransfer
<a href="https://bugs.webkit.org/show_bug.cgi?id=296776">https://bugs.webkit.org/show_bug.cgi?id=296776</a>
<a href="https://rdar.apple.com/156406312">rdar://156406312</a>

Reviewed by Brent Fulgham and Said Abou-Hallawa.

The regressing commit (275091@main) aimed to fix darker SVG filter
outputs in Cairo by creating SourceGraphic and SourceAlpha to the
operating color space, but omitted the USE(CAIRO) directive,
applying it universally and breaking filter effects in non-Cairo
software appliers.

* LayoutTests/svg/filters/feComponentTransfer-gamma-expected.html: Added.
* LayoutTests/svg/filters/feComponentTransfer-gamma.html: Added.
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::buildFilterEffectGraph):

Canonical link: <a href="https://commits.webkit.org/298332@main">https://commits.webkit.org/298332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69dc292b69deec12dc3621cdd0f3f55ea9c94ceb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65733 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96346812-5a36-4006-bd03-0890da53c365) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87461 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad60399e-6eee-4d59-aa9a-72719b60e651) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67890 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64861 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124396 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96042 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41246 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38056 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47473 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41477 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44796 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->