### PR TITLE
Fix annotations guarding ServiceWorkersEnabled endpoints

### DIFF
--- a/LayoutTests/http/wpt/push-api/pushEvent.any.serviceworker.html
+++ b/LayoutTests/http/wpt/push-api/pushEvent.any.serviceworker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ PushAPIEnabled=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/push-api/pushManager.any.html
+++ b/LayoutTests/http/wpt/push-api/pushManager.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ PushAPIEnabled=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/push-api/pushManager.any.serviceworker.html
+++ b/LayoutTests/http/wpt/push-api/pushManager.any.serviceworker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ PushAPIEnabled=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/push-api/pushSubscription.https.any.html
+++ b/LayoutTests/http/wpt/push-api/pushSubscription.https.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ PushAPIEnabled=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/push-api/pushSubscription.https.any.serviceworker.html
+++ b/LayoutTests/http/wpt/push-api/pushSubscription.https.any.serviceworker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ PushAPIEnabled=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/push-api/pushSubscriptionChangeEvent.any.serviceworker.html
+++ b/LayoutTests/http/wpt/push-api/pushSubscriptionChangeEvent.any.serviceworker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ PushAPIEnabled=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -57,6 +57,7 @@ ServiceWorkerDownloadTask::ServiceWorkerDownloadTask(NetworkSession& session, Ne
     , m_fetchIdentifier(fetchIdentifier)
     , m_downloadID(downloadID)
     , m_networkProcess(*serviceWorkerConnection.networkProcess())
+    , m_sharedPreferences(serviceWorkerConnection.sharedPreferencesForWebProcess())
 {
     auto expectedContentLength = response.expectedContentLength();
     if (expectedContentLength != -1)
@@ -271,6 +272,11 @@ void ServiceWorkerDownloadTask::didFailDownload(std::optional<ResourceError>&& e
         if (RefPtr client = m_client.get())
             client->didCompleteWithError(resourceError);
     });
+}
+
+std::optional<SharedPreferencesForWebProcess> ServiceWorkerDownloadTask::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
+{
+    return m_sharedPreferences;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -65,6 +65,8 @@ public:
     void start();
     void stop() { cancel(); }
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const;
+
 private:
     ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& response, DownloadID);
     void startListeningForIPC();
@@ -103,6 +105,7 @@ private:
     uint64_t m_downloadBytesWritten { 0 };
     std::optional<uint64_t> m_expectedContentLength;
     State m_state { State::Suspended };
+    std::optional<SharedPreferencesForWebProcess> m_sharedPreferences;
 };
 
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
@@ -21,7 +21,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    ExceptionForEnabledBy,
+    SharedPreferencesNeedsConnection,
+    EnabledBy=ServiceWorkersEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -625,6 +625,15 @@ RefPtr<NetworkResourceLoader> ServiceWorkerFetchTask::protectedLoader() const
     return m_loader.get();
 }
 
+std::optional<SharedPreferencesForWebProcess> ServiceWorkerFetchTask::sharedPreferencesForWebProcess() const
+{
+    RefPtr loader = m_loader.get();
+    if (!loader)
+        return std::nullopt;
+
+    return loader->connectionToWebProcess().sharedPreferencesForWebProcess();
+}
+
 } // namespace WebKit
 
 #undef SWFETCH_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DownloadID.h"
+#include "SharedPreferencesForWebProcess.h"
 #include <WebCore/FetchIdentifier.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
@@ -89,6 +90,8 @@ public:
     bool convertToDownload(DownloadManager&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
 
     MonotonicTime startTime() const;
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
     ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=ServiceWorkersEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -27,28 +27,28 @@
 ]
 messages -> WebSWServerConnection {
     # When possible, these messages can be implemented directly by WebCore::SWClientConnection
-    [EnabledBySetting=ServiceWorkersEnabled] ScheduleJobInServer(struct WebCore::ServiceWorkerJobData jobData)
-    [EnabledBySetting=ServiceWorkersEnabled] ScheduleUnregisterJobInServer(WebCore::ServiceWorkerJobIdentifier jobIdentifier, WebCore::ServiceWorkerRegistrationIdentifier identifier, WebCore::ServiceWorkerOrClientIdentifier documentIdentifier) -> (Expected<bool, WebCore::ExceptionData> result)
+    [EnabledBy=ServiceWorkersEnabled] ScheduleJobInServer(struct WebCore::ServiceWorkerJobData jobData)
+    [EnabledBy=ServiceWorkersEnabled] ScheduleUnregisterJobInServer(WebCore::ServiceWorkerJobIdentifier jobIdentifier, WebCore::ServiceWorkerRegistrationIdentifier identifier, WebCore::ServiceWorkerOrClientIdentifier documentIdentifier) -> (Expected<bool, WebCore::ExceptionData> result)
 
-    [EnabledBySetting=ServiceWorkersEnabled] FinishFetchingScriptInServer(struct WebCore::ServiceWorkerJobDataIdentifier jobDataIdentifier, WebCore::ServiceWorkerRegistrationKey registrationKey, struct WebCore::WorkerFetchResult result)
-    [EnabledBySetting=ServiceWorkersEnabled] AddServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier identifier)
-    [EnabledBySetting=ServiceWorkersEnabled] RemoveServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] FinishFetchingScriptInServer(struct WebCore::ServiceWorkerJobDataIdentifier jobDataIdentifier, WebCore::ServiceWorkerRegistrationKey registrationKey, struct WebCore::WorkerFetchResult result)
+    [EnabledBy=ServiceWorkersEnabled] AddServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] RemoveServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier identifier)
 
