### PR TITLE
Rename toRef that takes only JSValue

### DIFF
--- a/Source/JavaScriptCore/API/APICast.h
+++ b/Source/JavaScriptCore/API/APICast.h
@@ -165,7 +165,7 @@ inline JSValueRef toRef(JSC::JSGlobalObject* globalObject, JSC::JSValue v)
 }
 
 #if CPU(ADDRESS64)
-inline JSValueRef toRef(JSC::JSValue v)
+inline JSValueRef toRefWithoutGlobalObject(JSC::JSValue v)
 {
     return std::bit_cast<JSValueRef>(JSC::Integrity::audit(v));
 }

--- a/Source/JavaScriptCore/API/JSValueRef.cpp
+++ b/Source/JavaScriptCore/API/JSValueRef.cpp
@@ -321,7 +321,7 @@ JSValueRef JSValueMakeUndefined(JSContextRef ctx)
     JSLockHolder locker(globalObject);
     return toRef(globalObject, jsUndefined());
 #else
-    return toRef(jsUndefined());
+    return toRefWithoutGlobalObject(jsUndefined());
 #endif
 }
 
@@ -336,7 +336,7 @@ JSValueRef JSValueMakeNull(JSContextRef ctx)
     JSLockHolder locker(globalObject);
     return toRef(globalObject, jsNull());
 #else
-    return toRef(jsNull());
+    return toRefWithoutGlobalObject(jsNull());
 #endif
 }
 
@@ -351,7 +351,7 @@ JSValueRef JSValueMakeBoolean(JSContextRef ctx, bool value)
     JSLockHolder locker(globalObject);
     return toRef(globalObject, jsBoolean(value));
 #else
-    return toRef(jsBoolean(value));
+    return toRefWithoutGlobalObject(jsBoolean(value));
 #endif
 }
 
@@ -366,7 +366,7 @@ JSValueRef JSValueMakeNumber(JSContextRef ctx, double value)
     JSLockHolder locker(globalObject);
     return toRef(globalObject, jsNumber(purifyNaN(value)));
 #else
-    return toRef(jsNumber(purifyNaN(value)));
+    return toRefWithoutGlobalObject(jsNumber(purifyNaN(value)));
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -285,7 +285,7 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
 
         JSC::JSValue resultPayload = objectResult->get(frontendGlobalObject, JSC::Identifier::fromString(frontendGlobalObject->vm(), "result"_s));
 
-        if (auto extracted = JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(resultPayload)))
+        if (auto extracted = JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(frontendGlobalObject, resultPayload)))
             completionHandler(WTFMove(*extracted), std::nullopt);
         else
             completionHandler(makeUnexpected(std::nullopt), std::nullopt);
@@ -467,7 +467,7 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
 
         JSC::JSValue resultPayload = objectResult->get(frontendGlobalObject, JSC::Identifier::fromString(frontendGlobalObject->vm(), "result"_s));
 
-        if (auto extracted = JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(resultPayload)))
+        if (auto extracted = JavaScriptEvaluationResult::extract(JSContextGetGlobalContext(toRef(frontendGlobalObject)), toRef(frontendGlobalObject, resultPayload)))
             completionHandler(WTFMove(*extracted), std::nullopt);
         else
             completionHandler(makeUnexpected(std::nullopt), std::nullopt);


### PR DESCRIPTION
#### 3b1f4c2b10e6f982c03d44b5cdab063fb74b2a7b
<pre>
Rename toRef that takes only JSValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=296837">https://bugs.webkit.org/show_bug.cgi?id=296837</a>
<a href="https://rdar.apple.com/157341445">rdar://157341445</a>

Reviewed by Yusuke Suzuki.

This will reduce the number of times I have compile failures only on watchOS device.

* Source/JavaScriptCore/API/APICast.h:
(toRefWithoutGlobalObject):
* Source/JavaScriptCore/API/JSValueRef.cpp:
(JSValueMakeUndefined):
(JSValueMakeNull):
(JSValueMakeBoolean):
(JSValueMakeNumber):

Canonical link: <a href="https://commits.webkit.org/298161@main">https://commits.webkit.org/298161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6956b3fbfa13d4a07517c330716846763a5afd26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65167 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/86980 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/41877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64303 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106852 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123827 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113019 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/30941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95799 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/98979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95584 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37491 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18337 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46858 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137226 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/40937 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36696 "Found 1 new JSC stress test failure: stress/builtin-function-is-construct-type-none.js.dfg-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->