### PR TITLE
Enable Neon optimizations within libwebrtc's Opus.

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/opus.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/opus.xcconfig
@@ -14,15 +14,18 @@ PUBLIC_HEADERS_FOLDER_PATH = $(INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_P
 USE_HEADERMAP = NO;
 WARNING_CFLAGS = -Wno-incompatible-pointer-types $(inherited)
 GCC_PREPROCESSOR_DEFINITIONS = VAR_ARRAYS OPUS_BUILD OPUS_EXPORT= HAVE_LRINT HAVE_LRINTF $(inherited);
-GCC_PREPROCESSOR_DEFINITIONS[arch=arm64*] = $(inherited) OPUS_ARM_PRESUME_AARCH64_NEON_INTR;
+GCC_PREPROCESSOR_DEFINITIONS[arch=arm64*] = $(inherited) OPUS_ARM_MAY_HAVE_NEON_INTR OPUS_ARM_PRESUME_NEON OPUS_ARM_PRESUME_NEON_INTR OPUS_ARM_PRESUME_AARCH64_NEON_INTR;
 GCC_PREPROCESSOR_DEFINITIONS[arch=x86_64] = $(inherited) OPUS_X86_MAY_HAVE_SSE2 OPUS_X86_PRESUME_SSE2 $(SSE4_FLAG);
 GCC_PREPROCESSOR_DEFINITIONS[config=Debug] = $(inherited) OPUS_WILL_BE_SLOW
 
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*] = *_sse.c *_sse4_1.c x86_silk_map.c;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvsimulator*] = *_sse.c *_sse4_1.c x86_silk_map.c;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=xrsimulator*] = *_sse.c *_sse4_1.c x86_silk_map.c;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=watchsimulator*] = *_sse.c *_sse4_1.c x86_silk_map.c;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_IS_CATALYST));
 EXCLUDED_SOURCE_FILE_NAMES_YES = *_sse4_1.c x86_silk_map.c;
