### PR TITLE
[Materials] Add support for the clear variant of glass

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1935,6 +1935,8 @@ constexpr CSSValueID toCSSValueID(AppleVisualEffect effect)
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
         return CSSValueAppleSystemGlassMaterial;
+    case AppleVisualEffect::GlassClearMaterial:
+        return CSSValueAppleSystemGlassMaterialClear;
     case AppleVisualEffect::GlassSubduedMaterial:
         return CSSValueAppleSystemGlassMaterialSubdued;
     case AppleVisualEffect::GlassMediaControlsMaterial:
@@ -1981,6 +1983,8 @@ template<> constexpr AppleVisualEffect fromCSSValueID(CSSValueID valueID)
 #if HAVE(MATERIAL_HOSTING)
     case CSSValueAppleSystemGlassMaterial:
         return AppleVisualEffect::GlassMaterial;
+    case CSSValueAppleSystemGlassMaterialClear:
+        return AppleVisualEffect::GlassClearMaterial;
     case CSSValueAppleSystemGlassMaterialSubdued:
         return AppleVisualEffect::GlassSubduedMaterial;
     case CSSValueAppleSystemGlassMaterialMediaControls:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12366,6 +12366,10 @@
                     "enable-if": "HAVE_MATERIAL_HOSTING"
                 },
                 {
+                    "value": "-apple-system-glass-material-clear",
+                    "enable-if": "HAVE_MATERIAL_HOSTING"
+                },
+                {
                     "value": "-apple-system-glass-material-subdued",
                     "enable-if": "HAVE_MATERIAL_HOSTING"
                 },

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1434,6 +1434,7 @@ apple-invert-lightness
 -apple-system-blur-material-thick enable-if=HAVE_CORE_MATERIAL
 -apple-system-blur-material-chrome enable-if=HAVE_CORE_MATERIAL
 -apple-system-glass-material enable-if=HAVE_MATERIAL_HOSTING
+-apple-system-glass-material-clear enable-if=HAVE_MATERIAL_HOSTING
 -apple-system-glass-material-subdued enable-if=HAVE_MATERIAL_HOSTING
 -apple-system-glass-material-media-controls enable-if=HAVE_MATERIAL_HOSTING
 -apple-system-glass-material-media-controls-subdued enable-if=HAVE_MATERIAL_HOSTING

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -44,6 +44,7 @@ bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
     case AppleVisualEffect::None:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
     case AppleVisualEffect::GlassSubduedMaterial:
     case AppleVisualEffect::GlassMediaControlsMaterial:
     case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
@@ -74,6 +75,7 @@ bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
     case AppleVisualEffect::GlassSubduedMaterial:
     case AppleVisualEffect::GlassMediaControlsMaterial:
     case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
