### PR TITLE
Sorting of retrieved font properties in the UI process is not necessary

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/XTSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/XTSPI.h
@@ -36,3 +36,16 @@ enum {
 };
 
 typedef uint32_t XTScope;
+
+enum {
+    kXTOptionsDefault                   = 0,
+    kXTOptionsPreferAppleSystemFonts    = 1 << 0,
+    kXTOptionsRemoveDuplicateFonts      = 1 << 1,
+    kXTOptionsRemoveInvisibleFonts      = 1 << 2,
+    kXTOptionsRestrictToPostScriptName  = 1 << 3,
+    kXTOptionsDoNotSortResults          = 1 << 4,
+    kXTOptionsIncludeDisabledFonts      = 1 << 5,
+    kXTOptionsDisableFontProviders      = 1 << 16,
+    kXTOptionsDisableAutoActivation     = 1 << 17
+};
+typedef uint32_t XTOptions;


### PR DESCRIPTION
#### 3ee589a572973112275f3b7ea119070181f756c4
<pre>
Sorting of retrieved font properties in the UI process is not necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=296855">https://bugs.webkit.org/show_bug.cgi?id=296855</a>
<a href="https://rdar.apple.com/157402374">rdar://157402374</a>

Reviewed by NOBODY (OOPS!).

Draft.

* Source/WTF/wtf/spi/cocoa/XTSPI.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(SOFT_LINK_CONSTANT):
(WebKit::WebProcessPool::registerUserInstalledFonts):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee589a572973112275f3b7ea119070181f756c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34276 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24739 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65254 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34905 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42836 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87046 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41955 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27814 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/24739 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/26999 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/24739 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64376 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106925 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97191 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/24739 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123901 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113093 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41543 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/42836 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41920 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/24739 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95649 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40814 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/24739 "Hash 3ee589a5 for PR 48873 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37588 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41422 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46932 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137308 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41008 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36720 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->