### PR TITLE
Don't create fragmented blob made of other blobs with fetch data

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -440,31 +440,56 @@ RefPtr<JSC::ArrayBuffer> FetchBodyConsumer::takeAsArrayBuffer()
 
 Ref<Blob> FetchBodyConsumer::takeAsBlob(ScriptExecutionContext* context, const String& contentType)
 {
-    static constexpr size_t MaximumBlobSize = 512 * 1024 * 1024;
-
     String normalizedContentType = Blob::normalizedContentType(extractMIMETypeFromMediaType(contentType));
 
     if (!m_buffer)
         return Blob::create(context, Vector<uint8_t>(), normalizedContentType);
 
-    RefPtr buffer = m_buffer.take();
-    if (!context || buffer->isContiguous() || buffer->size() < MaximumBlobSize)
-        return blobFromData(context, buffer->extractData(), normalizedContentType);
+    // Minimise the number of DataSegments to reduce overall memory allocation.
+    // We pack it in 8MiB minimum segment.
+    static constexpr size_t MinimumBlobSize = 8 * 1024 * 1024;
 
-    Vector<RefPtr<SharedBuffer>> segments;
+    RefPtr buffer = m_buffer.take();
+    if (buffer->size() <= MinimumBlobSize)
+        return Blob::create(context, buffer->extractData(), normalizedContentType);
+
+    size_t packedBufferSize = std::min(buffer->size(), MinimumBlobSize);
+    Vector<uint8_t> packedBuffer;
+    packedBuffer.reserveInitialCapacity(packedBufferSize);
+
+    Vector<Ref<SharedBuffer>> segments;
     segments.reserveInitialCapacity(buffer->segmentsCount());
     buffer->forEachSegmentAsSharedBuffer([&](Ref<SharedBuffer>&& sharedBuffer) {
         segments.append(WTFMove(sharedBuffer));
     });
     buffer = nullptr; // So that the segments above hold each a single refcount to allow extractData to move the content.
 
-    Vector<BlobPartVariant> blobPartsFromBuffer { segments.size(), [&](auto index) {
-        RefPtr blob = Blob::create(context, std::exchange(segments[index], nullptr)->extractData(), normalizedContentType);
-        return blob;
-    } };
+    SharedBufferBuilder bufferBuilder;
+    for (auto&& segment : segments) {
+        if (segment->size() >= MinimumBlobSize) {
+            if (packedBuffer.size()) {
+                bufferBuilder.append(std::exchange(packedBuffer, { }));
+                packedBuffer.reserveInitialCapacity(packedBufferSize);
+            }
+            bufferBuilder.append(WTFMove(segment));
+            continue;
+        }
+        if (packedBuffer.size() + segment->size() <= MinimumBlobSize) {
+            packedBuffer.appendVector(segment->extractData());
+            continue;
+        }
+        ASSERT(packedBuffer.size() <= MinimumBlobSize);
+        size_t leftInPacked = MinimumBlobSize - packedBuffer.size();
+        auto segmentData = segment->extractData();
+        packedBuffer.appendVector(segmentData.subvector(0, leftInPacked));
+        bufferBuilder.append(std::exchange(packedBuffer, { }));
+        packedBuffer.reserveInitialCapacity(packedBufferSize);
+        packedBuffer.appendVector(segmentData.subvector(leftInPacked));
+    };
+    if (!packedBuffer.isEmpty())
+        bufferBuilder.append(WTFMove(packedBuffer));
 
-    BlobPropertyBag propertyBag = { .type = normalizedContentType };
-    return Blob::create(*context, WTFMove(blobPartsFromBuffer), propertyBag);
+    return Blob::create(context, bufferBuilder.take(), normalizedContentType);
 }
 
 String FetchBodyConsumer::takeAsText()

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -182,6 +182,18 @@ Blob::Blob(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, { BlobPart(WTFMove(data)) }, contentType);
 }
 
