### PR TITLE
Refactor synthesizedBaseline to take in baseline type and writing mode for synthesis

### DIFF
--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -32,6 +32,9 @@
 
 namespace WebCore {
 
+enum class BaselineSynthesisEdge : uint8_t;
+enum class FontBaseline : uint8_t;
+enum class LineDirection : bool;
 class RenderBox;
 
 // These classes are used to implement the Baseline Alignment logic, as described in the CSS Box Alignment
@@ -105,7 +108,9 @@ public:
     void updateSharedGroup(const RenderBox& alignmentSubject, ItemPosition preference, LayoutUnit ascent);
     Vector<BaselineGroup>& sharedGroups();
 
+    static FontBaseline dominantBaseline(WritingMode);
     static WritingMode usedWritingModeForBaselineAlignment(LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode, WritingMode alignmentSubjectWritingMode);
+    static LayoutUnit synthesizedBaseline(const RenderBox&, FontBaseline baselineType, WritingMode writingModeForSynthesis, LineDirection, BaselineSynthesisEdge);
 
 private:
     BaselineGroup& findCompatibleSharedGroup(const RenderBox& alignmentSubject, ItemPosition preference);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5375,27 +5375,6 @@ LayoutBoxExtent RenderBox::scrollPaddingForViewportRect(const LayoutRect& viewpo
     return Style::extentForRect(style().scrollPaddingBox(), viewportRect);
 }
 
-LayoutUnit synthesizedBaseline(const RenderBox& box, const RenderStyle& parentStyle, LineDirection direction, BaselineSynthesisEdge edge)
-{
-    auto parentWritingMode = parentStyle.writingMode();
-    // https://drafts.csswg.org/css-inline-3/#alignment-baseline-property
-    // https://drafts.csswg.org/css-inline-3/#dominant-baseline-property
-    auto baselineType = parentWritingMode.prefersCentralBaseline() ? FontBaseline::Central : FontBaseline::Alphabetic;
-
-    auto boxSize = direction == LineDirection::Horizontal ? box.height() : box.width();
-    if (edge == BaselineSynthesisEdge::ContentBox)
-        boxSize -= direction == LineDirection::Horizontal ? box.verticalBorderAndPaddingExtent() : box.horizontalBorderAndPaddingExtent();
-    else if (edge == BaselineSynthesisEdge::MarginBox)
-        boxSize += direction == LineDirection::Horizontal ? box.verticalMarginExtent() : box.horizontalMarginExtent();
-    
-    if (baselineType == FontBaseline::Alphabetic) {
-        auto shouldTreatAsHorizontal = direction == LineDirection::Horizontal
-            || (parentWritingMode.isSidewaysOrientation() && parentWritingMode.computedWritingMode() == StyleWritingMode::VerticalRl);
-        return shouldTreatAsHorizontal ? boxSize : LayoutUnit();
-    }
-    return boxSize / 2;
-}
-
 LayoutUnit RenderBox::intrinsicLogicalWidth() const
 {
     return writingMode().isHorizontal() ? intrinsicSize().width() : intrinsicSize().height();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -875,8 +875,6 @@ inline RenderBox* RenderBox::nextInFlowSiblingBox() const
     return nullptr;
 }
 
-LayoutUnit synthesizedBaseline(const RenderBox&, const RenderStyle& parentStyle, LineDirection, BaselineSynthesisEdge);
-
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderBox, isRenderBox())

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -283,7 +283,9 @@ std::optional<LayoutUnit> RenderFlexibleBox::firstLineBaseline() const
         // FIXME: We should pass |direction| into firstLineBoxBaseline and stop bailing out if we're a writing mode root.
         // This would also fix some cases where the flexbox is orthogonal to its container.
         auto direction = isHorizontalWritingMode() ? LineDirection::Horizontal : LineDirection::Vertical;
-        return synthesizedBaseline(*baselineFlexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + baselineFlexItem->logicalTop();
+        auto flexboxWritingMode = style().writingMode();
+        return BaselineAlignmentState::synthesizedBaseline(*baselineFlexItem, BaselineAlignmentState::dominantBaseline(flexboxWritingMode),
+            flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox) + baselineFlexItem->logicalTop();
     }
 
     return LayoutUnit { (baseline.value() + baselineFlexItem->logicalTop()).toInt() };
@@ -308,7 +310,9 @@ std::optional <LayoutUnit> RenderFlexibleBox::lastLineBaseline() const
         // FIXME: We should pass |direction| into firstLineBoxBaseline and stop bailing out if we're a writing mode root.
         // This would also fix some cases where the flexbox is orthogonal to its container.
         auto direction = isHorizontalWritingMode() ? LineDirection::Horizontal : LineDirection::Vertical;
-        return synthesizedBaseline(*baselineFlexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + baselineFlexItem->logicalTop();
+        auto flexboxWritingMode = style().writingMode();
+        return BaselineAlignmentState::synthesizedBaseline(*baselineFlexItem, BaselineAlignmentState::dominantBaseline(flexboxWritingMode),
+            flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox) + baselineFlexItem->logicalTop();
     }
 
     return LayoutUnit { (baseline.value() + baselineFlexItem->logicalTop()).toInt() };
