### PR TITLE
[jsc] Migrate, where possible, to using TZoneMalloc in Source/JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObject.cpp
+++ b/Source/JavaScriptCore/API/JSCallbackObject.cpp
@@ -26,10 +26,14 @@
 
 #include "config.h"
 #include "JSCallbackObject.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #include "JSCInlines.h"
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSCallbackObjectData);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSCallbackObjectData::JSPrivatePropertyMap);
 
 static JSC_DECLARE_HOST_FUNCTION(callJSNonFinalObjectCallbackObject);
 static JSC_DECLARE_HOST_FUNCTION(constructJSNonFinalObjectCallbackObject);

--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -31,11 +31,12 @@
 #include "JSValueRef.h"
 #include "JSObject.h"
 #include <wtf/PlatformCallingConventions.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 struct JSCallbackObjectData {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSCallbackObjectData);
+    WTF_MAKE_TZONE_ALLOCATED(JSCallbackObjectData);
 public:
     JSCallbackObjectData(void* privateData, JSClassRef jsClass)
         : privateData(privateData)
@@ -84,7 +85,7 @@ public:
     void* privateData;
     JSClassRef jsClass;
     struct JSPrivatePropertyMap {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSPrivatePropertyMap);
+        WTF_MAKE_TZONE_ALLOCATED(JSPrivatePropertyMap);
     public:
         JSValue getPrivateProperty(const Identifier& propertyName) const
         {

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -30,12 +30,17 @@
 #include "InitializeThreading.h"
 #include "JSCInlines.h"
 #include "JSCallbackObject.h"
+#include <wtf/TZoneMallocInlines.h>
 
 using namespace JSC;
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 const JSClassDefinition kJSClassDefinitionEmpty = { 0, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StaticValueEntry);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StaticFunctionEntry);
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(OpaqueJSClassContextData);
 
 OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass* protoClass) 
     : parentClass(definition->parentClass)

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -37,7 +37,7 @@
     WTF_VTBL_FUNCPTR_PTRAUTH_STR("StaticValueEntry." #method) method
 
 struct StaticValueEntry {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StaticValueEntry);
+    WTF_MAKE_TZONE_ALLOCATED(StaticValueEntry);
 public:
     StaticValueEntry(JSObjectGetPropertyCallback _getProperty, JSObjectSetPropertyCallback _setProperty, JSPropertyAttributes _attributes, String& propertyName)
         : getProperty(_getProperty)
@@ -59,7 +59,7 @@ public:
     WTF_VTBL_FUNCPTR_PTRAUTH_STR("StaticFunctionEntry." #method) method
 
 struct StaticFunctionEntry {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StaticFunctionEntry);
+    WTF_MAKE_TZONE_ALLOCATED(StaticFunctionEntry);
 public:
     StaticFunctionEntry(JSObjectCallAsFunctionCallback _callAsFunction, JSPropertyAttributes _attributes)
         : callAsFunction(_callAsFunction), attributes(_attributes)
@@ -80,7 +80,8 @@ struct OpaqueJSClass;
 // An OpaqueJSClass (JSClass) is created without a context, so it can be used with any context, even across context groups.
 // This structure holds data members that vary across context groups.
 struct OpaqueJSClassContextData {
-    WTF_MAKE_NONCOPYABLE(OpaqueJSClassContextData); WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OpaqueJSClassContextData);
+    WTF_MAKE_NONCOPYABLE(OpaqueJSClassContextData);
+    WTF_MAKE_TZONE_ALLOCATED(OpaqueJSClassContextData);
 public:
     OpaqueJSClassContextData(JSC::VM&, OpaqueJSClass*);
 

--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -48,6 +48,7 @@
 #include "PropertyNameArray.h"
 #include "ProxyObject.h"
 #include "RegExpConstructor.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JSGlobalObjectInspectorController.h"
@@ -787,7 +788,7 @@ JSObjectRef JSObjectCallAsConstructor(JSContextRef ctx, JSObjectRef object, size
 }
 
 struct OpaqueJSPropertyNameArray {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(OpaqueJSPropertyNameArray);
+    WTF_MAKE_TZONE_ALLOCATED(OpaqueJSPropertyNameArray);
 public:
     // FIXME: Why not inherit from RefCounted?
     OpaqueJSPropertyNameArray(VM* vm)
@@ -800,6 +801,8 @@ public:
     VM* vm;
     Vector<Ref<OpaqueJSString>> array;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueJSPropertyNameArray);
 
 JSPropertyNameArrayRef JSObjectCopyPropertyNames(JSContextRef ctx, JSObjectRef object)
 {

--- a/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
+++ b/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
@@ -45,13 +45,14 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 class CallbackArgument {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CallbackArgument);
+    WTF_MAKE_TZONE_ALLOCATED(CallbackArgument);
 public:
     virtual ~CallbackArgument();
     virtual void set(NSInvocation *, NSInteger, JSContext *, JSValueRef, JSValueRef*) = 0;
 
     std::unique_ptr<CallbackArgument> m_next;
 };
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CallbackArgument);
 
 CallbackArgument::~CallbackArgument() = default;
 
@@ -280,7 +281,7 @@ public:
 };
 
 class CallbackResult {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CallbackResult);