-    [EnabledBySetting=ServiceWorkersEnabled] PostMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destination, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerOrClientIdentifier source)
+    [EnabledBy=ServiceWorkersEnabled] PostMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destination, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerOrClientIdentifier source)
 
-    [EnabledBySetting=ServiceWorkersEnabled] DidResolveRegistrationPromise(WebCore::ServiceWorkerRegistrationKey key)
+    [EnabledBy=ServiceWorkersEnabled] DidResolveRegistrationPromise(WebCore::ServiceWorkerRegistrationKey key)
 
-    [EnabledBySetting=ServiceWorkersEnabled] MatchRegistration(WebCore::SecurityOriginData topOrigin, URL clientURL) -> (struct std::optional<WebCore::ServiceWorkerRegistrationData> registration)
-    [EnabledBySetting=ServiceWorkersEnabled] WhenRegistrationReady(WebCore::SecurityOriginData topOrigin, URL clientURL) -> (struct std::optional<WebCore::ServiceWorkerRegistrationData> registration)
-    [EnabledBySetting=ServiceWorkersEnabled] GetRegistrations(WebCore::SecurityOriginData topOrigin, URL clientURL) -> (Vector<WebCore::ServiceWorkerRegistrationData> registrations)
-    [EnabledBySetting=ServiceWorkersEnabled] RegisterServiceWorkerClient(struct WebCore::ClientOrigin clientOrigin, struct WebCore::ServiceWorkerClientData data, std::optional<WebCore::ServiceWorkerRegistrationIdentifier> controllingServiceWorkerRegistrationIdentifier, String userAgent)
-    [EnabledBySetting=ServiceWorkersEnabled] UnregisterServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] MatchRegistration(WebCore::SecurityOriginData topOrigin, URL clientURL) -> (struct std::optional<WebCore::ServiceWorkerRegistrationData> registration)
+    [EnabledBy=ServiceWorkersEnabled] WhenRegistrationReady(WebCore::SecurityOriginData topOrigin, URL clientURL) -> (struct std::optional<WebCore::ServiceWorkerRegistrationData> registration)
+    [EnabledBy=ServiceWorkersEnabled] GetRegistrations(WebCore::SecurityOriginData topOrigin, URL clientURL) -> (Vector<WebCore::ServiceWorkerRegistrationData> registrations)
+    [EnabledBy=ServiceWorkersEnabled] RegisterServiceWorkerClient(struct WebCore::ClientOrigin clientOrigin, struct WebCore::ServiceWorkerClientData data, std::optional<WebCore::ServiceWorkerRegistrationIdentifier> controllingServiceWorkerRegistrationIdentifier, String userAgent)
+    [EnabledBy=ServiceWorkersEnabled] UnregisterServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier identifier)
 