@@ -1601,11 +1605,17 @@ LayoutUnit RenderFlexibleBox::marginBoxAscentForFlexItem(const RenderBox& flexIt
     auto isHorizontalFlow = this->isHorizontalFlow();
     auto direction = isHorizontalFlow ? LineDirection::Horizontal : LineDirection::Vertical;
 
-    if (!mainAxisIsFlexItemInlineAxis(flexItem))
-        return synthesizedBaseline(flexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+    if (!mainAxisIsFlexItemInlineAxis(flexItem)) {
+        auto flexboxWritingMode = style().writingMode();
+        return BaselineAlignmentState::synthesizedBaseline(flexItem, BaselineAlignmentState::dominantBaseline(flexboxWritingMode),
+            flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+    }
     auto ascent = alignmentForFlexItem(flexItem) == ItemPosition::LastBaseline ? flexItem.lastLineBaseline() : flexItem.firstLineBaseline();
-    if (!ascent)
-        return synthesizedBaseline(flexItem, style(), direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+    if (!ascent) {
+        auto flexboxWritingMode = style().writingMode();
+        return BaselineAlignmentState::synthesizedBaseline(flexItem, BaselineAlignmentState::dominantBaseline(flexboxWritingMode),
+            flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+    }
 
     if (!flexItem.writingMode().isBlockMatchingAny(writingMode())) {
         // Baseline from flex item with opposite block direction needs to be resolved as if flex item had the same block direction.

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2014,8 +2014,10 @@ std::optional<LayoutUnit> RenderGrid::firstLineBaseline() const
     if (!baseline) {
         // FIXME: We should pass |direction| into firstLineBaseline and stop bailing out if we're a writing
         // mode root. This would also fix some cases where the grid is orthogonal to its container.
+        auto gridWritingMode = style().writingMode();
+        auto dominantBaseline = BaselineAlignmentState::dominantBaseline(gridWritingMode);
         auto direction = isHorizontalWritingMode() ? LineDirection::Horizontal : LineDirection::Vertical;
-        return synthesizedBaseline(*baselineGridItem, style(), direction, BaselineSynthesisEdge::BorderBox) + logicalTopForChild(*baselineGridItem);
+        return BaselineAlignmentState::synthesizedBaseline(*baselineGridItem, dominantBaseline, gridWritingMode, direction, BaselineSynthesisEdge::BorderBox) + logicalTopForChild(*baselineGridItem);
     }
     return baseline.value() + baselineGridItem->logicalTop().toInt();
 }
@@ -2032,7 +2034,9 @@ std::optional<LayoutUnit> RenderGrid::lastLineBaseline() const
     auto baseline = GridLayoutFunctions::isOrthogonalGridItem(*this, *baselineGridItem) ? std::nullopt : baselineGridItem->lastLineBaseline();
     if (!baseline) {
         auto direction = isHorizontalWritingMode() ? LineDirection::Horizontal : LineDirection::Vertical;
-        return synthesizedBaseline(*baselineGridItem, style(), direction, BaselineSynthesisEdge::BorderBox) + logicalTopForChild(*baselineGridItem);
+        auto gridWritingMode = style().writingMode();
+        auto dominantBaseline = BaselineAlignmentState::dominantBaseline(gridWritingMode);
+        return BaselineAlignmentState::synthesizedBaseline(*baselineGridItem, dominantBaseline, gridWritingMode, direction, BaselineSynthesisEdge::BorderBox) + logicalTopForChild(*baselineGridItem);
 
     }
 


### PR DESCRIPTION
#### 2c2c247d82cde905fba95b94056312928310ae96
<pre>
Refactor synthesizedBaseline to take in baseline type and writing mode for synthesis
<a href="https://bugs.webkit.org/show_bug.cgi?id=296823">https://bugs.webkit.org/show_bug.cgi?id=296823</a>
<a href="https://rdar.apple.com/157320099">rdar://157320099</a>

Reviewed by Alan Baradlay.

We currently take in the parent&apos;s writing mode in synthesizedBaseline
and then determine both the type of baseline and writing mode which
determines the line over/under edges from it. However, it seems like
this may not always be correct as the writing modes for both may be
different.

The type of baseline that is synthesized, the dominant baseline, should
come from the writing mode of the parent since it is what is used to
&quot;align content within the box.&quot;
<a href="https://drafts.csswg.org/css-inline-3/#dominant-baseline-property">https://drafts.csswg.org/css-inline-3/#dominant-baseline-property</a>

On the other hand, the writing mode which is used to determine the line
under/over edges may or may not be the same as the parent&apos;s writing
mode. In fact, css-align calls this scenario towards the bottom of
&quot;Determining the Baselines of a Box.&quot;
<a href="https://drafts.csswg.org/css-align-3/#baseline-rules">https://drafts.csswg.org/css-align-3/#baseline-rules</a>

In preparation to fix a bug which is a result of this mismatch, we can
refactor synthesizedBaseline to instead take in these two parameters
instead of trying to determine them from just the parent&apos;s style.

We can instead have these functions live on BaselineAlignmentState
instead of RenderBox since that may be a better fit for them in terms of
organization.

Canonical link: <a href="https://commits.webkit.org/298216@main">https://commits.webkit.org/298216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fcbc0dc3efac8b7f2e89ddcad82096741630432

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65126 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a21b46ec-060d-481c-bcac-fb645ef06436) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86950 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41853 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08c7d60b-ab8b-4aec-8730-617835928edd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67343 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20877 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64259 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/20992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123779 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41421 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30903 "Found 1 new test failure: fast/parser/entity-comment-in-style.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95773 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40711 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18547 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37457 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46809 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40893 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44200 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->