### PR TITLE
[WTF] Modernize wtf/MathExtras.h

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -123,19 +123,53 @@ constexpr float grad2turn(float g) { return deg2turn(grad2deg(g)); }
 constexpr float turn2rad(float t) { return deg2rad(turn2deg(t)); }
 constexpr float rad2turn(float r) { return deg2turn(rad2deg(r)); }
 
+namespace WTF {
+
+// FIXME: Replace with std::isnan() once std::isnan() is constexpr. requires C++23
+template<std::floating_point T>
+constexpr bool isNaNConstExpr(T value)
+{
+#if COMPILER_HAS_CLANG_BUILTIN(__builtin_isnan)
+    return __builtin_isnan(value);
+#else
+    return value != value;
+#endif
+}
+
+template<std::integral T>
+constexpr bool isNaNConstExpr(T)
+{
+    return false;
+}
+
+// FIXME: Replace with std::fabs() once std::fabs() is constexpr. requires C++23
+template<std::floating_point T>
+constexpr T fabsConstExpr(T value)
+{
+    if (value != value)
+        return value;
+    if (!value)
+        return 0.0; // -0.0 should be converted to +0.0
+    if (value < 0.0)
+        return -value;
+    return value;
+}
+
+} // namespace WTF
+
 inline double roundTowardsPositiveInfinity(double value) { return std::floor(value + 0.5); }
 inline float roundTowardsPositiveInfinity(float value) { return std::floor(value + 0.5f); }
 
 // std::numeric_limits<T>::min() returns the smallest positive value for floating point types
-template<typename T> constexpr T defaultMinimumForClamp() { return std::numeric_limits<T>::min(); }
-template<> constexpr float defaultMinimumForClamp() { return -std::numeric_limits<float>::max(); }
-template<> constexpr double defaultMinimumForClamp() { return -std::numeric_limits<double>::max(); }
-template<typename T> constexpr T defaultMaximumForClamp() { return std::numeric_limits<T>::max(); }
+template<typename T> consteval T defaultMinimumForClamp() { return std::numeric_limits<T>::min(); }
+template<> consteval float defaultMinimumForClamp() { return -std::numeric_limits<float>::max(); }
+template<> consteval double defaultMinimumForClamp() { return -std::numeric_limits<double>::max(); }
+template<typename T> consteval T defaultMaximumForClamp() { return std::numeric_limits<T>::max(); }
 
 // Same type in and out.
 template<typename TargetType, typename SourceType>