-    [EnabledBySetting=ServiceWorkersEnabled] TerminateWorkerFromClient(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
-    [EnabledBySetting=ServiceWorkersEnabled] WhenServiceWorkerIsTerminatedForTesting(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
+    [EnabledBy=ServiceWorkersEnabled] TerminateWorkerFromClient(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
+    [EnabledBy=ServiceWorkersEnabled] WhenServiceWorkerIsTerminatedForTesting(WebCore::ServiceWorkerIdentifier workerIdentifier) -> ()
 
-    [EnabledBySetting=ServiceWorkersEnabled] SetThrottleState(bool isThrottleable)
-    [EnabledBySetting=ServiceWorkersEnabled] StoreRegistrationsOnDisk() -> ()
+    [EnabledBy=ServiceWorkersEnabled] SetThrottleState(bool isThrottleable)
+    [EnabledBy=ServiceWorkersEnabled] StoreRegistrationsOnDisk() -> ()
 
     [EnabledBy=PushAPIEnabled] SubscribeToPushService(WebCore::ServiceWorkerRegistrationIdentifier identifier, Vector<uint8_t> applicationServerKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)
     [EnabledBy=PushAPIEnabled] UnsubscribeFromPushService(WebCore::ServiceWorkerRegistrationIdentifier serviceWorkerRegistrationIdentifier, WebCore::PushSubscriptionIdentifier pushSubscriptionIdentifier) -> (Expected<bool, WebCore::ExceptionData> result)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -509,5 +509,14 @@ void WebSWServerToContextConnection::reportNetworkUsageToWorkerClient(const WebC
 }
 #endif
 
+std::optional<SharedPreferencesForWebProcess> WebSWServerToContextConnection::sharedPreferencesForWebProcess() const
+{
+    if (RefPtr connection = m_connection.get())
+        return connection->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
+}
+
+
 #undef MESSAGE_CHECK
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -103,6 +103,7 @@ public:
     void reportNetworkUsageToWorkerClient(const WebCore::ScriptExecutionContextIdentifier, uint64_t bytesTransferredOverNetworkDelta) final;
 #endif
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 private:
     WebSWServerToContextConnection(NetworkConnectionToWebProcess&, WebPageProxyIdentifier, WebCore::Site&&, std::optional<WebCore::ScriptExecutionContextIdentifier>, WebCore::SWServer&);
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -28,23 +28,23 @@
 messages -> WebSWServerToContextConnection {
     # When possible, these messages can be implemented directly by WebCore::SWServerToContextConnection
 
-    [EnabledBySetting=ServiceWorkersEnabled] ScriptContextFailedToStart(struct std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String message)
-    [EnabledBySetting=ServiceWorkersEnabled] ScriptContextStarted(struct std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool doesHandleFetch)
-    [EnabledBySetting=ServiceWorkersEnabled] DidFinishInstall(struct std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool wasSuccessful)
-    [EnabledBySetting=ServiceWorkersEnabled] DidFinishActivation(WebCore::ServiceWorkerIdentifier identifier)
-    [EnabledBySetting=ServiceWorkersEnabled] SetServiceWorkerHasPendingEvents(WebCore::ServiceWorkerIdentifier identifier, bool hasPendingEvents)
-    [EnabledBySetting=ServiceWorkersEnabled] SkipWaiting(WebCore::ServiceWorkerIdentifier identifier) -> ()
-    [EnabledBySetting=ServiceWorkersEnabled] WorkerTerminated(WebCore::ServiceWorkerIdentifier identifier)
-    [EnabledBySetting=ServiceWorkersEnabled] FindClientByVisibleIdentifier(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String clientIdentifier) -> (struct std::optional<WebCore::ServiceWorkerClientData> data)
-    [EnabledBySetting=ServiceWorkersEnabled] MatchAll(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, struct WebCore::ServiceWorkerClientQueryOptions options) -> (Vector<WebCore::ServiceWorkerClientData> clientsData);
-    [EnabledBySetting=ServiceWorkersEnabled] Claim(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier) -> (struct std::optional<WebCore::ExceptionData> result)
-    [EnabledBySetting=ServiceWorkersEnabled] Focus(WebCore::ScriptExecutionContextIdentifier serviceWorkerClientIdentifier) -> (struct std::optional<WebCore::ServiceWorkerClientData> result)
-    [EnabledBySetting=ServiceWorkersEnabled] Navigate(WebCore::ScriptExecutionContextIdentifier clientIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> result)
-    [EnabledBySetting=ServiceWorkersEnabled] SetScriptResource(WebCore::ServiceWorkerIdentifier identifier, URL scriptURL, struct WebCore::ServiceWorkerImportedScript script)
-    [EnabledBySetting=ServiceWorkersEnabled] PostMessageToServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier destination, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerIdentifier source, String sourceOrigin)
-    [EnabledBySetting=ServiceWorkersEnabled] DidFailHeartBeatCheck(WebCore::ServiceWorkerIdentifier identifier)
-    [EnabledBySetting=ServiceWorkersEnabled] SetAsInspected(WebCore::ServiceWorkerIdentifier identifier, bool isInspected)
+    [EnabledBy=ServiceWorkersEnabled] ScriptContextFailedToStart(struct std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String message)
+    [EnabledBy=ServiceWorkersEnabled] ScriptContextStarted(struct std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool doesHandleFetch)
+    [EnabledBy=ServiceWorkersEnabled] DidFinishInstall(struct std::optional<WebCore::ServiceWorkerJobDataIdentifier> jobDataIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool wasSuccessful)
+    [EnabledBy=ServiceWorkersEnabled] DidFinishActivation(WebCore::ServiceWorkerIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] SetServiceWorkerHasPendingEvents(WebCore::ServiceWorkerIdentifier identifier, bool hasPendingEvents)
+    [EnabledBy=ServiceWorkersEnabled] SkipWaiting(WebCore::ServiceWorkerIdentifier identifier) -> ()
+    [EnabledBy=ServiceWorkersEnabled] WorkerTerminated(WebCore::ServiceWorkerIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] FindClientByVisibleIdentifier(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String clientIdentifier) -> (struct std::optional<WebCore::ServiceWorkerClientData> data)
+    [EnabledBy=ServiceWorkersEnabled] MatchAll(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, struct WebCore::ServiceWorkerClientQueryOptions options) -> (Vector<WebCore::ServiceWorkerClientData> clientsData);
+    [EnabledBy=ServiceWorkersEnabled] Claim(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier) -> (struct std::optional<WebCore::ExceptionData> result)
+    [EnabledBy=ServiceWorkersEnabled] Focus(WebCore::ScriptExecutionContextIdentifier serviceWorkerClientIdentifier) -> (struct std::optional<WebCore::ServiceWorkerClientData> result)
+    [EnabledBy=ServiceWorkersEnabled] Navigate(WebCore::ScriptExecutionContextIdentifier clientIdentifier, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> result)
+    [EnabledBy=ServiceWorkersEnabled] SetScriptResource(WebCore::ServiceWorkerIdentifier identifier, URL scriptURL, struct WebCore::ServiceWorkerImportedScript script)
+    [EnabledBy=ServiceWorkersEnabled] PostMessageToServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier destination, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerIdentifier source, String sourceOrigin)
+    [EnabledBy=ServiceWorkersEnabled] DidFailHeartBeatCheck(WebCore::ServiceWorkerIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] SetAsInspected(WebCore::ServiceWorkerIdentifier identifier, bool isInspected)
 
-    [EnabledBySetting=ServiceWorkersEnabled] OpenWindow(WebCore::ServiceWorkerIdentifier identifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> newClientData)
-    [EnabledBySetting=ServiceWorkersEnabled] ReportConsoleMessage(WebCore::ServiceWorkerIdentifier identifier, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message, uint64_t requestIdentifier);
+    [EnabledBy=ServiceWorkersEnabled] OpenWindow(WebCore::ServiceWorkerIdentifier identifier, URL url) -> (Expected<std::optional<WebCore::ServiceWorkerClientData>, WebCore::ExceptionData> newClientData)
+    [EnabledBy=ServiceWorkersEnabled] ReportConsoleMessage(WebCore::ServiceWorkerIdentifier identifier, enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message, uint64_t requestIdentifier);
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -105,8 +105,8 @@ messages -> WebProcessProxy WantsDispatchMessage {
 #endif
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
-    CreateServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL url, enum:bool WebCore::ServiceWorkerIsInspectable isInspectable) -> (bool shouldWaitForAutoInspection) Async
-    DeleteServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier)
-    SendMessageToInspector(WebCore::ServiceWorkerIdentifier identifier, String message)
+    [EnabledBy=ServiceWorkersEnabled] CreateServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL url, enum:bool WebCore::ServiceWorkerIsInspectable isInspectable) -> (bool shouldWaitForAutoInspection) Async
+    [EnabledBy=ServiceWorkersEnabled] DeleteServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier)
+    [EnabledBy=ServiceWorkersEnabled] SendMessageToInspector(WebCore::ServiceWorkerIdentifier identifier, String message)
 #endif
 }