+Blob::Blob(ScriptExecutionContext* context, Ref<FragmentedSharedBuffer>&& buffer, const String& contentType)
+    : ActiveDOMObject(context)
+    , m_type(contentType)
+    , m_size(buffer->size())
+    , m_memoryCost(buffer->size())
+    , m_internalURL(BlobURL::createInternalURL())
+{
+    BlobBuilder builder(EndingType::Transparent);
+    builder.append(WTFMove(buffer));
+    ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, builder.finalize(), contentType);
+}
+
 Blob::Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext* context, const Blob& blob)
     : ActiveDOMObject(context)
     , m_type(blob.type())

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -53,6 +53,7 @@ namespace WebCore {
 class Blob;
 class BlobLoader;
 class DeferredPromise;
+class FragmentedSharedBuffer;
 class ReadableStream;
 class ScriptExecutionContext;
 class FragmentedSharedBuffer;
@@ -73,21 +74,28 @@ public:
 
     static Ref<Blob> create(ScriptExecutionContext* context)
     {
-        auto blob = adoptRef(*new Blob(context));
+        Ref blob = adoptRef(*new Blob(context));
         blob->suspendIfNeeded();
         return blob;
     }
 
     static Ref<Blob> create(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const BlobPropertyBag& propertyBag)
     {
-        auto blob = adoptRef(*new Blob(context, WTFMove(blobPartVariants), propertyBag));
+        Ref blob = adoptRef(*new Blob(context, WTFMove(blobPartVariants), propertyBag));
         blob->suspendIfNeeded();
         return blob;
     }
 
     static Ref<Blob> create(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String& contentType)
     {
-        auto blob = adoptRef(*new Blob(context, WTFMove(data), contentType));
+        Ref blob = adoptRef(*new Blob(context, WTFMove(data), contentType));
+        blob->suspendIfNeeded();
+        return blob;
+    }
+
+    static Ref<Blob> create(ScriptExecutionContext* context, Ref<FragmentedSharedBuffer>&& buffer, const String& contentType)
+    {
+        Ref blob = adoptRef(*new Blob(context, WTFMove(buffer), contentType));
         blob->suspendIfNeeded();
         return blob;
     }
@@ -95,7 +103,7 @@ public:
     static Ref<Blob> deserialize(ScriptExecutionContext* context, const URL& srcURL, const String& type, long long size, long long memoryCost, const String& fileBackedPath)
     {
         ASSERT(Blob::isNormalizedContentType(type));
-        auto blob = adoptRef(*new Blob(deserializationContructor, context, srcURL, type, size, memoryCost, fileBackedPath));
+        Ref blob = adoptRef(*new Blob(deserializationContructor, context, srcURL, type, size, memoryCost, fileBackedPath));
         blob->suspendIfNeeded();
         return blob;
     }
@@ -138,6 +146,7 @@ protected:
     WEBCORE_EXPORT explicit Blob(ScriptExecutionContext*);
     Blob(ScriptExecutionContext&, Vector<BlobPartVariant>&&, const BlobPropertyBag&);
     Blob(ScriptExecutionContext*, Vector<uint8_t>&&, const String& contentType);
+    Blob(ScriptExecutionContext*, Ref<FragmentedSharedBuffer>&&, const String& contentType);
 
     enum ReferencingExistingBlobConstructor { referencingExistingBlobConstructor };
     Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext*, const Blob&);

