### PR TITLE
Reduce CPP unsafeness in the network process

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -73,7 +73,8 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
     self.cancellable = YES;
     self.cancellationHandler = makeBlockPtr([weakSelf = WeakObjCPtr<WKDownloadProgress> { self }] () mutable {
         ensureOnMainRunLoop([weakSelf = WTFMove(weakSelf)] {
-            [weakSelf performCancel];
+            if (RetainPtr protectedSelf = weakSelf.get())
+                [protectedSelf performCancel];
         });
     }).get();
 

--- a/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
@@ -78,7 +78,7 @@
     if (!connection)
         return completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
     connection->sendWithAsyncReply(Messages::NetworkProcessProxy::DataTaskReceivedChallenge(*_identifier, challenge), [completionHandler = makeBlockPtr(completionHandler)](WebKit::AuthenticationChallengeDisposition disposition, WebCore::Credential&& credential) {
-        completionHandler(fromAuthenticationChallengeDisposition(disposition), credential.nsCredential());
+        completionHandler(fromAuthenticationChallengeDisposition(disposition), RetainPtr { credential.nsCredential() }.get());
     });
 }
 
@@ -120,8 +120,8 @@
     if (!connection)
         return;
     connection->send(Messages::NetworkProcessProxy::DataTaskDidCompleteWithError(*_identifier, error), 0);
-    if (_session)
-        _session->removeDataTask(*_identifier);
+    if (CheckedPtr session = _session.get())
+        session->removeDataTask(*_identifier);
 }
 
 @end

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -60,7 +60,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
         m_topOrigin = clientOrigin.topOrigin;
 
     bool shouldBlockCookies = storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::EphemeralStateless;
-    if (CheckedPtr networkStorageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
+    if (CheckedPtr session = networkSession(); CheckedPtr networkStorageSession = session ? session->networkStorageSession() : nullptr) {
         if (!shouldBlockCookies)
             shouldBlockCookies = networkStorageSession->shouldBlockCookies(request, frameID, pageID, shouldRelaxThirdPartyCookieBlocking());
     }

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,8 +1,6 @@
 NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
 NetworkProcess/DatabaseUtilities.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
-NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
-NetworkProcess/cocoa/WebSocketTaskCocoa.mm
 Platform/IPC/ArgumentCoders.h
 Platform/cocoa/_WKWebViewTextInputNotifications.mm
 Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -2,7 +2,6 @@ GPUProcess/mac/GPUProcessMac.mm
 GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
 GeneratedWebKitSecureCoding.mm
 NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
-NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
 NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
 NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
 NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -10,7 +9,6 @@ NetworkProcess/cache/NetworkCacheDataCocoa.mm
 NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
 NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
 NetworkProcess/cocoa/NetworkProcessCocoa.mm
-NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
 NetworkProcess/mac/NetworkProcessMac.mm
 NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
 NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm


### PR DESCRIPTION
#### f11bb0c5aa68d0e4f0a7107e01a538eb8a27a10a
<pre>
Reduce CPP unsafeness in the network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=296810">https://bugs.webkit.org/show_bug.cgi?id=296810</a>

Reviewed by Anne van Kesteren.

Address a few of assorted Safer CPP warnings in a few cocoa-specific
classes in the network process.

* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm:
(-[WKDownloadProgress initWithDownloadTask:download:URL:sandboxExtension:]):
* Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm:
(-[WKURLSessionTaskDelegate URLSession:task:didReceiveChallenge:completionHandler:]):
(-[WKURLSessionTaskDelegate URLSession:task:didCompleteWithError:]):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::WebSocketTask):
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/298281@main">https://commits.webkit.org/298281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28adeb23601bcbb38aca29e02f02ee431ed7a9c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65651 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43278 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27349 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41974 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/31379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24421 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19010 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47384 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41393 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->