-typename std::enable_if<std::is_same<TargetType, SourceType>::value, TargetType>::type
-clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
+    requires std::same_as<TargetType, SourceType>
+constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
 {
     if (value >= max)
         return max;
@@ -146,10 +180,10 @@ clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(),
 
 // Floating point source.
 template<typename TargetType, typename SourceType>
-typename std::enable_if<!std::is_same<TargetType, SourceType>::value
-    && std::is_floating_point<SourceType>::value
-    && !(std::is_floating_point<TargetType>::value && sizeof(TargetType) > sizeof(SourceType)), TargetType>::type
-clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
+    requires (!std::same_as<TargetType, SourceType>
+          &&   std::floating_point<SourceType>
+          && !(std::floating_point<TargetType> && sizeof(TargetType) > sizeof(SourceType)))
+constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
 {
     if (value >= static_cast<SourceType>(max))
         return max;
@@ -160,11 +194,11 @@ clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(),
 }
 
 template<typename TargetType, typename SourceType>
-typename std::enable_if<!std::is_same<TargetType, SourceType>::value
-    && std::is_floating_point<SourceType>::value
-    && std::is_floating_point<TargetType>::value
-    && (sizeof(TargetType) > sizeof(SourceType)), TargetType>::type
-clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
+    requires (!std::same_as<TargetType, SourceType>
+          &&   std::floating_point<SourceType>
+          &&   std::floating_point<TargetType>
+          &&   sizeof(TargetType) > sizeof(SourceType))
+constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
 {
     TargetType convertedValue = static_cast<TargetType>(value);
     if (convertedValue >= max)
@@ -176,12 +210,12 @@ clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(),
 
 // Source and Target have the same sign and Source is larger or equal to Target
 template<typename TargetType, typename SourceType>
-typename std::enable_if<!std::is_same<TargetType, SourceType>::value
-    && std::numeric_limits<SourceType>::is_integer
-    && std::numeric_limits<TargetType>::is_integer
-    && std::numeric_limits<TargetType>::is_signed == std::numeric_limits<SourceType>::is_signed
-    && sizeof(SourceType) >= sizeof(TargetType), TargetType>::type
-clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
+    requires (!std::same_as<TargetType, SourceType>
+          &&   std::integral<SourceType>
+          &&   std::integral<TargetType>
+          &&   std::signed_integral<TargetType> == std::signed_integral<SourceType>
+          &&   sizeof(SourceType) >= sizeof(TargetType))
+constexpr TargetType clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(), TargetType max = defaultMaximumForClamp<TargetType>())
 {
     if (value >= static_cast<SourceType>(max))
         return max;
@@ -192,13 +226,11 @@ clampTo(SourceType value, TargetType min = defaultMinimumForClamp<TargetType>(),
 
 // Clamping a unsigned integer to the max signed value.
 template<typename TargetType, typename SourceType>
-typename std::enable_if<!std::is_same<TargetType, SourceType>::value
-    && std::numeric_limits<SourceType>::is_integer
-    && std::numeric_limits<TargetType>::is_integer
-    && std::numeric_limits<TargetType>::is_signed
-    && !std::numeric_limits<SourceType>::is_signed
-    && sizeof(SourceType) >= sizeof(TargetType), TargetType>::type
-clampTo(SourceType value)
+    requires (!std::same_as<TargetType, SourceType>
+          &&   std::unsigned_integral<SourceType>
+          &&   std::signed_integral<TargetType>
+          &&   sizeof(SourceType) >= sizeof(TargetType))
+constexpr TargetType clampTo(SourceType value)
 {
     TargetType max = std::numeric_limits<TargetType>::max();
     if (value >= static_cast<SourceType>(max))
@@ -208,13 +240,11 @@ clampTo(SourceType value)
 
 // Clamping a signed integer into a valid unsigned integer.
 template<typename TargetType, typename SourceType>
-typename std::enable_if<!std::is_same<TargetType, SourceType>::value
-    && std::numeric_limits<SourceType>::is_integer
-    && std::numeric_limits<TargetType>::is_integer
-    && !std::numeric_limits<TargetType>::is_signed
-    && std::numeric_limits<SourceType>::is_signed
-    && sizeof(SourceType) == sizeof(TargetType), TargetType>::type
-clampTo(SourceType value)
+    requires (!std::same_as<TargetType, SourceType>
+          &&   std::unsigned_integral<TargetType>
+          &&   std::signed_integral<SourceType>
+          &&   sizeof(SourceType) == sizeof(TargetType))
+constexpr TargetType clampTo(SourceType value)
 {
     if (value < 0)
         return 0;
@@ -222,13 +252,11 @@ clampTo(SourceType value)
 }
 
 template<typename TargetType, typename SourceType>
-typename std::enable_if<!std::is_same<TargetType, SourceType>::value
-    && std::numeric_limits<SourceType>::is_integer
-    && std::numeric_limits<TargetType>::is_integer
-    && !std::numeric_limits<TargetType>::is_signed
-    && std::numeric_limits<SourceType>::is_signed
-    && (sizeof(SourceType) > sizeof(TargetType)), TargetType>::type
-clampTo(SourceType value)
+    requires (!std::same_as<TargetType, SourceType>
+          &&   std::unsigned_integral<TargetType>
+          &&   std::signed_integral<SourceType>
+          &&   sizeof(SourceType) > sizeof(TargetType))
+constexpr TargetType clampTo(SourceType value)
 {
     if (value < 0)
         return 0;
@@ -238,37 +266,35 @@ clampTo(SourceType value)
     return static_cast<TargetType>(value);
 }
 
-inline int clampToInteger(double value)
+constexpr int clampToInteger(double value)
 {
     return clampTo<int>(value);
 }
 
-inline unsigned clampToUnsigned(double value)
+constexpr unsigned clampToUnsigned(double value)
 {
     return clampTo<unsigned>(value);
 }
 
-inline float clampToFloat(double value)
+constexpr float clampToFloat(double value)
 {
     return clampTo<float>(value);
 }
 
-inline int clampToPositiveInteger(double value)
+constexpr int clampToPositiveInteger(double value)
 {
     return clampTo<int>(value, 0);
 }
 
-inline int clampToInteger(float value)
+constexpr int clampToInteger(float value)
 {
     return clampTo<int>(value);
 }
 
-template<typename T>
-inline int clampToInteger(T x)
+template<std::integral T>
+constexpr int clampToInteger(T x)
 {
-    static_assert(std::numeric_limits<T>::is_integer, "T must be an integer.");
-
-    const T intMax = static_cast<unsigned>(std::numeric_limits<int>::max());
+    constexpr T intMax = static_cast<unsigned>(std::numeric_limits<int>::max());
 
     if (x >= intMax)
         return std::numeric_limits<int>::max();
@@ -277,17 +303,18 @@ inline int clampToInteger(T x)
 
 // Explicitly accept 64bit result when clamping double value.
 // Keep in mind that double can only represent 53bit integer precisely.
-template<typename T> constexpr T clampToAccepting64(double value, T min = defaultMinimumForClamp<T>(), T max = defaultMaximumForClamp<T>())
+template<typename T>
+constexpr T clampToAccepting64(double value, T min = defaultMinimumForClamp<T>(), T max = defaultMaximumForClamp<T>())
 {
     return (value >= static_cast<double>(max)) ? max : ((value <= static_cast<double>(min)) ? min : static_cast<T>(value));
 }
 
-inline bool isWithinIntRange(float x)
+constexpr bool isWithinIntRange(float x)
 {
     return x > static_cast<float>(std::numeric_limits<int>::min()) && x < static_cast<float>(std::numeric_limits<int>::max());
 }
 
-inline float normalizedFloat(float value)
+constexpr float normalizedFloat(float value)
 {
     if (value > 0 && value < std::numeric_limits<float>::min())
         return std::numeric_limits<float>::min();
@@ -296,27 +323,32 @@ inline float normalizedFloat(float value)
     return value;
 }
 
-template<typename T> constexpr bool hasOneBitSet(T value)
+template<typename T>
+constexpr bool hasOneBitSet(T value)
 {
     return !((value - 1) & value) && value;
 }
 
-template<typename T> constexpr bool hasZeroOrOneBitsSet(T value)
+template<typename T>
+constexpr bool hasZeroOrOneBitsSet(T value)
 {
     return !((value - 1) & value);
 }
 
-template<typename T> constexpr bool hasTwoOrMoreBitsSet(T value)
+template<typename T>
+constexpr bool hasTwoOrMoreBitsSet(T value)
 {
     return !hasZeroOrOneBitsSet(value);
 }
 
-template<typename T> inline T divideRoundedUp(T a, T b)
+template<typename T>
+constexpr T divideRoundedUp(T a, T b)
 {
     return (a + b - 1) / b;
 }
 
-template<typename T> inline T timesThreePlusOneDividedByTwo(T value)
+template<typename T>
+constexpr T timesThreePlusOneDividedByTwo(T value)
 {
     // Mathematically equivalent to:
     //   (value * 3 + 1) / 2;
@@ -326,17 +358,20 @@ template<typename T> inline T timesThreePlusOneDividedByTwo(T value)
     return value + (value >> 1) + (value & 1);
 }
 
-template<typename T> inline bool isNotZeroAndOrdered(T value)
+template<typename T>
+constexpr bool isNotZeroAndOrdered(T value)
 {
     return value > 0.0 || value < 0.0;
 }
 
-template<typename T> inline bool isZeroOrUnordered(T value)
+template<typename T>
+constexpr bool isZeroOrUnordered(T value)
 {
     return !isNotZeroAndOrdered(value);
 }
 
-template<typename T> inline bool isGreaterThanNonZeroPowerOfTwo(T value, unsigned power)
+template<typename T>
+constexpr bool isGreaterThanNonZeroPowerOfTwo(T value, unsigned power)
 {
     // The crazy way of testing of index >= 2 ** power
     // (where I use ** to denote pow()).
@@ -425,7 +460,7 @@ constexpr unsigned maskForSize(unsigned size)
     return roundUpToPowerOfTwo(size) - 1;
 }
 
-inline constexpr unsigned fastLog2(unsigned i)
+constexpr unsigned fastLog2(unsigned i)
 {
     if (!i)
         return 0;
@@ -436,7 +471,7 @@ inline constexpr unsigned fastLog2(unsigned i)
     return log2;
 }
 
-inline constexpr unsigned fastLog2(uint64_t value)
+constexpr unsigned fastLog2(uint64_t value)
 {
     unsigned high = static_cast<unsigned>(value >> 32);
     if (high)
@@ -444,8 +479,8 @@ inline constexpr unsigned fastLog2(uint64_t value)
     return fastLog2(static_cast<unsigned>(value));
 }
 
-template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value, T>::type safeFPDivision(T u, T v)
+template<std::floating_point T>
+constexpr T safeFPDivision(T u, T v)
 {
     // Protect against overflow / underflow.
     if (v < 1 && u > v * std::numeric_limits<T>::max())
@@ -461,8 +496,8 @@ inline typename std::enable_if<std::is_floating_point<T>::value, T>::type safeFP
 // [1] Knuth, D. E. "Accuracy of Floating Point Arithmetic." The Art of Computer Programming. 3rd ed. Vol. 2.
 //     Boston: Addison-Wesley, 1998. 229-45.
 // [2] http://www.boost.org/doc/libs/1_34_0/libs/test/doc/components/test_tools/floating_point_comparison.html
-template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type areEssentiallyEqual(T u, T v, T epsilon = std::numeric_limits<T>::epsilon())
+template<std::floating_point T>
+constexpr bool areEssentiallyEqual(T u, T v, T epsilon = std::numeric_limits<T>::epsilon())
 {
     if (u == v)
         return true;
@@ -472,33 +507,33 @@ inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type are
 }
 
 // Match behavior of Math.min, where NaN is returned if either argument is NaN.
-template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value, T>::type nanPropagatingMin(T a, T b)
+template<std::floating_point T>
+constexpr T nanPropagatingMin(T a, T b)
 {
-    return std::isnan(a) || std::isnan(b) ? std::numeric_limits<T>::quiet_NaN() : std::min(a, b);
+    return isNaNConstExpr(a) || isNaNConstExpr(b) ? std::numeric_limits<T>::quiet_NaN() : std::min(a, b);
 }
 
 // Match behavior of Math.max, where NaN is returned if either argument is NaN.
-template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value, T>::type nanPropagatingMax(T a, T b)
+template<std::floating_point T>
+constexpr T nanPropagatingMax(T a, T b)
 {
-    return std::isnan(a) || std::isnan(b) ? std::numeric_limits<T>::quiet_NaN() : std::max(a, b);
+    return isNaNConstExpr(a) || isNaNConstExpr(b) ? std::numeric_limits<T>::quiet_NaN() : std::max(a, b);
 }
 
-inline constexpr bool isIntegral(float value)
+constexpr bool isIntegral(float value)
 {
     return !std::isinf(value) && std::trunc(value) == value;
 }
 
 template<typename T>
-inline void incrementWithSaturation(T& value)
+constexpr void incrementWithSaturation(T& value)
 {
     if (value != std::numeric_limits<T>::max())
-        value++;
+        ++value;
 }
 
 template<typename T>
-inline T leftShiftWithSaturation(T value, unsigned shiftAmount, T max = std::numeric_limits<T>::max())
+constexpr T leftShiftWithSaturation(T value, unsigned shiftAmount, T max = std::numeric_limits<T>::max())
 {
     T result = value << shiftAmount;
     // We will have saturated if shifting right doesn't recover the original value.
@@ -511,10 +546,10 @@ inline T leftShiftWithSaturation(T value, unsigned shiftAmount, T max = std::num
 
 // Check if two ranges overlap assuming that neither range is empty.
 template<typename T>
-inline bool nonEmptyRangesOverlap(T leftMin, T leftMax, T rightMin, T rightMax)
+constexpr bool nonEmptyRangesOverlap(T leftMin, T leftMax, T rightMin, T rightMax)
 {
-    ASSERT(leftMin < leftMax);
-    ASSERT(rightMin < rightMax);
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(leftMin < leftMax);
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(rightMin < rightMax);
 
     return leftMax > rightMin && rightMax > leftMin;
 }
@@ -524,10 +559,10 @@ inline bool nonEmptyRangesOverlap(T leftMin, T leftMax, T rightMin, T rightMax)
 //
 //     rangesOverlap(0, 8, 8, 16)
 template<typename T>
-inline bool rangesOverlap(T leftMin, T leftMax, T rightMin, T rightMax)
+constexpr bool rangesOverlap(T leftMin, T leftMax, T rightMin, T rightMax)
 {
-    ASSERT(leftMin <= leftMax);
-    ASSERT(rightMin <= rightMax);
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(leftMin <= leftMax);
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(rightMin <= rightMax);
     
     // Empty ranges interfere with nothing.
     if (leftMin == leftMax)
@@ -539,19 +574,19 @@ inline bool rangesOverlap(T leftMin, T leftMax, T rightMin, T rightMax)
 }
 
 template<typename VectorType, typename RandomFunc>
-void shuffleVector(VectorType& vector, size_t size, const RandomFunc& randomFunc)
+constexpr void shuffleVector(VectorType& vector, size_t size, const RandomFunc& randomFunc)
 {
     for (size_t i = 0; i + 1 < size; ++i)
         std::swap(vector[i], vector[i + randomFunc(size - i)]);
 }
 
 template<typename VectorType, typename RandomFunc>
-void shuffleVector(VectorType& vector, const RandomFunc& randomFunc)
+constexpr void shuffleVector(VectorType& vector, const RandomFunc& randomFunc)
 {
     shuffleVector(vector, vector.size(), randomFunc);
 }
 
-template <typename T>
+template<typename T>
 constexpr unsigned clzConstexpr(T value)
 {
     constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
@@ -580,7 +615,7 @@ inline unsigned clz(T value)
     return bitSize;
 }
 
-template <typename T>
+template<typename T>
 constexpr unsigned ctzConstexpr(T value)
 {
     constexpr unsigned bitSize = sizeof(T) * CHAR_BIT;
@@ -657,72 +692,41 @@ inline uint32_t reverseBits32(uint32_t value)
 #endif
 }
 
-// FIXME: Replace with std::isnan() once std::isnan() is constexpr. requires C++23
-template<typename T> constexpr typename std::enable_if_t<std::is_floating_point_v<T>, bool> isNaNConstExpr(T value)
-{
-#if COMPILER_HAS_CLANG_BUILTIN(__builtin_isnan)
-    return __builtin_isnan(value);
-#else
-    return value != value;
-#endif
-}
-
-template<typename T> constexpr typename std::enable_if_t<std::is_integral_v<T>, bool> isNaNConstExpr(T)
-{
-    return false;
-}
-
-// FIXME: Replace with std::fabs() once std::fabs() is constexpr. requires C++23
-template<typename T> constexpr T fabsConstExpr(T value)
-{
-    static_assert(std::is_floating_point_v<T>);
-    if (value != value)
-        return value;
-    if (!value)
-        return 0.0; // -0.0 should be converted to +0.0
-    if (value < 0.0)
-        return -value;
-    return value;
-}
-
 // For use in places where we could negate std::numeric_limits<T>::min and would like to avoid UB.
-template<typename T>
-requires std::is_integral_v<T>
+template<std::integral T>
 constexpr T negate(T v)
 {
     return static_cast<T>(~unsignedCast(v) + 1U);
 }
 
 template<typename BitsType, typename InputType>
-inline bool isIdentical(InputType left, InputType right)
+constexpr bool isIdentical(InputType left, InputType right)
 {
-    BitsType leftBits = std::bit_cast<BitsType>(left);
-    BitsType rightBits = std::bit_cast<BitsType>(right);
-    return leftBits == rightBits;
+    return std::bit_cast<BitsType>(left) == std::bit_cast<BitsType>(right);
 }
 
-inline bool isIdentical(int32_t left, int32_t right)
+constexpr bool isIdentical(int32_t left, int32_t right)
 {
     return isIdentical<int32_t>(left, right);
 }
 
-inline bool isIdentical(int64_t left, int64_t right)
+constexpr bool isIdentical(int64_t left, int64_t right)
 {
     return isIdentical<int64_t>(left, right);
 }
 
-inline bool isIdentical(double left, double right)
+constexpr bool isIdentical(double left, double right)
 {
     return isIdentical<int64_t>(left, right);
 }
 
-inline bool isIdentical(float left, float right)
+constexpr bool isIdentical(float left, float right)
 {
     return isIdentical<int32_t>(left, right);
 }
 
 template<typename ResultType, typename InputType, typename BitsType>
-inline bool isRepresentableAsImpl(InputType originalValue)
+constexpr bool isRepresentableAsImpl(InputType originalValue)
 {
     // Convert the original value to the desired result type.
     ResultType result = static_cast<ResultType>(originalValue);
@@ -735,25 +739,25 @@ inline bool isRepresentableAsImpl(InputType originalValue)
 }
 
 template<typename ResultType>
-inline bool isRepresentableAs(int32_t value)
+constexpr bool isRepresentableAs(int32_t value)
 {
     return isRepresentableAsImpl<ResultType, int32_t, int32_t>(value);
 }
 
 template<typename ResultType>
-inline bool isRepresentableAs(int64_t value)
+constexpr bool isRepresentableAs(int64_t value)
 {
     return isRepresentableAsImpl<ResultType, int64_t, int64_t>(value);
 }
 
 template<typename ResultType>
-inline bool isRepresentableAs(size_t value)
+constexpr bool isRepresentableAs(size_t value)
 {
     return isRepresentableAsImpl<ResultType, size_t, size_t>(value);
 }
 
 template<typename ResultType>
-inline bool isRepresentableAs(double value)
+constexpr bool isRepresentableAs(double value)
 {
     return isRepresentableAsImpl<ResultType, double, int64_t>(value);
 }
@@ -767,26 +771,28 @@ ALWAYS_INLINE constexpr T roundUpToMultipleOfImpl(size_t divisor, T x)
 
 // Efficient implementation that takes advantage of powers of two.
 template<typename T>
-inline constexpr T roundUpToMultipleOf(size_t divisor, T x)
+constexpr T roundUpToMultipleOf(size_t divisor, T x)
 {
     ASSERT_UNDER_CONSTEXPR_CONTEXT(divisor && isPowerOfTwo(divisor));
     return roundUpToMultipleOfImpl<T>(divisor, x);
 }
 
-template<size_t divisor> constexpr size_t roundUpToMultipleOf(size_t x)
+template<size_t divisor>
+constexpr size_t roundUpToMultipleOf(size_t x)
 {
     static_assert(divisor && isPowerOfTwo(divisor));
     return roundUpToMultipleOfImpl(divisor, x);
 }
 
-template<size_t divisor, typename T> inline constexpr T* roundUpToMultipleOf(T* x)
+template<size_t divisor, typename T>
+constexpr T* roundUpToMultipleOf(T* x)
 {
     static_assert(sizeof(T*) == sizeof(size_t));
     return reinterpret_cast<T*>(roundUpToMultipleOf<divisor>(reinterpret_cast<size_t>(x)));
 }
 
 template<typename T>
-inline constexpr T roundUpToMultipleOfNonPowerOfTwo(size_t divisor, T x)
+constexpr T roundUpToMultipleOfNonPowerOfTwo(size_t divisor, T x)
 {
     T remainder = x % divisor;
     if (!remainder)
@@ -795,7 +801,7 @@ inline constexpr T roundUpToMultipleOfNonPowerOfTwo(size_t divisor, T x)
 }
 
 template<typename T, typename C>
-inline constexpr Checked<T, C> roundUpToMultipleOfNonPowerOfTwo(Checked<T, C> divisor, Checked<T, C> x)
+constexpr Checked<T, C> roundUpToMultipleOfNonPowerOfTwo(Checked<T, C> divisor, Checked<T, C> x)
 {
     if (x.hasOverflowed() || divisor.hasOverflowed())
         return ResultOverflowed;
@@ -807,27 +813,29 @@ inline constexpr Checked<T, C> roundUpToMultipleOfNonPowerOfTwo(Checked<T, C> di
 
 // Returns positive distance to next multiple of a power-of-two divisor.
 template<size_t divisor>
-inline constexpr size_t distanceToMultipleOf(size_t x)
+constexpr size_t distanceToMultipleOf(size_t x)
 {
     static_assert(divisor && isPowerOfTwo(divisor));
     return (divisor - (x % divisor)) % divisor;
 }
 
 template<typename T>
-inline constexpr T roundDownToMultipleOf(size_t divisor, T x)
+constexpr T roundDownToMultipleOf(size_t divisor, T x)
 {
     ASSERT_UNDER_CONSTEXPR_CONTEXT(divisor && isPowerOfTwo(divisor));
     static_assert(sizeof(T) == sizeof(uintptr_t), "sizeof(T) must be equal to sizeof(uintptr_t).");
     return static_cast<T>(mask(static_cast<uintptr_t>(x), ~(divisor - 1ul)));
 }
 
-template<typename T> inline constexpr T* roundDownToMultipleOf(size_t divisor, T* x)
+template<typename T>
+constexpr T* roundDownToMultipleOf(size_t divisor, T* x)
 {
     ASSERT_UNDER_CONSTEXPR_CONTEXT(isPowerOfTwo(divisor));
     return reinterpret_cast<T*>(mask(reinterpret_cast<uintptr_t>(x), ~(divisor - 1ul)));
 }
 
-template<size_t divisor, typename T> constexpr T roundDownToMultipleOf(T x)
+template<size_t divisor, typename T>
+constexpr T roundDownToMultipleOf(T x)
 {
     static_assert(isPowerOfTwo(divisor), "'divisor' must be a power of two.");
     return roundDownToMultipleOf(divisor, x);


### PR DESCRIPTION
#### 38b34df1ab771b304387f2c75c6f1a775f22028f
<pre>
[WTF] Modernize wtf/MathExtras.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=296832">https://bugs.webkit.org/show_bug.cgi?id=296832</a>

Reviewed by Darin Adler.

Does a pass of modernizing wtf/MathExtras.h by utilizing
concepts/requires and adopting constexpr more broadly.

* Source/WTF/wtf/MathExtras.h:
(WTF::isNaNConstExpr):
(WTF::fabsConstExpr):
(defaultMinimumForClamp):
(defaultMaximumForClamp):
(clampTo):
(clampToInteger):
(clampToUnsigned):
(clampToFloat):
(clampToPositiveInteger):
(isWithinIntRange):
(normalizedFloat):
(divideRoundedUp):
(timesThreePlusOneDividedByTwo):
(isNotZeroAndOrdered):
(isZeroOrUnordered):
(isGreaterThanNonZeroPowerOfTwo):
(WTF::fastLog2):
(WTF::safeFPDivision):
(WTF::areEssentiallyEqual):
(WTF::nanPropagatingMin):
(WTF::nanPropagatingMax):
(WTF::isIntegral):
(WTF::incrementWithSaturation):
(WTF::leftShiftWithSaturation):
(WTF::nonEmptyRangesOverlap):
(WTF::rangesOverlap):
(WTF::shuffleVector):
(WTF::isIdentical):
(WTF::isRepresentableAsImpl):
(WTF::isRepresentableAs):
(WTF::roundUpToMultipleOf):
(WTF::roundUpToMultipleOfNonPowerOfTwo):
(WTF::distanceToMultipleOf):
(WTF::roundDownToMultipleOf):
(sizeof): Deleted.

Canonical link: <a href="https://commits.webkit.org/298169@main">https://commits.webkit.org/298169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8adb9e52adbbff4cd9333531e11cd9ad1e7102cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114492 "35 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87016 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64338 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106888 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123863 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113055 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30973 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/95836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18618 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37540 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46894 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137272 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40972 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36707 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->