### PR TITLE
[WPT import friction] We should use a well-known location for the wpt repo clone that is not inside WebKitBuild

### DIFF
--- a/Tools/Scripts/import-webdriver-tests
+++ b/Tools/Scripts/import-webdriver-tests
@@ -33,6 +33,7 @@ import argparse
 import os
 import sys
 
+from webkitpy.w3c.common import WPTPaths
 from webkitpy.common.host import Host
 from webkitpy.common.system.filesystem import FileSystem
 from webkitpy.common.system.logutils import configure_logging
@@ -103,7 +104,7 @@ importers = []
 
 if options.w3c:
     importer_config_path = webkit_finder.path_from_webkit_base('WebDriverTests', 'imported', 'w3c', 'importer.json')
-    download_path = webkit_finder.path_from_webkit_base('WebKitBuild', 'w3c-tests', 'web-platform-tests')
+    download_path = WPTPaths.default_wpt_checkout_path(webkit_finder)
     import_path = webkit_finder.path_from_webkit_base('WebDriverTests', 'imported', 'w3c')
     importers.append(Importer(importer_config_path, download_path, import_path))
 

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -38,7 +38,7 @@ mock_linter = None
 class TestExporterTest(testing.PathTestCase):
     maxDiff = None
     BUGZILLA_URL = 'https://bugs.example.com'
-    basepath = 'mock/repository/WebKitBuild/w3c-tests/web-platform-tests'
+    basepath = 'mock/repository/wpt'
 
     def setUp(self):
         super().setUp()
@@ -104,6 +104,9 @@ class TestExporterTest(testing.PathTestCase):
         ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', '1@main', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
@@ -117,12 +120,13 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n"
+            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
                 'Fetching web-platform-tests repository',
                 'Cleaning web-platform-tests master branch',
                 'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
@@ -146,6 +150,8 @@ class TestExporterTest(testing.PathTestCase):
         ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-bn', 'wpt-export-branch', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
@@ -158,12 +164,13 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n"
+            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
                 'Fetching web-platform-tests repository',
                 'Cleaning web-platform-tests master branch',
                 'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
@@ -187,6 +194,8 @@ class TestExporterTest(testing.PathTestCase):
         ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]):
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
             options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--no-clean', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, TestExporterTest.MockWPTLinter, 1)
@@ -199,12 +208,13 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n"
+            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
                 'Fetching web-platform-tests repository',
                 'Cleaning web-platform-tests master branch',
                 'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -139,7 +139,7 @@ To import a web-platform-tests suite from a local checkout in ~/dev/wpt:
                         help='Import into a specified directory relative to the LayoutTests root. By default, imports into imported/w3c')
 
     parser.add_argument('-s', '--src-dir', dest='source', default=None,
-                        help='Import from a specific web-platform-tests directory. If not provided, the script will clone the necessary repository.')
+                        help='Import from a specific web-platform-tests directory. If not provided, the script will clone the necessary repository. By default, the repository will be cloned into the parent directory of your WebKit checkout (e.g. ~/WebKit/../wpt).')
 
     parser.add_argument('-v', '--verbose', action='store_true', default=False,
                         help='Print maximal log')
@@ -204,24 +204,20 @@ class TestImporter(object):
         }
 
     def do_import(self):
-        if self.source_directory:
-            directory = self._get_wpt_directory(self.source_directory)
-            _log.debug(f"Using {directory!r} for {self.source_directory!r}")
-            if directory is None:
-                return
+        finder = WebKitFinder(self.filesystem)
+        self.source_directory = self.source_directory or WPTPaths.ensure_wpt_repository(finder, self.source_directory)
 
