### PR TITLE
Explicitly stop getUserMedia/getDisplayMedia tracks in layout tests

### DIFF
--- a/LayoutTests/fast/media/media-player-uaf.html
+++ b/LayoutTests/fast/media/media-player-uaf.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <script>
   onload = async () => {
     if (window.testRunner)

--- a/LayoutTests/fast/media/template-hidden.html
+++ b/LayoutTests/fast/media/template-hidden.html
@@ -18,11 +18,14 @@ async function getStream()
        return navigator.mediaDevices.getUserMedia({video:true}).then(stream => stream, () => { });
 }
 
-promise_test(async () => {
+promise_test(async test => {
     const clone = aVideoTemplate.content.cloneNode(true);
     myTemplatedVideo.appendChild(clone);
 
-    myVideo.srcObject = await getStream();
+    const stream = await getStream();
+    if (stream)
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+    myVideo.srcObject = stream;
     // Fallback to regular video streaming if getUserMedia is not available.
     if (!myVideo.srcObject)
         myVideo.src = "../../media/content/test.mp4";

--- a/LayoutTests/fast/mediastream/MediaDevices-addEventListener.html
+++ b/LayoutTests/fast/mediastream/MediaDevices-addEventListener.html
@@ -20,6 +20,7 @@
         testRunner.setUserMediaPermission(true);
 
         const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const captureFailurePromise = new Promise(resolve => stream.getAudioTracks()[0].onended = resolve);
 
         let devices = await navigator.mediaDevices.enumerateDevices();

--- a/LayoutTests/fast/mediastream/MediaDevices-getUserMedia.html
+++ b/LayoutTests/fast/mediastream/MediaDevices-getUserMedia.html
@@ -55,6 +55,8 @@
             }
 
             function gotStreamWithConstraints3(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 7 generated.");
 
@@ -78,6 +80,8 @@
             }
 
             function gotStreamWithConstraints2(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 6 generated.");
 
@@ -96,6 +100,8 @@
             }
 
             function gotStreamWithConstraints1(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 5 generated.");
 
@@ -120,6 +126,8 @@
             }
 
             function gotStream4(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 4 generated.");
                 shouldBe("stream.getAudioTracks().length", "1");
@@ -141,6 +149,8 @@
             }
 
             function gotStream3(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 3 generated.");
                 shouldBe("stream.getAudioTracks().length", "1");
@@ -153,6 +163,8 @@
             }
 
             function gotStream2(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 2 generated.");
                 shouldBe("stream.getAudioTracks().length", "0");
@@ -165,6 +177,8 @@
             }
 
             function gotStream1(s) {
+                if (stream)
+                    stream.getTracks().forEach(track => track.stop());
                 stream = s;
                 testPassed("Stream 1 generated.");
                 shouldBe("stream.getAudioTracks().length", "1");

--- a/LayoutTests/fast/mediastream/MediaStream-MediaElement-setObject-null.html
+++ b/LayoutTests/fast/mediastream/MediaStream-MediaElement-setObject-null.html
@@ -30,6 +30,7 @@ function abort()
 {
     shouldBe('video.duration', 'Number.NaN');
     finishJSTest();
+    stream.getTracks().forEach(track => track.stop());
 }
 
 function runTest()

--- a/LayoutTests/fast/mediastream/MediaStream-MediaElement-srcObject.html
+++ b/LayoutTests/fast/mediastream/MediaStream-MediaElement-srcObject.html
@@ -25,6 +25,7 @@
                 shouldNotThrow("streamObj = audio.srcObject;");
                 shouldBe('streamObj', 'null');
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             function gotStream(s)

--- a/LayoutTests/fast/mediastream/MediaStream-add-ended-tracks.html
+++ b/LayoutTests/fast/mediastream/MediaStream-add-ended-tracks.html
@@ -29,6 +29,7 @@
             {
                 debug("*** stream2 is active again");
                 shouldBe('stream2.active', 'true');
+                stream.getTracks().forEach(track => track.stop());
                 finishJSTest();
             }
 

--- a/LayoutTests/fast/mediastream/MediaStream-add-remove-null-undefined-tracks.html
+++ b/LayoutTests/fast/mediastream/MediaStream-add-remove-null-undefined-tracks.html
@@ -24,6 +24,7 @@
                 shouldThrow("stream.removeTrack(undefined);");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             getUserMedia("allow", {audio:true, video:true}, gotStream);

--- a/LayoutTests/fast/mediastream/MediaStream-add-remove-tracks.html
+++ b/LayoutTests/fast/mediastream/MediaStream-add-remove-tracks.html
@@ -55,6 +55,8 @@
                 setTimeout(() => {
                     shouldBe('stream2.active', 'false');
                     finishJSTest();
+                    stream1.getTracks().forEach(track => track.stop());
+                    stream2.getTracks().forEach(track => track.stop());
                 }, 1000);
 
                 audioTrack = stream1.getAudioTracks()[0];

--- a/LayoutTests/fast/mediastream/MediaStream-add-tracks-to-inactive-stream.html
+++ b/LayoutTests/fast/mediastream/MediaStream-add-tracks-to-inactive-stream.html
@@ -29,6 +29,7 @@
                 tryAddTrack(stream2, audioTrack);
                 shouldBe('stream2.getAudioTracks().length', '1');
                 finishJSTest();
+                stream1.getTracks().forEach(track => track.stop());
             }
 
             function gotStream1(s)

--- a/LayoutTests/fast/mediastream/MediaStream-clone.html
+++ b/LayoutTests/fast/mediastream/MediaStream-clone.html
@@ -39,6 +39,8 @@
                 checkTracks(mediaStream.getVideoTracks()[0], newMediaStream.getVideoTracks()[0]);
 
                 finishJSTest();
+                mediaStream.getTracks().forEach(track => track.stop());
+                newMediaStream.getTracks().forEach(track => track.stop());
             }
 
             function start() {

--- a/LayoutTests/fast/mediastream/MediaStream-getTracks.html
+++ b/LayoutTests/fast/mediastream/MediaStream-getTracks.html
@@ -50,6 +50,8 @@
                 shouldBeNull('stream2.getTrackById("foo-id")');
 
                 finishJSTest();
+                stream1.getTracks().forEach(track => track.stop());
+                stream2.getTracks().forEach(track => track.stop());
             }
 
             function gotStream2(s)

--- a/LayoutTests/fast/mediastream/MediaStream-removeTrack-while-playing.html
+++ b/LayoutTests/fast/mediastream/MediaStream-removeTrack-while-playing.html
@@ -11,6 +11,7 @@
         <script>
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const audioTrack = localStream.getAudioTracks()[0];
     const videoTrack = localStream.getVideoTracks()[0];
 

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-change-audio-route.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-change-audio-route.html
@@ -11,6 +11,7 @@
     <script>
 promise_test(async (test) => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
 
     await video.play();
 

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-enter-background.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-enter-background.html
@@ -11,6 +11,7 @@
     <script>
 promise_test(async (test) => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     const track = video.srcObject.getTracks()[0];
 
     await video.play();

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-remove-track.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-remove-track.html
@@ -53,6 +53,7 @@
                 shouldBe('mediaStream.getAudioTracks().length', '0');
 
                 finishJSTest();
+                mediaStream.getTracks().forEach(track => track.stop());
             }
 
             function canplay()

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-track-stop.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-track-stop.html
@@ -38,6 +38,7 @@
 
                 debug("");
                 finishJSTest();
+                mediaStream.getTracks().forEach(track => track.stop());
             }
 
             function recheckVideoElementAfterEnabledChange()

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled-then-enabled.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled-then-enabled.html
@@ -64,6 +64,7 @@
             if (timeout)
                 clearTimeout(timeout);
             finishJSTest();
+            mediaStream.getTracks().forEach(track => track.stop());
         }
     }
 

--- a/LayoutTests/fast/mediastream/MediaStream-video-element.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element.html
@@ -84,6 +84,7 @@
 
                 debug("");
                 finishJSTest();
+                mediaStream.getTracks().forEach(track => track.stop());
             }
 
             function canplay()

--- a/LayoutTests/fast/mediastream/MediaStreamConstructor.html
+++ b/LayoutTests/fast/mediastream/MediaStreamConstructor.html
@@ -73,6 +73,7 @@
                 verifyStream("new MediaStream([stream.getVideoTracks()[0], stream.getAudioTracks()[0], stream.getVideoTracks()[0]])", 1, 1);
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             function verifyStream(script, numAudioTracks, numVideoTracks) {

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-clone.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-clone.html
@@ -46,6 +46,8 @@
                 shouldBe('videoTrack.readyState', 'videoTrack3.readyState');
 
                 finishJSTest();
+                videoTrack2.stop();
+                videoTrack3.stop();
             }
 
             function start() {

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
@@ -74,14 +74,7 @@
                         debug(`  capabilities.${property} = ${value}`);
                 }
                 debug("");
-            }
-
-            function gotStream(stream)
-            {
-                mediaStream = stream;
-                listTrackProperties(mediaStream.getVideoTracks()[0]);
-                listTrackProperties(mediaStream.getAudioTracks()[0]);
-                finishJSTest();
+                track.stop();
             }
 
             async function start()

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings.html
@@ -55,11 +55,14 @@
                 checkTrackSettings(stream.getVideoTracks()[0]);
                 checkTrackSettings(stream.getAudioTracks()[0]);
 
+                stream.getTracks().forEach(track => track.stop());
+
                 debug('Validate sampleRate constraints appears correctly in track settings');
                 stream = await navigator.mediaDevices.getUserMedia({audio: { sampleRate : 48000 } });
                 listTrackSettings(stream.getAudioTracks()[0]);
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             window.jsTestIsAsync = true;

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-kind.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-kind.html
@@ -16,6 +16,7 @@
                 shouldBeEqualToString('mediaStream.getVideoTracks()[0].kind', 'video');
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             function start() {

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-stop.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-stop.html
@@ -45,6 +45,7 @@
                 shouldNotBe('track.enabled', 'enabled');
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             function start() {

--- a/LayoutTests/fast/mediastream/MediaStreamTrackEvent-constructor.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrackEvent-constructor.html
@@ -60,6 +60,7 @@
                 shouldBeNonNull("mediaStream.getVideoTracks()[0]");
                 mediaStreamTrack = mediaStream.getVideoTracks()[0];
                 testMediaStreamTrackEvent();
+                mediaStreamTrack.stop();
             }
 
             function primeTimeout(msg)

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-add-removeTrack.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-add-removeTrack.html
@@ -96,6 +96,7 @@
                 shouldThrow("pc.removeTrack(null);");
                 shouldThrow("pc.removeTrack(undefined);");
 
+                stream.getTracks().forEach(track => track.stop());
                 finishJSTest();
             })
             .catch(function (error) {

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-addIceCandidate.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-addIceCandidate.html
@@ -101,6 +101,7 @@
             })
             .then(function () {
                 testPassed("End of test promise chain");
+                stream.getTracks().forEach(track => track.stop());
                 finishJSTest();
             })
             .catch(function (error) {

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html
@@ -67,6 +67,7 @@
                 shouldBe("pc.getSenders().length", "2");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-addTransceiver.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-addTransceiver.html
@@ -108,6 +108,7 @@
                 });
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error caught in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-closed-state.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-closed-state.html
@@ -58,6 +58,7 @@
                 testPassed("getStats rejected on closed state");
                 debug("");
                 testNonPromise()
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (e) {
                 testFailed("Error caught in promise chain: " + e);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-icecandidate-event.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-icecandidate-event.html
@@ -48,7 +48,9 @@
               finishJSTest();
             }
 
