### PR TITLE
Add Storage Access API testRunner support for `test_driver.set_permission`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Cross-site HTTP redirects from a frame with storage-access are not credentialed by default Test timed out
+FAIL Cross-site HTTP redirects from a frame with storage-access are not credentialed by default assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
@@ -1,7 +1,7 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
+Blocked access to external URL https://www.localhost:9443/storage-access-api/resources/script-with-cookie-header.py?script=embedded_responder.js
 
 Harness Error (TIMEOUT), message = null
 
-TIMEOUT Grants have per-frame scope Test timed out
-NOTRUN Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others.
+FAIL Grants have per-frame scope assert_true: requestStorageAccess doesn't require a gesture since the permission has already been granted. expected true got false
+TIMEOUT Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Workers don't inherit storage access Test timed out
-NOTRUN Workers don't observe parent's storage access
+FAIL Workers don't inherit storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
+FAIL Workers don't observe parent's storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-nested-same-origin-iframe.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-nested-same-origin-iframe.sub.https.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS [nested-same-origin-frame] document.requestStorageAccess() should exist on the document interface
 PASS [nested-same-origin-frame] document.requestStorageAccess() should resolve in top-level frame or same-site iframe, otherwise reject with a NotAllowedError with no user gesture.
-FAIL [nested-same-origin-frame] document.requestStorageAccess() should be resolved with no user gesture when a permission grant exists, and should allow cookie access promise_test: Unhandled rejection with value: object "Error: Unsupported permission name "storage-access"."
+PASS [nested-same-origin-frame] document.requestStorageAccess() should be resolved with no user gesture when a permission grant exists, and should allow cookie access
 PASS [nested-same-origin-frame] document.requestStorageAccess() should resolve without permission grant or user gesture
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT WebSocket inherits storage access Test timed out
-NOTRUN WebSocket omits unpartitioned cookies without storage access
+FAIL WebSocket inherits storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
+PASS WebSocket omits unpartitioned cookies without storage access
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS [top-level-context] document.requestStorageAccess() should exist on the document interface
 PASS [top-level-context] document.requestStorageAccess() should resolve in top-level frame or same-site iframe, otherwise reject with a NotAllowedError with no user gesture.
-FAIL [top-level-context] document.requestStorageAccess() should be resolved with no user gesture when a permission grant exists, and should allow cookie access promise_test: Unhandled rejection with value: object "Error: Unsupported permission name "storage-access"."
+PASS [top-level-context] document.requestStorageAccess() should be resolved with no user gesture when a permission grant exists, and should allow cookie access
 PASS [top-level-context] document.requestStorageAccess() should resolve without permission grant or user gesture
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BroadcastChannel.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BroadcastChannel.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Broadcast Channel Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Broadcast Channel assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for BroadcastChannel" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.SharedWorker.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.SharedWorker.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Shared Worker Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Shared Worker assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for SharedWorker" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Blob Storage Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Blob Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for blobStorage" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.caches.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.caches.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Cache Storage Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Cache Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for caches" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.cookies.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.cookies.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Cookies Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Cookies assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for cookies" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.estimate.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.estimate.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Quota Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Quota assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for estimate" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.getDirectory.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.getDirectory.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Origin Private File System Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Origin Private File System assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for getDirectory" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.indexedDB.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.indexedDB.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for IndexedDB Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for IndexedDB assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for indexedDB" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.localStorage.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.localStorage.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Local Storage Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Local Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for localStorage" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.locks.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.locks.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Web Locks Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Web Locks assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for locks" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for None Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for None assert_equals: Storage Access API should not allow access for empty requests. expected "HasAccess for none" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.sessionStorage.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.sessionStorage.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for Session Storage Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies for Session Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for sessionStorage" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.unpartitioned.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.unpartitioned.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies when unpartitioned Test timed out
+FAIL Verify StorageAccessAPIBeyondCookies when unpartitioned assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for unpartitioned" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
@@ -1,22 +1,19 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-
-Harness Error (TIMEOUT), message = null
 
 PASS Sec-Fetch-Storage-Access is omitted when credentials are omitted
 FAIL Sec-Fetch-Storage-Access is `none` when unpartitioned cookies are unavailable. assert_array_equals: value is undefined, expected array
