### PR TITLE
[WebXR + WebGPU] Foveated rendering is not supported

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
@@ -97,9 +97,18 @@ void XRProjectionLayerImpl::setDeltaPose(WebXRRigidTransform* pose)
 }
 
 // WebXRLayer
-void XRProjectionLayerImpl::startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex)
+void XRProjectionLayerImpl::startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&& rateMap)
 {
-    wgpuXRProjectionLayerStartFrame(m_backing.get(), frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex);
+#if ENABLE(WEBXR)
+    wgpuXRProjectionLayerStartFrame(m_backing.get(), frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex, rateMap.screenSize.width(), rateMap.screenSize.height(), WTFMove(rateMap.horizontalSamplesLeft), WTFMove(rateMap.horizontalSamplesRight), WTFMove(rateMap.verticalSamples));
+#else
+    UNUSED_PARAM(frameIndex);
+    UNUSED_PARAM(colorBuffer);
+    UNUSED_PARAM(depthBuffer);
+    UNUSED_PARAM(completionSyncEvent);
+    UNUSED_PARAM(reusableTextureIndex);
+    UNUSED_PARAM(rateMap);
+#endif
 }
 
 void XRProjectionLayerImpl::endFrame()

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h
@@ -73,7 +73,7 @@ private:
 
     // WebXRLayer
 #if PLATFORM(COCOA)
-    void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex) final;
+    void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) final;
 #endif
     void endFrame() final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
@@ -43,6 +43,10 @@ namespace WebCore {
 class WebXRRigidTransform;
 }
 
+namespace PlatformXR {
+struct RateMapDescription;
+}
+
 namespace WebCore::WebGPU {
 
 class Device;
@@ -74,7 +78,7 @@ public:
 
     // WebXRLayer
 #if PLATFORM(COCOA)
-    virtual void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex) = 0;
+    virtual void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) = 0;
 #endif
     virtual void endFrame() = 0;
 

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
@@ -57,7 +57,7 @@ void XRProjectionLayer::startFrame(PlatformXR::FrameData& data)
     if (frameData->layerSetup && frameData->textureData) {
         m_layerData = frameData;
         auto& textureData = frameData->textureData;
-        m_backing->startFrame(frameData->renderingFrameIndex, WTFMove(textureData->colorTexture.handle), WTFMove(textureData->depthStencilBuffer.handle), WTFMove(frameData->layerSetup->completionSyncEvent), textureData->reusableTextureIndex);
+        m_backing->startFrame(frameData->renderingFrameIndex, WTFMove(textureData->colorTexture.handle), WTFMove(textureData->depthStencilBuffer.handle), WTFMove(frameData->layerSetup->completionSyncEvent), textureData->reusableTextureIndex, WTFMove(frameData->layerSetup->foveationRateMapDesc));
     }
 }
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -21,7 +21,6 @@ Modules/WebGPU/Implementation/WebGPUShaderModuleImpl.cpp
 Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
 Modules/WebGPU/Implementation/WebGPUTextureViewImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
-Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
 Modules/airplay/WebMediaSessionManager.cpp
 Modules/applepay/cocoa/PaymentMerchantSessionCocoa.mm

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -242,6 +242,14 @@ struct RequestData {
     DepthRange depthRange;
 };
 
