### PR TITLE
[Win] Layout Tests gardening

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -98,6 +98,13 @@ fast/shadow-dom/pointerlockelement-in-shadow-tree.html [ Skip ]
 fast/shadow-dom/pointerlockelement-in-slot.html [ Skip ]
 pointer-lock [ Skip ]
 
+# WEB_AUTHN is disabled
+http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
+
+# WEB_CODECS is disabled
+fast/webcodecs/audio-data-copy-to-crash.html [ Skip ]
+
 # WebGPU is disabled
 http/tests/webgpu [ Skip ]
 fast/webgpu [ Skip ]
@@ -218,6 +225,9 @@ fast/images/image-size-unsigned-overflow.html [ Skip ]
 fast/events/clipboard-dataTransferItemList.html [ Skip ]
 fast/events/drag-dataTransferItemList.html [ Skip ]
 fast/events/drag-dataTransferItemList-file-handling.html [ Skip ]
+
+# WebTransport only has a stub implementation
+imported/w3c/web-platform-tests/webtransport/ [ Skip ]
 
 # Drag and drop isn't supported yet, and GDI resource leaks <webkit.org/b/264999>
 editing/selection/drag-text-delay.html [ Skip ]
@@ -482,6 +492,15 @@ compositing/tiling/tiled-reflection-inwindow.html [ Skip ]
 
 # UIHelper.initiateUserScroll() doesn't resolve the promise
 http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html [ Skip ] # Timeout
+
+# Mix of errors related to the harness:
+# Unhandled Promise Rejection: TypeError: Load failed
+# Harness Error (TIMEOUT), message = null
+imported/w3c/web-platform-tests/scroll-to-text-fragment/redirects.html
+imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-after-DOMContentLoaded.html
+imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-scroll-to-center.html
+imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub.html
+imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html
 
 # WebKitTestRunner: test fonts are not available in GPU process
 webkit.org/b/278895 fast/canvas/canvas-blending-text.html [ Skip ]