-TIMEOUT Sec-Fetch-Storage-Access is `inactive` when unpartitioned cookies are available but not in use. Test timed out
-NOTRUN Sec-Fetch-Storage-Access is `active` after a valid retry with matching explicit allowed-origin.
-NOTRUN Sec-Fetch-Storage-Access is active after retry with wildcard `allowed-origin` value.
-NOTRUN 'Activate-Storage-Access: retry' is a no-op on a request without an `allowed-origin` value.
-NOTRUN 'Activate-Storage-Access: retry' is a no-op on a request from an origin that does not match its `allowed-origin` value.
-NOTRUN Activate-Storage-Access `retry` is a no-op on a request with a `none` Storage Access status.
-NOTRUN Activate-Storage-Access `load` header grants storage access to frame.
-NOTRUN Activate-Storage-Access `load` is honored for `active` cases.
-NOTRUN Activate-Storage-Access `load` header is a no-op for requests without storage access.
-NOTRUN Sec-Fetch-Storage-Access is `inactive` for ABA case.
-NOTRUN Storage Access can be activated for ABA cases by retrying.
-NOTRUN Sec-Fetch-Storage-Access maintains value on same-origin redirect.
-NOTRUN Sec-Fetch-Storage-Access is not 'active' after cross-origin same-site redirection.
-NOTRUN Sec-Fetch-Storage-Access loses value on a cross-site redirection.
-NOTRUN Activate-Storage-Access retry is handled before any redirects are followed.
+FAIL Sec-Fetch-Storage-Access is `inactive` when unpartitioned cookies are available but not in use. assert_array_equals: value is undefined, expected array
+FAIL Sec-Fetch-Storage-Access is `active` after a valid retry with matching explicit allowed-origin. assert_array_equals: value is undefined, expected array
+FAIL Sec-Fetch-Storage-Access is active after retry with wildcard `allowed-origin` value. assert_array_equals: value is undefined, expected array
+FAIL 'Activate-Storage-Access: retry' is a no-op on a request without an `allowed-origin` value. assert_array_equals: value is undefined, expected array
+FAIL 'Activate-Storage-Access: retry' is a no-op on a request from an origin that does not match its `allowed-origin` value. assert_array_equals: value is undefined, expected array
+FAIL Activate-Storage-Access `retry` is a no-op on a request with a `none` Storage Access status. assert_array_equals: value is undefined, expected array
+FAIL Activate-Storage-Access `load` header grants storage access to frame. assert_true: frame should have storage access because of the `load` header expected true got false
+FAIL Activate-Storage-Access `load` is honored for `active` cases. assert_true: expected true got false
+PASS Activate-Storage-Access `load` header is a no-op for requests without storage access.
+FAIL Sec-Fetch-Storage-Access is `inactive` for ABA case. assert_array_equals: value is undefined, expected array
+FAIL Storage Access can be activated for ABA cases by retrying. assert_array_equals: value is undefined, expected array
+FAIL Sec-Fetch-Storage-Access maintains value on same-origin redirect. assert_array_equals: value is undefined, expected array
+FAIL Sec-Fetch-Storage-Access is not 'active' after cross-origin same-site redirection. assert_array_equals: value is undefined, expected array
+FAIL Sec-Fetch-Storage-Access loses value on a cross-site redirection. assert_array_equals: value is undefined, expected array
+FAIL Activate-Storage-Access retry is handled before any redirects are followed. assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -545,6 +545,9 @@ window.test_driver_internal.set_permission = async function(permission_params)
     case "screen-wake-lock":
         testRunner.setScreenWakeLockPermission(permission_params.state == "granted");
         break;
+    case "storage-access":
+        await testRunner.setStorageAccessPermission(permission_params.state === "granted", location.href);
+        break;
     default:
         throw new Error(`Unsupported permission name "${permission_params.descriptor.name}".`);
     }

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -179,6 +179,9 @@ public:
 
     void hasStorageAccess(SubFrameDomain&&, TopFrameDomain&&, std::optional<WebCore::FrameIdentifier>, WebCore::PageIdentifier, CanRequestStorageAccessWithoutUserInteraction, CompletionHandler<void(bool)>&&);
     void requestStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::StorageAccessScope, CanRequestStorageAccessWithoutUserInteraction, CompletionHandler<void(StorageAccessStatus)>&&);
