### PR TITLE
[ iOS Release ] TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (api-tests) is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -1068,7 +1068,12 @@ static NSString *htmlStringForTotalQuotaRatioTest(uint64_t size, bool shouldPers
     </script>", size, shouldPersist ? "navigator.storage.persist()" : "new String('success')"];
 }
 
+// FIXME when rdar://154214201 is resolved.
+#if PLATFORM(IOS)
+TEST(WKWebsiteDataStoreConfiguration, DISABLED_TotalQuotaRatioWithPersistedDomain)
+#else
 TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)
+#endif
 {
     done = false;
     receivedScriptMessage = false;


### PR DESCRIPTION
#### db58bfdbda48f408123a0b0c09fb3ab0d0f0287a
<pre>
[ iOS Release ] TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithPersistedDomain (api-tests) is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=294918">https://bugs.webkit.org/show_bug.cgi?id=294918</a>
<a href="https://rdar.apple.com/154214201">rdar://154214201</a>

Unreviewed test gardening

Disabling API test that is a flaky timeout on iOS.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::(WKWebsiteDataStoreConfiguration, DISABLED_TotalQuotaRatioWithPersistedDomain)(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)):
(TestWebKitAPI::(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)): Deleted.

Canonical link: <a href="https://commits.webkit.org/298141@main">https://commits.webkit.org/298141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abe9ae6a5e516510c2c222450cb010035141751e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42710 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/86947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20873 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30898 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24347 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37455 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41298 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->