### PR TITLE
`git-webkit setup` can fail to install python dependencies when run from a branch

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -627,6 +627,17 @@ Automation may create pull requests and forks in unexpected locations
                         sys.stderr.write("Failed to open '{}' in the browser, continuing\n".format(info_url))
                 print('\n')
 
+            if repository.branch not in repository.DEFAULT_BRANCHES:
+                print(f'Setup is currently being run on {repository.branch}. This may result in undefined behavior.\nPlease ensure your branch is up-to-date with main or switch to main and rerun `git-webkit setup`.')
+                response = Terminal.choose(
+                    'Would you like to continue setup?',
+                    options=('No', 'Yes'),
+                    default='No',
+                )
+                if response == 'No':
+                    print('Setup cancelled')
+                    return 1
+
             result = cls.git(args, repository, **kwargs)
 
             if result:


### PR DESCRIPTION
#### d0907319b0466a1195baa96539383fe81e019bfb
<pre>
`git-webkit setup` can fail to install python dependencies when run from a branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=296780">https://bugs.webkit.org/show_bug.cgi?id=296780</a>
<a href="https://rdar.apple.com/155447156">rdar://155447156</a>

Reviewed by Alexey Proskuryakov.

Add a warning message when running `git-webkit setup` from a branch other than main.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:

Canonical link: <a href="https://commits.webkit.org/298203@main">https://commits.webkit.org/298203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f36704e5810597eae10b17997fff887e5dc16f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114295 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65014 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/063d44aa-e1ed-41e7-96c6-6103ea4aab94) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86855 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41779 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79bad379-b719-49e5-ac40-599dc49ea5ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67248 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/113669 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20777 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64148 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/96986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123669 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95681 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/113725 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95464 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37368 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18362 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41189 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->