### PR TITLE
Update details and hidden=until-found ancestor revealing algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS hidden=until-found and details revealing algorithm should abort if attribute states are mutated on beforematch events.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-001.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#ancestor-revealing-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<details id="a3">
+    <div id="a2" hidden="until-found">
+        <details id="a1" hidden="until-found">
+            <div id="a1child">Hidden</div>
+        </details>
+    </div>
+</details>
+
+<script>
+function test_state({ a1open, a1hidden, a2hidden, a3open }) {
+    assert_equals(a1.open, a1open, `a1 should ${a1open ? "" : "not "}be open`);
+    assert_equals(a1.hidden, a1hidden ? "until-found" : false, `a1 should ${a1hidden ? "" : "not "}be hidden`);
+    assert_equals(a2.hidden, a2hidden ? "until-found" : false, `a2 should ${a2hidden ? "" : "not "}be hidden`);
+    assert_equals(a3.open, a3open, `a3 should ${a3open ? "" : "not "}be open`);
+}
+t = async_test("hidden=until-found and details revealing algorithm should abort if attribute states are mutated on beforematch events.");
+test_state({
+    a1open: false,
+    a1hidden: true,
+    a2hidden: true,
+    a3open: false
+});
+a1.addEventListener("beforematch", t.step_func(() => {
+    test_state({
+        a1open: true, // We find the <details> element before finding hidden=until-found as a consequence of tree-traversal order.
+        a1hidden: true, // hidden=until-found removal happens after beforematch event.
+        a2hidden: true,
+        a3open: false
+    });
+    a2.addEventListener("beforematch", t.step_func((e) => {
+        assert_equals(e.target, a1, "a1 beforematch event bubbles up");
+        // No change in state, since it's part of the same event dispatch as above.
+        test_state({
+            a1open: true,
+            a1hidden: true,
+            a2hidden: true,
+            a3open: false
+        });
+        a1.hidden = true;
+        a2.addEventListener("beforematch", t.unreached_func("Algorithm should have aborted due to hidden attribute no longer being in the until-found state."));
+        a3.addEventListener("toggle", t.unreached_func("Algorithm should have aborted due to hidden attribute no longer being in the until-found state."));
+        t.done();
+    }), { once: true });
+}), { once: true });
+
+location.hash = "#a1child";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-002-expected.txt
@@ -1,0 +1,4 @@
+Hidden
+
+PASS hidden=until-found and details revealing algorithm should abort if attribute states are mutated on beforematch events.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-002.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#ancestor-revealing-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<details id="a3">
+    <div id="a2" hidden="until-found">
+        <details id="a1" hidden="until-found">
+            <div id="a1child">Hidden</div>
+        </details>
+    </div>
+</details>
+
+<script>
+function test_state({ a1open, a1hidden, a2hidden, a3open }) {
+    assert_equals(a1.open, a1open, `a1 should ${a1open ? "" : "not "}be open`);
+    assert_equals(a1.hidden, a1hidden ? "until-found" : false, `a1 should ${a1hidden ? "" : "not "}be hidden`);
+    assert_equals(a2.hidden, a2hidden ? "until-found" : false, `a2 should ${a2hidden ? "" : "not "}be hidden`);
+    assert_equals(a3.open, a3open, `a3 should ${a3open ? "" : "not "}be open`);
+}
+t = async_test("hidden=until-found and details revealing algorithm should abort if attribute states are mutated on beforematch events.");
+test_state({
+    a1open: false,
+    a1hidden: true,
+    a2hidden: true,
+    a3open: false
+});
+a1.addEventListener("beforematch", t.step_func(() => {
+    test_state({
+        a1open: true, // We find the <details> element before finding hidden=until-found as a consequence of tree-traversal order.
+        a1hidden: true, // hidden=until-found removal happens after beforematch event.
+        a2hidden: true,
+        a3open: false
+    });
+    a2.addEventListener("beforematch", t.step_func((e) => {
+        assert_equals(e.target, a1, "a1 beforematch event bubbles up");
+        // No change in state, since it's part of the same event dispatch as above.
+        test_state({
+            a1open: true,
+            a1hidden: true,
+            a2hidden: true,
+            a3open: false
+        });
+        a1.hidden = false;
+        a2.addEventListener("beforematch", t.unreached_func("Algorithm should have aborted due to hidden attribute no longer being in the until-found state."));
+        a3.addEventListener("toggle", t.unreached_func("Algorithm should have aborted due to hidden attribute no longer being in the until-found state."));
+        t.done();
+    }), { once: true });
+}), { once: true });
+
+location.hash = "#a1child";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS hidden=until-found and details revealing algorithm should abort if revealed node is removed.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-001.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#ancestor-revealing-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<details id="a3">
+    <div id="a2" hidden="until-found">
+        <details id="a1" hidden="until-found">
+            <div id="a1child">Hidden</div>
+        </details>
+    </div>
+</details>
+
+<script>
+function test_state({ a1open, a1hidden, a2hidden, a3open }) {
+    assert_equals(a1.open, a1open, `a1 should ${a1open ? "" : "not "}be open`);
+    assert_equals(a1.hidden, a1hidden ? "until-found" : false, `a1 should ${a1hidden ? "" : "not "}be hidden`);
+    assert_equals(a2.hidden, a2hidden ? "until-found" : false, `a2 should ${a2hidden ? "" : "not "}be hidden`);
+    assert_equals(a3.open, a3open, `a3 should ${a3open ? "" : "not "}be open`);
+}
+t = async_test("hidden=until-found and details revealing algorithm should abort if revealed node is removed.");
+test_state({
+    a1open: false,
+    a1hidden: true,
+    a2hidden: true,
+    a3open: false
+});
+a1.addEventListener("beforematch", t.step_func(() => {
+    test_state({
+        a1open: true, // We find the <details> element before finding hidden=until-found as a consequence of tree-traversal order.
+        a1hidden: true, // hidden=until-found removal happens after beforematch event.
+        a2hidden: true,
+        a3open: false
+    });
+    a2.addEventListener("beforematch", t.step_func((e) => {
+        assert_equals(e.target, a1, "a1 beforematch event bubbles up");
+        // No change in state, since it's part of the same event dispatch as above.
+        test_state({
+            a1open: true,
+            a1hidden: true,
+            a2hidden: true,
+            a3open: false
+        });
+        a1.remove();
+        a2.addEventListener("beforematch", t.unreached_func("Algorithm should have aborted due to node removal."));
+        a3.addEventListener("toggle", t.unreached_func("Algorithm should have aborted due to node removal."));
+        t.done();
+    }), { once: true });
+}), { once: true });
+
+location.hash = "#a1child";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-002-expected.txt
@@ -1,0 +1,3 @@
+
+PASS hidden=until-found and details revealing algorithm should abort if attribute states are mutated on beforematch events.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-002.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#ancestor-revealing-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<details id="a4">
+    <details id="a3">
+        <div id="a2" hidden="until-found">
+            <details id="a1" hidden="until-found">
+                <div id="a1child">Hidden</div>
+            </details>
+        </div>
+    </details>
+</details>
+
+<script>
+function test_state({ a1open, a1hidden, a2hidden, a3open }) {
+    assert_equals(a1.open, a1open, `a1 should ${a1open ? "" : "not "}be open`);
+    assert_equals(a1.hidden, a1hidden ? "until-found" : false, `a1 should ${a1hidden ? "" : "not "}be hidden`);
+    assert_equals(a2.hidden, a2hidden ? "until-found" : false, `a2 should ${a2hidden ? "" : "not "}be hidden`);
+    assert_equals(a3.open, a3open, `a3 should ${a3open ? "" : "not "}be open`);
+}
+t = async_test("hidden=until-found and details revealing algorithm should abort if attribute states are mutated on beforematch events.");
+test_state({
+    a1open: false,
+    a1hidden: true,
+    a2hidden: true,
+    a3open: false
+});
+a1.addEventListener("beforematch", t.step_func(() => {
+    test_state({
+        a1open: true, // We find the <details> element before finding hidden=until-found as a consequence of tree-traversal order.
+        a1hidden: true, // hidden=until-found removal happens after beforematch event.
+        a2hidden: true,
+        a3open: false
+    });
+    a2.addEventListener("beforematch", t.step_func((e) => {
+        assert_equals(e.target, a1, "a1 beforematch event bubbles up");
+        // No change in state, since it's part of the same event dispatch as above.
+        test_state({
+            a1open: true,
+            a1hidden: true,
+            a2hidden: true,
+            a3open: false
+        });
+        a1.hidden = false;
+        a2.addEventListener("beforematch", t.step_func((e) => {
+            assert_equals(e.target, a2, "beforematch event for a2");
+            test_state({
+                a1open: true,
+                a1hidden: false, // a1 was revealed after its beforematch event.
+                a2hidden: true,
+                a3open: false
+            });
+            a3.addEventListener("toggle", t.unreached_func("Algorithm should have aborted due to element removal."));
+            a3.remove();
+            a4.addEventListener("toggle", t.unreached_func("Algorithm should have aborted due to element removal."));
+            t.done();
+        }), { once: true });
+    }), { once: true });
+}), { once: true });
+
+location.hash = "#a1child";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-infinite-loop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-infinite-loop-expected.txt
@@ -1,5 +1,5 @@
 hidden 2
 hidden 1
 