+struct RateMapDescription {
+    WebCore::IntSize screenSize = { 0, 0 };
+    Vector<float> horizontalSamplesLeft;
+    Vector<float> horizontalSamplesRight;
+    // Vertical samples is shared by both horizontalSamples
+    Vector<float> verticalSamples;
+};
+
 struct FrameData {
     struct FloatQuaternion {
         float x { 0.0f };
@@ -276,14 +284,6 @@ struct FrameData {
     struct StageParameters {
         int id { 0 };
         Vector<WebCore::FloatPoint> bounds;
-    };
-
-    struct RateMapDescription {
-        WebCore::IntSize screenSize = { 0, 0 };
-        Vector<float> horizontalSamplesLeft;
-        Vector<float> horizontalSamplesRight;
-        // Vertical samples is shared by both horizontalSamples
-        Vector<float> verticalSamples;
     };
 
     static constexpr auto LayerSetupSizeMax = std::numeric_limits<uint16_t>::max();

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -655,6 +655,9 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
         if (mtlAttachment.loadAction == MTLLoadActionLoad && !texture->previouslyCleared())
             textureToClear = mtlAttachment.texture;
 
+        if (id<MTLRasterizationRateMap> rateMap = texture->apiParentTexture().rasterizationMapForSlice(texture->parentRelativeSlice()))
+            mtlDescriptor.rasterizationRateMap = rateMap;
+
         if (attachment.resolveTarget) {
             Ref resolveTarget = fromAPI(attachment.resolveTarget);
             if (!isValidToUseWith(resolveTarget, *this))
@@ -664,6 +667,8 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
             if (mtlTexture.sampleCount == 1 || resolveTexture.sampleCount != 1 || isMultisampleTexture(resolveTexture) || !isMultisampleTexture(mtlTexture) || !isRenderableTextureView(resolveTarget) || mtlTexture.pixelFormat != resolveTexture.pixelFormat || !Texture::supportsResolve(resolveTarget->format(), m_device))
                 return RenderPassEncoder::createInvalid(*this, m_device, @"resolve target is invalid");
 
+            if (id<MTLRasterizationRateMap> rateMap = resolveTarget->apiParentTexture().rasterizationMapForSlice(resolveTarget->parentRelativeSlice()))
+                mtlDescriptor.rasterizationRateMap = rateMap;
             mtlAttachment.resolveTexture = resolveTexture;
             mtlAttachment.resolveLevel = 0;
             mtlAttachment.resolveSlice = 0;

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -262,6 +262,8 @@ public:
     }
     void removeBufferFromCache(uint64_t address) { m_bufferMap.remove(address); }
     uint32_t appleGPUFamily() const { return m_appleGPUFamily; }
+    id<MTLRasterizationRateMap> rasterizationMapForTexture(MTLResourceID, uint32_t) const;
+    void setRasterizationMapsForTexture(MTLResourceID, id<MTLRasterizationRateMap> left, id<MTLRasterizationRateMap> right);
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/MetalSPI.h
+++ b/Source/WebGPU/WebGPU/MetalSPI.h
@@ -95,4 +95,10 @@ constexpr MTLPixelFormat MTLPixelFormatYCBCR12_444_2P_PACKED_PQ = static_cast<MT
 - (id <MTLSharedEvent>)newSharedEventWithMachPort:(mach_port_t)machPort;
 @end
 
+@protocol MTLRasterizationRateMapDescriptorSPI
+@property (nonatomic) float minFactor;
+@property (nonatomic) MTLMutability mutability;
+@property (nonatomic) BOOL skipSampleValidationAndApplySampleAtTileGranularity;
+@end
+
 #endif

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -205,8 +205,10 @@ private:
     float m_depthClearValue { 0 };
     uint64_t m_drawCount { 0 };
     const uint64_t m_maxDrawCount { 0 };
+    id<MTLRasterizationRateMap> m_rasterizationRateMap { nil };
     uint32_t m_stencilClearValue { 0 };
     std::optional<MTLViewport> m_viewport;
+    MTLDepthClipMode m_overrideDepthClipMode { MTLDepthClipModeClip };
     bool m_clearDepthAttachment { false };
     bool m_clearStencilAttachment { false };
     bool m_occlusionQueryActive { false };

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -139,6 +139,8 @@ public:
     void updateCompletionEvent(const std::pair<id<MTLSharedEvent>, uint64_t>&);
     id<MTLSharedEvent> sharedEvent() const;
     uint64_t sharedEventSignalValue() const;
+    void setRasterizationRateMaps(std::pair<id<MTLRasterizationRateMap>, id<MTLRasterizationRateMap>>&& rateMaps) { m_leftRightRasterizationMaps = WTFMove(rateMaps); }
+    id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice) { return slice ? m_leftRightRasterizationMaps.second : m_leftRightRasterizationMaps.first; }
 
 private:
     Texture(id<MTLTexture>, const WGPUTextureDescriptor&, Vector<WGPUTextureFormat>&& viewFormats, Device&);
@@ -170,6 +172,8 @@ private:
     bool m_canvasBacking { false };
     mutable Vector<uint64_t> m_commandEncoders;
     id<MTLSharedEvent> m_sharedEvent { nil };
+    std::pair<id<MTLRasterizationRateMap>, id<MTLRasterizationRateMap>> m_leftRightRasterizationMaps;
+
     uint64_t m_sharedEventSignalValue { 0 };
 // FIXME: remove @safe once rdar://151039766 lands
 } __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(refTexture, derefTexture);

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -151,7 +151,7 @@ WGPU_EXPORT WGPUTexture wgpuXRSubImageGetDepthStencilTexture(WGPUXRSubImage subI
 
 WGPU_EXPORT WGPUBool wgpuAdapterXRCompatible(WGPUAdapter adapter) WGPU_FUNCTION_ATTRIBUTE;
 
-WGPU_EXPORT void wgpuXRProjectionLayerStartFrame(WGPUXRProjectionLayer layer, size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuXRProjectionLayerStartFrame(WGPUXRProjectionLayer layer, size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, unsigned screenWidth, unsigned screenHeight, Vector<float>&& horizontalSamplesLeft, Vector<float>&& horizontalSamplesRight, Vector<float>&& verticalSamples) WGPU_FUNCTION_ATTRIBUTE;
 
 WGPU_EXPORT RetainPtr<CGImageRef> wgpuSwapChainGetTextureAsNativeImage(WGPUSwapChain swapChain, uint32_t bufferIndex, bool& isIOSurfaceSupportedFormat);
 WGPU_EXPORT WGPUBool wgpuExternalTextureIsValid(WGPUExternalTexture externalTexture) WGPU_FUNCTION_ATTRIBUTE;

--- a/Source/WebGPU/WebGPU/XRProjectionLayer.h
+++ b/Source/WebGPU/WebGPU/XRProjectionLayer.h
@@ -57,7 +57,7 @@ public:
     void setLabel(String&&);
 
     bool isValid() const;
-    void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex);
+    void startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, unsigned screenWidth, unsigned screenHeight, Vector<float>&& horizontalSamplesLeft, Vector<float>&& horizontalSamplesRight, Vector<float>&& verticalSamples);
 
     id<MTLTexture> colorTexture() const;
     id<MTLTexture> depthTexture() const;
@@ -68,6 +68,7 @@ public:
     WGPUTextureUsageFlags flags() const { return m_flags; }
     double scale() const { return m_scale; }
 
+    std::pair<id<MTLRasterizationRateMap>, id<MTLRasterizationRateMap>> rasterizationRateMaps() const { return std::make_pair(m_rasterizationMapLeft, m_rasterizationMapRight); }
 private:
     XRProjectionLayer(WGPUTextureFormat, WGPUTextureFormat*, WGPUTextureUsageFlags, double scale, Device&);
     XRProjectionLayer(Device&);
@@ -81,6 +82,8 @@ private:
     WGPUTextureFormat m_colorFormat { WGPUTextureFormat_Undefined };
     std::optional<WGPUTextureFormat> m_optionalDepthStencilFormat;
     WGPUTextureUsageFlags m_flags { WGPUTextureUsage_None };
+    id<MTLRasterizationRateMap> m_rasterizationMapLeft { nil };
+    id<MTLRasterizationRateMap> m_rasterizationMapRight { nil };
     double m_scale { 1.f };
 
     const Ref<Device> m_device;

--- a/Source/WebGPU/WebGPU/XRProjectionLayer.mm
+++ b/Source/WebGPU/WebGPU/XRProjectionLayer.mm
@@ -32,6 +32,50 @@
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/StdLibExtras.h>
 
+#if USE(APPLE_INTERNAL_SDK) && PLATFORM(VISION)
+#import <CompositorServices/CompositorServices_Private.h>
+#import <Metal/MTLRasterizationRate_Private.h>
+#import <wtf/SoftLinking.h>
+#import <wtf/darwin/WeakLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebCore, CompositorServices)
+
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, CP_OBJECT_cp_proxy_process_rasterization_rate_map)
+typedef CP_OBJECT_cp_proxy_process_rasterization_rate_map* cp_proxy_process_rasterization_rate_map_t;
+
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CompositorServices, cp_proxy_process_rasterization_rate_map_create, cp_proxy_process_rasterization_rate_map_t, (id<MTLDevice> device, cp_layer_renderer_layout layout, size_t view_count), (device, layout, view_count))
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CompositorServices, cp_proxy_process_rasterization_rate_map_create, cp_proxy_process_rasterization_rate_map_t, (id<MTLDevice> device, cp_layer_renderer_layout layout, size_t view_count), (device, layout, view_count))
+#define cp_proxy_process_rasterization_rate_map_create WebCore::softLink_CompositorServices_cp_proxy_process_rasterization_rate_map_create
+
+
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CompositorServices, cp_rasterization_rate_map_update_shared_from_layered_descriptor, void, (cp_proxy_process_rasterization_rate_map_t proxy_map, MTLRasterizationRateMapDescriptor* descriptor), (proxy_map, descriptor))
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CompositorServices, cp_rasterization_rate_map_update_shared_from_layered_descriptor, void, (cp_proxy_process_rasterization_rate_map_t proxy_map, MTLRasterizationRateMapDescriptor* descriptor), (proxy_map, descriptor))
+#define cp_rasterization_rate_map_update_shared_from_layered_descriptor WebCore::softLink_CompositorServices_cp_rasterization_rate_map_update_shared_from_layered_descriptor
+
+
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CompositorServices, cp_proxy_process_rasterization_rate_map_get_metal_maps, NSArray<id<MTLRasterizationRateMap>>*, (cp_proxy_process_rasterization_rate_map_t proxy_map), (proxy_map))
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CompositorServices, cp_proxy_process_rasterization_rate_map_get_metal_maps, NSArray<id<MTLRasterizationRateMap>>*, (cp_proxy_process_rasterization_rate_map_t proxy_map), (proxy_map))
+#define cp_proxy_process_rasterization_rate_map_get_metal_maps WebCore::softLink_CompositorServices_cp_proxy_process_rasterization_rate_map_get_metal_maps
+
+
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CompositorServices, cp_proxy_process_rasterization_rate_map_get_metal_descriptors, NSArray<MTLRasterizationRateMapDescriptor*>*, (cp_proxy_process_rasterization_rate_map_t proxy_map), (proxy_map))
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CompositorServices, cp_rasterization_rate_map_update_from_descriptor, void, (cp_proxy_process_rasterization_rate_map_t proxy_map, __unsafe_unretained MTLRasterizationRateMapDescriptor* descriptors[2]), (proxy_map, descriptors))
+SOFT_LINK_CLASS_FOR_SOURCE(WebCore, CompositorServices, CP_OBJECT_cp_proxy_process_rasterization_rate_map)
+
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CompositorServices, cp_drawable_get_layer_renderer_layout, cp_layer_renderer_layout_private, (cp_drawable_t drawable), (drawable))
+
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CompositorServices, cp_proxy_process_rasterization_rate_map_get_metal_descriptors, NSArray<MTLRasterizationRateMapDescriptor*>*, (cp_proxy_process_rasterization_rate_map_t proxy_map), (proxy_map))
+
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CompositorServices, cp_rasterization_rate_map_update_from_descriptor, void, (cp_proxy_process_rasterization_rate_map_t proxy_map, __unsafe_unretained MTLRasterizationRateMapDescriptor* descriptors[2]), (proxy_map, descriptors))
+
+#define cp_proxy_process_rasterization_rate_map_get_metal_descriptors WebCore::softLink_CompositorServices_cp_proxy_process_rasterization_rate_map_get_metal_descriptors
+#define cp_proxy_process_rasterization_rate_map_get_metal_descriptors WebCore::softLink_CompositorServices_cp_proxy_process_rasterization_rate_map_get_metal_descriptors
+#define cp_rasterization_rate_map_update_from_descriptor WebCore::softLink_CompositorServices_cp_rasterization_rate_map_update_from_descriptor
+#define cp_drawable_get_layer_renderer_layout WebCore::softLink_CompositorServices_cp_drawable_get_layer_renderer_layout
+
+#endif
+
+
 namespace WebGPU {
 
 XRProjectionLayer::XRProjectionLayer(WGPUTextureFormat colorFormat, WGPUTextureFormat* optionalDepthStencilFormat, WGPUTextureUsageFlags flags, double scale, Device& device)
@@ -83,9 +127,9 @@ size_t XRProjectionLayer::reusableTextureIndex() const
     return m_reusableTextureIndex;
 }
 