--- a/Source/WebCore/fileapi/BlobBuilder.h
+++ b/Source/WebCore/fileapi/BlobBuilder.h
@@ -41,6 +41,7 @@ class ArrayBufferView;
 namespace WebCore {
 
 class Blob;
+class FragmentedSharedBuffer;
 
 class BlobBuilder {
 public:
@@ -50,6 +51,7 @@ public:
     void append(RefPtr<JSC::ArrayBufferView>&&);
     void append(RefPtr<Blob>&&);
     void append(const String& text);
+    void append(Ref<FragmentedSharedBuffer>&&);
 
     Vector<BlobPart> finalize();
 

--- a/Source/WebCore/platform/network/BlobPart.h
+++ b/Source/WebCore/platform/network/BlobPart.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "SharedBuffer.h"
 #include <wtf/URL.h>
 
 namespace IPC {
@@ -37,6 +38,8 @@ class BlobPart {
 private:
     friend struct IPC::ArgumentCoder<BlobPart, void>;
 public:
+    using VariantType = Variant<Vector<uint8_t>, Ref<SharedBuffer>, URL>;
+
     enum class Type : bool {
         Data,
         Blob
@@ -47,12 +50,17 @@ public:
     {
     }
 
-    BlobPart(Vector<uint8_t>&& data)
+    explicit BlobPart(Vector<uint8_t>&& data)
         : m_dataOrURL(WTFMove(data))
     {
     }
 
-    BlobPart(const URL& url)
+    explicit BlobPart(Ref<SharedBuffer>&& data)
+        : m_dataOrURL(WTFMove(data))
+    {
+    }
+
+    explicit BlobPart(const URL& url)
         : m_dataOrURL(url)
     {
     }
@@ -62,10 +70,17 @@ public:
         return std::holds_alternative<URL>(m_dataOrURL) ? Type::Blob : Type::Data;
     }
 
-    Vector<uint8_t>&& moveData()
+    Vector<uint8_t> takeData()
     {
-        ASSERT(std::holds_alternative<Vector<uint8_t>>(m_dataOrURL));
-        return WTFMove(std::get<Vector<uint8_t>>(m_dataOrURL));
+        auto blobPartVariant = std::exchange(m_dataOrURL, Vector<uint8_t> { });
+        return switchOn(WTFMove(blobPartVariant), [](Ref<SharedBuffer>&& buffer) {
+            return buffer->extractData();
+        }, [](Vector<uint8_t>&& vector) {
+            return WTFMove(vector);
+        }, [](URL&&) {
+            ASSERT_NOT_REACHED();
+            return Vector<uint8_t> { };
+        });
     }
 
     const URL& url() const
@@ -81,12 +96,12 @@ public:
     }
 
 private:
-    BlobPart(Variant<Vector<uint8_t>, URL>&& dataOrURL)
+    explicit BlobPart(VariantType&& dataOrURL)
         : m_dataOrURL(WTFMove(dataOrURL))
     {
     }
 
-    Variant<Vector<uint8_t>, URL> m_dataOrURL;
+    VariantType m_dataOrURL;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -190,7 +190,7 @@ void BlobRegistryImpl::registerInternalBlobURL(const URL& url, Vector<BlobPart>&
     for (BlobPart& part : blobParts) {
         switch (part.type()) {
         case BlobPart::Type::Data: {
-            blobData->appendData(createDataSegment(part.moveData(), blobData));
+            blobData->appendData(createDataSegment(part.takeData(), blobData));
             break;
         }
         case BlobPart::Type::Blob: {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2305,7 +2305,7 @@ header: <WebCore/VP9Utilities.h>
 }
 
 class WebCore::BlobPart {
-    Variant<Vector<uint8_t>, URL> m_dataOrURL;
+    Variant<Vector<uint8_t>, Ref<WebCore::SharedBuffer>, URL> m_dataOrURL;
 };
 
 [WebKitPlatform] enum class WebCore::ColorSpace : uint8_t {


### PR DESCRIPTION
#### f3212ea2b8fc5b79d7e6d92beec18bbd3c72e206
<pre>
Don&apos;t create fragmented blob made of other blobs with fetch data
<a href="https://bugs.webkit.org/show_bug.cgi?id=296531">https://bugs.webkit.org/show_bug.cgi?id=296531</a>
<a href="https://rdar.apple.com/156827880">rdar://156827880</a>

Reviewed by Youenn Fablet.

Follow-up on 297885@main. Instead of constructing a Blob
made of multiple blobs, which would create a lot of Blob URLs, we instead
add the ability to create a Blob from a FragmentedSharedBuffer. A BlobPart
is also amended to allow for holding a SharedBuffer.

To reduce the amount of elements in the FragmentedSharedBuffer, we ensure
that the DataSegments it contains are at least 8MiB in size.

No change in JS observable behaviours. Covered by existing tests.

* Source/WebCore/platform/network/BlobPart.h:
(WebCore::BlobPart::BlobPart): Add SharedBuffer as variant, clean-up
code to follow SaferCPP coding guidelines.
(WebCore::BlobPart::takeData): Renamed for consistency and better indicate how the code was used.
(WebCore::BlobPart::moveData): Deleted.

Canonical link: <a href="https://commits.webkit.org/298227@main">https://commits.webkit.org/298227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9332c4573fc6cc09a53386f9ed08d68af557efa3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65446 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a59f46aa-41ca-4c55-8ef6-774f013b58de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87229 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9955f35e-b924-4d00-8052-415704ecebb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67619 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64593 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124127 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95823 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24391 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40995 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18839 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37826 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47162 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41211 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42958 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->