-FAIL hidden=until-found revealing algorithm should collect elements to reveal before revealing them. assert_false: beforematch should not have been fired on h2. expected false got true
+PASS hidden=until-found revealing algorithm should collect elements to reveal before revealing them.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-and-details-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-and-details-expected.txt
@@ -1,0 +1,4 @@
+Hidden
+
+PASS hidden=until-found and details revealing algorithm should reveal elements in a certain order.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-and-details.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-and-details.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#ancestor-revealing-algorithm">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<details id="a3">
+    <div id="a2" hidden="until-found">
+        <details id="a1" hidden="until-found">
+            <div id="a1child">Hidden</div>
+        </details>
+    </div>
+</details>
+
+<script>
+function test_state({ a1open, a1hidden, a2hidden, a3open }) {
+    assert_equals(a1.open, a1open, `a1 should ${a1open ? "" : "not "}be open`);
+    assert_equals(a1.hidden, a1hidden ? "until-found" : false, `a1 should ${a1hidden ? "" : "not "}be hidden`);
+    assert_equals(a2.hidden, a2hidden ? "until-found" : false, `a2 should ${a2hidden ? "" : "not "}be hidden`);
+    assert_equals(a3.open, a3open, `a3 should ${a3open ? "" : "not "}be open`);
+}
+t = async_test("hidden=until-found and details revealing algorithm should reveal elements in a certain order.");
+test_state({
+    a1open: false,
+    a1hidden: true,
+    a2hidden: true,
+    a3open: false
+});
+a1.addEventListener("beforematch", t.step_func(() => {
+    test_state({
+        a1open: true, // We find the <details> element before finding hidden=until-found as a consequence of tree-traversal order.
+        a1hidden: true, // hidden=until-found removal happens after beforematch event.
+        a2hidden: true,
+        a3open: false
+    });
+    a2.addEventListener("beforematch", t.step_func((e) => {
+        assert_equals(e.target, a1, "a1 beforematch event bubbles up");
+        // No change in state, since it's part of the same event dispatch as above.
+        test_state({
+            a1open: true,
+            a1hidden: true,
+            a2hidden: true,
+            a3open: false
+        });
+        a2.addEventListener("beforematch", t.step_func((e) => {
+            assert_equals(e.target, a2, "beforematch event for a2");
+            test_state({
+                a1open: true,
+                a1hidden: false, // a1 was revealed after its beforematch event.
+                a2hidden: true,
+                a3open: false
+            });
+            a3.addEventListener("toggle", t.step_func(() => {
+                test_state({
+                    a1open: true,
+                    a1hidden: false,
+                    a2hidden: false, // a2 was revealed after its beforematch event.
+                    a3open: true
+                });
+                t.done();
+            }), { once: true });
+        }), { once: true });
+    }), { once: true });
+}), { once: true });
+
+location.hash = "#a1child";
+</script>