@@ -1848,6 +1867,18 @@ imported/w3c/web-platform-tests/cookiestore [ Skip ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
 http/tests/cookies/cookie-store-get-secure.https.html [ Skip ]
 http/tests/cookies/cookie-store-set-secure.https.html [ Skip ]
+http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html [ Skip ]
+http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html [ Skip ]
+http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html [ Skip ]
+http/tests/workers/service/basic-install-event-sw-fetch-third-party.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__HostHttp.https.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__host.header.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__host.header.https.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.https.html [ Skip ]
+imported/w3c/web-platform-tests/cookies/prefix/__secure.header.html [ Skip ]
 
 # `scrollend` events are not supported on Windows
 webkit.org/b/201556 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-sequence-of-scrolls.tentative.html [ Skip ]
@@ -1929,6 +1960,7 @@ webkit.org/b/271223 fast/events/wheel/redispatched-wheel-event.html [ Skip ] # T
 
 # Trusted Types aren't implemented yet
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
+webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html [ Skip ]
@@ -1943,6 +1975,9 @@ webkit.org/b/267251 imported/w3c/web-platform-tests/css/selectors/invalidation/u
 #//////////////////////////////////////////////////////////////////////////////////////////
 # TEMPORARY SKIPS -- these areas still need to be addressed individually
 #//////////////////////////////////////////////////////////////////////////////////////////
+
+imported/w3c/web-platform-tests/event-timing/interaction-count-click.html [ Skip ]
+imported/w3c/web-platform-tests/event-timing/interaction-count-press-key.html [ Skip ]
 
 compositing/video [ Skip ]
 editing/pasteboard [ Skip ]
@@ -2386,6 +2421,7 @@ fast/text/cjk-multi-codepoint-cluster-vertical.html [ ImageOnlyFailure ]
 fast/text/combining-mark-paint.html [ ImageOnlyFailure ]
 fast/text/complex-small-caps-non-bmp-capitalize.html [ ImageOnlyFailure ]
 fast/text/emoji-overlap.html [ ImageOnlyFailure ]
+fast/text/emoji-style.html [ ImageOnlyFailure ]
 fast/text/emoji-synthesis.html [ ImageOnlyFailure ]
 fast/text/emoji-variation-selector.html [ ImageOnlyFailure ]
 fast/text/emoji-with-joiner.html [ Failure ]
@@ -4139,6 +4175,7 @@ compositing/layer-creation/scroll-partial-update.html [ Skip ]
 compositing/layer-creation/spanOverlapsCanvas.html [ Skip ]
 compositing/layer-creation/stacking-context-overlap-nested.html [ Skip ]
 compositing/layer-creation/stacking-context-overlap.html [ Skip ]
+compositing/layer-creation/sticky-overlap-extent.html [ Skip ]
 compositing/layer-creation/subpixel-adjacent-layers-overlap.html [ Skip ]
 compositing/layer-creation/translate-animation-overlap.html [ Skip ]
 compositing/layer-creation/translate-scale-animation-overlap.html [ Skip ]
@@ -4272,6 +4309,7 @@ fast/events/keydown-leftright-keys.html [ Failure ]
 fast/events/mouse-cursor-change.html [ Failure ]
 fast/events/mouse-cursor-no-mousemove.html [ Failure ]
 fast/events/mouse-cursor-udpate-during-raf.html [ Failure ]
+fast/events/page-visibility-resize-event-order.html [ Timeout ]
 fast/events/selectstart-by-single-click-with-shift.html [ Failure ]
 fast/text/font-download-font-face-src-list.html [ Failure ]
 fast/text/font-download-font-family-property.html [ Failure ]
@@ -4487,3 +4525,13 @@ http/tests/iframe-memory-monitor/media-video-autoplay-in-frames.html [ Skip ]
 dom/xsl/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
+
+# New imported 'focus' timeout failures
+imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-contentwindow.html [ Failure ]
+imported/w3c/web-platform-tests/focus/activeelement-after-focusing-same-site-iframe-contentwindow.html [ Failure ]
+imported/w3c/web-platform-tests/focus/activeelement-after-focusing-same-site-iframe.html [ Failure ]
+imported/w3c/web-platform-tests/focus/focus-restoration-in-same-site-iframes-window.html [ Failure ]
+imported/w3c/web-platform-tests/focus/hasfocus-same-site.html [ Failure ]
+imported/w3c/web-platform-tests/focus/iframe-contentwindow-focus-with-different-site-intermediate-frame.html [ Failure ]
+imported/w3c/web-platform-tests/focus/iframe-contentwindow-focus-with-same-as-top-intermediate-frame.html [ Failure ]
+imported/w3c/web-platform-tests/focus/iframe-focus-with-different-site-intermediate-frame.html [ Failure ]

--- a/LayoutTests/platform/win/fast/forms/number/number-min-max-spinbutton-appearance-none-percentage-width-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/number/number-min-max-spinbutton-appearance-none-percentage-width-expected.txt
@@ -1,0 +1,2 @@
+
+input width is 45

--- a/LayoutTests/platform/win/fast/forms/range/slider-zoomed-expected.txt
+++ b/LayoutTests/platform/win/fast/forms/range/slider-zoomed-expected.txt
@@ -1,0 +1,2 @@
+
+FAIL: expected slider value 73, got 72

--- a/LayoutTests/platform/win/overflow/overflow-transform-perspective-expected.txt
+++ b/LayoutTests/platform/win/overflow/overflow-transform-perspective-expected.txt
@@ -1,0 +1,12 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x134
+  RenderBlock {HTML} at (0,0) size 800x134
+    RenderBody {BODY} at (8,8) size 784x118
+      RenderBlock (anonymous) at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 364x17
+          text run at (0,0) width 364: "The result should have horizontal and vertical scrollbars."
+layer at (8,26) size 100x100 clip at (8,26) size 85x85 scrollWidth 89 scrollHeight 94
+  RenderBlock {DIV} at (0,18) size 100x100
+layer at (8,26) size 90x80 backgroundClip at (8,26) size 85x85 clip at (8,26) size 85x85
+  RenderBlock {DIV} at (0,0) size 90x80


### PR DESCRIPTION
#### eddd8ded2c64ffe304243fb2fcf4a56e7f19f6b6
<pre>
[Win] Layout Tests gardening
<a href="https://bugs.webkit.org/show_bug.cgi?id=296894">https://bugs.webkit.org/show_bug.cgi?id=296894</a>

Reviewed by Yusuke Suzuki.

Assorted test gardening:

* WEB_AUTHN tests moved, skipped on Windows
* Skip new cookie store tests
* Skip web codecs tests
* Skip new imported &apos;focus&apos; timeout failures
* Skip new Trusted Types test
* Skip Web Transport tests (stub implementation)
* Skip scroll-to-text-fragment tests (harness problems)

Canonical link: <a href="https://commits.webkit.org/298245@main">https://commits.webkit.org/298245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42ce072d1d02cc5acdfc6051c3cf9e7918e72811

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65489 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87255 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124164 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95847 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41686 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44563 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->