-void XRProjectionLayer::startFrame(size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex)
+void XRProjectionLayer::startFrame(size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, unsigned screenWidth, unsigned screenHeight, Vector<float>&& horizontalSamplesLeft, Vector<float>&& horizontalSamplesRight, Vector<float>&& verticalSamples)
 {
-#if !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(WATCHOS)
+#if USE(APPLE_INTERNAL_SDK) && PLATFORM(VISION) && !PLATFORM(IOS_FAMILY_SIMULATOR)
     id<MTLDevice> device = m_device->device();
     m_reusableTextureIndex = reusableTextureIndex;
     NSNumber* textureKey = @(reusableTextureIndex);
@@ -105,12 +149,45 @@ void XRProjectionLayer::startFrame(size_t frameIndex, WTF::MachSendRight&& color
 
     if (completionSyncEvent.sendRight())
         m_sharedEvent = std::make_pair([(id<MTLDeviceSPI>)device newSharedEventWithMachPort:completionSyncEvent.sendRight()], frameIndex);
+
+    if (m_rasterizationMapLeft.screenSize.width != screenWidth || m_rasterizationMapLeft.screenSize.height != screenHeight) {
+        MTLSize screenSize = MTLSizeMake(screenWidth, screenHeight, 0);
+        MTLRasterizationRateLayerDescriptor* layerLeft = [[MTLRasterizationRateLayerDescriptor alloc] initWithSampleCount:MTLSizeMake(horizontalSamplesLeft.size(), verticalSamples.size(), 0) horizontal:horizontalSamplesLeft.span().data() vertical:verticalSamples.span().data()];
+
+        MTLRasterizationRateLayerDescriptor* layerRight = [[MTLRasterizationRateLayerDescriptor alloc] initWithSampleCount:MTLSizeMake(horizontalSamplesRight.size(), verticalSamples.size(), 0) horizontal:horizontalSamplesRight.span().data() vertical:verticalSamples.span().data()];
+
+        auto setSpiProperties = ^(MTLRasterizationRateMapDescriptor* desc) {
+            auto spi = (id<MTLRasterizationRateMapDescriptorSPI>)desc;
+            spi.skipSampleValidationAndApplySampleAtTileGranularity = YES;
+            spi.mutability = MTLMutabilityMutable;
+            spi.minFactor = 0.01;
+        };
+        MTLRasterizationRateMapDescriptor* rateMapDescriptorLeft = [MTLRasterizationRateMapDescriptor rasterizationRateMapDescriptorWithScreenSize:screenSize layer:layerLeft];
+        setSpiProperties(rateMapDescriptorLeft);
+
+        MTLRasterizationRateMapDescriptor* rateMapDescriptorRight = [MTLRasterizationRateMapDescriptor rasterizationRateMapDescriptorWithScreenSize:screenSize layer:layerRight];
+        setSpiProperties(rateMapDescriptorRight);
+
+        __unsafe_unretained MTLRasterizationRateMapDescriptor* descriptors[] = { rateMapDescriptorLeft, rateMapDescriptorRight };
+        auto rateMap = cp_proxy_process_rasterization_rate_map_create(device, cp_layer_renderer_layout_dedicated, 2);
+        cp_rasterization_rate_map_update_from_descriptor(rateMap, descriptors);
+
+        NSArray<id<MTLRasterizationRateMap>>* rasterizationRateMaps = cp_proxy_process_rasterization_rate_map_get_metal_maps(rateMap);
+
+        m_rasterizationMapLeft = rasterizationRateMaps.firstObject;
+        m_rasterizationMapRight = rasterizationRateMaps.lastObject;
+    }
 #else
     UNUSED_PARAM(frameIndex);
     UNUSED_PARAM(colorBuffer);
     UNUSED_PARAM(depthBuffer);
     UNUSED_PARAM(completionSyncEvent);
     UNUSED_PARAM(reusableTextureIndex);
+    UNUSED_PARAM(screenWidth);
+    UNUSED_PARAM(screenHeight);
+    UNUSED_PARAM(horizontalSamplesLeft);
+    UNUSED_PARAM(horizontalSamplesRight);
+    UNUSED_PARAM(verticalSamples);
 #endif
 }
 
@@ -133,7 +210,7 @@ void wgpuXRProjectionLayerRelease(WGPUXRProjectionLayer projectionLayer)
     WebGPU::fromAPI(projectionLayer).deref();
 }
 