--- a/Source/WebCore/dom/FindRevealAlgorithms.h
+++ b/Source/WebCore/dom/FindRevealAlgorithms.h
@@ -29,9 +29,6 @@ namespace WebCore {
 
 class Node;
 
-void revealClosedDetailsAncestors(Node&);
-void revealHiddenUntilFoundAncestors(Node&);
-
 WEBCORE_EXPORT void revealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 73c50cc0dc4eaa68de3a548bc8646a932882c5a9
<pre>
Update details and hidden=until-found ancestor revealing algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=296797">https://bugs.webkit.org/show_bug.cgi?id=296797</a>
<a href="https://rdar.apple.com/157280008">rdar://157280008</a>

Reviewed by Darin Adler.

Follow <a href="https://github.com/whatwg/html/pull/11457">https://github.com/whatwg/html/pull/11457</a> which:
- Prevents infinite looping due to mutations on the beforematch event, by collecting the ancestors beforehand (covered by beforematch-infinite-loop.html)
- Combines both details and hidden=until-found ancestor revealing algorithms into a single one, to avoid two separate traversals (covered by hidden-until-found-and-details.html)
- Adds checks for attribute/element removal mutations during the beforematch event (covered by removal WPTs)

Also write WPTs for previously uncovered parts.

* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-attribute-removal-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-element-removal-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/beforematch-infinite-loop-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-and-details-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/the-hidden-attribute/hidden-until-found-and-details.html: Added.
* Source/WebCore/dom/FindRevealAlgorithms.cpp:
(WebCore::revealClosedDetailsAndHiddenUntilFoundAncestors):
(WebCore::revealClosedDetailsAncestors): Deleted.
(WebCore::revealHiddenUntilFoundAncestors): Deleted.
* Source/WebCore/dom/FindRevealAlgorithms.h:

Canonical link: <a href="https://commits.webkit.org/298164@main">https://commits.webkit.org/298164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/385cc365b81449c0a0ab5ebdf679c98a2d5ce4e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120645 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65191 "Failed to checkout and rebase branch from PR 48840") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/65191 "Failed to checkout and rebase branch from PR 48840") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117427 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/27769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/102810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67393 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/26953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/20937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64325 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/97146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/21051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123850 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41492 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/30962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41869 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/99001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95604 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24359 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/40767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/18606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37514 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46881 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->