-            navigator.mediaDevices.getUserMedia({ "video": true }).then(function (stream) {
+            let stream;
+            navigator.mediaDevices.getUserMedia({ "video": true }).then(function (s) {
+                stream = s;
                 pc.addTrack(stream.getTracks()[0], stream);
                 return pc.createOffer();
             }).then(function (offer) {
@@ -60,6 +62,7 @@
                     window.internals.emulateRTCPeerConnectionPlatformEvent(pc, "dispatch-fake-ice-candidates");
                 shouldDoChecking = true;
                 checkCandidates();
+                stream.getTracks().forEach(track => track.stop());
             }).catch(function (error) {
                 testFailed("Error in promise chain: " + error);
                 finishJSTest();

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html
@@ -42,9 +42,11 @@
                     finishJSTest();
             };
 
+            let stream1, stream2, stream3;
             navigator.mediaDevices.getUserMedia({ "video": true }).then(function (stream) {
-                const stream2 = stream.clone();
-                const stream3 = stream.clone();
+                stream1 = stream;
+                stream2 = stream.clone();
+                stream3 = stream.clone();
 
                 pc.addTrack(stream.getTracks()[0], stream);
                 pc.addTrack(stream2.getTracks()[0], stream2);
@@ -63,6 +65,9 @@
                 window.internals.emulateRTCPeerConnectionPlatformEvent(pc, "step-ice-transport-states");
                 testPassed("End of test promise chain");
                 debug("");
+                stream1.getTracks().forEach(track => track.stop());
+                stream2.getTracks().forEach(track => track.stop());
+                stream3.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-inspect-answer.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-inspect-answer.html
@@ -70,6 +70,7 @@
                 printComparableSessionDescription(answer, mediaDescriptionVariables);
 
                 finishJSTest();
+                remoteStream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-inspect-offer.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-inspect-offer.html
@@ -49,6 +49,7 @@
 
                 testPassed("End of promise chain");
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error caught in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-media-setup-callbacks-single-dialog.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-media-setup-callbacks-single-dialog.html
@@ -100,6 +100,7 @@
                     debug("");
 
                     finishJSTest();
+                    stream.getTracks().forEach(track => track.stop());
                 }, gotError);
             }
 

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-media-setup-single-dialog.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-media-setup-single-dialog.html
@@ -119,6 +119,7 @@
                 debug("");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html
@@ -172,6 +172,7 @@
                 debug("");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-more-media-to-negotiate.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-more-media-to-negotiate.html
@@ -68,6 +68,7 @@
                     testPassed("Answer set");
 
                     finishJSTest();
+                    stream.getTracks().forEach(track => track.stop());
                 })
                 .catch(function (error) {
                     testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-onnegotiationneeded.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-onnegotiationneeded.html
@@ -44,6 +44,7 @@
             {
                 testPassed('onNegotiationNeeded3 was called when a track was added.');
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             async function gotStream(s)

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-overloaded-operations-params.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-overloaded-operations-params.html
@@ -289,6 +289,8 @@
                 return testGetStats();
             })
             .then(function () {
+                if (selector)
+                    selector.stop();
                 finishJSTest();
             })
             .catch(function () {

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-setLocalDescription-offer.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-setLocalDescription-offer.html
@@ -135,6 +135,7 @@
                 shouldBeTrue("typeof videoTransceiver.mid == 'string'");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error caught in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-setRemoteDescription-offer.html
@@ -148,6 +148,7 @@
                 debug("");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-statsSelector.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-statsSelector.html
@@ -52,6 +52,7 @@
                 shouldBeGreaterThanOrEqual('timestamp', 'startTime');
                 shouldBe('local.kind', '"video"');
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             }
 
             var startTime = new Date().getTime();

--- a/LayoutTests/fast/mediastream/RTCRtpSender-replaceTrack.html
+++ b/LayoutTests/fast/mediastream/RTCRtpSender-replaceTrack.html
@@ -80,6 +80,7 @@
                 .then(function () {
                     debug("End of promise chain");
                     finishJSTest();
+                    stream.getTracks().forEach(track => track.stop());
                 })
                 .catch(function (error) {
                     testFailed("Error in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/RTCTrackEvent-constructor.html
+++ b/LayoutTests/fast/mediastream/RTCTrackEvent-constructor.html
@@ -64,6 +64,7 @@
                 debug("");
 
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
             })
             .catch(function (error) {
                 testFailed("Error caught in promise chain: " + error);

--- a/LayoutTests/fast/mediastream/anonymize-device-name.html
+++ b/LayoutTests/fast/mediastream/anonymize-device-name.html
@@ -20,6 +20,7 @@
         }
 
         let stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true })
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
         for (const track of stream.getAudioTracks()) {
             assert_false(track.label == originalLabel, "navigator.mediaDevices did not anonymize audio track label at all");

--- a/LayoutTests/fast/mediastream/applyConstraints-bad-constraints.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-bad-constraints.html
@@ -10,6 +10,7 @@
 async function doTest(test, isVideo, badConstraints)
 {
     const stream = await navigator.mediaDevices.getUserMedia({ video: isVideo, audio: !isVideo });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const track = stream.getTracks()[0];
 
     await track.applyConstraints(badConstraints).then(() => {

--- a/LayoutTests/fast/mediastream/applyConstraints-deviceId.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-deviceId.html
@@ -8,12 +8,14 @@
         <script>
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const deviceId = stream.getTracks()[0].getSettings().deviceId;
     await stream.getTracks()[0].applyConstraints({deviceId: {exact: deviceId}});
 }, "applyConstraint deviceId for audio");
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({video:true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const deviceId = stream.getTracks()[0].getSettings().deviceId;
     await stream.getTracks()[0].applyConstraints({deviceId: {exact: deviceId}});
 }, "applyConstraint deviceId for video");

--- a/LayoutTests/fast/mediastream/applyConstraints-parallel.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-parallel.html
@@ -10,6 +10,7 @@
     <script>
 promise_test(async (t) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const audioTrack = stream.getAudioTracks()[0];
     const videoTrack = stream.getVideoTracks()[0];
     return Promise.all[

--- a/LayoutTests/fast/mediastream/audio-bad-sampleRate.html
+++ b/LayoutTests/fast/mediastream/audio-bad-sampleRate.html
@@ -2,8 +2,9 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script>
-promise_test(async () => {
+promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({audio : { sampleRate : 24000 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     assert_true(stream.getAudioTracks()[0].getSettings().sampleRate > 40000);
 }, "Ideal sample rate outside of min/max should be ignored");
 </script>

--- a/LayoutTests/fast/mediastream/audio-session-category-capture-audio-context.html
+++ b/LayoutTests/fast/mediastream/audio-session-category-capture-audio-context.html
@@ -5,7 +5,7 @@
 <script src="../../webrtc/routines.js"></script>
 <script>
 
-promise_test(async() => {
+promise_test(async test => {
     if (!window.internals)
        return Promise.reject("Test requires internals API");
 
@@ -23,7 +23,8 @@ promise_test(async() => {
     // Make sure that a not audible AudioContext is still setting the category to AmbientSound.
     assert_equals(internals.audioSessionCategory(), "AmbientSound", "AmbientSound");
 
-    let stream = await navigator.mediaDevices.getUserMedia({audio : true});
+    const stream = await navigator.mediaDevices.getUserMedia({audio : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     assert_equals(internals.audioSessionCategory(), "PlayAndRecord", "PlayAndRecord1");
 
@@ -51,7 +52,7 @@ promise_test(async() => {
     assert_equals(internals.audioSessionCategory(), defaultCategory);
 }, "Check audio session state in case of stopped audio track and stopped audio context");
 
-promise_test(async() => {
+promise_test(async test => {
     if (!window.internals)
        return Promise.reject("Test requires internals API");
 
@@ -63,6 +64,7 @@ promise_test(async() => {
     const defaultCategory = internals.audioSessionCategory();
 
     const stream = await navigator.mediaDevices.getUserMedia({audio : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     assert_equals(internals.audioSessionCategory(), "PlayAndRecord");
 

--- a/LayoutTests/fast/mediastream/audio-settings-reset.html
+++ b/LayoutTests/fast/mediastream/audio-settings-reset.html
@@ -2,15 +2,18 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script>
-promise_test(async() => {
-    let stream = await navigator.mediaDevices.getUserMedia({audio : true });
-    assert_equals(stream.getAudioTracks()[0].getSettings().volume, 1, "test1");
+promise_test(async test => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({audio : true });
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
+    assert_equals(stream1.getAudioTracks()[0].getSettings().volume, 1, "test1");
 
-    stream = await navigator.mediaDevices.getUserMedia({audio : { volume : 0 } });
-    assert_equals(stream.getAudioTracks()[0].getSettings().volume, 0);
+    const stream2 = await navigator.mediaDevices.getUserMedia({audio : { volume : 0 } });
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
+    assert_equals(stream2.getAudioTracks()[0].getSettings().volume, 0);
 
-    stream = await navigator.mediaDevices.getUserMedia({audio : true });
-    assert_equals(stream.getAudioTracks()[0].getSettings().volume, 1, "test3");
+    const stream3 = await navigator.mediaDevices.getUserMedia({audio : true });
+    test.add_cleanup(() => stream3.getTracks().forEach(track => track.stop()));
+    assert_equals(stream3.getAudioTracks()[0].getSettings().volume, 1, "test3");
 }, "Volume should be reset to default value if not specified explicitly");
 </script>
 </body>

--- a/LayoutTests/fast/mediastream/camera-unknown-facing-mode.html
+++ b/LayoutTests/fast/mediastream/camera-unknown-facing-mode.html
@@ -18,11 +18,12 @@
         });
     }
 
-    async function getSettingsBeforeAndAfterRotation(deviceId)
+    async function getSettingsBeforeAndAfterRotation(test, deviceId)
     {
         testRunner.setMockCameraOrientation(0);
 
         const stream = await navigator.mediaDevices.getUserMedia({ video: { deviceId } });
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         video.srcObject = stream;
         await video.play();
 
@@ -43,7 +44,7 @@
      promise_test(async (test) => {
          await setup(test);
  
-         const results = await getSettingsBeforeAndAfterRotation("default");
+         const results = await getSettingsBeforeAndAfterRotation(test, "default");
  
          assert_equals(results[0].facingMode, "user");
          assert_equals(results[0].width, 640, "initial width");
@@ -66,7 +67,7 @@
         });
         stream.getVideoTracks()[0].stop();
 
-        const results = await getSettingsBeforeAndAfterRotation(deviceId);
+        const results = await getSettingsBeforeAndAfterRotation(test, deviceId);
 
          assert_equals(results[0].facingMode, undefined);
         assert_equals(results[0].width, 640, "initial width");

--- a/LayoutTests/fast/mediastream/change-tracks-media-stream-being-played.html
+++ b/LayoutTests/fast/mediastream/change-tracks-media-stream-being-played.html
@@ -12,8 +12,9 @@ function waitFor(duration)
     return new Promise((resolve) => setTimeout(resolve, duration));
 }
 
-promise_test(async () => {
+promise_test(async test => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const localTracks = stream.getTracks();
     video = document.createElement('video');
     video.autoplay = true;

--- a/LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio.html
+++ b/LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio.html
@@ -11,9 +11,10 @@
         <video id=video-2 autoplay playsinline controls></video>
 
         <script>
-            const validateStream = async (video, message) => {
+            const validateStream = async (test, video, message) => {
 
                 const stream = await navigator.mediaDevices.getUserMedia({ video: { aspectRatio: 1 }});
+                test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
                 const settings = stream.getVideoTracks()[0].getSettings();
                 assert_equals(settings.width, settings.height, `settings.width === setting.height for ${message}`);
@@ -30,13 +31,13 @@
             
             promise_test(async (test) => {
 
-                await validateStream(document.getElementById('video-1'), 'first stream');
+                await validateStream(test, document.getElementById('video-1'), 'first stream');
 
             }, 'First gUM stream');
 
             promise_test(async (test) => {
 
-                await validateStream(document.getElementById('video-2'), 'second stream');
+                await validateStream(test, document.getElementById('video-2'), 'second stream');
 
             }, 'Second gUM stream');
 

--- a/LayoutTests/fast/mediastream/constraint-intrinsic-size.html
+++ b/LayoutTests/fast/mediastream/constraint-intrinsic-size.html
@@ -17,6 +17,7 @@
                 let settings = stream.getVideoTracks()[0].getSettings();
                 defaultWidth = settings.width;
                 defaultHeight = settings.height;
+                stream.getTracks().forEach(track => track.stop());
             }, "setup");
             
             promise_test((test) => {
@@ -24,6 +25,7 @@
                     .then((stream) => {
                         let settings = stream.getVideoTracks()[0].getSettings()
                         assert_equals(settings.height, Math.floor(640 * (defaultHeight / defaultWidth)));
+                        stream.getTracks().forEach(track => track.stop());
                     })
             }, "height calculated correctly only width is specified");
 
@@ -33,6 +35,7 @@
                     .then((stream) => {
                         let settings = stream.getVideoTracks()[0].getSettings()
                         assert_equals(settings.width, Math.floor(240 * (defaultWidth / defaultHeight)));
+                        stream.getTracks().forEach(track => track.stop());
                     })
             }, "width calculated correctly only height is specified");
 

--- a/LayoutTests/fast/mediastream/default-camera-test.html
+++ b/LayoutTests/fast/mediastream/default-camera-test.html
@@ -25,12 +25,15 @@
 
         let stream = await navigator.mediaDevices.getUserMedia({ video: true });
         assert_equals(stream.getVideoTracks()[0].label, "my new camera");
+        stream.getTracks().forEach(track => track.stop());
 
         stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' } });
         assert_equals(stream.getVideoTracks()[0].label, "Mock video device 1");
+        stream.getTracks().forEach(track => track.stop());
 
         stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
         assert_equals(stream.getVideoTracks()[0].label, "Mock video device 2");
+        stream.getTracks().forEach(track => track.stop());
     }, "Check default cameras in case of default device having an unknown facing mode");
     </script>
 </body>

--- a/LayoutTests/fast/mediastream/delayed-permission-allowed.html
+++ b/LayoutTests/fast/mediastream/delayed-permission-allowed.html
@@ -20,6 +20,7 @@ if (window.testRunner)
 var options = {audio: true, video: true};
 navigator.mediaDevices.getUserMedia(options)
     .then(stream => {
+       stream.getTracks().forEach(track => track.stop());
        if (permissionSet) {
             testPassed('Success callback invoked');
             finishJSTest();

--- a/LayoutTests/fast/mediastream/device-change-event-2.html
+++ b/LayoutTests/fast/mediastream/device-change-event-2.html
@@ -15,7 +15,9 @@
         test.add_cleanup(() => { testRunner.resetMockMediaDevices(); });
 
         testRunner.setUserMediaPermission(true);
-        
+
+        if (stream)
+            stream.getTracks().forEach(track => track.stop());
         stream = null;
     }
 
@@ -70,6 +72,7 @@
         assert_equals(devices[0].label, "my mic");
 
         const micStream = await navigator.mediaDevices.getUserMedia({ audio : { deviceId : "id2" } });
+        test.add_cleanup(() => micStream.getTracks().forEach(track => track.stop()));
         assert_equals(micStream.getAudioTracks()[0].label, "my mic");
     }, "'devicechange' event fired when device list changes");
 
@@ -136,7 +139,7 @@
         await promise;
         assert_equals(document.visibilityState, "visible", "visible2");
 
-        return testPromise;
+        await testPromise;
     }, "'devicechange' event is not fired when the document is not visible");
     </script>
 </head>

--- a/LayoutTests/fast/mediastream/device-change-event-3.html
+++ b/LayoutTests/fast/mediastream/device-change-event-3.html
@@ -13,7 +13,8 @@
         promise = new Promise(resolve => {
             navigator.mediaDevices.ondevicechange = resolve;
         });
-        await navigator.mediaDevices.getUserMedia({ audio:true, video:false });
+        const stream1 = await navigator.mediaDevices.getUserMedia({ audio:true, video:false });
+        test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
 
         await promise;
         const devices2 = await navigator.mediaDevices.enumerateDevices();
@@ -21,7 +22,8 @@
         promise = new Promise(resolve => {
             navigator.mediaDevices.ondevicechange = resolve;
         });
-        await navigator.mediaDevices.getUserMedia({ audio:false, video:true });
+        const stream2 = await navigator.mediaDevices.getUserMedia({ audio:false, video:true });
+        test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
         await promise;
 
         await promise;

--- a/LayoutTests/fast/mediastream/device-change-event-4.html
+++ b/LayoutTests/fast/mediastream/device-change-event-4.html
@@ -12,7 +12,8 @@
         promise = new Promise(resolve => {
             navigator.mediaDevices.ondevicechange = resolve;
         });
-        await navigator.mediaDevices.getUserMedia({ audio:false, video:true });
+        const stream = await navigator.mediaDevices.getUserMedia({ audio:false, video:true });
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
         await promise;
         const devices2 = await navigator.mediaDevices.enumerateDevices();
@@ -20,7 +21,8 @@
         promise = new Promise(resolve => {
             navigator.mediaDevices.ondevicechange = resolve;
         });
-        await navigator.mediaDevices.getUserMedia({ audio:true, video:false });
+        const stream2 = await navigator.mediaDevices.getUserMedia({ audio:true, video:false });
+        test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
         await promise;
 
         await promise;

--- a/LayoutTests/fast/mediastream/enumerate-devices-change-event.html
+++ b/LayoutTests/fast/mediastream/enumerate-devices-change-event.html
@@ -20,7 +20,7 @@
                 reject("navigator.mediaDevices.ondevicechange took too long")
             }, 4000);
 
-            navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+            navigator.mediaDevices.getUserMedia({ audio:true, video:true }).then(stream => stream.getTracks().forEach(track => track.stop()));
         });
 
         let devices2 = await navigator.mediaDevices.enumerateDevices();

--- a/LayoutTests/fast/mediastream/enumerate-speaker.html
+++ b/LayoutTests/fast/mediastream/enumerate-speaker.html
@@ -25,7 +25,8 @@
     promise_test(async (test) => {
         window.internals.settings.setExposeSpeakersWithoutMicrophoneEnabled(false);
 
-        await navigator.mediaDevices.getUserMedia({ audio:true, video:true })
+        const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true })
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         let devices = await navigator.mediaDevices.enumerateDevices();
         assert_true(devices.length > 2, "after getting permission, more than 1 camera and 1 microphone are exposed");
         devices.forEach((device) => {

--- a/LayoutTests/fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-camera-denied-expose-with-capture.html
@@ -6,7 +6,8 @@
 <script src="../../resources/testharnessreport.js"></script>
 <script>
 promise_test(async (test) => {
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     if (window.testRunner)
        testRunner.resetUserMediaPermission();

--- a/LayoutTests/fast/mediastream/enumerateDevices-camera-denied.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-camera-denied.html
@@ -6,7 +6,8 @@
 <script src="../../resources/testharnessreport.js"></script>
 <script>
 promise_test(async (test) => {
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     if (window.testRunner)
        testRunner.resetUserMediaPermission();
@@ -19,7 +20,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(false);
 
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices)
         assert_true(device.label === "" || device.kind !== "videoinput");
@@ -29,7 +31,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(true);
 
-    await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices) {
         if (device.kind === "videoinput")

--- a/LayoutTests/fast/mediastream/enumerateDevices-microphone-denied-expose-with-capture.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-microphone-denied-expose-with-capture.html
@@ -6,7 +6,8 @@
 <script src="../../resources/testharnessreport.js"></script>
 <script>
 promise_test(async (test) => {
-    await navigator.mediaDevices.getUserMedia({ video : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
 
     if (window.testRunner)
        testRunner.resetUserMediaPermission();
@@ -19,7 +20,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(false);
 
-    await navigator.mediaDevices.getUserMedia({ video : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices)
         assert_true(device.label === "" || device.kind !== "audioinput");

--- a/LayoutTests/fast/mediastream/enumerateDevices-microphone-denied.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-microphone-denied.html
@@ -6,7 +6,8 @@
 <script src="../../resources/testharnessreport.js"></script>
 <script>
 promise_test(async (test) => {
-    await navigator.mediaDevices.getUserMedia({ video : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     if (window.testRunner)
        testRunner.resetUserMediaPermission();
@@ -19,7 +20,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(false);
 
-    await navigator.mediaDevices.getUserMedia({ video : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices)
         assert_true(device.label === "" || device.kind !== "audioinput");
@@ -29,7 +31,8 @@ promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setMicrophonePermission(true);
 
-    await navigator.mediaDevices.getUserMedia({ video : true });
+    const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const devices = await navigator.mediaDevices.enumerateDevices();
     for (const device of devices) {
         if (device.kind === "audioinput")

--- a/LayoutTests/fast/mediastream/get-display-media-capabilities.html
+++ b/LayoutTests/fast/mediastream/get-display-media-capabilities.html
@@ -21,6 +21,7 @@
                 let width = capabilities.width;
                 assert_equals(width.max, 1920);
                 assert_equals(width.min, 1);
+                stream.getTracks().forEach(track => track.stop());
             }, "check capabilities");
 
         </script>

--- a/LayoutTests/fast/mediastream/get-display-media-muted.html
+++ b/LayoutTests/fast/mediastream/get-display-media-muted.html
@@ -38,7 +38,8 @@
 
     promise_test(async (test) => {
         await new Promise(async (resolve, reject) => {
-            let stream = await callGetDisplayMedia({ video: true });
+            const stream = await callGetDisplayMedia({ video: true });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             let pageMediaState = internals.pageMediaState();
 
             assert_false(pageMediaState.includes('HasMutedScreenCaptureDevice'), 'page state does not include HasMutedScreenCaptureDevice');

--- a/LayoutTests/fast/mediastream/get-display-media-settings.html
+++ b/LayoutTests/fast/mediastream/get-display-media-settings.html
@@ -20,6 +20,8 @@
                 assert_true(typeof settings.deviceId === 'string', true);
                 assert_true(typeof capabilities.deviceId === 'string', true);
                 assert_equals(capabilities.deviceId, settings.deviceId);
+
+                stream.getTracks().forEach(track => track.stop());
             }, "check settings");
         </script>
     </body>

--- a/LayoutTests/fast/mediastream/get-user-media-background-tab.html
+++ b/LayoutTests/fast/mediastream/get-user-media-background-tab.html
@@ -13,6 +13,7 @@
                 shouldBe('tabState', "'foreground'");
                 stream = s;
                 shouldBe('stream.getAudioTracks().length', '1');
+                stream.getTracks().forEach(track => track.stop());
                 if (++streams == streamCount)
                     finishJSTest();
             }

--- a/LayoutTests/fast/mediastream/get-user-media-constraints.html
+++ b/LayoutTests/fast/mediastream/get-user-media-constraints.html
@@ -14,6 +14,7 @@
 
     promise_test(async (test) => {
         localVideo.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: {exact: 300}}});
+        test.add_cleanup(() => localVideo.srcObject.getTracks().forEach(track => track.stop()));
         await localVideo.play();
 
         assert_equals(localVideo.videoWidth, 300);

--- a/LayoutTests/fast/mediastream/get-user-media-ideal-constraints.html
+++ b/LayoutTests/fast/mediastream/get-user-media-ideal-constraints.html
@@ -11,6 +11,7 @@
 <script>
 promise_test(async (test) => {
     localVideo.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: 2000, height: 1200, frameRate: 30 }});
+    test.add_cleanup(() => localVideo.srcObject.getTracks().forEach(track => track.stop()));
 
     const settings = localVideo.srcObject.getVideoTracks()[0].getSettings();
     assert_equals(settings.width, 2000, "settings width");

--- a/LayoutTests/fast/mediastream/get-user-media-on-loadedmetadata.html
+++ b/LayoutTests/fast/mediastream/get-user-media-on-loadedmetadata.html
@@ -18,6 +18,7 @@
                     return Promise.reject("this test needs internals API");
 
                 return navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then((stream) => {
+                    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
                     window.internals.delayMediaStreamTrackSamples(stream.getAudioTracks()[0], .5);
                     window.internals.delayMediaStreamTrackSamples(stream.getVideoTracks()[0], .5);
 

--- a/LayoutTests/fast/mediastream/getDisplayMedia-displaySurface.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-displaySurface.html
@@ -10,10 +10,11 @@
     <body>
 
         <script>
-            promise_test(async () => {
+            promise_test(async test => {
                 assert_true(navigator.mediaDevices.getSupportedConstraints().displaySurface, "displaySurface constraint");
 
-                stream = await callGetDisplayMedia({ video: true });
+                const stream = await callGetDisplayMedia({ video: true });
+                test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
                 const settings = stream.getVideoTracks()[0].getSettings();
                 assert_equals(settings.displaySurface, "monitor", "displaySurface settings");

--- a/LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-frame-rate.html
@@ -21,6 +21,7 @@ promise_test(async t => {
     let currentCount = internals.trackVideoSampleCount;
     while (currentCount === internals.trackVideoSampleCount)
         await new Promise(resolve => setTimeout(resolve, 50));
+    stream.getTracks().forEach(track => track.stop());
 }, "Ensure getDisplayMedia generate frames");
 
 promise_test(async t => {
@@ -69,6 +70,9 @@ promise_test(async t => {
             return;
     };
     assert_not_equals(counter, 10);
+
+    stream.getTracks().forEach(track => track.stop());
+    stream2.getTracks().forEach(track => track.stop());
 }, "Ensure getDisplayMedia generate frames with valid frame rate and size in case of clones");
         </script>
     </body>

--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints1.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints1.html
@@ -16,6 +16,7 @@ promise_test(async () => {
     let settings = stream.getVideoTracks()[0].getSettings();
     defaultWidth = settings.width;
     defaultHeight = settings.height;
+    stream.getTracks().forEach(track => track.stop());
 }, "setup");
 
 promise_test(async (test) => {
@@ -26,6 +27,7 @@ promise_test(async (test) => {
 
     const settings = stream.getVideoTracks()[0].getSettings()
     assert_equals(settings.width, 500);
+    stream.getTracks().forEach(track => track.stop());
 }, "Maximize the width if max height is too big");
         </script>
     </body>

--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints2.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints2.html
@@ -11,8 +11,9 @@
         <script>
 let defaultWidth;
 let defaultHeight;
-promise_test(async () => {
-    stream = await callGetDisplayMedia({ video: true });
+promise_test(async (test) => {
+    const stream = await callGetDisplayMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     let settings = stream.getVideoTracks()[0].getSettings();
     defaultWidth = settings.width;
     defaultHeight = settings.height;
@@ -20,6 +21,7 @@ promise_test(async () => {
 
 promise_test(async (test) => {
     const stream = await callGetDisplayMedia({ video: { height: { max: 100 }, width : { max : 500 } } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const expectedWidth = Math.floor(100 * (defaultWidth / defaultHeight)) 
     await waitForWidth(stream.getVideoTracks()[0], expectedWidth);

--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints3.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints3.html
@@ -11,8 +11,9 @@
         <script>
 let defaultWidth;
 let defaultHeight;
-promise_test(async () => {
-    stream = await callGetDisplayMedia({ video: true });
+promise_test(async (test) => {
+    const stream = await callGetDisplayMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     let settings = stream.getVideoTracks()[0].getSettings();
     defaultWidth = settings.width;
     defaultHeight = settings.height;
@@ -20,6 +21,7 @@ promise_test(async () => {
 
 promise_test(async (test) => {
     const stream = await callGetDisplayMedia({ video: { height: { max: 500000 }, width : { max : 500000 } } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     assert_equals(stream.getVideoTracks()[0].getConstraints().height.max, 500000);
     assert_equals(stream.getVideoTracks()[0].getConstraints().width.max, 500000);
 

--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4.html
@@ -12,6 +12,7 @@
         <script>
 promise_test(async (test) => {
     const stream = await callGetDisplayMedia({ video: { height: { max: 2000 }, width : { max : 3000 } } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video.srcObject = stream;
     await video.play();
 

--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints5.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints5.html
@@ -27,7 +27,9 @@ async function validateSize(test, stream, width, height, name)
 
 promise_test(async (test) => {
     const stream = await callGetDisplayMedia({ video: { height: { max: 2000 }, width : { max : 3000 } } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const streamClone = stream.clone();
+    test.add_cleanup(() => streamClone.getTracks().forEach(track => track.stop()));
 
     await validateSize(test, stream, 1920, 1080, "video original")
     await validateSize(test, streamClone, 1920, 1080, "video clone")

--- a/LayoutTests/fast/mediastream/getDisplayMedia-size.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-size.html
@@ -11,14 +11,16 @@
         <video id="video1" autoplay></video>
         <video id="video2" autoplay></video>
         <script>
-promise_test(async () => {
+promise_test(async t => {
     const stream1 = await callGetDisplayMedia({ video: { width: 640, height:480 } });
+    t.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     video1.srcObject = stream1;
     await video1.play();
 
     assert_equals(video1.videoWidth, 640);
 
     const stream2 = stream1.clone();
+    t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     await stream2.getVideoTracks()[0].applyConstraints({ width: 320, height: 240 });
     video2.srcObject = stream2;
     await video2.play();
@@ -34,8 +36,9 @@ promise_test(async () => {
     }, "original source should stay at a small size");
 }, "Ensure getDisplayMedia size can be reduced with applyConstraints");
 
-promise_test(async () => {
+promise_test(async t => {
     const stream1 = await callGetDisplayMedia({ video: { width: 640, height:480 } });
+    t.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     video1.srcObject = stream1;
     await video1.play();
 

--- a/LayoutTests/fast/mediastream/getDisplayMedia-successive-call.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-successive-call.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/getUserMedia-deny-persistency-reload.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-deny-persistency-reload.html
@@ -22,10 +22,11 @@ function test() {
         });
     } else {
         window.localStorage.clear();
-        navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(() => {
+        navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(stream => {
             result.innerHTML = "PASS";
             if (window.testRunner)
                testRunner.notifyDone();
+            stream.getTracks().forEach(track => track.stop());
         }, () => {
             result.innerHTML = "FAIL";
             if (window.testRunner)

--- a/LayoutTests/fast/mediastream/getUserMedia-deny-persistency2.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-deny-persistency2.html
@@ -19,7 +19,8 @@ promise_test((test) => {
         });
     }).then(() => {
         return navigator.mediaDevices.getUserMedia({audio:false, video:true});
-    }).then(() => {
+    }).then(stream => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return navigator.mediaDevices.getUserMedia({audio:true, video:false}).then(assert_unreached, (e) => {
             assert_equals(e.name, "NotAllowedError");
         });

--- a/LayoutTests/fast/mediastream/getUserMedia-deny-persistency4.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-deny-persistency4.html
@@ -14,10 +14,12 @@ promise_test(async (test) => {
     });
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
-    await navigator.mediaDevices.getUserMedia({video:true});
+    const stream2 = await navigator.mediaDevices.getUserMedia({video:true});
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     if (window.testRunner)
         testRunner.setUserMediaPermission(false);
-    await navigator.mediaDevices.getUserMedia({video:true});
+    const stream3 = await navigator.mediaDevices.getUserMedia({video:true});
+    test.add_cleanup(() => stream3.getTracks().forEach(track => track.stop()));
 
     await navigator.mediaDevices.getUserMedia({audio:true}).then(assert_unreached, (e) => {
         assert_equals(e.name, "NotAllowedError");

--- a/LayoutTests/fast/mediastream/getUserMedia-deny-persistency5.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-deny-persistency5.html
@@ -25,22 +25,27 @@ promise_test(async (test) => {
     internals.withUserGesture(() => {
         promise = navigator.mediaDevices.getUserMedia({audio:false, video:true});
     });
-    await promise;
+    const stream = await promise;
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     // We still have audio denied.
     await navigator.mediaDevices.getUserMedia({audio:true, video:false}).then(assert_unreached, (e) => { });
     await navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(assert_unreached, (e) => { });
 
-    await navigator.mediaDevices.getUserMedia({audio:false, video:true});
+    const stream1 = await navigator.mediaDevices.getUserMedia({audio:false, video:true});
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
 
     internals.withUserGesture(() => {
         promise = navigator.mediaDevices.getUserMedia({audio:true, video:false});
     });
-    await promise;
+    const stream2 = await promise;
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
 
     // We should neither have audio nor video denied anymore.
-    await navigator.mediaDevices.getUserMedia({audio:true, video:false});
-    await navigator.mediaDevices.getUserMedia({audio:true, video:true});
+    const stream3 = await navigator.mediaDevices.getUserMedia({audio:true, video:false});
+    test.add_cleanup(() => stream3.getTracks().forEach(track => track.stop()));
+    const stream4 = await navigator.mediaDevices.getUserMedia({audio:true, video:true});
+    test.add_cleanup(() => stream4.getTracks().forEach(track => track.stop()));
 }, "Testing getUserMedia with and without user gesture after user denied access");
         </script>
     </body>

--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
@@ -1,21 +1,25 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script>
-promise_test(async () => {
+promise_test(async test => {
     const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } });
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     assert_false(stream1.getAudioTracks()[0].getSettings().echoCancellation);
 
     const stream2 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     assert_true(stream2.getAudioTracks()[0].getSettings().echoCancellation);
 }, "echoCancellation should be on by default if not explictly disabled");
 
-promise_test(async () => {
+promise_test(async test => {
     const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: { exact : false } } });
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     assert_false(stream1.getAudioTracks()[0].getSettings().echoCancellation);
 }, "echoCancellation should be off with exact false echoCancellation");
 
-promise_test(async () => {
+promise_test(async test => {
     const stream0 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream0.getTracks().forEach(track => track.stop()));
     assert_true(stream0.getAudioTracks()[0].getSettings().echoCancellation);
     assert_array_equals(stream0.getAudioTracks()[0].getCapabilities().echoCancellation, [true, false]);
 
@@ -29,10 +33,12 @@ promise_test(async () => {
     }
 
     const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { deviceId : deviceWithOnlyEchoCancellation.deviceId } });
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     assert_true(stream1.getAudioTracks()[0].getSettings().echoCancellation);
     assert_array_equals(stream1.getAudioTracks()[0].getCapabilities().echoCancellation, [true]);
 
     const stream2 = await navigator.mediaDevices.getUserMedia({ audio: { deviceId : deviceWithoutEchoCancellation.deviceId } });
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     assert_false(stream2.getAudioTracks()[0].getSettings().echoCancellation);
     assert_array_equals(stream2.getAudioTracks()[0].getCapabilities().echoCancellation, [false]);
 }, "Check capabilities with devices with only echo cancellation or without echo cancellation");

--- a/LayoutTests/fast/mediastream/getUserMedia-frame-rate-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-frame-rate-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS Ensure getDisplayMedia generate frames with valid frame rate and size in case of clones
+PASS Ensure getUserMedia generate frames with valid frame rate and size in case of clones
 

--- a/LayoutTests/fast/mediastream/getUserMedia-frame-rate.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-frame-rate.html
@@ -9,11 +9,13 @@
         <video id=video1 autoplay playsInline width=100px></video>
         <video id=video2 autoplay playsInline width=100px></video>
         <script>
-promise_test(async () => {
+promise_test(async test => {
     const stream = await navigator.mediaDevices.getUserMedia({ video: { width:1280, height:720, frameRate : 30 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     assert_equals(stream.getVideoTracks()[0].getSettings().frameRate, 30);
 
     const stream2 = await navigator.mediaDevices.getUserMedia({ video: { width:640, height:480, frameRate : 1 } });
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     assert_equals(stream2.getVideoTracks()[0].getSettings().frameRate, 1);
 
     video1.srcObject = stream;
@@ -40,7 +42,7 @@ promise_test(async () => {
     }
 
     assert_true(internals.trackVideoSampleCount - currentCount > 2);
-}, "Ensure getDisplayMedia generate frames with valid frame rate and size in case of clones");
+}, "Ensure getUserMedia generate frames with valid frame rate and size in case of clones");
         </script>
     </body>
 </html>

--- a/LayoutTests/fast/mediastream/getUserMedia-grant-persistency-reload.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-grant-persistency-reload.html
@@ -11,14 +11,16 @@ function test() {
         window.localStorage.setItem("gum-after-reload", "true")
         if (window.testRunner)
             testRunner.setUserMediaPermission(true);
-        navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(() => {
+        navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(stream => {
+            stream.getTracks().forEach(track => track.stop());
             internals.forceReload(true);
         });
     } else {
         window.localStorage.clear();
         if (window.testRunner)
             testRunner.setUserMediaPermission(false);
-        navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(() => {i
+        navigator.mediaDevices.getUserMedia({audio:true, video:true}).then(stream => {
+            stream.getTracks().forEach(track => track.stop());
             result.innerHTML = "FAIL";
             if (window.testRunner)
                testRunner.notifyDone();

--- a/LayoutTests/fast/mediastream/getUserMedia-grant-persistency2.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-grant-persistency2.html
@@ -11,14 +11,18 @@ promise_test((test) => {
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
     return navigator.mediaDevices.getUserMedia({audio:false, video:true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         if (window.testRunner)
             testRunner.setUserMediaPermission(false);
         return navigator.mediaDevices.getUserMedia({audio:false, video:true});
-    }).then(() => {
+    }).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     }).then(() => {
         window.location = "#navigateToSamePage";
     }).then(() => {
         return navigator.mediaDevices.getUserMedia({audio:false, video:true});
+    }).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     });
 }, "Testing same page getUserMedia grant persistency after in page navigation");
         </script>

--- a/LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint.html
@@ -35,7 +35,7 @@ for (let name in allowedVideoConstraints) {
     promise_test(async (t) => {
         const constraints = { };
         constraints[name] = { exact : allowedVideoConstraints[name] };
-        return navigator.mediaDevices.getUserMedia({ video: constraints  });
+        return navigator.mediaDevices.getUserMedia({ video: constraints  }).then( stream => t.add_cleanup(() => stream.getTracks().forEach(track => track.stop())));
     }, "Mandatory video allowed constraint " + name);
 }
 

--- a/LayoutTests/fast/mediastream/getUserMedia-media-element-display-none.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-media-element-display-none.html
@@ -10,6 +10,7 @@
         <script>
 promise_test(async (test) => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     await video.play();
     video.style.display = 'none';
     return new Promise((resolve, reject) => {

--- a/LayoutTests/fast/mediastream/getUserMedia-rvfc.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-rvfc.html
@@ -24,6 +24,7 @@ async function grabNextMetadata(video)
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     video.srcObject = localStream;
     await video.play();
 
@@ -47,6 +48,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     video.srcObject = localStream;
     await video.play();
 
@@ -69,6 +71,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     video.srcObject = localStream;
     await video.play();
 
@@ -87,6 +90,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     video.srcObject = localStream;
     await video.play();
     localStream.getVideoTracks()[0].enabled = false;

--- a/LayoutTests/fast/mediastream/getUserMedia-video-rescaling.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-video-rescaling.html
@@ -11,6 +11,7 @@
         <script>
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width : { exact : 100 }, height : { exact : 100 }, facingMode: "environment" } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 
     video.srcObject = localStream;
     await video.play();
@@ -21,6 +22,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width : { exact : 100 }, facingMode: "environment" } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 
     video.srcObject = localStream;
     await video.play();
@@ -31,6 +33,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { height : { exact : 100 }, facingMode: "environment" } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 
     video.srcObject = localStream;
     await video.play();

--- a/LayoutTests/fast/mediastream/getUserMedia-webaudio.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-webaudio.html
@@ -15,6 +15,7 @@ if (window.testRunner)
 var finishTest, errorTest;
 promise_test((test) => {
     return navigator.mediaDevices.getUserMedia({ audio: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             finishTest = resolve;
             errorTest = reject;
@@ -50,6 +51,7 @@ promise_test(async (test) => {
         return Promise.reject("Internals API required");
 
     const stream = await navigator.mediaDevices.getUserMedia({ audio: {deviceId: true}});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     internals.setMockAudioTrackChannelNumber(stream.getAudioTracks()[0], 1);
 
     var audioContext = new AudioContext();
@@ -71,6 +73,7 @@ promise_test(async (test) => {
     if (!window.internals)
         return Promise.reject("Internals API required");
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     internals.useMockAudioDestinationCocoa();
 
     var audioContext = new AudioContext();
@@ -107,10 +110,12 @@ promise_test(async (test) => {
     assert_true(stream.getAudioTracks()[0].getConstraints().echoCancellation);
     assert_true(stream.getAudioTracks()[0].getSettings().echoCancellation);
     assert_true(await checkForNoise(stream, false), "should not hear noise");
+    stream.getTracks().forEach(track => track.stop());
 
     stream = await navigator.mediaDevices.getUserMedia({audio: { echoCancellation : false}});
     assert_false(stream.getAudioTracks()[0].getSettings().echoCancellation, "settings is ok");
     assert_true(await checkForNoise(stream, true), "heard noise");
+    stream.getTracks().forEach(track => track.stop());
 
     context.close();
     context = null;

--- a/LayoutTests/fast/mediastream/granted-denied-request-management1.html
+++ b/LayoutTests/fast/mediastream/granted-denied-request-management1.html
@@ -26,7 +26,8 @@ promise_test(async (test) => {
     });
     await promise;
 
-    return navigator.mediaDevices.getUserMedia({ audio: true });
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 }, "Remove audio denied request upon successful audio request");
     </script>
 </body>

--- a/LayoutTests/fast/mediastream/image-capture-creation.html
+++ b/LayoutTests/fast/mediastream/image-capture-creation.html
@@ -13,6 +13,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getAudioTracks();
 
             assert_true(track.enabled);

--- a/LayoutTests/fast/mediastream/image-capture-get-photo-capabilities.html
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-capabilities.html
@@ -13,6 +13,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             assert_equals(track.readyState, 'live');
@@ -36,6 +37,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             const imageCapture = new ImageCapture(track);

--- a/LayoutTests/fast/mediastream/image-capture-get-photo-settings.html
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-settings.html
@@ -12,6 +12,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             assert_equals(track.readyState, 'live');
@@ -35,6 +36,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             assert_equals(track.readyState, 'live');
@@ -51,6 +53,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, torch : true } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             const imageCapture = new ImageCapture(track);

--- a/LayoutTests/fast/mediastream/image-capture-take-photo.html
+++ b/LayoutTests/fast/mediastream/image-capture-take-photo.html
@@ -11,6 +11,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             assert_equals(track.readyState, 'live');
@@ -34,6 +35,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             assert_equals(track.readyState, 'live');
@@ -50,6 +52,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
 
             const imageCapture = new ImageCapture(track);
@@ -67,6 +70,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 320 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
             const { width: originalWidth, height: originalHeight } = track.getSettings();
 
@@ -93,6 +97,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 320 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
             const imageCapture = new ImageCapture(track);
 
@@ -118,6 +123,7 @@
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 320 } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             const [track] = stream.getVideoTracks();
             const imageCapture = new ImageCapture(track);
 

--- a/LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html
+++ b/LayoutTests/fast/mediastream/keep-microphone-muted-on-uninterruption.html
@@ -10,6 +10,7 @@
     <script>
     promise_test(async (test) => {
         const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
         const onMutePromise = new Promise(resolve => stream.getAudioTracks()[0].onmute = resolve);
         if (window.internals)

--- a/LayoutTests/fast/mediastream/local-audio-playing-event.html
+++ b/LayoutTests/fast/mediastream/local-audio-playing-event.html
@@ -15,12 +15,14 @@
 
     promise_test(async (test) => {
         audio.srcObject = await navigator.mediaDevices.getUserMedia({audio: true});
+        test.add_cleanup(() => audio.srcObject.getTracks().forEach(track => track.stop()));
         var eventWatcher = new EventWatcher(test, audio, 'playing');
         return eventWatcher.wait_for('playing');
     }, 'Local audio playback fires playing event');
 
     promise_test(async (test) => {
         audioNoAutoplay.srcObject = await navigator.mediaDevices.getUserMedia({audio: true});
+        test.add_cleanup(() => audioNoAutoplay.srcObject.getTracks().forEach(track => track.stop()));
         audioNoAutoplay.play();
         var eventWatcher = new EventWatcher(test, audioNoAutoplay, 'playing');
         return eventWatcher.wait_for('playing');

--- a/LayoutTests/fast/mediastream/media-device-info.html
+++ b/LayoutTests/fast/mediastream/media-device-info.html
@@ -49,6 +49,7 @@
 
     promise_test(async (test) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const devices = await navigator.mediaDevices.enumerateDevices();
 
         const audioTrack = stream.getAudioTracks()[0];

--- a/LayoutTests/fast/mediastream/media-devices-enumerate-devices.html
+++ b/LayoutTests/fast/mediastream/media-devices-enumerate-devices.html
@@ -50,6 +50,7 @@
 
             return navigator.mediaDevices.getUserMedia({audio:{}, video:{}})
                 .then((stream) => {
+                    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
                     return navigator.mediaDevices.enumerateDevices()
                         .then((devices) => {
                             assert_equals(deviceCount, devices.length, "same devices revealed when authenticated as with persistent access");

--- a/LayoutTests/fast/mediastream/media-element-current-time.html
+++ b/LayoutTests/fast/mediastream/media-element-current-time.html
@@ -5,9 +5,10 @@
 <script src="../../media/utilities.js"></script>
 <script>
 
-promise_test(async() => {
+promise_test(async test => {
 
-    let stream = await navigator.mediaDevices.getUserMedia({video : true});
+    const stream = await navigator.mediaDevices.getUserMedia({video : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     video.srcObject = stream;
     assert_equals(video.currentTime, 0);

--- a/LayoutTests/fast/mediastream/media-stream-page-muted.html
+++ b/LayoutTests/fast/mediastream/media-stream-page-muted.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <title>mediastream page muted</title>
@@ -194,6 +194,7 @@
             }
 
             finishJSTest();
+            cameraStream.getTracks().forEach(track => track.stop());
         })()
 
     </script>

--- a/LayoutTests/fast/mediastream/media-stream-renders-first-frame.html
+++ b/LayoutTests/fast/mediastream/media-stream-renders-first-frame.html
@@ -38,8 +38,9 @@ function checkCanvas(canvas, stream)
     });
 }
 
-promise_test(async () => {
+promise_test(async test => {
     let stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    stream.getTracks().forEach(track => track.stop());
     stream = null;
 
     const devices = await navigator.mediaDevices.enumerateDevices();
@@ -48,6 +49,7 @@ promise_test(async () => {
     assert_true(cameraID !== undefined, "Found camera2");
     
     stream = await navigator.mediaDevices.getUserMedia({ video: { deviceId: { exact: cameraID } } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     
     return checkCanvas(canvas, stream);
 

--- a/LayoutTests/fast/mediastream/media-stream-track-muted-event.html
+++ b/LayoutTests/fast/mediastream/media-stream-track-muted-event.html
@@ -10,6 +10,7 @@
     <script>
     promise_test(async (test) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true});
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         if (!window.internals)
             return;
         const track = stream.getTracks()[0];

--- a/LayoutTests/fast/mediastream/media-stream-video-track-interrupted-from-audio.html
+++ b/LayoutTests/fast/mediastream/media-stream-video-track-interrupted-from-audio.html
@@ -10,6 +10,7 @@
     <script>
     promise_test(async (test) => {
         const stream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const track = stream.getVideoTracks()[0];
         if (!window.testRunner)
             return;

--- a/LayoutTests/fast/mediastream/mediaElement-gc.html
+++ b/LayoutTests/fast/mediastream/mediaElement-gc.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/mediaPlayer-visibility.html
+++ b/LayoutTests/fast/mediastream/mediaPlayer-visibility.html
@@ -7,22 +7,24 @@
 <script src="../../resources/testharnessreport.js"></script>
 <script>
 
-promise_test(async() => {
+promise_test(async test => {
     if (!window.internals)
        return Promise.reject("Test requires internals API");
 
     const stream = await navigator.mediaDevices.getUserMedia({video : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video1.srcObject = stream;
     await video1.play();
 
     assert_true(internals.isPlayerVisibleInViewport(video1), "video1");
 }, "Check default media stream player visibility");
 
-promise_test(async() => {
+promise_test(async test => {
    if (!window.internals)
         return Promise.reject("Test requires internals API");
 
     const stream = await navigator.mediaDevices.getUserMedia({video : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video2.srcObject = stream;
     await video2.play();
 
@@ -37,12 +39,13 @@ promise_test(async() => {
     assert_false(internals.isPlayerVisibleInViewport(video2), "video2 3");
 }, "Check media stream player visibility with CSS");
 
-promise_test(async() => {
+promise_test(async test => {
     if (!window.internals)
         return Promise.reject("Test requires internals API");
 
     const video3 = document.createElement("video");
     const stream = await navigator.mediaDevices.getUserMedia({video : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video3.srcObject = stream;
     video3.playsInline = true;
     await video3.play();

--- a/LayoutTests/fast/mediastream/mediaStream-with-rotation.html
+++ b/LayoutTests/fast/mediastream/mediaStream-with-rotation.html
@@ -35,6 +35,7 @@
         if (window.testRunner)
             testRunner.setMockCameraOrientation(90);
         const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         let result1 = await setVideo(t, stream);
 
         let blob = await record(stream, 'video/webm');
@@ -48,6 +49,7 @@
         if (window.testRunner)
             testRunner.setMockCameraOrientation(90);
         const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         let result1 = await setVideo(t, stream);
 
         let blob = await record(stream, 'video/mp4');

--- a/LayoutTests/fast/mediastream/mediastreamtrack-audio-mute.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-audio-mute.html
@@ -11,6 +11,7 @@
 var context = new AudioContext();
 promise_test(async (t) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const audioTrack = stream.getAudioTracks()[0];
 
     assert_true(await doHumAnalysis(stream, true), "Heard hum from track");

--- a/LayoutTests/fast/mediastream/mediastreamtrack-audiovideo-mutepage.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-audiovideo-mutepage.html
@@ -10,6 +10,7 @@
     <script>
     promise_test(async (t) => {
         video.srcObject = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        t.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
         await video.play();
 
         if (!window.internals)

--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html
@@ -14,6 +14,7 @@
             return;
 
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const track = stream.getAudioTracks()[0];
 
         video.srcObject = stream;
@@ -39,6 +40,7 @@
             return;
 
         const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const track = stream.getVideoTracks()[0];
 
         video.srcObject = stream;

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur.html
@@ -12,12 +12,14 @@
             assert_true(navigator.mediaDevices.getSupportedConstraints().backgroundBlur, "supported constraint");
 
             const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode : "environment" } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             assert_array_equals(stream.getVideoTracks()[0].getCapabilities().backgroundBlur, [true], 'capabilities');
             assert_true(stream.getVideoTracks()[0].getSettings().backgroundBlur, 'settings');
         }, 'getUserMedia backgroundBlur on');
 
         promise_test(async (test) => {
             const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode : "user" } });
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             assert_array_equals(stream.getVideoTracks()[0].getCapabilities().backgroundBlur, [false], 'capabilities');
             assert_false(stream.getVideoTracks()[0].getSettings().backgroundBlur, 'settings');
         }, 'getUserMedia backgroundBlur off');

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html
@@ -12,7 +12,9 @@
     <script>
 promise_test(async (t) => {
     const stream1 = await navigator.mediaDevices.getUserMedia({ video: { width: 720, frameRate : 30 } });
+    t.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     const stream2 = stream1.clone();
+    t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
 
     await stream2.getVideoTracks()[0].applyConstraints({ width : 160, frameRate : 5 });
 

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html
@@ -12,7 +12,10 @@
     <script>
 promise_test(async (t) => {
     const stream1 = await navigator.mediaDevices.getUserMedia({ video: { width: 160, frameRate : 5 } });
+    t.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
+    
     const stream2 = stream1.clone();
+    t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
 
     await stream2.getVideoTracks()[0].applyConstraints({ width : 720, frameRate : 30 });
 

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-decreasing.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-decreasing.html
@@ -12,7 +12,9 @@
     <script>
 promise_test(async (t) => {
     const stream1 = await navigator.mediaDevices.getUserMedia({ video: { width: 720, frameRate : 30 } });
+    t.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     const stream2 = await navigator.mediaDevices.getUserMedia({ video: { width: 160, frameRate : 5 } });
+    t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
 
     // We adapt frame rate after 1 second of samples.
     await new Promise(resolve => setTimeout(resolve, 1000));

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-increasing.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-frameRate-increasing.html
@@ -12,7 +12,9 @@
     <script>
 promise_test(async (t) => {
     const stream1 = await navigator.mediaDevices.getUserMedia({ video: { width: 160, frameRate : 5 } });
+    t.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
     const stream2 = await navigator.mediaDevices.getUserMedia({ video: { width: 720, frameRate : 30 } });
+    t.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
 
     // We adapt frame rate after 1 second of samples.
     await new Promise(resolve => setTimeout(resolve, 1000));

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-resize-event.html
@@ -34,6 +34,7 @@ async function validateVideoFrameSize(video, width)
 
 promise_test(async (t) => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { width: 1280 } });
+    t.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     if (video.requestVideoFrameCallback)
         await new Promise((resolve, reject) => {
             video.requestVideoFrameCallback(resolve);

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-torch.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-torch.html
@@ -16,6 +16,7 @@
             stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
             assert_equals(stream.getVideoTracks()[0].getSettings().torch, undefined, 'settings-1');
             assert_equals(stream.getVideoTracks()[0].getCapabilities().torch, undefined, 'capabilities-1');
+            stream.getTracks().forEach(track => track.stop());
 
             stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, torch : true } });
             assert_equals(stream.getVideoTracks()[0].getCapabilities().torch, true, 'capabilities-2');
@@ -26,6 +27,7 @@
             await stream.getVideoTracks()[0].applyConstraints({ torch : false });
             assert_equals(stream.getVideoTracks()[0].getSettings().torch, false, 'settings -3');
 
+            stream.getTracks().forEach(track => track.stop());
         }, 'getUserMedia torch');
     </script>
 </body>

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-white-balance-mode.html
@@ -16,6 +16,7 @@
             stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
             assert_equals(stream.getVideoTracks()[0].getSettings().whiteBalanceMode, undefined, 'settings-1');
             assert_equals(stream.getVideoTracks()[0].getCapabilities().whiteBalanceMode, undefined, 'capabilities-1');
+            stream.getTracks().forEach(track => track.stop());
 
             stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, whiteBalanceMode : 'single-shot' } });
             assert_equals(stream.getVideoTracks()[0].getSettings().whiteBalanceMode, 'single-shot', 'settings-2');
@@ -23,6 +24,7 @@
             await stream.getVideoTracks()[0].applyConstraints({ whiteBalanceMode : 'manual' });
             assert_equals(stream.getVideoTracks()[0].getSettings().whiteBalanceMode, 'manual', 'settings -3');
 
+            stream.getTracks().forEach(track => track.stop());
         }, 'getUserMedia whiteBalanceMode');
     </script>
 </body>

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-zoom.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-zoom.html
@@ -41,13 +41,15 @@ function isVideoRed(startX, startY, grabbedWidth, grabbedHeight)
     return true;
 }
 var stream;
-promise_test(async (t) => {
-    stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640 } });
+promise_test(async test => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ video: { width: 640 } });
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
 
-    assert_equals(stream.getVideoTracks()[0].getSettings().zoom, undefined, "settings");
-    assert_equals(stream.getVideoTracks()[0].getCapabilities().zoom, undefined, "capabilities");
+    assert_equals(stream1.getVideoTracks()[0].getSettings().zoom, undefined, "settings");
+    assert_equals(stream1.getVideoTracks()[0].getCapabilities().zoom, undefined, "capabilities");
 
-    stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, facingMode: "environment" } });
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, facingMode: "environment" } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     assert_equals(stream.getVideoTracks()[0].getSettings().zoom, 1, "settings2");
     assert_equals(stream.getVideoTracks()[0].getCapabilities().zoom.min, 1, "min2");

--- a/LayoutTests/fast/mediastream/mock-media-source-webaudio.html
+++ b/LayoutTests/fast/mediastream/mock-media-source-webaudio.html
@@ -67,6 +67,7 @@
                 assert_true(heardBip);
                 assert_true(heardBop);
                 test.done();
+                stream.getTracks().forEach(track => track.stop());
             };
 
             var timeout = setTimeout(() => { done(); }, 3000);

--- a/LayoutTests/fast/mediastream/mock-media-source.html
+++ b/LayoutTests/fast/mediastream/mock-media-source.html
@@ -13,6 +13,7 @@
                         mediaStream = stream;
                         shouldBeType("mediaStream", "Object");
                         shouldBe("mediaStream.getTracks().length", "2");
+                        mediaStream.getTracks().forEach(track => track.stop());
 
                         if (nextTest)
                             nextTest();

--- a/LayoutTests/fast/mediastream/now-playing-and-mediastream.html
+++ b/LayoutTests/fast/mediastream/now-playing-and-mediastream.html
@@ -27,6 +27,7 @@ promise_test(async test => {
     assert_false(!!internals.nowPlayingState.uniqueIdentifier, "test1");
 
     video.srcObject = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     await video.play();
 
     await waitFor(500);

--- a/LayoutTests/fast/mediastream/play-newly-added-audio-track.html
+++ b/LayoutTests/fast/mediastream/play-newly-added-audio-track.html
@@ -5,8 +5,9 @@
         <script src="../../resources/testharness.js"></script>
         <script src="../../resources/testharnessreport.js"></script>
         <script>
-promise_test(async () => {
-    let stream = await navigator.mediaDevices.getUserMedia({ video : true });
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video.srcObject = stream;
 
     await video.play();
@@ -16,7 +17,8 @@ promise_test(async () => {
             assert_true(internals.shouldAudioTrackPlay(video.audioTracks[0]));
     };
 
-    let stream2 = await navigator.mediaDevices.getUserMedia({ audio : true });
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     video.srcObject.addTrack(stream2.getAudioTracks()[0]);
     await new Promise(resolve => setTimeout(resolve, 50));
 
@@ -24,8 +26,9 @@ promise_test(async () => {
     stream2.getTracks().forEach(t => t.stop());
 }, "Add an audio track while playing video");
 
-promise_test(async () => {
-    let stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video.srcObject = stream.clone();
 
     await video.play();

--- a/LayoutTests/fast/mediastream/screencapture-user-gesture.html
+++ b/LayoutTests/fast/mediastream/screencapture-user-gesture.html
@@ -12,7 +12,9 @@ promise_test(() => {
 promise_test(() => {
     let promise;
     internals.withUserGesture(() => {
-        const promise1 = navigator.mediaDevices.getDisplayMedia({video : true});
+        const promise1 = navigator.mediaDevices.getDisplayMedia({video : true}).then(stream => {
+            stream.getTracks().forEach(track => track.stop());
+        });
         const promise2 = navigator.mediaDevices.getDisplayMedia({video : true}).then(() => {
             return Promise.reject("Second promise should reject");
         }, () => {

--- a/LayoutTests/fast/mediastream/stop-clone-when-muted.html
+++ b/LayoutTests/fast/mediastream/stop-clone-when-muted.html
@@ -7,6 +7,7 @@
     <script>
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ video:true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const track = stream.getVideoTracks()[0];
     const trackClone = track.clone();
 

--- a/LayoutTests/fast/mediastream/stream-switch.html
+++ b/LayoutTests/fast/mediastream/stream-switch.html
@@ -6,8 +6,9 @@
 <script src="../../media/utilities.js"></script>
 <script src="../../webrtc/routines.js"></script>
 <script>
-promise_test(async() => {
-    let stream = await navigator.mediaDevices.getUserMedia({audio : true});
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({audio : true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     let cptr = 0;
     let videoFile = "../../media/" + findMediaFile('video', 'content/test');
     while (++cptr < 20) {
@@ -23,8 +24,9 @@ promise_test(async() => {
     stream.getTracks().forEach(t => t.stop());
 }, "Check switching between playing with and without stream");
 
-promise_test(async() => {
-    let stream = await navigator.mediaDevices.getUserMedia({audio : true, video: true});
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({audio : true, video: true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     localVideo.srcObject = stream;
     await localVideo.play();

--- a/LayoutTests/fast/mediastream/success.html
+++ b/LayoutTests/fast/mediastream/success.html
@@ -17,6 +17,7 @@ var options = {audio: true, video: true};
 navigator.mediaDevices.getUserMedia(options)
     .then(stream => {
         finishJSTest();
+        stream.getTracks().forEach(track => track.stop());
     })
     .catch(err => {
         testFailed('Error callback invoked unexpectedly');

--- a/LayoutTests/fast/mediastream/video-background-with-canvas.html
+++ b/LayoutTests/fast/mediastream/video-background-with-canvas.html
@@ -27,6 +27,7 @@ promise_test(async (test) => {
         return Promise.reject("Test requires internals API");
 
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video1.srcObject = stream;
     video2.srcObject = stream;
     await video1.play();
@@ -52,6 +53,7 @@ promise_test(async (test) => {
     internals.setPageVisibility(true);
 
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video1.srcObject = stream;
     video2.srcObject = stream;
     await video1.play();

--- a/LayoutTests/fast/mediastream/video-created-while-interrupted.html
+++ b/LayoutTests/fast/mediastream/video-created-while-interrupted.html
@@ -17,6 +17,7 @@
         document.body.appendChild(video);
 
         const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         video.srcObject = stream;
 
         let counter = 0;

--- a/LayoutTests/fast/mediastream/video-media-stream-inline.html
+++ b/LayoutTests/fast/mediastream/video-media-stream-inline.html
@@ -8,12 +8,13 @@
 <body>
 <video id="video" autoplay=""></video>
 <script>
-promise_test(async () => {
+promise_test(async test => {
     if (window.internals) {
         internals.settings.setAllowsInlineMediaPlayback(true);
         internals.settings.setInlineMediaPlaybackRequiresPlaysInlineAttribute(true);
     }
     video.srcObject = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     return video.play();
 });
 </script>

--- a/LayoutTests/fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html
+++ b/LayoutTests/fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html
@@ -26,8 +26,9 @@ async function waitForPause(video)
      return new Promise(resolve => { video.onpause = resolve; });
 }
 
-promise_test(async () => {
+promise_test(async (test) => {
      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+     test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
      localVideo1.srcObject = stream;
      localVideo2.srcObject = stream;
 

--- a/LayoutTests/fast/mediastream/video-rotation-clone.html
+++ b/LayoutTests/fast/mediastream/video-rotation-clone.html
@@ -21,8 +21,9 @@ async function testRotation(testName)
     await waitForVideoSize(video, 400, 200, testName + " 0");
 }
 
-promise_test(async() => {
+promise_test(async test => {
     video.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: 400, height: 200} });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     await video.play();
 
     const clone = video.srcObject.getVideoTracks()[0].clone();

--- a/LayoutTests/fast/mediastream/video-rotation-gpu-process-crash.html
+++ b/LayoutTests/fast/mediastream/video-rotation-gpu-process-crash.html
@@ -119,6 +119,7 @@ onload = async () => {
         console.log(e);
     }
 
+    video.srcObject.getTracks().forEach(track => track.stop());
     if (window.testRunner)
         testRunner.notifyDone();
 }

--- a/LayoutTests/fast/mediastream/video-rotation.html
+++ b/LayoutTests/fast/mediastream/video-rotation.html
@@ -104,6 +104,7 @@ onload = async () => {
         console.log(e);
     }
 
+    video.srcObject.getTracks().forEach(track => track.stop());
     if (window.testRunner)
         testRunner.notifyDone();
 }

--- a/LayoutTests/fast/mediastream/video-rotation2.html
+++ b/LayoutTests/fast/mediastream/video-rotation2.html
@@ -47,11 +47,12 @@ function isGreenPixel(data, i)
     return data[i] < 50 && data[i + 1] > 100 && data[i + 1] < 150 && data[i + 2] < 50;
 }
 
-promise_test(async () => {
+promise_test(async (test) => {
     if (!window.testRunner)
         return;
 
     video.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: 400, height: 200} });
+    test.add_cleanup(() => video.srcObject.getTracks().forEach(track => track.stop()));
     if (window.testRunner)
         testRunner.setMockCameraOrientation(90);
     await video.play();

--- a/LayoutTests/fast/speechrecognition/start-recognition-after-gum.html
+++ b/LayoutTests/fast/speechrecognition/start-recognition-after-gum.html
@@ -4,10 +4,11 @@
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script>
-promise_test(async () => {
+promise_test(async test => {
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
-    await navigator.mediaDevices.getUserMedia({audio:true});
+    const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
     if (window.testRunner)
         testRunner.setUserMediaPermission(false);
 

--- a/LayoutTests/http/tests/media/media-stream/device-change-event-in-iframe.html
+++ b/LayoutTests/http/tests/media/media-stream/device-change-event-in-iframe.html
@@ -14,6 +14,7 @@
             testRunner.waitUntilDone();
         }
 
+        let stream;
         let count = new Set();
         let success = true;
         let results = [];
@@ -29,6 +30,8 @@
             if (results.length == 4) {
                 setTimeout(() => {
                     result.innerHTML = results.sort().join('<br>');
+                    if (stream)
+                        stream.getTracks().forEach(track => track.stop());
                     if (window.testRunner) {
                         testRunner.notifyDone();
                         testRunner.resetMockMediaDevices();
@@ -39,7 +42,7 @@
         
         async function start()
         {
-            await window.navigator.mediaDevices.getUserMedia({audio:true});
+            stream = await window.navigator.mediaDevices.getUserMedia({audio:true});
 
             navigator.mediaDevices.ondevicechange = () => { countEvent('main'); };
             window.onmessage = (event) => { countEvent(event.data); };

--- a/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
+++ b/LayoutTests/http/tests/media/media-stream/enumerate-devices-source-id.html
@@ -47,7 +47,7 @@
                 if (++eventCount != 6)
                     return;
 
-                await navigator.mediaDevices.getUserMedia({video: true, audio: true });
+                const stream = await navigator.mediaDevices.getUserMedia({video: true, audio: true });
                 let devices = await navigator.mediaDevices.enumerateDevices();
                 devices.forEach(device => checkID(self.origin, device));
 
@@ -55,6 +55,8 @@
                 if (internals)
                     internals.setTrackingPreventionEnabled(true);
                 finishJSTest();
+
+                stream.getTracks().forEach(t => t.stop());
             }
 
             addEventListener("message", handler, false);

--- a/LayoutTests/http/tests/media/media-stream/get-display-media-prompt.html
+++ b/LayoutTests/http/tests/media/media-stream/get-display-media-prompt.html
@@ -32,6 +32,7 @@
         shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "1");
         shouldBe("stream.getAudioTracks().length", "0");
         shouldBe("stream.getVideoTracks().length", "1");
+        stream.getTracks().forEach(track => track.stop());
     }
 
     async function promptForVideoOnly() {
@@ -41,6 +42,7 @@
         shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "1");
         shouldBe("stream.getAudioTracks().length", "0");
         shouldBe("stream.getVideoTracks().length", "1");
+        stream.getTracks().forEach(track => track.stop());
     }
 
     async function promptForAudioAndVideo() {
@@ -50,6 +52,7 @@
         shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "1");
         shouldBe("stream.getAudioTracks().length", "0");
         shouldBe("stream.getVideoTracks().length", "1");
+        stream.getTracks().forEach(track => track.stop());
     }
     
     async function promptWithExactVideoConstraints() {
@@ -103,6 +106,7 @@
         shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "1");
         shouldBe("stream.getAudioTracks().length", "0");
         shouldBe("stream.getVideoTracks().length", "1");
+        stream.getTracks().forEach(track => track.stop());
     }
 
     async function promptWithInvalidAudioConstraint() {
@@ -114,6 +118,7 @@
         shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "1");
         shouldBe("stream.getAudioTracks().length", "0");
         shouldBe("stream.getVideoTracks().length", "1");
+        stream.getTracks().forEach(track => track.stop());
     }
     
     (async function() {

--- a/LayoutTests/http/tests/media/media-stream/get-user-media-localhost.html
+++ b/LayoutTests/http/tests/media/media-stream/get-user-media-localhost.html
@@ -20,7 +20,8 @@
             else {
                 window.addEventListener("load", async () => {
                     try {
-                        await window.navigator.mediaDevices.getUserMedia({audio:true});
+                        const stream = await window.navigator.mediaDevices.getUserMedia({audio:true});
+                        stream.getTracks().forEach(track => track.stop());
                         testPassed("getUserMedia succeeded");
                     } catch(err) {
                         testFailed(`getUserMedia should have succeeded but failed with error "${err}"`);

--- a/LayoutTests/http/tests/media/media-stream/get-user-media-prompt.html
+++ b/LayoutTests/http/tests/media/media-stream/get-user-media-prompt.html
@@ -12,6 +12,7 @@
                 return testRunner.userMediaPermissionRequestCount();
             }
 
+            let stream1, stream2;
             function gotStream3(s)
             {
                 stream = s;
@@ -21,10 +22,15 @@
 
                 debug("");
                 finishJSTest();
+                stream.getTracks().forEach(track => track.stop());
+                stream1.getTracks().forEach(track => track.stop());
+                stream2.getTracks().forEach(track => track.stop());
             }
 
             function gotStream2(s)
             {
+                stream2 = s;
+
                 stream = s;
                 shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "2");
                 shouldBe("stream.getAudioTracks().length", "0");
@@ -36,6 +42,8 @@
 
             function gotStream1(s)
             {
+                stream1 = s;
+
                 stream = s;
                 shouldBe("numberOfTimesGetUserMediaPromptHasBeenCalled()", "1");
                 shouldBe("stream.getAudioTracks().length", "1");

--- a/LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-ephemeral-id-iframe.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/enumerate-devices-ephemeral-id-iframe.html
@@ -7,7 +7,7 @@
             testRunner.addMockCameraDevice(event.data.cameraId, event.data.cameraName);
         }
 
-        await navigator.mediaDevices.getUserMedia({ video: true });
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
 
         testRunner.setMockMediaDeviceIsEphemeral(event.data.cameraId, event.data.isEphemeral);
 
@@ -19,6 +19,7 @@
         });
 
         parent.postMessage(JSON.stringify(result), '*');
+        stream.getTracks().forEach(track => track.stop());
     }
 
     window.addEventListener('message', enumerate);

--- a/LayoutTests/http/tests/media/media-stream/resources/get-display-media-devices-iframe.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/get-display-media-devices-iframe.html
@@ -12,8 +12,10 @@
     {
         let result;
         await callGetDisplayMedia({video: true})
-            .then((s) => result = "allow")
-            .catch((e) => result = "deny");
+            .then((stream) => {
+                result = "allow"; 
+                stream.getTracks().forEach(track => track.stop());
+            }).catch((e) => result = "deny");
         parent.postMessage(`${event.data}:${result}`, '*');
         result.innerHTML = result;
     }

--- a/LayoutTests/http/tests/media/media-stream/resources/get-user-media-embed.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/get-user-media-embed.html
@@ -1,6 +1,7 @@
 <script>
 onload = () => {
-    navigator.mediaDevices.getUserMedia({ video: true }).then(() => {
+    navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+        stream.getTracks().forEach(track => track.stop());
         parent.postMessage("OK", "*");
     }, () => {
         parent.postMessage("KO", "*");

--- a/LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-starts-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getDisplayMedia-starts-frame.html
@@ -5,6 +5,8 @@ window.internals.withUserGesture(() => {
     streamPromise = navigator.mediaDevices.getDisplayMedia({ video: true });
 });
 streamPromise
-    .then(() => { window.parent.postMessage('success', '*'); })
-    .catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
+    .then((stream) => {
+         window.parent.postMessage('success', '*');
+         stream.getTracks().forEach(track => track.stop());
+     }).catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/getUserMedia-audio-starts-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getUserMedia-audio-starts-frame.html
@@ -4,6 +4,8 @@ window.internals.withUserGesture(() => {
     streamPromise = navigator.mediaDevices.getUserMedia({ audio: true });
 });
 streamPromise
-    .then(() => { window.parent.postMessage('success', '*'); })
-    .catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
+    .then((stream) => {
+        window.parent.postMessage('success', '*');
+        stream.getTracks().forEach(t => t.stop());
+     }).catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/getUserMedia-video-starts-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/getUserMedia-video-starts-frame.html
@@ -4,6 +4,8 @@ window.internals.withUserGesture(() => {
     streamPromise = navigator.mediaDevices.getUserMedia({ video: true });
 });
 streamPromise
-    .then(() => { window.parent.postMessage('success', '*'); })
-    .catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
+    .then(stream => {
+        window.parent.postMessage('success', '*');
+        stream.getTracks().forEach(t => t.stop());
+    }).catch(error => { window.parent.postMessage(`fail (${error})`, '*'); });
 </script>

--- a/LayoutTests/http/tests/ssl/media-stream/resources/get-user-media-frame.html
+++ b/LayoutTests/http/tests/ssl/media-stream/resources/get-user-media-frame.html
@@ -37,6 +37,8 @@
                 debug('<br><span class="pass">TEST COMPLETE</span>');
                 if (window.testRunner)
                     testRunner.notifyDone();
+                if (stream)
+                    stream.srcObject.getTracks().forEach(t => t.stop());
             }
 
             debug(`URL: ${window.location.href}`);

--- a/LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html
+++ b/LayoutTests/http/tests/webrtc/muted-video-mediastream-invisible-autoplay.html
@@ -30,6 +30,7 @@ promise_test(async () => {
      myVideo1.muted = false;
      await new Promise(resolve => myVideo1.onplay = resolve);
      assert_false(myVideo1.paused, "test4");
+     myVideo1.srcObject.getTracks().forEach(t => t.stop());
 }, "Unmuting a video that was hidden-then-muted should restart playing it");
 
 promise_test(async () => {
@@ -49,6 +50,7 @@ promise_test(async () => {
     myVideo2.muted = false;
     await new Promise(resolve => myVideo2.onplay = resolve);
     assert_false(myVideo2.paused, "test4");
+    myVideo2.srcObject.getTracks().forEach(t => t.stop());
 }, "Muting a hidden video should pause and unmuting the hidden video should restart playing it");
 
         </script>

--- a/LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html
+++ b/LayoutTests/http/tests/webrtc/paused-video-mediastream-invisible-autoplay.html
@@ -65,6 +65,7 @@
                 doLog('** test finished');
                 if (window.testRunner)
                     testRunner.notifyDone();
+                myVideo.srcObject.getTracks().forEach(t => t.stop());
             }
             start();
         </script>

--- a/LayoutTests/http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html
+++ b/LayoutTests/http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html
@@ -64,6 +64,7 @@
                 doLog('** test finished');
                 if (window.testRunner)
                     testRunner.notifyDone();
+                myVideo.srcObject.getTracks().forEach(t => t.stop());
             }
             start();
         </script>

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate-mp4-opus.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate-mp4-opus.html
@@ -10,6 +10,7 @@
 <script>
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const bitRates = [128000, 256000];
         let promises = [];
         bitRates.forEach(bitRate => {

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate-webm.html
@@ -10,6 +10,7 @@
 <script>
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const bitRates = [128000, 256000];
         let promises = [];
         bitRates.forEach(bitRate => {

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html
@@ -11,6 +11,7 @@
 
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const bitRates = [128000, 256000];
         let promises = [];
         bitRates.forEach(bitRate => {

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-audio-samplingrate-change.html
@@ -22,6 +22,7 @@
 
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
         setTimeout(() => {
             stream.getAudioTracks()[0].applyConstraints({sampleRate:48000});
@@ -41,6 +42,7 @@
 
     promise_test(async (t) => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
         setTimeout(() => {
             stream.getAudioTracks()[0].applyConstraints({sampleRate:48000});

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-bitrate.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-bitrate.html
@@ -9,6 +9,7 @@
 <script>
 promise_test(async (t) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     let recorder = new MediaRecorder(stream, { bitsPerSecond : 1000000 });
     assert_equals(recorder.audioBitsPerSecond, 100000, "test 1");
@@ -22,6 +23,7 @@ promise_test(async (t) => {
 
 promise_test(async (t) => {
     const stream = await navigator.mediaDevices.getUserMedia({ video : true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     let recorder = new MediaRecorder(stream, { bitsPerSecond : 1000000 });
     assert_equals(recorder.videoBitsPerSecond, 900000, "test 1");
@@ -35,6 +37,7 @@ promise_test(async (t) => {
 
 promise_test(async (t) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio : true, video : true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     let recorder = new MediaRecorder(stream, { bitsPerSecond : 1000000 });
     assert_equals(recorder.audioBitsPerSecond, 100000, "test 1");

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-dataavailable.html
@@ -116,6 +116,7 @@
 
     promise_test(async t => {
         const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const recorder = new MediaRecorder(stream);
 
         let count = 0;

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-frame.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-frame.html
@@ -20,6 +20,7 @@ function withFrame(url)
 promise_test(async (t) => {
     const frame = await withFrame('/');
     const stream = await navigator.mediaDevices.getUserMedia({ audio : true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     const Recorder = frame.contentWindow.MediaRecorder;
     let recorder1 = new Recorder(stream);
     let recorder2 = new Recorder(stream);

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-multiple-start-stop.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-multiple-start-stop.html
@@ -12,6 +12,7 @@
 <script>
     promise_test(async t => {
         const video = await navigator.mediaDevices.getUserMedia({ audio : true, video : true });
+        t.add_cleanup(() => video.getTracks().forEach(track => track.stop()));
         const recorder = new MediaRecorder(video);
 
         assert_equals(recorder.stream, video);

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice.html
@@ -12,6 +12,7 @@
 <script>
     promise_test(async t => {
         const video = await navigator.mediaDevices.getUserMedia({ audio : true, video : true });
+        t.add_cleanup(() => video.getTracks().forEach(track => track.stop()));
         const recorder = new MediaRecorder(video);
 
         assert_equals(recorder.stream, video);
@@ -26,6 +27,7 @@
 
     promise_test(async t => {
         const video = await navigator.mediaDevices.getUserMedia({ audio : true, video : true });
+        t.add_cleanup(() => video.getTracks().forEach(track => track.stop()));
         const recorder = new MediaRecorder(video);
 
         let isStarted = false;

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-video-bitrate.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-video-bitrate.html
@@ -14,7 +14,10 @@
         const promise = new Promise((resolve, reject) => {
             let count = 0;
             let blobs = [];
-            recorder.ondataavailable = (e) => resolve(e.data);
+            recorder.ondataavailable = (e) => {
+                stream.getTracks().forEach(track => track.stop());
+                resolve(e.data);
+            }
             setTimeout(() => reject("datavailable event timed out"), 15000);
         });
         recorder.start();

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html
@@ -15,7 +15,10 @@ async function record(mimeType)
 
     const recorder = new MediaRecorder(stream, { mimeType : mimeType });
     const promise = new Promise((resolve, reject) => {
-        recorder.ondataavailable = (e) => resolve(e.data);
+        recorder.ondataavailable = (e) => {
+            stream.getTracks().forEach(track => track.stop());
+            resolve(e.data);
+        }
         setTimeout(() => reject("datavailable event timed out"), 15000);
     });
     recorder.start();

--- a/LayoutTests/http/wpt/mediarecorder/mimeType.html
+++ b/LayoutTests/http/wpt/mediarecorder/mimeType.html
@@ -33,8 +33,9 @@ mimeTypeTests.forEach(mimeTypeTest => {
     }, "MediaRecorder.isTypeSupported - '" + mimeTypeTest[0] + "'");
 });
 
-promise_test(async () => {
+promise_test(async (test) => {
     const mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => mediaStream.getTracks().forEach(track => track.stop()));
 
     let recorder = new MediaRecorder(mediaStream);
     assert_equals(recorder.mimeType, "");
@@ -68,8 +69,9 @@ promise_test(async () => {
 
 }, "MediaRecorder mimeType MP4");
 
-promise_test(async () => {
+promise_test(async (test) => {
     const mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => mediaStream.getTracks().forEach(track => track.stop()));
 
     recorder = new MediaRecorder(new MediaStream([mediaStream.getVideoTracks()[0]]), { mimeType: "video/webm" });
     assert_equals(recorder.mimeType, "video/webm");
@@ -85,8 +87,9 @@ promise_test(async () => {
 
 }, "MediaRecorder mimeType WebM");
 
-promise_test(async () => {
+promise_test(async (test) => {
     const mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => mediaStream.getTracks().forEach(track => track.stop()));
 
     recorder = new MediaRecorder(new MediaStream([mediaStream.getAudioTracks()[0]]), { mimeType: "audio/mp4; codecs=opus" });
     assert_equals(recorder.mimeType, "audio/mp4; codecs=opus");

--- a/LayoutTests/http/wpt/mediarecorder/mute-tracks.html
+++ b/LayoutTests/http/wpt/mediarecorder/mute-tracks.html
@@ -138,6 +138,7 @@ async function checkVideoBlack(expected, canvas, video, errorMessage, counter)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const localTrack = stream.getAudioTracks()[0];
     localTrack.enabled = false;
@@ -164,6 +165,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const localTrack = stream.getAudioTracks()[0];
     setTimeout(() => localTrack.enabled = false, 50);
@@ -189,6 +191,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const localTrack = stream.getVideoTracks()[0];
     setTimeout(() => localTrack.enabled = false, 50);

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice.html
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice.html
@@ -14,6 +14,7 @@ function waitFor(duration)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const recorder = new MediaRecorder(stream);
 

--- a/LayoutTests/http/wpt/mediarecorder/record-96KHz-sources.html
+++ b/LayoutTests/http/wpt/mediarecorder/record-96KHz-sources.html
@@ -26,6 +26,7 @@
 
         const mic96KHz = deviceFromLabel(devices, "Mock audio device 3");
         stream = await navigator.mediaDevices.getUserMedia({ audio: { deviceId:mic96KHz.deviceId, sampleRate:96000 } })
+        test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
 
         assert_equals(stream.getAudioTracks()[0].getSettings().deviceId, mic96KHz.deviceId);
         assert_equals(stream.getAudioTracks()[0].getSettings().sampleRate, 96000);

--- a/LayoutTests/http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html
+++ b/LayoutTests/http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html
@@ -17,6 +17,7 @@ function waitFor(duration)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video1.srcObject = stream;
     await video1.play();
 

--- a/LayoutTests/http/wpt/mediarecorder/video-rotation.html
+++ b/LayoutTests/http/wpt/mediarecorder/video-rotation.html
@@ -11,6 +11,7 @@
         <script>
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     let expectedWidth = 640;
     let expectedHeight = 480;
 

--- a/LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection.html
+++ b/LayoutTests/http/wpt/mediasession/gpuProcessCrash-voiceDetection.html
@@ -45,6 +45,8 @@ function setMicrophoneActive(value)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
     video.srcObject = stream;
     await video.play();
 

--- a/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html
@@ -23,6 +23,8 @@ async function waitForInternalAudioCategory(expectedCategory)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
     const track = stream.getTracks()[0];
 
     const recorder = new MediaRecorder(stream);

--- a/LayoutTests/http/wpt/mediasession/setCaptureState-permission.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-permission.html
@@ -5,6 +5,8 @@
 <script>
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
     const track = stream.getTracks()[0];
 
     testRunner.setCaptureState(false, true, true);
@@ -28,6 +30,8 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
     const track = stream.getTracks()[0];
 
     testRunner.setCaptureState(true, false, true);

--- a/LayoutTests/http/wpt/mediasession/voiceActivityDetection.html
+++ b/LayoutTests/http/wpt/mediasession/voiceActivityDetection.html
@@ -172,6 +172,8 @@ promise_test(async (test) => {
             break;
     }
     assert_less_than(testCounter, 10);
+
+    frame1.contentWindow.stopCapture();
 }, "voiceActivity detection tests");
 </script>
 </body>

--- a/LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html
+++ b/LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html
@@ -40,6 +40,10 @@
 
                 assert_not_equals(stream1.getVideoTracks()[0].getSettings().deviceId, stream2.getVideoTracks()[0].getSettings().deviceId);
                 assert_equals(stream1.getVideoTracks()[0].getSettings().deviceId, stream3.getVideoTracks()[0].getSettings().deviceId);
+
+                stream1.getTracks().forEach(track => track.stop());
+                stream2.getTracks().forEach(track => track.stop());
+                stream3.getTracks().forEach(track => track.stop());
             }, "check deviceId persistency");
         </script>
     </body>

--- a/LayoutTests/http/wpt/mediastream/resources/getUserMedia-rvfc-remove-iframe.html
+++ b/LayoutTests/http/wpt/mediastream/resources/getUserMedia-rvfc-remove-iframe.html
@@ -10,6 +10,7 @@ async function start()
 
     video.requestVideoFrameCallback(() => { });
     video.requestVideoFrameCallback(() => {
+        localStream.getTracks().forEach(t => t.stop());
         self.parent.window.removeFrame();
     });
     video.requestVideoFrameCallback(() => { });

--- a/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
+++ b/LayoutTests/http/wpt/webrtc/audiovideo-script-transform.html
@@ -46,13 +46,13 @@ function createTransforms(worker, mediaType)
     return [senderTransform, receiverTransform];
 }
 
-let videoSenderTransform, videoReceiverTransform, audioSenderTransform, audioReceiverTransform;
+let localStream, videoSenderTransform, videoReceiverTransform, audioSenderTransform, audioReceiverTransform;
 promise_test(async (test) => {
     worker = new Worker('audio-video-transform.js');
     const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
     assert_equals(data, "registered");
 
-    const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
 
     [audioSenderTransform, audioReceiverTransform] = createTransforms(worker, 'audio');
     [videoSenderTransform, videoReceiverTransform] = createTransforms(worker, 'video');
@@ -160,6 +160,8 @@ promise_test(async (test) => {
     videoSenderTransform.port.postMessage("tryAccessingMetadata");
     metadata =await waitForMessage(videoSenderTransform.port);
     assert_array_equals(Object.keys(metadata), ["contributingSources", "dependencies", "frameId", "height", "mimeType", "payloadType", "rtpTimestamp", "spatialIndex", "synchronizationSource", "temporalIndex", "width"]);
+
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 }, "Check metadata getter");
         </script>
     </body>

--- a/LayoutTests/http/wpt/webrtc/resources/third-party-frame-ice-candidate-filtering-iframe.html
+++ b/LayoutTests/http/wpt/webrtc/resources/third-party-frame-ice-candidate-filtering-iframe.html
@@ -21,9 +21,16 @@ function isFilteringEnabled()
     });
 }
 
-async function doGetUserMedia() {
-    var result = await navigator.mediaDevices.getUserMedia({video:true});
+let stream;
+async function doGetUserMedia()
+{
+    stream = await navigator.mediaDevices.getUserMedia({video:true});
     return true;
+}
+
+function stopCapture()
+{
+    stream.getTracks().forEach(t => t.stop());
 }
 
 window.onmessage = async (event) => {
@@ -33,6 +40,10 @@ window.onmessage = async (event) => {
     }
     if (event.data === "capture") {
         event.source.postMessage(await doGetUserMedia(), event.origin);
+        return;
+    }
+    if (event.data === "stopCapture") {
+        event.source.postMessage(await stopCapture(), event.origin);
         return;
     }
     event.source.postMessage("unknown message", event.origin);

--- a/LayoutTests/http/wpt/webrtc/rtcNetworkInterface.html
+++ b/LayoutTests/http/wpt/webrtc/rtcNetworkInterface.html
@@ -18,7 +18,8 @@ function with_iframe(url) {
 
 async function testNetworkInterface(test, frame)
 {
-    await frame.contentWindow.navigator.mediaDevices.getUserMedia({ video: true });
+    const localStream = await frame.contentWindow.navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 
     const pc = new frame.contentWindow.RTCPeerConnection();
     pc.createDataChannel("test");

--- a/LayoutTests/http/wpt/webrtc/sframe-transform-error.html
+++ b/LayoutTests/http/wpt/webrtc/sframe-transform-error.html
@@ -16,6 +16,7 @@ promise_test(async (test) => {
     const key4 = await crypto.subtle.importKey("raw", new Uint8Array([146, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
     let receiver;
     const stream = await new Promise((resolve, reject) => {
         const connections = createConnections(test, (firstConnection) => {
@@ -50,6 +51,7 @@ promise_test(async (test) => {
     const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
     assert_equals(data, "registered");
     const localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 
     let sender, receiver;
 

--- a/LayoutTests/http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html
+++ b/LayoutTests/http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html
@@ -57,6 +57,8 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     assert_true(await doIFrameTest(frame3, "checkFiltering"));
+
+    test.add_cleanup(() => doIFrameTest(frame2, "stopCapture"));
 }, "Check filtering of frame with different origin as top and capturing frame origins");
 
 </script>

--- a/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.html
+++ b/LayoutTests/http/wpt/webrtc/video-rtpTimestamp-transform.html
@@ -29,13 +29,14 @@ let senderTransform, receiverTransform;
 let stream;
 let worker;
 
-async function doSetup(senderPCCallback)
+async function doSetup(test, senderPCCallback)
 {
     worker = new Worker('video-rtpTimestamp-transform.js');
     const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
     assert_equals(data, "registered");
 
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 
     const senderChannel = new MessageChannel;
     const receiverChannel = new MessageChannel;
@@ -78,7 +79,7 @@ promise_test(async (test) => {
     const codecs = RTCRtpSender.getCapabilities("video").codecs;
     const vp8Codec = codecs.filter(codec => { return codec.mimeType === "video/VP8"; })[0];
 
-    const [pc1, pc2 ] = await doSetup(senderPc => senderPc.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([vp8Codec]); }));
+    const [pc1, pc2 ] = await doSetup(test, senderPc => senderPc.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([vp8Codec]); }));
 
     senderTransform.port.postMessage("validateRTPTimestamp");
     receiverTransform.port.postMessage("validateRTPTimestamp");
@@ -94,7 +95,7 @@ promise_test(async (test) => {
     const codecs = RTCRtpSender.getCapabilities("video").codecs;
     const h264Codec = codecs.filter(codec => { return codec.mimeType === "video/H264"; })[0];
 
-    const [pc1, pc2 ] = await doSetup(senderPc => senderPc.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([h264Codec]); }));
+    const [pc1, pc2 ] = await doSetup(test, senderPc => senderPc.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([h264Codec]); }));
 
     senderTransform.port.postMessage("validateRTPTimestamp");
     receiverTransform.port.postMessage("validateRTPTimestamp");

--- a/LayoutTests/http/wpt/webrtc/video-script-transform-keyframe-only.html
+++ b/LayoutTests/http/wpt/webrtc/video-script-transform-keyframe-only.html
@@ -26,6 +26,7 @@ promise_test(async (test) => {
     assert_equals(data, "registered");
 
     const localStream = await navigator.mediaDevices.getUserMedia({video: { frameRate: 5, width: 320, height: 240 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 
     const senderTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'sender'});
     const receiverTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'receiver'});

--- a/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html
+++ b/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html
@@ -25,13 +25,13 @@ function waitForMessage(port, data)
     return promise;
 }
 
-let worker;
+let localStream, worker;
 promise_test(async (test) => {
     worker = new Worker('context-transform.js');
     const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
     assert_equals(data, "registered");
 
-    const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    localStream = await navigator.mediaDevices.getUserMedia({video: true});
 
     const senderChannel = new MessageChannel;
     const receiverChannelL = new MessageChannel;
@@ -117,10 +117,11 @@ async function waitForVideoSize(video, width, height)
         return Promise.reject("Video size not expected : " + video.videoWidth + " " + video.videoHeight);
 }
 
-promise_test(async () => {
+promise_test(async test => {
     await Promise.all([videoL.play(), videoM.play()]);
     await waitForVideoSize(videoL, 320, 240);
     await waitForVideoSize(videoM, 640, 480);
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 }, "videos are playing with the correct resolutions");
         </script>
     </body>

--- a/LayoutTests/http/wpt/webrtc/video-script-transform.html
+++ b/LayoutTests/http/wpt/webrtc/video-script-transform.html
@@ -24,13 +24,13 @@ function waitForMessage(port, data)
 }
 
 let senderTransform, receiverTransform;
-let stream;
+let localStream, stream;
 promise_test(async (test) => {
     worker = new Worker('context-transform.js');
     const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
     assert_equals(data, "registered");
 
-    const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    localStream = await navigator.mediaDevices.getUserMedia({video: true});
 
     const senderChannel = new MessageChannel;
     const receiverChannel = new MessageChannel;
@@ -85,6 +85,7 @@ promise_test(async (test) => {
     await waitForMessage(receiverTransform.port, "video frame key");
     receiverTransform.port.postMessage("endKeyFrames");
 
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 }, "key frame requests from receiver");
         </script>
     </body>

--- a/LayoutTests/platform/mac-wk2/fast/mediastream/play-newly-added-audio-track-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/mediastream/play-newly-added-audio-track-expected.txt
@@ -1,7 +1,0 @@
-CONSOLE MESSAGE: A capture MediaStreamTrack was destroyed without having been stopped explicitly
-CONSOLE MESSAGE: A capture MediaStreamTrack was destroyed without having been stopped explicitly
-
-
-PASS Add an audio track while playing video
-PASS Add an audio track while playing audio
-

--- a/LayoutTests/platform/mac/http/tests/site-isolation/resources/getDisplayMedia-starts-frame-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/site-isolation/resources/getDisplayMedia-starts-frame-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584


### PR DESCRIPTION
#### b435ce5ca3d4f719939c4c926f06076f8413692c
<pre>
Explicitly stop getUserMedia/getDisplayMedia tracks in layout tests
<a href="https://rdar.apple.com/157287595">rdar://157287595</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296799">https://bugs.webkit.org/show_bug.cgi?id=296799</a>

Reviewed by Jean-Yves Avenard.

We expliclity stop capture tracks to prevent flakiness in tests, in particular the warning message when a capture track gets GCed while live.

Canonical link: <a href="https://commits.webkit.org/298547@main">https://commits.webkit.org/298547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a29d40c0a0910dba944d4c4403a646285631721

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65138 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d809d04-ea69-4f83-919c-0f341d9c53d0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86961 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41863 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1488b060-e0a1-4938-b4ba-5929401471f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102764 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67354 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20890 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64275 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123795 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95780 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24560 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18613 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37469 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41317 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42658 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->