-void wgpuXRProjectionLayerStartFrame(WGPUXRProjectionLayer layer, size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex)
+void wgpuXRProjectionLayerStartFrame(WGPUXRProjectionLayer layer, size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, unsigned screenWidth, unsigned screenHeight, Vector<float>&& horizontalSamplesLeft, Vector<float>&& horizontalSamplesRight, Vector<float>&& verticalSamples)
 {
-    WebGPU::protectedFromAPI(layer)->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex);
+    WebGPU::protectedFromAPI(layer)->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex, screenWidth, screenHeight, WTFMove(horizontalSamplesLeft), WTFMove(horizontalSamplesRight), WTFMove(verticalSamples));
 }

--- a/Source/WebGPU/WebGPU/XRSubImage.mm
+++ b/Source/WebGPU/WebGPU/XRSubImage.mm
@@ -104,6 +104,7 @@ void XRSubImage::update(const XRProjectionLayer& projectionLayer)
         };
         auto newTexture = Texture::create(colorTexture, colorTextureDescriptor, { colorFormat }, *device);
         newTexture->updateCompletionEvent(sharedEvent);
+        newTexture->setRasterizationRateMaps(projectionLayer.rasterizationRateMaps());
         m_colorTextures.set(currentTextureIndex, newTexture.ptr());
     } else
         texture->updateCompletionEvent(sharedEvent);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
