### PR TITLE
In some cases, we can't follow file:// links from a local file

### DIFF
--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -127,6 +127,11 @@ SandboxExtensionHandle::SandboxExtensionHandle()
 {
 }
 
+SandboxExtensionHandle::SandboxExtensionHandle(const SandboxExtensionHandle& handle)
+{
+    m_sandboxExtension = WTF::makeUnique<SandboxExtensionImpl>(handle.m_sandboxExtension->getSerializedFormat());
+}
+
 SandboxExtensionHandle::SandboxExtensionHandle(SandboxExtensionHandle&&) = default;
 SandboxExtensionHandle& SandboxExtensionHandle::operator=(SandboxExtensionHandle&&) = default;
 

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -79,9 +79,9 @@ private:
 #endif
 
 class SandboxExtensionHandle {
-    WTF_MAKE_NONCOPYABLE(SandboxExtensionHandle);
 public:
     SandboxExtensionHandle();
+    SandboxExtensionHandle(const SandboxExtensionHandle&);
 #if ENABLE(SANDBOX_EXTENSIONS)
     SandboxExtensionHandle(SandboxExtensionHandle&&);
     SandboxExtensionHandle& operator=(SandboxExtensionHandle&&);
@@ -159,6 +159,7 @@ String resolveAndCreateReadWriteDirectoryForSandboxExtension(StringView path);
 #if !ENABLE(SANDBOX_EXTENSIONS)
 
 inline SandboxExtensionHandle::SandboxExtensionHandle() { }
+inline SandboxExtensionHandle::SandboxExtensionHandle(const SandboxExtensionHandle&) { }
 inline SandboxExtensionHandle::~SandboxExtensionHandle() { }
 inline RefPtr<SandboxExtension> SandboxExtension::create(Handle&&) { return nullptr; }
 inline auto SandboxExtension::createHandle(StringView, Type) -> std::optional<Handle> { return Handle { }; }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2874,4 +2874,14 @@ void WebProcessPool::initializeAccessibilityIfNecessary()
 }
 #endif
 
+std::optional<SandboxExtension::Handle> WebProcessPool::sandboxExtensionForFile(const String& fileName)
+{
+    return m_fileSandboxExtensions.getOptional(fileName);
+}
+
+void WebProcessPool::addSandboxExtensionForFile(const String& fileName, SandboxExtension::Handle handle)
+{
+    m_fileSandboxExtensions.add(fileName, handle);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -644,6 +644,9 @@ public:
     void initializeAccessibilityIfNecessary();
 #endif
 
+    std::optional<SandboxExtension::Handle> sandboxExtensionForFile(const String& fileName);
+    void addSandboxExtensionForFile(const String& fileName, SandboxExtension::Handle);
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);
@@ -1039,6 +1042,8 @@ private:
 
     bool m_hasReceivedAXRequestInUIProcess { false };
     bool m_suppressEDR { false };
+
+    HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
 };
 
 template<typename T>


### PR DESCRIPTION
#### f6ee9227ffe23e2640afe07fc01fc2d3ec768067
<pre>
In some cases, we can&apos;t follow file:// links from a local file
<a href="https://bugs.webkit.org/show_bug.cgi?id=296808">https://bugs.webkit.org/show_bug.cgi?id=296808</a>
<a href="https://rdar.apple.com/156619146">rdar://156619146</a>

Reviewed by Brent Fulgham.

When dropping a local file in a WKWebView or in the chrome of the embedding application, WebKit is normally only provided with a
temporary sandbox extension to that location in the UI process by the system or embedding application. If we later visit the same
local file URL, either by going back/forward in history, or manually entering the file URL in the address field, we are no longer
able to create a sandbox extension to that location for the WebContent process, since the temporary sandbox extension has been
revoked in the UI process. To address this, we can add a sandbox extension cache in the process pool, which lets us send a
sandbox extension to the WebContent process in these cases. This requires the SandboxExtensionHandle class to be copyable.

* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionHandle::SandboxExtensionHandle):
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::sandboxExtensionForFile):
(WebKit::WebProcessPool::addSandboxExtensionForFile):
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/298140@main">https://commits.webkit.org/298140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34612214b70276f5d65c9cbd665c5fa6e5c0a3fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65106 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26874 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95537 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40692 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37441 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18327 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46790 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->