-            self.source_directory = directory
-            source_path = self.filesystem.join(self.source_directory, 'web-platform-tests')
-            try:
-                self.upstream_revision = Git(source_path).find('HEAD').hash
-            except OSError:
-                self.upstream_revision = None
-        else:
-            _log.info('Downloading W3C test repositories')
-            self.filesystem.maybe_make_directory(self.tests_download_path)
-            self.test_downloader().download_tests(self.options.use_tip_of_tree)
-            self.upstream_revision = self.test_downloader().upstream_revision
-            self.source_directory = self.tests_download_path
+        directory = self._get_wpt_directory(self.source_directory)
+        _log.debug(f"Using {directory!r} for {self.source_directory!r}")
+        if directory is None:
+            return
+
+        self.source_directory = directory
+        source_path = self.filesystem.join(self.source_directory, 'web-platform-tests')
+        try:
+            self.upstream_revision = Git(source_path).find('HEAD').hash
+        except OSError:
+            self.upstream_revision = None
 
         for test_path in self.test_paths:
             if test_path != "web-platform-tests" and not test_path.startswith(

--- a/Tools/Scripts/webkitpy/w3c/wpt_runner.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_runner.py
@@ -156,7 +156,9 @@ class WPTRunner(object):
             test_downloader = self._downloader_class(WPTPaths.checkout_directory(self._finder),
                 self._host, self._downloader_class.default_options())
             test_downloader.clone_tests()
-            self._options.wpt_checkout = WPTPaths.wpt_checkout_path(self._finder)
+            self._options.wpt_checkout = self._host.filesystem.join(
+                WPTPaths.checkout_directory(self._finder),
+                "web-platform-tests")
 
         if not self._options.wpt_checkout or not self._host.filesystem.exists(self._options.wpt_checkout):
             _log.error("Valid web-platform-tests directory required")

--- a/Tools/Scripts/webkitpy/w3c/wpt_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_runner_unittest.py
@@ -26,6 +26,7 @@ from webkitpy.common.config.ports_mock import MockPort
 from webkitpy.common.host_mock import MockHost
 from webkitpy.w3c.wpt_runner import WPTRunner, parse_args
 
+WPT_CHECKOUT_PATH = f"/web-platform-tests"
 
 class WPTRunnerTest(unittest.TestCase):
 
@@ -88,9 +89,8 @@ class WPTRunnerTest(unittest.TestCase):
 
         self.assertTrue(instance.runner.prepare_wpt_checkout())
 
-        expected_wpt_checkout = "/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests"
-        self.assertEqual(instance.runner._options.wpt_checkout, expected_wpt_checkout)
-        self.assertTrue(instance.host.filesystem.isdir(expected_wpt_checkout))
+        self.assertEqual(instance.runner._options.wpt_checkout, WPT_CHECKOUT_PATH)
+        self.assertTrue(instance.host.filesystem.isdir(WPT_CHECKOUT_PATH))
 
     def test_prepare_wpt_checkout_specified_path(self):
         # Tests the prepare_wpt_checkout() method with WPT checkout specified in options.
@@ -108,12 +108,12 @@ class WPTRunnerTest(unittest.TestCase):
         # Goal of this test is for the WPT spawn command to match the desired WPT directory and
         # arguments. No options or arguments are used.
 
-        spawn_wpt_func = WPTRunnerTest.MockSpawnWPT(self,
-            "/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests",
-            ["run", "--webkit-port=MockPort", "--processes=4",
-                "--webdriver-binary=/mock-webdriver/bin/webdriver",
-                "--binary=/mock-webdriver/bin/browser",
-                "--binary-arg=webdriver_arg1", "--binary-arg=webdriver_arg2", "webkit"])
+        spawn_wpt_func = WPTRunnerTest.MockSpawnWPT(self, WPT_CHECKOUT_PATH, [
+            "run", "--webkit-port=MockPort", "--processes=4",
+            "--webdriver-binary=/mock-webdriver/bin/webdriver",
+            "--binary=/mock-webdriver/bin/browser",
+            "--binary-arg=webdriver_arg1", "--binary-arg=webdriver_arg2", "webkit"]
+        )
 
         options, _ = parse_args([])
         instance = WPTRunnerTest.TestInstance(options, spawn_wpt_func)
@@ -163,12 +163,12 @@ class WPTRunnerTest(unittest.TestCase):
 
         specified_args = ["test1.html", "test2.html"]
 
-        spawn_wpt_func = WPTRunnerTest.MockSpawnWPT(self,
-            "/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests",
-            ["run", "--webkit-port=MockPort", "--processes=4",
-                "--webdriver-binary=/mock-webdriver/bin/webdriver",
-                "--binary=/mock-webdriver/bin/browser",
-                "--binary-arg=webdriver_arg1", "--binary-arg=webdriver_arg2", "webkit"] + specified_args)
+        spawn_wpt_func = WPTRunnerTest.MockSpawnWPT(self, WPT_CHECKOUT_PATH, [
+            "run", "--webkit-port=MockPort", "--processes=4",
+            "--webdriver-binary=/mock-webdriver/bin/webdriver",
+            "--binary=/mock-webdriver/bin/browser",
+            "--binary-arg=webdriver_arg1", "--binary-arg=webdriver_arg2", "webkit"] + specified_args
+        )
 
         options, _ = parse_args([])
         instance = WPTRunnerTest.TestInstance(options, spawn_wpt_func)


### PR DESCRIPTION
#### 141e123bffe5b5adc3b2899a467f8d2c14b6e696
<pre>
[WPT import friction] We should use a well-known location for the wpt repo clone that is not inside WebKitBuild
<a href="https://bugs.webkit.org/show_bug.cgi?id=277279">https://bugs.webkit.org/show_bug.cgi?id=277279</a>
<a href="https://rdar.apple.com/132753363">rdar://132753363</a>

Reviewed by Sam Sneddon and Tim Nguyen.

This PR changes the default location of the WPT clone to the same dir as the WebKit checkout.
  - For example, if your directory is  ~/WebKit, then we will create ~/wpt.

The import and export scripts will prompt you for a directory to clone WPT into if not specified.
This defaults to the location described above. Notably, the name will default to &apos;wpt&apos; instead of &apos;web-platform-tests&apos;!

* Tools/Scripts/import-webdriver-tests: Use WPTPaths.

* Tools/Scripts/webkitpy/w3c/common.py:
(WPTPaths): Remove &apos;w3c-tests&apos; from the checkout path and use &apos;wpt&apos;.
(WPTPaths.checkout_directory): Use the dir of webkit_base as the checkout directory dir.
(WPTPaths.default_wpt_checkout_path): Rename of wpt_checkout_path.
(WPTPaths.ensure_wpt_repository):
    - This method returns the location of the WPT repo and clones it if it doesn&apos;t exist.
    - If no directory is passed in, it will prompt the user.
    - If run in non-interactive mode, it will default to one level below Webkit.
(WPTPaths.wpt_checkout_path): Deleted.

* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.__init__):
(WebPlatformTestExporter._get_wpt_repository):
(WebPlatformTestExporter.do_export):
(parse_args):
(configure_logging): Use &apos;webkitpy.w3c&apos; logger to pick up common.py logs.
(WebPlatformTestExporter._ensure_wpt_repository):

* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest): Remove &apos;WebKitBuild&apos; from the mock path.
(TestExporterTest.test_export):
(TestExporterTest.test_export_with_specific_branch):
(TestExporterTest.test_export_no_clean):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.do_import):
    - NEW: If a source directory is passed in, we try to clone it if it doesn&apos;t exist.
    - Use WPTPaths.ensure_wpt_repository in interactive mode to clone and return the directory path.

* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
    - Add FAKE_WPT_DIR = &apos;/wpt&apos; and replace old dir with this variable.
    - Remove test_checkout_directory since we&apos;re no longer using path_from_webkit_outputdir in common.py.
    - Remove all mentions of &apos;WebKitBuild&apos;.
    - Add mock symlink to setup for each test.
    - Add &apos;wpt&apos; and &apos;testharness.js&apos; files to the mock filesystem to mimic WPT repo.

* Tools/Scripts/webkitpy/w3c/wpt_runner.py:
(WPTRunner.prepare_wpt_checkout): Use WPTPaths.checkout_directory to construct the directory.

* Tools/Scripts/webkitpy/w3c/wpt_runner_unittest.py: Add WPT_CHECKOUT_PATH and replace old paths.
(WPTRunnerTest.test_prepare_wpt_checkout):
(WPTRunnerTest.test_run):
(WPTRunnerTest.test_run_with_args):

Canonical link: <a href="https://commits.webkit.org/300244@main">https://commits.webkit.org/300244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b64b2b202ad0c5d7ca183c54625323006633f506

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128181 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73753 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0debbd2f-9b30-4ba2-b007-4d819e86cde3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61471 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd80ebde-7850-46d5-a427-0a10427fb928) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33565 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73108 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e83c5dab-240b-45dd-9997-11472007c881) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/121020 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32581 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71698 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130978 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101016 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100907 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46282 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45298 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48456 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47925 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->