+    WTF_MAKE_TZONE_ALLOCATED(CallbackResult);
 public:
     virtual ~CallbackResult()
     {
@@ -288,6 +289,7 @@ public:
 
     virtual JSValueRef get(NSInvocation *, JSContext *, JSValueRef*) = 0;
 };
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CallbackResult);
 
 class CallbackResultVoid final : public CallbackResult {
     JSValueRef get(NSInvocation *, JSContext *context, JSValueRef*) final
@@ -410,7 +412,7 @@ enum CallbackType {
 namespace JSC {
 
 class ObjCCallbackFunctionImpl final {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ObjCCallbackFunctionImpl);
+    WTF_MAKE_TZONE_ALLOCATED(ObjCCallbackFunctionImpl);
 public:
     ObjCCallbackFunctionImpl(NSInvocation *invocation, CallbackType type, Class instanceClass, std::unique_ptr<CallbackArgument> arguments, std::unique_ptr<CallbackResult> result)
         : m_type(type)
@@ -466,6 +468,7 @@ private:
     std::unique_ptr<CallbackArgument> m_arguments;
     std::unique_ptr<CallbackResult> m_result;
 };
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ObjCCallbackFunctionImpl);
 
 static JSValueRef objCCallbackFunctionCallAsFunction(JSContextRef callerContext, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {

--- a/Source/JavaScriptCore/API/glib/JSCGLibWrapperObject.h
+++ b/Source/JavaScriptCore/API/glib/JSCGLibWrapperObject.h
@@ -21,11 +21,13 @@
 
 #include <glib.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 class JSCGLibWrapperObject {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSCGLibWrapperObject);
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(JSCGLibWrapperObject);
 public:
     JSCGLibWrapperObject(gpointer object, GDestroyNotify destroyFunction)
         : m_object(object)

--- a/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
@@ -34,6 +34,8 @@
 
 namespace JSC {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WrapperMap);
+
 WrapperMap::WrapperMap(JSGlobalContextRef jsContext)
     : m_cachedJSWrappers(makeUnique<JSC::WeakGCMap<gpointer, JSC::JSObject>>(toJS(jsContext)->vm()))
 {

--- a/Source/JavaScriptCore/API/glib/JSCWrapperMap.h
+++ b/Source/JavaScriptCore/API/glib/JSCWrapperMap.h
@@ -36,7 +36,7 @@ namespace JSC {
 class JSObject;
 
 class WrapperMap {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WrapperMap);
+    WTF_MAKE_TZONE_ALLOCATED(WrapperMap);
 public:
     explicit WrapperMap(JSGlobalContextRef);
     ~WrapperMap();

--- a/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.cpp
@@ -29,6 +29,7 @@
 #include "InlineCacheCompiler.h"
 #include "LinkBuffer.h"
 #include "StructureStubInfo.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(JIT)
 
@@ -109,5 +110,7 @@ CCallHelpers::JumpList AccessCaseSnippetParams::emitSlowPathCalls(InlineCacheCom
 }
 
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSC::AccessCaseSnippetParams::SlowPathCallGenerator);
 
 #endif

--- a/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.h
+++ b/Source/JavaScriptCore/bytecode/AccessCaseSnippetParams.h
@@ -45,7 +45,7 @@ public:
     }
 
     class SlowPathCallGenerator {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SlowPathCallGenerator);
+        WTF_MAKE_TZONE_ALLOCATED(SlowPathCallGenerator);
     public:
         virtual ~SlowPathCallGenerator() { }
         virtual CCallHelpers::JumpList generate(InlineCacheCompiler&, const RegisterSetBuilder& usedRegistersBySnippet, CCallHelpers&) = 0;

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -32,6 +32,7 @@
 #include <wtf/MallocPtr.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -42,6 +43,7 @@ namespace JSC {
 
 class ExpressionInfo {
     WTF_MAKE_NONCOPYABLE(ExpressionInfo);
+    // This is not TZone malloc'd because it's a dynamically-sized type
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ExpressionInfo);
 public:
     enum class FieldID : uint8_t { InstPC, Divot, Start, End, Line, Column };

--- a/Source/JavaScriptCore/bytecode/InstructionStream.cpp
+++ b/Source/JavaScriptCore/bytecode/InstructionStream.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "InstructionStream.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/JavaScriptCore/bytecode/InstructionStream.h
+++ b/Source/JavaScriptCore/bytecode/InstructionStream.h
@@ -1,4 +1,5 @@
 /*
+    WTF_MAKE_TZONE_ALLOCATED(AlignedMemoryAllocator);
  * Copyright (C) 2018 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +29,7 @@
 
 #include "BytecodeIndex.h"
 #include "Instruction.h"
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -42,7 +44,7 @@ struct InstructionStreamBufferMalloc final : public InstructionStreamMalloc {
 
 template<typename InstructionType>
 class InstructionStream {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(InstructionStream);
+    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(InstructionStream);
 
     template<typename> friend class InstructionStreamWriter;
     friend class CachedInstructionStream;
@@ -55,10 +57,11 @@ public:
     }
 
     using Offset = unsigned;
-
 private:
     template<class InstructionBuffer>
     class BaseRef {
+        // For this to be TZone-allocated, we will need a new macro which can
+        // handle the fact that its parent-class is a template
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(BaseRef);
 
         template<typename> friend class InstructionStream;
@@ -203,9 +206,12 @@ protected:
     InstructionBuffer m_instructions;
 };
 
+WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<typename InstructionType>, InstructionStream<InstructionType>);
+
 template<typename InstructionType>
 class InstructionStreamWriter : public InstructionStream<InstructionType> {
     friend class BytecodeRewriter;
+    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(InstructionStreamWriter);
 public:
     using InstructionStream<InstructionType>::InstructionStream;
     using typename InstructionStream<InstructionType>::InstructionBuffer;
@@ -360,6 +366,8 @@ private:
     unsigned m_position { 0 };
     bool m_finalized { false };
 };
+
+WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<typename InstructionType>, InstructionStreamWriter<InstructionType>);
 
 using JSInstructionStream = InstructionStream<JSInstruction>;
 using JSInstructionStreamWriter = InstructionStreamWriter<JSInstruction>;

--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "RecordedStatuses.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(RecordedStatuses);
 
 CallLinkStatus* RecordedStatuses::addCallLinkStatus(const CodeOrigin& codeOrigin, const CallLinkStatus& status)
 {

--- a/Source/JavaScriptCore/bytecode/RecordedStatuses.h
+++ b/Source/JavaScriptCore/bytecode/RecordedStatuses.h
@@ -32,11 +32,12 @@
 #include "InByStatus.h"
 #include "PutByStatus.h"
 #include "SetPrivateBrandStatus.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 struct RecordedStatuses {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RecordedStatuses);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(RecordedStatuses);
 
     RecordedStatuses() = default;
 

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp
@@ -31,10 +31,13 @@
 #include "DFGJITCode.h"
 #include "InlineCacheCompiler.h"
 #include "Repatch.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 #if ENABLE(JIT)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SharedJITStubSet);
 
 RefPtr<PolymorphicAccessJITStubRoutine> SharedJITStubSet::getStatelessStub(StatelessCacheKey key) const
 {

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -27,13 +27,14 @@
 
 #include "DOMJITGetterSetter.h"
 #include "StructureStubInfo.h"
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 #if ENABLE(JIT)
 
 class SharedJITStubSet {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SharedJITStubSet);
+    WTF_MAKE_TZONE_ALLOCATED(SharedJITStubSet);
 public:
     SharedJITStubSet() = default;
 

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -29,6 +29,7 @@
 #include "BlockDirectory.h"
 #include "HeapInlines.h"
 #include "Subspace.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { 
 
@@ -54,6 +55,8 @@ void AlignedMemoryAllocator::registerSubspace(Subspace* subspace)
     RELEASE_ASSERT(!subspace->nextSubspaceInAlignedMemoryAllocator());
     m_subspaces.append(std::mem_fn(&Subspace::setNextSubspaceInAlignedMemoryAllocator), subspace);
 }
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AlignedMemoryAllocator);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -27,6 +27,7 @@
 
 #include <wtf/PrintStream.h>
 #include <wtf/SinglyLinkedListWithTail.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -36,7 +37,7 @@ class Subspace;
 
 class AlignedMemoryAllocator {
     WTF_MAKE_NONCOPYABLE(AlignedMemoryAllocator);
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(AlignedMemoryAllocator);
+    WTF_MAKE_TZONE_ALLOCATED(AlignedMemoryAllocator);
 public:
     AlignedMemoryAllocator();
     virtual ~AlignedMemoryAllocator();

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "GigacageAlignedMemoryAllocator.h"
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 #include <wtf/text/MakeString.h>
@@ -33,6 +34,8 @@
 #include <wtf/text/StringView.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GigacageAlignedMemoryAllocator);
 
 GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator(Gigacage::Kind kind)
     : m_kind(kind)

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.h
@@ -27,6 +27,7 @@
 
 #include "AlignedMemoryAllocator.h"
 #include <wtf/Gigacage.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 #include <wtf/DebugHeap.h>
@@ -35,6 +36,7 @@
 namespace JSC {
 
 class GigacageAlignedMemoryAllocator final : public AlignedMemoryAllocator {
+    WTF_MAKE_TZONE_ALLOCATED(GigacageAlignedMemoryAllocator);
 public:
     GigacageAlignedMemoryAllocator(Gigacage::Kind);
     ~GigacageAlignedMemoryAllocator() final;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -92,6 +92,7 @@
 #include <wtf/SimpleStats.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/Threading.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if USE(BMALLOC_MEMORY_FOOTPRINT_API)
 #include <bmalloc/bmalloc.h>
@@ -111,6 +112,9 @@ namespace HeapInternal {
 static constexpr bool verbose = false;
 static constexpr bool verboseStop = false;
 }
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Heap::SpaceAndSet);
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Heap::ScriptExecutableSpaceAndSets);
 
 namespace {
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -26,6 +26,7 @@
 #include "CollectionScope.h"
 #include "CollectorPhase.h"
 #include "CompleteSubspace.h"
+#include <cstddef>
 #include "DeleteAllCodeEffort.h"
 #include "GCConductor.h"
 #include "GCIncomingRefCountedSet.h"
@@ -57,6 +58,7 @@
 #include <wtf/Markable.h>
 #include <wtf/NotFound.h>
 #include <wtf/ParallelHelperPool.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -1129,7 +1131,7 @@ public:
     std::unique_ptr<type> m_##name;
     
     struct SpaceAndSet {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SpaceAndSet);
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(SpaceAndSet);
 
         IsoSubspace space;
         IsoCellSet set;
@@ -1160,7 +1162,7 @@ public:
     }
 
     struct ScriptExecutableSpaceAndSets {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ScriptExecutableSpaceAndSets);
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(ScriptExecutableSpaceAndSets);
 
         IsoSubspace space;
         IsoCellSet clearableCodeSet;

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.cpp
@@ -41,6 +41,7 @@
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapSnapshotBuilder);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapSnapshotBuilder::Client);
 
 NodeIdentifier HeapSnapshotBuilder::nextAvailableObjectIdentifier = 1;
 NodeIdentifier HeapSnapshotBuilder::getNextObjectIdentifier() { return nextAvailableObjectIdentifier++; }

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -136,7 +136,7 @@ public:
     bool hasOverflowed() const { return m_hasOverflowed; }
 
     class Client : public CanMakeCheckedPtr<Client> {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Client);
+        WTF_MAKE_TZONE_ALLOCATED(Client);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
     public:
         virtual ~Client() = default;

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -35,6 +35,7 @@
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GCClient::IsoSubspace);
 
 IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<AlignedMemoryAllocator>&& allocator)
     : Subspace(SubspaceKind::IsoSubspace, name, heap)

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -77,7 +77,7 @@ namespace GCClient {
 
 class IsoSubspace {
     WTF_MAKE_NONCOPYABLE(IsoSubspace);
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(IsoSubspace);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(IsoSubspace, JS_EXPORT_PRIVATE);
 public:
     JS_EXPORT_PRIVATE IsoSubspace(JSC::IsoSubspace&);
     JS_EXPORT_PRIVATE ~IsoSubspace() = default;

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -50,12 +50,15 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
 #include <wtf/OSAllocator.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if OS(UNIX) && ASSERT_ENABLED
 #include <sys/mman.h>
 #endif
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(StructureAlignedMemoryAllocator);
 
 StructureAlignedMemoryAllocator::StructureAlignedMemoryAllocator() = default;
 StructureAlignedMemoryAllocator::~StructureAlignedMemoryAllocator() = default;

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
@@ -27,6 +27,7 @@
 
 #include "AlignedMemoryAllocator.h"
 #include <wtf/Gigacage.h>
+#include <wtf/TZoneMalloc.h>
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
 #include <wtf/DebugHeap.h>
@@ -35,6 +36,7 @@
 namespace JSC {
 
 class StructureAlignedMemoryAllocator final : public AlignedMemoryAllocator {
+    WTF_MAKE_TZONE_ALLOCATED(StructureAlignedMemoryAllocator);
 public:
     StructureAlignedMemoryAllocator();
     ~StructureAlignedMemoryAllocator() final;

--- a/Source/JavaScriptCore/inspector/augmentable/AlternateDispatchableAgent.h
+++ b/Source/JavaScriptCore/inspector/augmentable/AlternateDispatchableAgent.h
@@ -31,12 +31,13 @@
 #include "InspectorAgentBase.h"
 #include "InspectorAlternateBackendDispatchers.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace Inspector {
 
 template<typename TBackendDispatcher, typename TAlternateDispatcher>
 class AlternateDispatchableAgent final : public InspectorAgentBase {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(AlternateDispatchableAgent);
+    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(AlternateDispatchableAgent);
 public:
     AlternateDispatchableAgent(const String& domainName, AugmentableInspectorController& controller, std::unique_ptr<TAlternateDispatcher> alternateDispatcher)
         : InspectorAgentBase(domainName)
@@ -64,6 +65,14 @@ private:
     std::unique_ptr<TAlternateDispatcher> m_alternateDispatcher;
     const Ref<TBackendDispatcher> m_backendDispatcher;
 };
+
+#define TZONE_TEMPLATE_PARAMS template<typename TBackendDispatcher, typename TAlternateDispatcher>
+#define TZONE_TYPE AlternateDispatchableAgent<TBackendDispatcher, TAlternateDispatcher>
+
+WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS();
+
+#undef TZONE_TEMPLATE_PARAMS
+#undef TZONE_TYPE
 
 } // namespace Inspector
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
@@ -27,10 +27,13 @@
 #include "RemoteInspectorMessageParser.h"
 
 #include <wtf/ByteOrder.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 
 namespace Inspector {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MessageParser);
 
 /*
 | <--- one message for send / didReceiveData ---> |

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h
@@ -28,12 +28,13 @@
 #if ENABLE(REMOTE_INSPECTOR)
 
 #include <wtf/Function.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace Inspector {
 
 class MessageParser {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(MessageParser);
+    WTF_MAKE_TZONE_ALLOCATED(MessageParser);
 public:
     static Vector<uint8_t> createMessage(std::span<const uint8_t>);
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1128,6 +1128,8 @@ private:
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FixedVMPoolExecutableAllocator::Islands);
 #endif // ENABLE(JUMP_ISLANDS)
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ExecutableAllocator);
+
 // Keep this pointer in a mutable global variable to help Leaks find it.
 // But we do not use this pointer.
 static FixedVMPoolExecutableAllocator* globalFixedVMPoolExecutableAllocatorToWorkAroundLeaks = nullptr;

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -312,9 +312,7 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 class ExecutableAllocator : private ExecutableAllocatorBase {
-    // This does not need to be TZONE_ALLOCATED because it is only used as a singleton, and
-    // is only allocated once long before any script is executed.
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ExecutableAllocator);
+    WTF_MAKE_TZONE_ALLOCATED(ExecutableAllocator);
 public:
     using Base = ExecutableAllocatorBase;
 
@@ -363,9 +361,7 @@ private:
 #else
 
 class ExecutableAllocator : public ExecutableAllocatorBase {
-    // This does not need to be TZONE_ALLOCATED because it is only used as a singleton, and
-    // is only allocated once long before any script is executed.
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ExecutableAllocator);
+    WTF_MAKE_TZONE_ALLOCATED(ExecutableAllocator);
 public:
     static ExecutableAllocator& singleton();
     static void initialize();

--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
@@ -46,6 +46,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMalloc.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -341,7 +342,7 @@ static void unregisterCodeEntry(JITCodeEntry* entry)
 
 template <typename THeader>
 class DebugSectionBase {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DebugSectionBase);
+    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(DebugSectionBase);
 
 public:
     virtual ~DebugSectionBase() = default;
@@ -360,6 +361,8 @@ public:
 
     using Header = THeader;
 };
+
+WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template <typename THeader>, DebugSectionBase<THeader>);
 
 struct MachOSectionHeader {
     char sectname[16];
@@ -645,7 +648,7 @@ void ELFSection::populateHeader(Writer::Slot<ELFSection::Header> header, ELFStri
 
 #if OS(DARWIN)
 class MachO {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(MachO);
+    WTF_MAKE_TZONE_ALLOCATED(MachO);
 
 public:
     size_t addSection(std::unique_ptr<MachOSection> section)
@@ -819,6 +822,7 @@ private:
 
     Vector<std::unique_ptr<MachOSection>> m_sections { };
 };
+WTF_MAKE_TZONE_ALLOCATED_IMPL(MachO);
 #endif // OS(DARWIN)
 
 #if OS(LINUX)

--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -55,6 +55,10 @@ class AccessCase;
 // See GCAwareJITStubRoutine.h for the other stub routines.
 class JITStubRoutine {
     WTF_MAKE_NONCOPYABLE(JITStubRoutine);
+    // Migrating this to TZones, along with the half-dozen or so child classes
+    // that inherit from this, causes a crash due to some type being allocated
+    // with TZone but then freed via FastMalloc via a hash-table.
+    // For now keeping it in FastMalloc until that issue can be resolved.
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JITStubRoutine);
 public:
     enum class Type : uint8_t {

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -590,7 +590,7 @@ private:
     static constexpr unsigned DontEnum = 0 | PropertyAttribute::DontEnum;
 
     class PropertyFilter : public SideDataRepository::SideData {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PropertyFilter);
+        WTF_MAKE_TZONE_ALLOCATED(PropertyFilter);
     public:
         void add(UniquedStringImpl* uid)
         {
@@ -946,6 +946,8 @@ private:
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception*);
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(GlobalObject, JSGlobalObject);
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GlobalObject::PropertyFilter);
 
 static bool supportsRichSourceInfo = true;
 static bool shellSupportsRichSourceInfo(const JSGlobalObject*)

--- a/Source/JavaScriptCore/parser/SourceCodeKey.h
+++ b/Source/JavaScriptCore/parser/SourceCodeKey.h
@@ -29,6 +29,7 @@
 #include "ParserModes.h"
 #include "UnlinkedSourceCode.h"
 #include <wtf/HashTraits.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
@@ -65,7 +66,7 @@ private:
 };
 
 class SourceCodeKey {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SourceCodeKey);
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(SourceCodeKey);
     friend class CachedSourceCodeKey;
 
 public:

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.cpp
@@ -34,8 +34,11 @@
 #include "SourceCodeKey.h"
 #include "IsoCellSetInlines.h"
 #include "JSCJSValueInlines.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(FunctionExecutable::RareData);
 
 const ClassInfo FunctionExecutable::s_info = { "FunctionExecutable"_s, &ScriptExecutable::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(FunctionExecutable) };
 

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -30,6 +30,7 @@
 #include "SourceCode.h"
 #include <wtf/Box.h>
 #include <wtf/Markable.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -292,7 +293,7 @@ public:
     }
 
     struct RareData {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RareData);
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(RareData);
 
         static constexpr ptrdiff_t offsetOfAsString() { return OBJECT_OFFSETOF(RareData, m_asString); }
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -311,6 +311,7 @@
 #include <wtf/SystemTracing.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JSGlobalObjectDebuggable.h"
@@ -323,6 +324,8 @@
 #endif
 
 namespace JSC {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(JSGlobalObject::RareData);
 
 #define CHECK_FEATURE_FLAG_TYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
 static_assert(std::is_same_v<std::remove_cv_t<decltype(featureFlag)>, bool> || std::is_same_v<std::remove_cv_t<decltype(featureFlag)>, bool&>);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -41,13 +41,15 @@
 #include "StrongInlines.h"
 #include "StructureInlines.h"
 #include <wtf/Hasher.h>
+#include <wtf/TZoneMalloc.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
 struct JSGlobalObject::RareData {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(JSGlobalObject);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(RareData, JS_EXPORT_PRIVATE);
+public:
 
     unsigned profileGroup { 0 };
     UncheckedKeyHashMap<OpaqueJSClass*, std::unique_ptr<OpaqueJSClassContextData>> opaqueJSClassData;

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
@@ -40,6 +40,7 @@
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JSRunLoopTimer::Manager);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(JSRunLoopTimer::Manager::PerVMData);
 
 JSRunLoopTimer::Manager::PerVMData::PerVMData(Manager& manager, RunLoop& runLoop)
     : runLoop(runLoop)

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -66,11 +66,13 @@ public:
         void ref() const { }
         void deref() const { }
 
+        class PerVMDData;
+
     private:
         Lock m_lock;
 
         class PerVMData {
-            WTF_DEPRECATED_MAKE_FAST_ALLOCATED(PerVMData);
+            WTF_MAKE_TZONE_ALLOCATED(PerVMData);
             WTF_MAKE_NONCOPYABLE(PerVMData);
         public:
             PerVMData(Manager&, WTF::RunLoop&);

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -45,6 +45,7 @@
 #include <wtf/NumberOfCores.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TranslatedProcess.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/threads/Signals.h>
@@ -81,12 +82,11 @@ namespace OptionsHelper {
 // VM run time. For now, the only field it contains is a copy of Options defaults
 // which are only used to provide more info for Options dumps.
 struct Metadata {
-    // This struct does not need to be TZONE_ALLOCATED because it is only used for transient memory
-    // during Options initialization, and will not be re-allocated thereafter. See comment above.
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Metadata);
+    WTF_MAKE_TZONE_ALLOCATED(Metadata);
 public:
     OptionsStorage defaults;
 };
+WTF_MAKE_TZONE_ALLOCATED_IMPL(Metadata);
 
 static LazyNeverDestroyed<std::unique_ptr<Metadata>> g_metadata;
 static LazyNeverDestroyed<WTF::BitSet<NumberOfOptions>> g_optionWasOverridden;

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -30,10 +30,13 @@
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
 
 const ClassInfo RegExp::s_info = { "RegExp"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(RegExp) };
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(RegExp::RareData);
 
 #if REGEXP_FUNC_TEST_DATA_GEN
 const char* const RegExpFunctionalTestCollector::s_fileName = "/tmp/RegExpTestsData";

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -27,6 +27,7 @@
 #include "Structure.h"
 #include "Yarr.h"
 #include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(YARR_JIT)
@@ -207,7 +208,7 @@ private:
 #endif
 
     struct RareData {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RareData);
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(RareData);
         unsigned m_numDuplicateNamedCaptureGroups;
         Vector<String> m_captureGroupNames;
 

--- a/Source/JavaScriptCore/runtime/SideDataRepository.cpp
+++ b/Source/JavaScriptCore/runtime/SideDataRepository.cpp
@@ -25,8 +25,11 @@
 
 #include "config.h"
 #include "SideDataRepository.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SideDataRepository::SideData);
 
 auto SideDataRepository::add(void* owner, void* key, std::unique_ptr<SideData> sideData) -> AddResult
 {

--- a/Source/JavaScriptCore/runtime/SideDataRepository.h
+++ b/Source/JavaScriptCore/runtime/SideDataRepository.h
@@ -28,13 +28,14 @@
 #include <wtf/HashMap.h>
 #include <wtf/Locker.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
 class SideDataRepository {
 public:
     class SideData {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SideData);
+        WTF_MAKE_TZONE_ALLOCATED(SideData);
     public:
         virtual ~SideData() = default;
     };

--- a/Source/JavaScriptCore/runtime/StructureRareData.cpp
+++ b/Source/JavaScriptCore/runtime/StructureRareData.cpp
@@ -44,6 +44,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SpecialPropertyCacheEntry);
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SpecialPropertyCache);
+
 const ClassInfo StructureRareData::s_info = { "StructureRareData"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(StructureRareData) };
 
 Structure* StructureRareData::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -39,7 +39,7 @@ namespace JSC {
 // FIXME: Use ObjectPropertyConditionSet instead.
 // https://bugs.webkit.org/show_bug.cgi?id=216112
 struct SpecialPropertyCacheEntry {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SpecialPropertyCacheEntry);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(SpecialPropertyCacheEntry);
     ~SpecialPropertyCacheEntry();
 
     static constexpr ptrdiff_t offsetOfValue() { return OBJECT_OFFSETOF(SpecialPropertyCacheEntry, m_value); }
@@ -50,7 +50,7 @@ struct SpecialPropertyCacheEntry {
 };
 
 struct SpecialPropertyCache {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SpecialPropertyCache);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(SpecialPropertyCache);
     SpecialPropertyCacheEntry m_cache[numberOfCachedSpecialPropertyKeys];
 
     static constexpr ptrdiff_t offsetOfCache(CachedSpecialPropertyKey key)

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -33,10 +33,12 @@
 #include "JSCJSValueInlines.h"
 #include "ResourceExhaustion.h"
 #include "TypeProfiler.h"
-
 #include <wtf/CommaPrinter.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SymbolTable::SymbolTableRareData);
 
 const ClassInfo SymbolTable::s_info = { "SymbolTable"_s, nullptr, nullptr, nullptr, CREATE_METHOD_TABLE(SymbolTable) };
 

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -766,7 +766,7 @@ public:
     void dump(PrintStream&) const;
 
     struct SymbolTableRareData {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SymbolTableRareData);
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(SymbolTableRareData);
         UniqueIDMap m_uniqueIDMap;
         OffsetToVariableMap m_offsetToVariableMap;
         UniqueTypeSetMap m_uniqueTypeSetMap;

--- a/Source/JavaScriptCore/runtime/TypeProfilerLog.h
+++ b/Source/JavaScriptCore/runtime/TypeProfilerLog.h
@@ -41,7 +41,8 @@ class TypeProfilerLog {
     WTF_MAKE_TZONE_ALLOCATED(TypeProfilerLog);
 public:
     struct LogEntry {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(LogEntry);
+        // This cannot be TZone-allocated since it's allocated via operator new[]
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LogEntry);
     public:
         friend class LLIntOffsetsExtractor;
 

--- a/Source/JavaScriptCore/runtime/WeakGCMap.h
+++ b/Source/JavaScriptCore/runtime/WeakGCMap.h
@@ -29,6 +29,7 @@
 #include "Weak.h"
 #include "WeakGCHashTable.h"
 #include <wtf/HashMap.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
@@ -36,7 +37,7 @@ namespace JSC {
 
 template<typename KeyArg, typename ValueArg, typename HashArg = DefaultHash<KeyArg>, typename KeyTraitsArg = HashTraits<KeyArg>>
 class WeakGCMap final : public WeakGCHashTable {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WeakGCMap);
+    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(WeakGCMap);
     typedef Weak<ValueArg> ValueType;
     typedef UncheckedKeyHashMap<KeyArg, ValueType, HashArg, KeyTraitsArg> HashMapType;
 
@@ -110,5 +111,13 @@ private:
     HashMapType m_map;
     VM& m_vm;
 };
+
+#define TZONE_TEMPLATE_PARAMS template<typename KeyArg, typename ValueArg, typename HashArg, typename KeyTraitsArg>
+#define TZONE_TYPE WeakGCMap<KeyArg, ValueArg, HashArg, KeyTraitsArg>
+
+WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS();
+
+#undef TZONE_TEMPLATE_PARAMS
+#undef TZONE_TYPE
 
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -40,6 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HeapVerifier);
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(HeapVerifier::GCCycle);
 
 HeapVerifier::HeapVerifier(Heap* heap, unsigned numberOfGCCyclesToRecord)
     : m_heap(heap)

--- a/Source/JavaScriptCore/tools/HeapVerifier.h
+++ b/Source/JavaScriptCore/tools/HeapVerifier.h
@@ -67,7 +67,7 @@ public:
 
 private:
     struct GCCycle {
-        WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(GCCycle);
+        WTF_MAKE_STRUCT_TZONE_ALLOCATED(GCCycle);
 
         GCCycle()
             : before("Before Marking")

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -35,8 +35,28 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/TZoneMallocInlines.h>
 
 namespace JSC { namespace Wasm {
+
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Import);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Export);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(GlobalInformation);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(FunctionData);
+    WTF_MAKE_TZONE_ALLOCATED_IMPL(I32InitExpr);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Segment);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Element);
+    WTF_MAKE_TZONE_ALLOCATED_IMPL(TableInformation);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(CustomSection);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(UnlinkedWasmToWasmCall);
+#if ENABLE(JIT)
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Entrypoint);
+#endif
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(InternalFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(WasmCallableFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(WasmToWasmImportableFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(WasmOrJSImportableFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(WasmOrJSImportableFunctionCallLinkInfo);
 
 constexpr CalleeBits NullWasmCallee = CalleeBits::nullCallee();
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -502,7 +502,7 @@ inline ASCIILiteral makeString(ExternalKind kind)
 }
 
 struct Import {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Import);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(Import);
     const Name module;
     const Name field;
     ExternalKind kind;
@@ -510,7 +510,7 @@ struct Import {
 };
 
 struct Export {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Export);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(Export);
     const Name field;
     ExternalKind kind;
     unsigned kindIndex; // Index in the vector of the corresponding kind.
@@ -519,7 +519,7 @@ struct Export {
 String makeString(const Name& characters);
 
 struct GlobalInformation {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(GlobalInformation);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(GlobalInformation);
 
     enum InitializationType : uint8_t {
         IsImport,
@@ -546,7 +546,7 @@ struct GlobalInformation {
 };
 
 struct FunctionData {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(FunctionData);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(FunctionData);
     size_t start;
     size_t end;
     Vector<uint8_t> data;
@@ -601,7 +601,7 @@ private:
 };
 
 struct Segment {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Segment);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(Segment);
 
     enum class Kind : uint8_t {
         Active,
@@ -627,7 +627,7 @@ struct Segment {
 };
 
 struct Element {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Element);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(Element);
 
     enum class Kind : uint8_t {
         Active,
@@ -717,7 +717,7 @@ private:
 };
     
 struct CustomSection {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(CustomSection);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(CustomSection);
     Name name;
     Vector<uint8_t> payload;
 };
@@ -778,7 +778,7 @@ private:
 };
 
 struct UnlinkedWasmToWasmCall {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(UnlinkedWasmToWasmCall);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(UnlinkedWasmToWasmCall);
     CodeLocationNearCall<WasmEntryPtrTag> callLocation;
     FunctionSpaceIndex functionIndexSpace;
     CodeLocationDataLabelPtr<WasmEntryPtrTag> calleeLocation;
@@ -787,7 +787,7 @@ struct UnlinkedWasmToWasmCall {
 
 #if ENABLE(JIT)
 struct Entrypoint {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Entrypoint);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(Entrypoint);
     std::unique_ptr<Compilation> compilation;
     RegisterAtOffsetList calleeSaveRegisters;
 };
@@ -798,7 +798,7 @@ using StackMap = FixedVector<OSREntryValue>;
 using StackMaps = UncheckedKeyHashMap<CallSiteIndex, StackMap>;
 
 struct InternalFunction {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(InternalFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(InternalFunction);
 #if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
     StackMaps stackmaps;
 #endif
@@ -815,7 +815,7 @@ struct InternalFunction {
 extern const CalleeBits NullWasmCallee;
 
 struct alignas(8) WasmCallableFunction {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(alignas);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(WasmCallableFunction);
     using LoadLocation = CodePtr<WasmEntryPtrTag>*;
     static constexpr ptrdiff_t offsetOfEntrypointLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, entrypointLoadLocation); }
     static constexpr ptrdiff_t offsetOfBoxedWasmCalleeLoadLocation() { return OBJECT_OFFSETOF(WasmCallableFunction, boxedWasmCalleeLoadLocation); }
@@ -831,7 +831,7 @@ struct alignas(8) WasmCallableFunction {
 // with all imports, and then all internal functions. WasmToWasmImportableFunction and FunctionIndexSpace are only
 // meant as fast lookup tables for these opcodes and do not own code.
 struct WasmToWasmImportableFunction : public WasmCallableFunction {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WasmToWasmImportableFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(WasmToWasmImportableFunction);
     static constexpr ptrdiff_t offsetOfSignatureIndex() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, typeIndex); }
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, rtt); }
 
@@ -843,7 +843,7 @@ struct WasmToWasmImportableFunction : public WasmCallableFunction {
 using FunctionIndexSpace = Vector<WasmToWasmImportableFunction>;
 
 struct WasmOrJSImportableFunction : public WasmToWasmImportableFunction {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WasmOrJSImportableFunction);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(WasmOrJSImportableFunction);
     using LoadLocation = CodePtr<WasmEntryPtrTag>*;
 
     CodePtr<WasmEntryPtrTag> importFunctionStub;
@@ -852,7 +852,7 @@ struct WasmOrJSImportableFunction : public WasmToWasmImportableFunction {
 };
 
 struct WasmOrJSImportableFunctionCallLinkInfo final : public WasmOrJSImportableFunction {
-    WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WasmOrJSImportableFunctionCallLinkInfo);
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(WasmOrJSImportableFunctionCallLinkInfo);
     std::unique_ptr<DataOnlyCallLinkInfo> callLinkInfo { };
     static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(WasmOrJSImportableFunctionCallLinkInfo, callLinkInfo); }
 };

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
@@ -30,6 +30,7 @@
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(COCOA)
@@ -41,6 +42,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 namespace Wasm {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WasmOpcodeCounter);
 
 WasmOpcodeCounter& WasmOpcodeCounter::singleton()
 {

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.h
@@ -28,12 +28,13 @@
 
 #include "WasmTypeDefinition.h"
 #include <wtf/Atomics.h>
+#include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 namespace Wasm {
 
 class WasmOpcodeCounter {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WasmOpcodeCounter);
+    WTF_MAKE_TZONE_ALLOCATED(WasmOpcodeCounter);
     using NumberOfRegisteredOpcodes = size_t;
     using CounterSize = size_t;
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -47,6 +47,7 @@ namespace JSC { namespace Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeDefinition);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeInformation);
+WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(RTT);
 
 String TypeDefinition::toString() const
 {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -744,7 +744,7 @@ enum class RTTKind : uint8_t {
 };
 
 class RTT_ALIGNMENT RTT final : public ThreadSafeRefCounted<RTT>, private TrailingArray<RTT, const RTT*> {
-    WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED(RTT);
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(RTT);
     WTF_MAKE_NONMOVABLE(RTT);
     using TrailingArrayType = TrailingArray<RTT, const RTT*>;
     friend TrailingArrayType;


### PR DESCRIPTION
#### 1a015273c8c677a1fcfc85353709000ff86546d2
<pre>
[jsc] Migrate, where possible, to using TZoneMalloc in Source/JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=296828">https://bugs.webkit.org/show_bug.cgi?id=296828</a>
<a href="https://rdar.apple.com/157329141">rdar://157329141</a>

Reviewed by NOBODY (OOPS!).

As part of our effort to deprecate MAKE_FAST_ALLOCATED, any objects that
can be allocated using TZoneMalloc should be made to do so. Not all
types can be so moved: e.g. variable-sized types are generally excluded.
This patch moves all types which can use TZones over to using TZones.
Qualifying types in the rest of the repository will be moved in a later
patch.

One notable omission is handling for the WebInspector codegen classes,
which do create a few FastMalloc-allocated types. I made a first pass at
converting those as well but ran into strange issues which persuaded me
to leave that for later so as to get this change, which is
rebase-sensitive, out of the door.

The other big category I had to skip over was that of types tagged with
WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER, as the
equivalent functionality is not yet implemented in TZoneMalloc (and
doing so would be out of scope for this patch).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a015273c8c677a1fcfc85353709000ff86546d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114629 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65351 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/565b9d53-239e-43b5-ab4c-cf5af423400b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87140 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42041 "") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bad2521-0342-4d55-8427-708d0de7c760) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67528 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21073 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64472 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107021 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123997 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113192 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95955 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95736 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40896 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18740 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37740 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41519 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47031 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41105 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36742 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44412 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->