@@ -85,9 +85,9 @@ void RemoteXRProjectionLayer::destruct()
 }
 
 #if PLATFORM(COCOA)
-void RemoteXRProjectionLayer::startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex)
+void RemoteXRProjectionLayer::startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex, PlatformXR::RateMapDescription&& rateMapDescription)
 {
-    protectedBacking()->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex);
+    protectedBacking()->startFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex, WTFMove(rateMapDescription));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -31,6 +31,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <WebCore/AlphaPremultiplication.h>
+#include <WebCore/PlatformXR.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
@@ -44,6 +45,7 @@
 
 namespace PlatformXR {
 struct FrameData;
+struct RateMapDescription;
 }
 
 namespace WebCore {
@@ -102,7 +104,7 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();
 #if PLATFORM(COCOA)
-    void startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex);
+    void startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex, PlatformXR::RateMapDescription&&);
 #endif
     void endFrame();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in
@@ -29,8 +29,8 @@
     EnabledBy=WebXRWebGPUBindingsEnabled
 ]
 messages -> RemoteXRProjectionLayer Stream {
-#if PLATFORM(COCOA)
-    void StartFrame(uint64_t frameIndex, MachSendRight colorBuffer, MachSendRight depthBuffer, MachSendRight completionSyncEvent, uint64_t textureIndex) NotStreamEncodable
+#if PLATFORM(VISION)
+    void StartFrame(uint64_t frameIndex, MachSendRight colorBuffer, MachSendRight depthBuffer, MachSendRight completionSyncEvent, uint64_t textureIndex, struct PlatformXR::RateMapDescription rateMapDescription) NotStreamEncodable
 #endif
     void EndFrame()
     void Destruct()

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -967,6 +967,7 @@ def headers_for_type(type, for_implementation_file=False):
         'PAL::UserInterfaceIdiom': ['<pal/system/ios/UserInterfaceIdiom.h>'],
         'PlatformXR::FrameData': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::Layout': ['<WebCore/PlatformXR.h>'],
+        'PlatformXR::RateMapDescription': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::ReferenceSpaceType': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::RequestData': ['<WebCore/PlatformXR.h>'],
         'PlatformXR::SessionFeature': ['<WebCore/PlatformXR.h>'],

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -111,7 +111,8 @@ header: <WebCore/PlatformXR.h>
     Vector<WebCore::FloatPoint> bounds;
 };
 