-EXCLUDED_SOURCE_FILE_NAMES[arch=arm64*] = *_sse.c *_sse2.c *_sse4_1.c x86_silk_map.c;
+EXCLUDED_SOURCE_FILE_NAMES[arch=arm64*] = $(inherited) x86/*;
+EXCLUDED_SOURCE_FILE_NAMES[arch=x86_64] = $(inherited) arm/*;
 
 // The iOS Simulator and Catalyst can't use SSE4 intrinsics, but macOS can.
 SSE4_FLAG[sdk=macosx*] = $(SSE4_FLAG_$(WK_IS_CATALYST))

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -57,6 +57,19 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		295762D42E1DBF01006C2416 /* pitch_neon_intr.c in Sources */ = {isa = PBXBuildFile; fileRef = 295762D12E1DBF01006C2416 /* pitch_neon_intr.c */; };
+		295762D92E1DBF01006C2416 /* celt_neon_intr.c in Sources */ = {isa = PBXBuildFile; fileRef = 295762C72E1DBF01006C2416 /* celt_neon_intr.c */; };
+		295762E02E1DBF01006C2416 /* pitch_arm.h in Headers */ = {isa = PBXBuildFile; fileRef = 295762D02E1DBF01006C2416 /* pitch_arm.h */; };
+		29FAED1B2E1EE70C00F5645C /* fixed_arm64.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAED1A2E1EE70C00F5645C /* fixed_arm64.h */; };
+		29FAED2F2E1EE83200F5645C /* macros_arm64.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAED212E1EE83200F5645C /* macros_arm64.h */; };
+		29FAED3A2E1EE8BC00F5645C /* LPC_inv_pred_gain_arm.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAED392E1EE8BC00F5645C /* LPC_inv_pred_gain_arm.h */; };
+		29FAED3C2E1EE8C900F5645C /* LPC_inv_pred_gain_neon_intr.c in Sources */ = {isa = PBXBuildFile; fileRef = 29FAED3B2E1EE8C900F5645C /* LPC_inv_pred_gain_neon_intr.c */; };
+		29FAED3E2E1EE8DD00F5645C /* NSQ_del_dec_arm.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAED3D2E1EE8DD00F5645C /* NSQ_del_dec_arm.h */; };
+		29FAED402E1EE8ED00F5645C /* NSQ_del_dec_neon_intr.c in Sources */ = {isa = PBXBuildFile; fileRef = 29FAED3F2E1EE8ED00F5645C /* NSQ_del_dec_neon_intr.c */; };
+		29FAED432E1EE8F800F5645C /* NSQ_neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAED412E1EE8F800F5645C /* NSQ_neon.h */; };
+		29FAED442E1EE8F800F5645C /* NSQ_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 29FAED422E1EE8F800F5645C /* NSQ_neon.c */; };
+		29FAED472E1EE91C00F5645C /* biquad_alt_arm.h in Headers */ = {isa = PBXBuildFile; fileRef = 29FAED452E1EE91C00F5645C /* biquad_alt_arm.h */; };
+		29FAED482E1EE91C00F5645C /* biquad_alt_neon_intr.c in Sources */ = {isa = PBXBuildFile; fileRef = 29FAED462E1EE91C00F5645C /* biquad_alt_neon_intr.c */; };
 		2D6BFF60280A93DF00A1A74F /* video_coding.h in Headers */ = {isa = PBXBuildFile; fileRef = 4131C45B234C81710028A615 /* video_coding.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D6BFF61280A93EC00A1A74F /* video_codec_initializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 4131C45E234C81720028A615 /* video_codec_initializer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D6BFF62280A93F400A1A74F /* video_codec_interface.h in Headers */ = {isa = PBXBuildFile; fileRef = 4131C45F234C81720028A615 /* video_codec_interface.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -5771,6 +5784,19 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		295762C72E1DBF01006C2416 /* celt_neon_intr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = celt_neon_intr.c; sourceTree = "<group>"; };
+		295762D02E1DBF01006C2416 /* pitch_arm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pitch_arm.h; sourceTree = "<group>"; };
+		295762D12E1DBF01006C2416 /* pitch_neon_intr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pitch_neon_intr.c; sourceTree = "<group>"; };
+		29FAED1A2E1EE70C00F5645C /* fixed_arm64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fixed_arm64.h; sourceTree = "<group>"; };
+		29FAED212E1EE83200F5645C /* macros_arm64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = macros_arm64.h; sourceTree = "<group>"; };
+		29FAED392E1EE8BC00F5645C /* LPC_inv_pred_gain_arm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LPC_inv_pred_gain_arm.h; sourceTree = "<group>"; };
+		29FAED3B2E1EE8C900F5645C /* LPC_inv_pred_gain_neon_intr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = LPC_inv_pred_gain_neon_intr.c; sourceTree = "<group>"; };
+		29FAED3D2E1EE8DD00F5645C /* NSQ_del_dec_arm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSQ_del_dec_arm.h; sourceTree = "<group>"; };
+		29FAED3F2E1EE8ED00F5645C /* NSQ_del_dec_neon_intr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = NSQ_del_dec_neon_intr.c; sourceTree = "<group>"; };
+		29FAED412E1EE8F800F5645C /* NSQ_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSQ_neon.h; sourceTree = "<group>"; };
+		29FAED422E1EE8F800F5645C /* NSQ_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = NSQ_neon.c; sourceTree = "<group>"; };
+		29FAED452E1EE91C00F5645C /* biquad_alt_arm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = biquad_alt_arm.h; sourceTree = "<group>"; };
+		29FAED462E1EE91C00F5645C /* biquad_alt_neon_intr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = biquad_alt_neon_intr.c; sourceTree = "<group>"; };
 		3178AB2C2D80C9A8002F8CF9 /* libgmock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libgmock.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3178AB2E2D810582002F8CF9 /* libgtest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libgtest.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		410091CD242CFD5E00C5EDA2 /* aes_nohw.cc.inc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.pascal; path = aes_nohw.cc.inc; sourceTree = "<group>"; };
@@ -11629,6 +11655,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		295762D22E1DBF01006C2416 /* arm */ = {
+			isa = PBXGroup;
+			children = (
+				295762C72E1DBF01006C2416 /* celt_neon_intr.c */,
+				29FAED1A2E1EE70C00F5645C /* fixed_arm64.h */,
+				295762D02E1DBF01006C2416 /* pitch_arm.h */,
+				295762D12E1DBF01006C2416 /* pitch_neon_intr.c */,
+			);
+			path = arm;
+			sourceTree = "<group>";
+		};
+		29FAED2A2E1EE83200F5645C /* arm */ = {
+			isa = PBXGroup;
+			children = (
+				29FAED452E1EE91C00F5645C /* biquad_alt_arm.h */,
+				29FAED462E1EE91C00F5645C /* biquad_alt_neon_intr.c */,
+				29FAED392E1EE8BC00F5645C /* LPC_inv_pred_gain_arm.h */,
+				29FAED3B2E1EE8C900F5645C /* LPC_inv_pred_gain_neon_intr.c */,
+				29FAED212E1EE83200F5645C /* macros_arm64.h */,
+				29FAED3D2E1EE8DD00F5645C /* NSQ_del_dec_arm.h */,
+				29FAED3F2E1EE8ED00F5645C /* NSQ_del_dec_neon_intr.c */,
+				29FAED422E1EE8F800F5645C /* NSQ_neon.c */,
+				29FAED412E1EE8F800F5645C /* NSQ_neon.h */,
+			);
+			path = arm;
+			sourceTree = "<group>";
+		};
 		410091EF242E360800C5EDA2 /* h265 */ = {
 			isa = PBXGroup;
 			children = (
@@ -19918,6 +19971,7 @@
 		5CDD8CAC1E43C72300621E92 /* celt */ = {
 			isa = PBXGroup;
 			children = (
+				295762D22E1DBF01006C2416 /* arm */,
 				5CDD8D131E43C75500621E92 /* x86 */,
 				5CDD8CAD1E43C75200621E92 /* _kiss_fft_guts.h */,
 				5CDD8CAE1E43C75200621E92 /* arch.h */,
@@ -19990,6 +20044,7 @@
 		5CDD8D5D1E43C7C700621E92 /* silk */ = {
 			isa = PBXGroup;
 			children = (
+				29FAED2A2E1EE83200F5645C /* arm */,
 				5CDD8F021E43CA1300621E92 /* fixed */,
 				5CDD8E9B1E43C9A400621E92 /* float */,
 				5CDD8E241E43C7DC00621E92 /* x86 */,
@@ -21244,6 +21299,7 @@
 				5CDD8E3C1E43C80C00621E92 /* API.h in Headers */,
 				5CDD8D301E43C79C00621E92 /* arch.h in Headers */,
 				5CDD8D321E43C79C00621E92 /* bands.h in Headers */,
+				29FAED472E1EE91C00F5645C /* biquad_alt_arm.h in Headers */,
 				5CDD8D381E43C79C00621E92 /* celt.h in Headers */,
 				5CDD8D361E43C79C00621E92 /* celt_lpc.h in Headers */,
 				5CDD8E461E43C80C00621E92 /* control.h in Headers */,
@@ -21256,15 +21312,18 @@
 				5CDD8D401E43C79C00621E92 /* entdec.h in Headers */,
 				5CDD8D421E43C79C00621E92 /* entenc.h in Headers */,
 				5CDD8E551E43C80C00621E92 /* errors.h in Headers */,
+				29FAED1B2E1EE70C00F5645C /* fixed_arm64.h in Headers */,
 				5CDD8D431E43C79C00621E92 /* fixed_debug.h in Headers */,
 				5CDD8D441E43C79C00621E92 /* fixed_generic.h in Headers */,
 				5CDD8D451E43C79C00621E92 /* float_cast.h in Headers */,
 				5CDD8E5A1E43C80C00621E92 /* Inlines.h in Headers */,
 				5CDD8D471E43C79C00621E92 /* kiss_fft.h in Headers */,
 				5CDD8D491E43C79C00621E92 /* laplace.h in Headers */,
+				29FAED3A2E1EE8BC00F5645C /* LPC_inv_pred_gain_arm.h in Headers */,
 				5CDD8E621E43C80C00621E92 /* MacroCount.h in Headers */,
 				5CDD8E631E43C80C00621E92 /* MacroDebug.h in Headers */,
 				5CDD8E641E43C80C00621E92 /* macros.h in Headers */,
+				29FAED2F2E1EE83200F5645C /* macros_arm64.h in Headers */,
 				5CDD8E651E43C80C00621E92 /* main.h in Headers */,
 				5CDD8F471E43CB1E00621E92 /* main_FIX.h in Headers */,
 				5CDD8EF21E43C9F600621E92 /* main_FLP.h in Headers */,
@@ -21275,11 +21334,14 @@
 				5C4B4AB91E42C574002651C8 /* mlp.h in Headers */,
 				5CDD8D501E43C79C00621E92 /* modes.h in Headers */,
 				5CDD8E701E43C80C00621E92 /* NSQ.h in Headers */,
+				29FAED3E2E1EE8DD00F5645C /* NSQ_del_dec_arm.h in Headers */,
+				29FAED432E1EE8F800F5645C /* NSQ_neon.h in Headers */,
 				CDC1F47625CF69EA0084CA16 /* opus_defines.h in Headers */,
 				5C4B4AC11E42C574002651C8 /* opus_private.h in Headers */,
 				CDC1F47725CF6A640084CA16 /* opus_types.h in Headers */,
 				5CDD8D511E43C79C00621E92 /* os_support.h in Headers */,
 				5CDD8D531E43C79C00621E92 /* pitch.h in Headers */,
+				295762E02E1DBF01006C2416 /* pitch_arm.h in Headers */,
 				5CDD8E711E43C80C00621E92 /* pitch_est_defines.h in Headers */,
 				5CDD8E741E43C80C00621E92 /* PLC.h in Headers */,
 				5CDD8D551E43C79C00621E92 /* quant_bands.h in Headers */,
@@ -25094,6 +25156,7 @@
 				5CDD8EE11E43C9F600621E92 /* autocorrelation_FLP.c in Sources */,
 				5CDD8D311E43C79C00621E92 /* bands.c in Sources */,
 				5CDD8E3D1E43C80C00621E92 /* biquad_alt.c in Sources */,
+				29FAED482E1EE91C00F5645C /* biquad_alt_neon_intr.c in Sources */,
 				5CDD8F3C1E43CB1E00621E92 /* burg_modified_FIX.c in Sources */,
 				5CDD8EE21E43C9F600621E92 /* burg_modified_FLP.c in Sources */,
 				5CDD8E3F1E43C80C00621E92 /* bwexpander.c in Sources */,
@@ -25103,6 +25166,7 @@
 				5CDD8D331E43C79C00621E92 /* celt_decoder.c in Sources */,
 				5CDD8D341E43C79C00621E92 /* celt_encoder.c in Sources */,
 				5CDD8D351E43C79C00621E92 /* celt_lpc.c in Sources */,
+				295762D92E1DBF01006C2416 /* celt_neon_intr.c in Sources */,
 				5CDD8E401E43C80C00621E92 /* check_control_input.c in Sources */,
 				5CDD8E411E43C80C00621E92 /* CNG.c in Sources */,
 				5CDD8E421E43C80C00621E92 /* code_signs.c in Sources */,
@@ -25158,6 +25222,7 @@
 				4153CD2721CC661000C3E188 /* LPC_fit.c in Sources */,
 				5CDD8E611E43C80C00621E92 /* LPC_inv_pred_gain.c in Sources */,
 				5CDD8EEF1E43C9F600621E92 /* LPC_inv_pred_gain_FLP.c in Sources */,
+				29FAED3C2E1EE8C900F5645C /* LPC_inv_pred_gain_neon_intr.c in Sources */,
 				5CDD8F451E43CB1E00621E92 /* LTP_analysis_filter_FIX.c in Sources */,
 				5CDD8EF01E43C9F600621E92 /* LTP_analysis_filter_FLP.c in Sources */,
 				5CDD8F461E43CB1E00621E92 /* LTP_scale_ctrl_FIX.c in Sources */,
@@ -25179,7 +25244,9 @@
 				5CDD8EF31E43C9F600621E92 /* noise_shape_analysis_FLP.c in Sources */,
 				5CDD8E6F1E43C80C00621E92 /* NSQ.c in Sources */,
 				5CDD8E6E1E43C80C00621E92 /* NSQ_del_dec.c in Sources */,
+				29FAED402E1EE8ED00F5645C /* NSQ_del_dec_neon_intr.c in Sources */,
 				418938C2242A3D46007FDC41 /* NSQ_del_dec_sse4_1.c in Sources */,
+				29FAED442E1EE8F800F5645C /* NSQ_neon.c in Sources */,
 				418938C3242A3D46007FDC41 /* NSQ_sse4_1.c in Sources */,
 				5C4B4AC21E42C574002651C8 /* opus.c in Sources */,
 				5C4B4ABB1E42C574002651C8 /* opus_decoder.c in Sources */,
@@ -25191,6 +25258,7 @@
 				5CDD8F491E43CB1E00621E92 /* pitch_analysis_core_FIX.c in Sources */,
 				5CDD8EF41E43C9F600621E92 /* pitch_analysis_core_FLP.c in Sources */,
 				5CDD8E721E43C80C00621E92 /* pitch_est_tables.c in Sources */,
+				295762D42E1DBF01006C2416 /* pitch_neon_intr.c in Sources */,
 				5CDD8E731E43C80C00621E92 /* PLC.c in Sources */,
 				5CDD8F4B1E43CB1E00621E92 /* process_gains_FIX.c in Sources */,
 				5CDD8EF61E43C9F600621E92 /* process_gains_FLP.c in Sources */,


### PR DESCRIPTION
#### 5ddd462f59cd4d419092cec493236d7324719254
<pre>
Enable Neon optimizations within libwebrtc&apos;s Opus.
<a href="https://bugs.webkit.org/show_bug.cgi?id=295575">https://bugs.webkit.org/show_bug.cgi?id=295575</a>

Reviewed by Youenn Fablet.

Added missing files and preprocessor definitions.
Mostly mimic of what was done within BUILD.gn.
This is a reland of <a href="https://commits.webkit.org/298080@main">https://commits.webkit.org/298080@main</a>
with fixed exclude filters.

* Source/ThirdParty/libwebrtc/Configurations/opus.xcconfig:
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/298886@main">https://commits.webkit.org/298886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f1eca9d8b4f6d6e08d27b0048143f1df1447ebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88700 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43112 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dom/jit-set-profiling-access-type-only-for-get-by-id-self.html, js/structuredClone/structured-clone-of-CachedString-in-map.html, js/structuredClone/structured-clone-of-ResizableSharedArrayBuffer.html, storage/indexeddb/modern/idbtransaction-objectstore-failures-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, transforms/2d/scale-composited.html, webgl/gl-clear-preserve-drawing-buffer-bug.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22887 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126018 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97368 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42493 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20434 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39715 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43593 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->