+    enum class AddedRecord : bool { No, Yes };
+    std::pair<AddedRecord, std::optional<unsigned>> grantStorageAccessPermission(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain);
+    void revokeStorageAccessPermission(const RegistrableDomain&);
     void grantStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::StorageAccessPromptWasShown, WebCore::StorageAccessScope, CompletionHandler<void(WebCore::StorageAccessWasGranted)>&&);
 
     void logFrameNavigation(const NavigatedToDomain&, const TopFrameDomain&, const NavigatedFromDomain&, bool isRedirect, bool isMainFrame, Seconds delayAfterMainFrameDocumentLoad, bool wasPotentiallyInitiatedByUser);
@@ -303,7 +306,6 @@ private:
     void grantStorageAccessInternal(SubFrameDomain&&, TopFrameDomain&&, std::optional<WebCore::FrameIdentifier>, WebCore::PageIdentifier, WebCore::StorageAccessPromptWasShown, WebCore::StorageAccessScope, CanRequestStorageAccessWithoutUserInteraction, CompletionHandler<void(WebCore::StorageAccessWasGranted)>&&);
     void markAsPrevalentIfHasRedirectedToPrevalent();
     
-    enum class AddedRecord : bool { No, Yes };
     // reason is used for logging purpose.
     std::pair<AddedRecord, std::optional<unsigned>> ensureResourceStatisticsForRegistrableDomain(const RegistrableDomain&, ASCIILiteral reason) WARN_UNUSED_RETURN;
     bool shouldRemoveAllWebsiteDataFor(const DomainData&, bool shouldCheckForGrandfathering);

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -229,6 +229,8 @@ public:
     void clearFrameLoadRecordsForStorageAccess(WebCore::FrameIdentifier);
     void clearFrameLoadRecordsForStorageAccess(WebPageProxyIdentifier);
 
+    void setStorageAccessPermissionForTesting(bool, RegistrableDomain&& topFrameDomain, RegistrableDomain&& subFrameDomain, CompletionHandler<void()>&&);
+
 private:
     explicit WebResourceLoadStatisticsStore(NetworkSession&, const String&, ShouldIncludeLocalhost, WebCore::ResourceLoadStatistics::IsEphemeral);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1372,6 +1372,16 @@ void NetworkProcess::grantStorageAccessForTesting(PAL::SessionID sessionID, Vect
     completionHandler();
 }
 