@@ -99,6 +101,7 @@ bool appleVisualEffectIsHostedMaterial(AppleVisualEffect effect)
 {
     switch (effect) {
     case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
     case AppleVisualEffect::GlassSubduedMaterial:
     case AppleVisualEffect::GlassMediaControlsMaterial:
     case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
@@ -149,6 +152,9 @@ TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
         ts << "glass-material"_s;
+        break;
+    case AppleVisualEffect::GlassClearMaterial:
+        ts << "glass-material-clear"_s;
         break;
     case AppleVisualEffect::GlassSubduedMaterial:
         ts << "glass-material-subdued"_s;

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -44,6 +44,7 @@ enum class AppleVisualEffect : uint8_t {
     BlurChromeMaterial,
 #if HAVE(MATERIAL_HOSTING)
     GlassMaterial,
+    GlassClearMaterial,
     GlassSubduedMaterial,
     GlassMediaControlsMaterial,
     GlassSubduedMediaControlsMaterial,

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
@@ -39,6 +39,7 @@
 typedef NS_ENUM(NSInteger, WKHostedMaterialEffectType) {
     WKHostedMaterialEffectTypeNone,
     WKHostedMaterialEffectTypeGlass,
+    WKHostedMaterialEffectTypeClearGlass,
     WKHostedMaterialEffectTypeSubduedGlass,
     WKHostedMaterialEffectTypeMediaControlsGlass,
     WKHostedMaterialEffectTypeSubduedMediaControlsGlass,

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -93,6 +93,8 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
             return nil
         case .glass:
             return ._glass(.regular)
+        case .clearGlass:
+            return ._glass(.clear)
         case .subduedGlass:
             return ._glass(.regular.forceSubdued())
         case .mediaControlsGlass:

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -169,6 +169,7 @@ static MTCoreMaterialRecipe materialRecipeForAppleVisualEffect(AppleVisualEffect
         return PAL::get_CoreMaterial_MTCoreMaterialRecipeNone();
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
     case AppleVisualEffect::GlassSubduedMaterial:
     case AppleVisualEffect::GlassMediaControlsMaterial:
     case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
@@ -210,6 +211,7 @@ static MTCoreMaterialVisualStyle materialVisualStyleForAppleVisualEffect(AppleVi
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
     case AppleVisualEffect::GlassSubduedMaterial:
     case AppleVisualEffect::GlassMediaControlsMaterial:
     case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
@@ -240,6 +242,7 @@ static MTCoreMaterialVisualStyleCategory materialVisualStyleCategoryForAppleVisu
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::GlassMaterial:
+    case AppleVisualEffect::GlassClearMaterial:
     case AppleVisualEffect::GlassSubduedMaterial:
     case AppleVisualEffect::GlassMediaControlsMaterial:
     case AppleVisualEffect::GlassSubduedMediaControlsMaterial:
@@ -256,6 +259,8 @@ static WKHostedMaterialEffectType hostedMaterialEffectTypeForAppleVisualEffect(A
     switch (effect) {
     case AppleVisualEffect::GlassMaterial:
         return WKHostedMaterialEffectTypeGlass;
+    case AppleVisualEffect::GlassClearMaterial:
+        return WKHostedMaterialEffectTypeClearGlass;
     case AppleVisualEffect::GlassSubduedMaterial:
         return WKHostedMaterialEffectTypeSubduedGlass;
     case AppleVisualEffect::GlassMediaControlsMaterial:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8190,6 +8190,7 @@ enum class WebCore::AppleVisualEffect : uint8_t {
     BlurChromeMaterial,
 #if HAVE(MATERIAL_HOSTING)
     GlassMaterial,
+    GlassClearMaterial,
     GlassSubduedMaterial,
     GlassMediaControlsMaterial,
     GlassSubduedMediaControlsMaterial,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppleVisualEffectTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppleVisualEffectTests.mm
@@ -127,6 +127,28 @@ TEST(AppleVisualEffect, SubduedGlassMaterialParsingWithoutUseSystemAppearance)
     EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.querySelector('#test')).getPropertyValue('-apple-visual-effect')"]);
 }
 
+TEST(AppleVisualEffect, ClearGlassMaterialParsing)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView _setUseSystemAppearance:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<div id='test'></div>"];
+    [webView stringByEvaluatingJavaScript:@"document.querySelector('#test').style.setProperty('-apple-visual-effect', '-apple-system-glass-material-clear')"];
+
+    EXPECT_WK_STREQ("-apple-system-glass-material-clear", [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.querySelector('#test')).getPropertyValue('-apple-visual-effect')"]);
+}
+
+TEST(AppleVisualEffect, ClearGlassMaterialParsingWithoutUseSystemAppearance)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView _setUseSystemAppearance:NO];
+
+    [webView synchronouslyLoadHTMLString:@"<div id='test'></div>"];
+    [webView stringByEvaluatingJavaScript:@"document.querySelector('#test').style.setProperty('-apple-visual-effect', '-apple-system-glass-material-clear')"];
+
+    EXPECT_WK_STREQ("", [webView stringByEvaluatingJavaScript:@"getComputedStyle(document.querySelector('#test')).getPropertyValue('-apple-visual-effect')"]);
+}
+
 TEST(AppleVisualEffect, NoCrashWhenRemovingLayers)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 89363228efd8c668eb6a0a4b09d4ced577a8907f
<pre>
[Materials] Add support for the clear variant of glass
<a href="https://bugs.webkit.org/show_bug.cgi?id=296819">https://bugs.webkit.org/show_bug.cgi?id=296819</a>
<a href="https://rdar.apple.com/157227748">rdar://157227748</a>

Reviewed by Richard Robinson.

Introduce `-apple-system-glass-material-clear`, which maps to `Glass.clear`.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectNeedsBackdrop):
(WebCore::appleVisualEffectAppliesFilter):
(WebCore::appleVisualEffectIsHostedMaterial):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
(MaterialHostingView.resolvedMaterialEffect(for:)):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::materialVisualStyleForAppleVisualEffect):
(WebKit::materialVisualStyleCategoryForAppleVisualEffect):
(WebKit::hostedMaterialEffectTypeForAppleVisualEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppleVisualEffectTests.mm:
(TestWebKitAPI::TEST(AppleVisualEffect, ClearGlassMaterialParsing)):
(TestWebKitAPI::TEST(AppleVisualEffect, ClearGlassMaterialParsingWithoutUseSystemAppearance)):

Canonical link: <a href="https://commits.webkit.org/298145@main">https://commits.webkit.org/298145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/162eb23f1b79de4f18943aabc86ccf112f455a42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65114 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bec32f52-f3d4-46bb-9be1-f2aa240b1099) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/731ebf6b-26c2-449d-ab61-6a7fbc272c0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67333 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64249 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123769 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95760 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95544 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37449 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18331 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46799 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40883 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->