### PR DESCRIPTION
#### 095c9dd02d7f84891cf4a3d00063343c4de0dc97
<pre>
Fix annotations guarding ServiceWorkersEnabled endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=296802">https://bugs.webkit.org/show_bug.cgi?id=296802</a>
<a href="https://rdar.apple.com/157291144">rdar://157291144</a>

Reviewed by Sihui Liu.

Annotate endpoints with ServiceWorkersEnabled
Prevent incorrect annotations from being used in .messages.in files.

* LayoutTests/http/wpt/push-api/pushEvent.any.serviceworker.html:
* LayoutTests/http/wpt/push-api/pushManager.any.html:
* LayoutTests/http/wpt/push-api/pushManager.any.serviceworker.html:
* LayoutTests/http/wpt/push-api/pushSubscription.https.any.html:
* LayoutTests/http/wpt/push-api/pushSubscription.https.any.serviceworker.html:
* LayoutTests/http/wpt/push-api/pushSubscriptionChangeEvent.any.serviceworker.html:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::ServiceWorkerDownloadTask):
(WebKit::ServiceWorkerDownloadTask::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
* Source/WebKit/Scripts/webkit/parser.py:
(parse):
(parse_coalescing_keys):
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:

Canonical link: <a href="https://commits.webkit.org/298775@main">https://commits.webkit.org/298775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/721b3c03a6b632f8e0a98c29c7b430ce0b7e7530

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67160 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88552 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b1b5a30-4b23-4f48-819c-6f6063eb77a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69012 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115963 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22706 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66328 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125799 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97223 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97015 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24706 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39450 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48974 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42840 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->