+void NetworkProcess::setStorageAccessPermissionForTesting(PAL::SessionID sessionID, bool granted, RegistrableDomain&& topFrameDomain, RegistrableDomain&& subFrameDomain, CompletionHandler<void()>&& completionHandler)
+{
+    if (CheckedPtr session = networkSession(sessionID)) {
+        if (RefPtr resourceLoadStatistics = session->resourceLoadStatistics())
+            return resourceLoadStatistics->setStorageAccessPermissionForTesting(granted, WTFMove(topFrameDomain), WTFMove(subFrameDomain), WTFMove(completionHandler));
+    } else
+        ASSERT_NOT_REACHED();
+    completionHandler();
+}
+
 void NetworkProcess::hasIsolatedSession(PAL::SessionID sessionID, const WebCore::RegistrableDomain& domain, CompletionHandler<void(bool)>&& completionHandler) const
 {
     bool result = false;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -299,6 +299,7 @@ public:
     void setCrossSiteLoadWithLinkDecorationForTesting(PAL::SessionID, RegistrableDomain&& fromDomain, RegistrableDomain&& toDomain, DidFilterKnownLinkDecoration, CompletionHandler<void()>&&);
     void resetCrossSiteLoadsWithLinkDecorationForTesting(PAL::SessionID, CompletionHandler<void()>&&);
     void grantStorageAccessForTesting(PAL::SessionID, Vector<WebCore::RegistrableDomain>&& subFrameDomains, WebCore::RegistrableDomain&& topFrameDomain, CompletionHandler<void(void)>&&);
+    void setStorageAccessPermissionForTesting(PAL::SessionID, bool, WebCore::RegistrableDomain&& topFrameDomain, WebCore::RegistrableDomain&& subFrameDomain, CompletionHandler<void()>&&);
     void hasIsolatedSession(PAL::SessionID, const WebCore::RegistrableDomain&, CompletionHandler<void(bool)>&&) const;
     void closeITPDatabase(PAL::SessionID, CompletionHandler<void()>&&);
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -146,6 +146,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     SetCrossSiteLoadWithLinkDecorationForTesting(PAL::SessionID sessionID, WebCore::RegistrableDomain fromDomain, WebCore::RegistrableDomain toDomain, enum:bool WebKit::DidFilterKnownLinkDecoration didFilterKnownLinkDecoration) -> ()
     ResetCrossSiteLoadsWithLinkDecorationForTesting(PAL::SessionID sessionID) -> ()
     GrantStorageAccessForTesting(PAL::SessionID sessionID, Vector<WebCore::RegistrableDomain> subFrameDomain, WebCore::RegistrableDomain topFrameDomain) -> ()
+    SetStorageAccessPermissionForTesting(PAL::SessionID sessionID, bool granted, WebCore::RegistrableDomain topFrameDomain, WebCore::RegistrableDomain subFrameDomain) -> ()
     DeleteCookiesForTesting(PAL::SessionID sessionID, WebCore::RegistrableDomain domain, bool includeHttpOnlyCookies) -> ()
     HasIsolatedSession(PAL::SessionID sessionID, WebCore::RegistrableDomain domain) -> (bool hasIsolatedSession)
     CloseITPDatabase(PAL::SessionID sessionID) -> ()

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -796,3 +796,10 @@ void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataS
         callback(context);
 #endif
 }
+
+void WKWebsiteDataStoreSetStorageAccessPermissionForTesting(WKWebsiteDataStoreRef dataStoreRef, bool granted, WKStringRef topFrame, WKStringRef subFrame, void* context, WKWebsiteDataStoreSetStorageAccessPermissionForTestingFunction completionHandler)
+{
+    WebKit::toProtectedImpl(dataStoreRef)->setStorageAccessPermissionForTesting(granted, WebKit::toProtectedImpl(topFrame)->string(), WebKit::toProtectedImpl(subFrame)->string(), [context, completionHandler] {
+        completionHandler(context);
+    });
+}

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h
@@ -231,6 +231,9 @@ WK_EXPORT void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRe
 typedef void (*KWebsiteDataStoreResetResourceMonitorThrottler)(void* functionContext);
 WK_EXPORT void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataStoreRef, void* context, KWebsiteDataStoreResetResourceMonitorThrottler callback);
 
+typedef void (*WKWebsiteDataStoreSetStorageAccessPermissionForTestingFunction)(void* functionContext);
+WK_EXPORT void WKWebsiteDataStoreSetStorageAccessPermissionForTesting(WKWebsiteDataStoreRef dataStoreRef, bool granted, WKStringRef topFrame, WKStringRef subFrame, void* context, WKWebsiteDataStoreSetStorageAccessPermissionForTestingFunction completionHandler);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2906,4 +2906,9 @@ void WebsiteDataStore::setCookies(Vector<WebCore::Cookie>&& cookies, CompletionH
     protectedNetworkProcess()->sendWithAsyncReply(Messages::WebCookieManager::SetCookie(m_sessionID, WTFMove(cookies), ++m_cookiesVersion), WTFMove(completionHandler));
 }
 
+void WebsiteDataStore::setStorageAccessPermissionForTesting(bool granted, const String& topFrame, const String& subFrame, CompletionHandler<void()>&& completionHandler)
+{
+    protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetStorageAccessPermissionForTesting(m_sessionID, granted, WebCore::RegistrableDomain(URL(topFrame)), WebCore::RegistrableDomain(URL(subFrame))), WTFMove(completionHandler));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -517,6 +517,8 @@ public:
     uint64_t cookiesVersion() const { return m_cookiesVersion; }
     void setCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
 
