### PR TITLE
Improve handling of invalid identifiers in RemoteDisplayListRecorder

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -147,12 +147,8 @@ void RemoteDisplayListRecorder::setFillColor(const Color& color)
 
 void RemoteDisplayListRecorder::setFillCachedGradient(RenderingResourceIdentifier identifier, const AffineTransform& spaceTransform)
 {
-    RefPtr gradient = resourceCache().cachedGradient(identifier);
-    if (!gradient) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    context().setFillGradient(gradient.releaseNonNull(), spaceTransform);
+    if (RefPtr gradient = resourceCache().cachedGradient(identifier))
+        context().setFillGradient(gradient.releaseNonNull(), spaceTransform);
 }
 
 void RemoteDisplayListRecorder::setFillGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
@@ -162,12 +158,8 @@ void RemoteDisplayListRecorder::setFillGradient(Ref<Gradient>&& gradient, const 
 
 void RemoteDisplayListRecorder::setFillPattern(RenderingResourceIdentifier tileImageIdentifier, const PatternParameters& parameters)
 {
-    auto tileImage = sourceImage(tileImageIdentifier);
-    if (!tileImage) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    context().setFillPattern(Pattern::create(WTFMove(*tileImage), parameters));
+    if (auto tileImage = sourceImage(tileImageIdentifier))
+        context().setFillPattern(Pattern::create(WTFMove(*tileImage), parameters));
 }
 
 void RemoteDisplayListRecorder::setFillRule(WindRule rule)
@@ -187,12 +179,8 @@ void RemoteDisplayListRecorder::setStrokeColor(const WebCore::Color& color)
 
 void RemoteDisplayListRecorder::setStrokeCachedGradient(RenderingResourceIdentifier identifier, const AffineTransform& spaceTransform)
 {
-    RefPtr gradient = resourceCache().cachedGradient(identifier);
-    if (!gradient) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    context().setStrokeGradient(gradient.releaseNonNull(), spaceTransform);
+    if (RefPtr gradient = resourceCache().cachedGradient(identifier))
+        context().setStrokeGradient(gradient.releaseNonNull(), spaceTransform);
 }
 
 void RemoteDisplayListRecorder::setStrokeGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
@@ -202,12 +190,8 @@ void RemoteDisplayListRecorder::setStrokeGradient(Ref<Gradient>&& gradient, cons
 
 void RemoteDisplayListRecorder::setStrokePattern(RenderingResourceIdentifier tileImageIdentifier, const PatternParameters& parameters)
 {
-    auto tileImage = sourceImage(tileImageIdentifier);
-    if (!tileImage) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    context().setStrokePattern(Pattern::create(WTFMove(*tileImage), parameters));
+    if (auto tileImage = sourceImage(tileImageIdentifier))
+        context().setStrokePattern(Pattern::create(WTFMove(*tileImage), parameters));
 }
 
 void RemoteDisplayListRecorder::setStrokePackedColorAndThickness(PackedColor::RGBA color, float thickness)
@@ -326,13 +310,8 @@ void RemoteDisplayListRecorder::clipOutRoundedRect(const FloatRoundedRect& rect)
 
 void RemoteDisplayListRecorder::clipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect)
 {
-    RefPtr clipImage = imageBuffer(imageBufferIdentifier);
-    if (!clipImage) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    context().clipToImageBuffer(*clipImage, destinationRect);
+    if (RefPtr clipImage = imageBuffer(imageBufferIdentifier))
+        context().clipToImageBuffer(*clipImage, destinationRect);
 }
 
 void RemoteDisplayListRecorder::clipOutToPath(const Path& path)
@@ -357,7 +336,6 @@ void RemoteDisplayListRecorder::drawFilteredImageBufferInternal(std::optional<Re
     if (sourceImageIdentifier) {
         sourceImageBuffer = imageBuffer(*sourceImageIdentifier);
         if (!sourceImageBuffer) {
-            ASSERT_NOT_REACHED();
             return;
         }
     }
@@ -367,7 +345,6 @@ void RemoteDisplayListRecorder::drawFilteredImageBufferInternal(std::optional<Re
 
         auto effectImage = sourceImage(feImage->sourceImage().imageIdentifier());
         if (!effectImage) {
-            ASSERT_NOT_REACHED();
             return;
         }
 
@@ -390,7 +367,6 @@ void RemoteDisplayListRecorder::drawFilteredImageBuffer(std::optional<RenderingR
     RefPtr cachedFilter = resourceCache().cachedFilter(filter->renderingResourceIdentifier());
     RefPtr cachedSVGFilter = dynamicDowncast<SVGFilter>(WTFMove(cachedFilter));
     if (!cachedSVGFilter) {
-        ASSERT_NOT_REACHED();
         return;
     }
 
@@ -406,63 +382,43 @@ void RemoteDisplayListRecorder::drawFilteredImageBuffer(std::optional<RenderingR
 
 void RemoteDisplayListRecorder::drawGlyphs(RenderingResourceIdentifier fontIdentifier, IPC::ArrayReferenceTuple<GlyphBufferGlyph, FloatSize> glyphsAdvances, FloatPoint localAnchor, FontSmoothingMode fontSmoothingMode)
 {
-    RefPtr font = resourceCache().cachedFont(fontIdentifier);
-    if (!font) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    context().drawGlyphs(*font, glyphsAdvances.span<0>(), Vector<GlyphBufferAdvance>(glyphsAdvances.span<1>()), localAnchor, fontSmoothingMode);
+    if (RefPtr font = resourceCache().cachedFont(fontIdentifier))
+        context().drawGlyphs(*font, glyphsAdvances.span<0>(), Vector<GlyphBufferAdvance>(glyphsAdvances.span<1>()), localAnchor, fontSmoothingMode);
 }
 
 void RemoteDisplayListRecorder::drawDecomposedGlyphs(RenderingResourceIdentifier fontIdentifier, RenderingResourceIdentifier decomposedGlyphsIdentifier)
 {
     RefPtr font = resourceCache().cachedFont(fontIdentifier);
     if (!font) {
-        ASSERT_NOT_REACHED();
         return;
     }
 
     RefPtr decomposedGlyphs = resourceCache().cachedDecomposedGlyphs(decomposedGlyphsIdentifier);
     if (!decomposedGlyphs) {
-        ASSERT_NOT_REACHED();
         return;
     }
+
     context().drawDecomposedGlyphs(*font, *decomposedGlyphs);
 }
 
 void RemoteDisplayListRecorder::drawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    RefPtr sourceImage = imageBuffer(imageBufferIdentifier);
-    if (!sourceImage) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    context().drawImageBuffer(*sourceImage, destinationRect, srcRect, options);
+    if (RefPtr sourceImage = imageBuffer(imageBufferIdentifier))
+        context().drawImageBuffer(*sourceImage, destinationRect, srcRect, options);
 }
 
 void RemoteDisplayListRecorder::drawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    RefPtr image = resourceCache().cachedNativeImage(imageIdentifier);
-    if (!image) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    context().drawNativeImage(*image, destRect, srcRect, options);
+    if (RefPtr image = resourceCache().cachedNativeImage(imageIdentifier))
+        context().drawNativeImage(*image, destRect, srcRect, options);
 }
 
 void RemoteDisplayListRecorder::drawSystemImage(Ref<SystemImage>&& systemImage, const FloatRect& destinationRect)
 {
 #if USE(SYSTEM_PREVIEW)
     if (auto* badge = dynamicDowncast<ARKitBadgeSystemImage>(systemImage.get())) {
-        RefPtr nativeImage = resourceCache().cachedNativeImage(badge->imageIdentifier());
-        if (!nativeImage) {
-            ASSERT_NOT_REACHED();
-            return;
-        }
-        badge->setImage(BitmapImage::create(nativeImage.releaseNonNull()));
+        if (RefPtr nativeImage = resourceCache().cachedNativeImage(badge->imageIdentifier()))
+            badge->setImage(BitmapImage::create(nativeImage.releaseNonNull()));
     }
 #endif
     context().drawSystemImage(systemImage, destinationRect);
@@ -470,22 +426,14 @@ void RemoteDisplayListRecorder::drawSystemImage(Ref<SystemImage>&& systemImage, 
 
 void RemoteDisplayListRecorder::drawPatternNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& transform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    RefPtr image = resourceCache().cachedNativeImage(imageIdentifier);
-    if (!image) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    context().drawPattern(*image, destRect, tileRect, transform, phase, spacing, options);
+    if (RefPtr image = resourceCache().cachedNativeImage(imageIdentifier))
+        context().drawPattern(*image, destRect, tileRect, transform, phase, spacing, options);
 }
 
 void RemoteDisplayListRecorder::drawPatternImageBuffer(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& transform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    RefPtr image = imageBuffer(imageIdentifier);
-    if (!image) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-    context().drawPattern(*image, destRect, tileRect, transform, phase, spacing, options);
+    if (RefPtr image = imageBuffer(imageIdentifier))
+        context().drawPattern(*image, destRect, tileRect, transform, phase, spacing, options);
 }
 
 void RemoteDisplayListRecorder::beginTransparencyLayer(float opacity)


### PR DESCRIPTION
#### ce3907b254082c9dcc62f836cdc50620499523e7
<pre>
Improve handling of invalid identifiers in RemoteDisplayListRecorder
<a href="https://bugs.webkit.org/show_bug.cgi?id=296809">https://bugs.webkit.org/show_bug.cgi?id=296809</a>
<a href="https://rdar.apple.com/157300424">rdar://157300424</a>

Reviewed by NOBODY (OOPS!).

Replaces the previous reliance of ASSERT_NOT_REACHED with checks to improve robustness when fuzzing.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::setFillCachedGradient):
(WebKit::RemoteDisplayListRecorder::setFillPattern):
(WebKit::RemoteDisplayListRecorder::setStrokeCachedGradient):
(WebKit::RemoteDisplayListRecorder::setStrokePattern):
(WebKit::RemoteDisplayListRecorder::clipToImageBuffer):
(WebKit::RemoteDisplayListRecorder::drawFilteredImageBufferInternal):
(WebKit::RemoteDisplayListRecorder::drawFilteredImageBuffer):
(WebKit::RemoteDisplayListRecorder::drawGlyphs):
(WebKit::RemoteDisplayListRecorder::drawDecomposedGlyphs):
(WebKit::RemoteDisplayListRecorder::drawImageBuffer):
(WebKit::RemoteDisplayListRecorder::drawNativeImage):
(WebKit::RemoteDisplayListRecorder::drawSystemImage):
(WebKit::RemoteDisplayListRecorder::drawPatternNativeImage):
(WebKit::RemoteDisplayListRecorder::drawPatternImageBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce3907b254082c9dcc62f836cdc50620499523e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65088 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86910 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41826 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26852 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64219 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95734 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95518 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40667 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18506 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37423 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46767 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->