### PR TITLE
Reduce complexity of out-of-flow calculations in availableLogicalHeightForPercentageComputation()

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3138,16 +3138,6 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
             );
         }
 
-        // A positioned element that specified both top/bottom or that specifies
-        // height should be treated as though it has a height explicitly specified
-        // that can be used for any percentage computations.
-        auto isOutOfFlowPositionedWithSpecifiedHeight = isOutOfFlowPositioned() && (!style.logicalHeight().isAuto() || (!style.logicalTop().isAuto() && !style.logicalBottom().isAuto()));
-        if (isOutOfFlowPositionedWithSpecifiedHeight) {
-            // Don't allow this to affect the block' size() member variable, since this
-            // can get called while the block is still laying out its kids.
-            return std::max(0_lu, computeLogicalHeight(logicalHeight(), 0_lu).m_extent - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight());
-        }
-
         if (style.logicalHeight().isPercentOrCalculated()) {
             if (auto heightWithScrollbar = computePercentageLogicalHeight(style.logicalHeight())) {
                 auto contentBoxHeightWithScrollbar = adjustContentBoxLogicalHeightForBoxSizing(*heightWithScrollbar);
@@ -3156,6 +3146,17 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
                 return std::max(0_lu, constrainContentBoxLogicalHeightByMinMax(contentBoxHeightWithScrollbar - scrollbarLogicalHeight(), { }));
             }
             return { };
+        }
+
+        // A positioned element that specified both top/bottom or that specifies
+        // height should be treated as though it has a height explicitly specified
+        // that can be used for any percentage computations.
+        if (isOutOfFlowPositioned() && !style.hasStaticBlockPosition(style.writingMode().isHorizontal())) {
+            // Don't allow this to affect the block' size() member variable, since this
+            // can get called while the block is still laying out its kids.
+            PositionedLayoutConstraints constraints(*this, LogicalBoxAxis::Block);
+            constraints.computeInsets();
+            return std::max(0_lu, constraints.availableContentSpace() - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight());
         }
 
         if (isRenderView())


### PR DESCRIPTION
#### a667497e726f27ba87dcb2ff18012fe19eab9db2
<pre>
Reduce complexity of out-of-flow calculations in availableLogicalHeightForPercentageComputation()
<a href="https://bugs.webkit.org/show_bug.cgi?id=296766">https://bugs.webkit.org/show_bug.cgi?id=296766</a>

Reviewed by NOBODY (OOPS!).

Use PositionedLayoutConstraints directly so we avoid doing excess work or
forgetting to handle something as absolute positioning gets more complex.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a667497e726f27ba87dcb2ff18012fe19eab9db2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42695 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86932 "Found 11 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendants-017.html imported/w3c/web-platform-tests/css/css-position/position-absolute-semi-replaced-stretch-input.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41839 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117337 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27691 "Found 2 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67324 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26873 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendants-017.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-020.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20859 "Found 9 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-020.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97067 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20974 "Found 9 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-020.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123762 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41403 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30899 "Found 9 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-020.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95754 "Found 11 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-grid/abspos/positioned-grid-descendants-017.html imported/w3c/web-platform-tests/css/css-position/position-absolute-semi-replaced-stretch-input.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95538 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40693 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18530 "Found 9 new test failures: fast/block/positioning/child-of-absolute-with-auto-height.html fast/block/positioning/complex-percentage-height.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-010.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-011.html imported/w3c/web-platform-tests/css/css-sizing/intrinsic-percent-replaced-020.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37442 "Hash a667497e for PR 48834 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46791 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->