+    void setStorageAccessPermissionForTesting(bool, const String& topFrameDomain, const String& subFrameDomain, CompletionHandler<void()>&&);
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -371,6 +371,7 @@ interface TestRunner {
     // Storage Access API
     undefined getAllStorageAccessEntries(object callback);
     undefined setRequestStorageAccessThrowsExceptionUntilReload(boolean enabled);
+    Promise<undefined> setStorageAccessPermission(boolean value, DOMString subFrameURL);
 
     // Open panel
     undefined setOpenPanelFiles(object filesArray);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1566,6 +1566,14 @@ void TestRunner::setRequestStorageAccessThrowsExceptionUntilReload(bool enabled)
     postSynchronousPageMessage("SetRequestStorageAccessThrowsExceptionUntilReload", enabled);
 }
 
+void TestRunner::setStorageAccessPermission(JSContextRef context, bool granted, JSStringRef subFrameURL, JSValueRef callback)
+{
+    postMessageWithAsyncReply(context, "SetStorageAccessPermission", createWKDictionary({
+        { "Value", adoptWK(WKBooleanCreate(granted)) },
+        { "SubFrameURL", toWK(subFrameURL) },
+    }), callback);
+}
+
 void TestRunner::loadedSubresourceDomains(JSContextRef context, JSValueRef callback)
 {
     postMessageWithAsyncReply(context, "LoadedSubresourceDomains", callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -482,6 +482,7 @@ public:
     // Storage Access API
     void getAllStorageAccessEntries(JSContextRef, JSValueRef callback);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
+    void setStorageAccessPermission(JSContextRef, bool, JSStringRef, JSValueRef callback);
 
     // Open panel
     void setOpenPanelFiles(JSContextRef, JSValueRef);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2431,6 +2431,14 @@ void TestController::didReceiveAsyncMessageFromInjectedBundle(WKStringRef messag
         });
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetStorageAccessPermission")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        auto value = booleanValue(messageBodyDictionary, "Value");
+        auto subFrameURL = stringValue(messageBodyDictionary, "SubFrameURL");
+        auto mainFrameURL = adoptWK(WKURLCopyString(WKPageCopyActiveURL(TestController::singleton().mainWebView()->page())));
+        return WKWebsiteDataStoreSetStorageAccessPermissionForTesting(websiteDataStore(), value, mainFrameURL.get(), subFrameURL, completionHandler.leak(), adoptAndCallCompletionHandler);
+    }
+
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
#### 22ca61291b156fd13f44a4169e50d6b11c7fb4e5
<pre>
Add Storage Access API testRunner support for `test_driver.set_permission`
<a href="https://bugs.webkit.org/show_bug.cgi?id=296783">https://bugs.webkit.org/show_bug.cgi?id=296783</a>
<a href="https://rdar.apple.com/157258859">rdar://157258859</a>

Reviewed by Matthew Finkel.

test_driver.set_permission must be able to set the same state that is set when a user accepts or denies
a Storage Access API prompt. This patch adds testRunner support to change that state in the network
process.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-nested-same-origin-iframe.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BroadcastChannel.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.SharedWorker.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.caches.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.cookies.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.estimate.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.getDirectory.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.indexedDB.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.localStorage.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.locks.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.sessionStorage.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.unpartitioned.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt:
* LayoutTests/resources/testdriver-vendor.js:
(async switch):
(window.test_driver_internal.set_permission):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::grantStorageAccessPermission):
(WebKit::ResourceLoadStatisticsStore::revokeStorageAccessPermission):
(WebKit::ResourceLoadStatisticsStore::grantStorageAccess):
(WebKit::ResourceLoadStatisticsStore::clearUserInteraction):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setStorageAccessPermissionForTesting):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setStorageAccessPermissionForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreSetStorageAccessPermissionForTesting):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setStorageAccessPermissionForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setStorageAccessPermission):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/298158@main">https://commits.webkit.org/298158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9d007466b5b087eca870d3e619353ec00ae936

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114437 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65152 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86968 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20898 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64289 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123809 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30926 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95571 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40735 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18568 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37480 "Failed to checkout and rebase branch from PR 48809") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->