-[Nested] struct PlatformXR::FrameData::RateMapDescription {
+header: <WebCore/PlatformXR.h>
+[CustomHeader] struct PlatformXR::RateMapDescription {
     WebCore::IntSize screenSize;
     Vector<float> horizontalSamplesLeft;
     Vector<float> horizontalSamplesRight;
@@ -121,7 +122,7 @@ header: <WebCore/PlatformXR.h>
 [Nested, RValue] struct PlatformXR::FrameData::LayerSetupData {
     std::array<std::array<uint16_t, 2>, 2> physicalSize;
     std::array<WebCore::IntRect, 2> viewports;
-    PlatformXR::FrameData::RateMapDescription foveationRateMapDesc;
+    PlatformXR::RateMapDescription foveationRateMapDesc;
 #if PLATFORM(COCOA)
     MachSendRight completionSyncEvent;
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
@@ -54,10 +54,19 @@ RemoteXRProjectionLayerProxy::~RemoteXRProjectionLayerProxy()
 }
 
 #if PLATFORM(COCOA)
-void RemoteXRProjectionLayerProxy::startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex)
+void RemoteXRProjectionLayerProxy::startFrame(size_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, PlatformXR::RateMapDescription&& rateMapDescription)
 {
-    auto sendResult = send(Messages::RemoteXRProjectionLayer::StartFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex));
+#if PLATFORM(VISION)
+    auto sendResult = send(Messages::RemoteXRProjectionLayer::StartFrame(frameIndex, WTFMove(colorBuffer), WTFMove(depthBuffer), WTFMove(completionSyncEvent), reusableTextureIndex, WTFMove(rateMapDescription)));
     UNUSED_VARIABLE(sendResult);
+#else
+    UNUSED_VARIABLE(frameIndex);
+    UNUSED_VARIABLE(colorBuffer);
+    UNUSED_VARIABLE(depthBuffer);
+    UNUSED_VARIABLE(completionSyncEvent);
+    UNUSED_VARIABLE(reusableTextureIndex);
+    UNUSED_VARIABLE(rateMapDescription);
+#endif
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
@@ -83,7 +83,7 @@ private:
 
     // WebXRLayer
 #if PLATFORM(COCOA)
-    void startFrame(size_t frameIndex, MachSendRight&&, MachSendRight&&, MachSendRight&&, size_t reusableTextureIndex) final;
+    void startFrame(size_t frameIndex, MachSendRight&&, MachSendRight&&, MachSendRight&&, size_t reusableTextureIndex, PlatformXR::RateMapDescription&&) final;
 #endif
     void endFrame() final;
 


### PR DESCRIPTION
#### 133afe142afe4e7355d7586f310997282b6f6d83
<pre>
[WebXR + WebGPU] Foveated rendering is not supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=296597">https://bugs.webkit.org/show_bug.cgi?id=296597</a>
<a href="https://rdar.apple.com/156956791">rdar://156956791</a>

Reviewed by Dan Glastonbury.

Add foveated rendering support to WebGPU + WebXR.

We re-create the foveation map whenever the virtualized screen size changes, if
we switched from static to dynamic foveation a different mechanism for identifying
foveation changes would be required.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp:
(WebCore::WebGPU::XRProjectionLayerImpl::startFrame):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h:
* Source/WebCore/Modules/webxr/XRProjectionLayer.cpp:
(WebCore::XRProjectionLayer::startFrame):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::setViewport):
* Source/WebGPU/WebGPU/Texture.h:
(WebGPU::Texture::setRasterizationRateMaps):
(WebGPU::Texture::rasterizationMapForSlice):
* Source/WebGPU/WebGPU/WebGPUExt.h:
* Source/WebGPU/WebGPU/XRProjectionLayer.h:
(WebGPU::XRProjectionLayer::rasterizationRateMaps const):
* Source/WebGPU/WebGPU/XRProjectionLayer.mm:
(WebGPU::XRProjectionLayer::startFrame):
(wgpuXRProjectionLayerStartFrame):
* Source/WebGPU/WebGPU/XRSubImage.mm:
(WebGPU::XRSubImage::update):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp:
(WebKit::RemoteXRProjectionLayer::startFrame):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp:
(WebKit::WebGPU::RemoteXRProjectionLayerProxy::startFrame):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h:

Canonical link: <a href="https://commits.webkit.org/298235@main">https://commits.webkit.org/298235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09552c907eeede01ff586ed4335ac86e9fdd2f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65422 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c88fd173-fe8e-4ab2-b2fa-b21445103cc6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b06554a2-5c53-43d6-a202-c1afa7d2399e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67593 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/114105 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64563 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96014 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24397 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37809 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41616 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47130 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41189 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42936 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->