### PR TITLE
[WTF] Replace `isNaNConstExpr()` and `fabsConstExpr()` with `std::isnan()` and `std::fabs()` Respectively

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -123,40 +123,6 @@ constexpr float grad2turn(float g) { return deg2turn(grad2deg(g)); }
 constexpr float turn2rad(float t) { return deg2rad(turn2deg(t)); }
 constexpr float rad2turn(float r) { return deg2turn(rad2deg(r)); }
 
-namespace WTF {
-
-// FIXME: Replace with std::isnan() once std::isnan() is constexpr. requires C++23
-template<std::floating_point T>
-constexpr bool isNaNConstExpr(T value)
-{
-#if COMPILER_HAS_CLANG_BUILTIN(__builtin_isnan)
-    return __builtin_isnan(value);
-#else
-    return value != value;
-#endif
-}
-
-template<std::integral T>
-constexpr bool isNaNConstExpr(T)
-{
-    return false;
-}
-
-// FIXME: Replace with std::fabs() once std::fabs() is constexpr. requires C++23
-template<std::floating_point T>
-constexpr T fabsConstExpr(T value)
-{
-    if (value != value)
-        return value;
-    if (!value)
-        return 0.0; // -0.0 should be converted to +0.0
-    if (value < 0.0)
-        return -value;
-    return value;
-}
-
-} // namespace WTF
-
 inline double roundTowardsPositiveInfinity(double value) { return std::floor(value + 0.5); }
 inline float roundTowardsPositiveInfinity(float value) { return std::floor(value + 0.5f); }
 
@@ -510,14 +476,14 @@ constexpr bool areEssentiallyEqual(T u, T v, T epsilon = std::numeric_limits<T>:
 template<std::floating_point T>
 constexpr T nanPropagatingMin(T a, T b)
 {
-    return isNaNConstExpr(a) || isNaNConstExpr(b) ? std::numeric_limits<T>::quiet_NaN() : std::min(a, b);
+    return std::isnan(a) || std::isnan(b) ? std::numeric_limits<T>::quiet_NaN() : std::min(a, b);
 }
 
 // Match behavior of Math.max, where NaN is returned if either argument is NaN.
 template<std::floating_point T>
 constexpr T nanPropagatingMax(T a, T b)
 {
-    return isNaNConstExpr(a) || isNaNConstExpr(b) ? std::numeric_limits<T>::quiet_NaN() : std::max(a, b);
+    return std::isnan(a) || std::isnan(b) ? std::numeric_limits<T>::quiet_NaN() : std::max(a, b);
 }
 
 constexpr bool isIntegral(float value)
@@ -848,8 +814,6 @@ using WTF::clz;
 using WTF::ctz;
 using WTF::getLSBSet;
 using WTF::getMSBSet;
-using WTF::isNaNConstExpr;
-using WTF::fabsConstExpr;
 using WTF::reverseBits32;
 using WTF::roundDownToMultipleOf;
 using WTF::roundUpToMultipleOf;

--- a/Source/WebCore/platform/graphics/ColorComponents.h
+++ b/Source/WebCore/platform/graphics/ColorComponents.h
@@ -169,7 +169,7 @@ constexpr bool operator==(const ColorComponents<T, N>& a, const ColorComponents<
     for (size_t i = 0; i < N; ++i) {
         if (a[i] == b[i])
             continue;
-        if (isNaNConstExpr(a[i]) && isNaNConstExpr(b[i]))
+        if (std::isnan(a[i]) && std::isnan(b[i]))
             continue;
         return false;
     }

--- a/Source/WebCore/platform/graphics/ColorTypes.h
+++ b/Source/WebCore/platform/graphics/ColorTypes.h
@@ -142,12 +142,12 @@ constexpr void assertInRange(ColorType color)
 {
     auto components = asColorComponents(color.unresolved());
     for (unsigned i = 0; i < 3; ++i) {
-        if (isNaNConstExpr(components[i]))
+        if (std::isnan(components[i]))
             continue;
         ASSERT_WITH_MESSAGE(components[i] >= ColorType::Model::componentInfo[i].min, "Component at index %d is %f and is less than the allowed minimum %f", i, components[i], ColorType::Model::componentInfo[i].min);
         ASSERT_WITH_MESSAGE(components[i] <= ColorType::Model::componentInfo[i].max, "Component at index %d is %f and is greater than the allowed maximum %f", i, components[i], ColorType::Model::componentInfo[i].max);
     }
-    if (!isNaNConstExpr(components[3])) {
+    if (!std::isnan(components[3])) {
         ASSERT_WITH_MESSAGE(components[3] >= AlphaTraits<typename ColorType::ComponentType>::transparent, "Alpha is %f and is less than the allowed minimum (transparent) %f", components[3], AlphaTraits<typename ColorType::ComponentType>::transparent);
         ASSERT_WITH_MESSAGE(components[3] <= AlphaTraits<typename ColorType::ComponentType>::opaque, "Alpha is %f and is greater than the allowed maximum (opaque) %f", components[3], AlphaTraits<typename ColorType::ComponentType>::opaque);
     }

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -313,7 +313,7 @@ constexpr FloatPoint FloatPoint::nanPoint()
 
 constexpr bool FloatPoint::isNaN() const
 {
-    return isNaNConstExpr(x());
+    return std::isnan(x());
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatPoint&);

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -344,7 +344,7 @@ constexpr FloatRect FloatRect::nanRect()
 
 constexpr bool FloatRect::isNaN() const
 {
-    return isNaNConstExpr(x()) || isNaNConstExpr(y());
+    return std::isnan(x()) || std::isnan(y());
 }
 
 inline void FloatRect::inflate(float deltaX, float deltaY, float deltaMaxX, float deltaMaxY)

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -159,7 +159,7 @@ private:
 
 constexpr bool FloatSize::isZero() const
 {
-    return fabsConstExpr(m_width) < std::numeric_limits<float>::epsilon() && fabsConstExpr(m_height) < std::numeric_limits<float>::epsilon();
+    return std::fabs(m_width) < std::numeric_limits<float>::epsilon() && std::fabs(m_height) < std::numeric_limits<float>::epsilon();
 }
 
 inline FloatSize& operator+=(FloatSize& a, const FloatSize& b)
@@ -256,7 +256,7 @@ constexpr FloatSize FloatSize::nanSize()
 
 constexpr bool FloatSize::isNaN() const
 {
-    return isNaNConstExpr(width());
+    return std::isnan(width());
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatSize&);


### PR DESCRIPTION
#### 6ea9ffbf062c4ba915a34e6a56d6869608a339c5
<pre>
[WTF] Replace `isNaNConstExpr()` and `fabsConstExpr()` with `std::isnan()` and `std::fabs()` Respectively
<a href="https://bugs.webkit.org/show_bug.cgi?id=296863">https://bugs.webkit.org/show_bug.cgi?id=296863</a>

Reviewed by NOBODY (OOPS!).

Replace `isNaNConstExpr()` and `fabsConstExpr()` with `std::isnan()` and `std::fabs()` respectively.

* Source/WTF/wtf/MathExtras.h:
(WTF::nanPropagatingMin):
(WTF::nanPropagatingMax):
(WTF::isNaNConstExpr): Deleted.
(WTF::fabsConstExpr): Deleted.
* Source/WebCore/platform/graphics/ColorComponents.h:
(WebCore::operator==):
* Source/WebCore/platform/graphics/ColorTypes.h:
* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::FloatPoint::isNaN const):
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::FloatRect::isNaN const):
* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::FloatSize::isZero const):
(WebCore::FloatSize::isNaN const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ea9ffbf062c4ba915a34e6a56d6869608a339c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87056 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/41976 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/20989 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64387 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106936 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123912 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113104 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95875 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95658 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40822 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18659 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37862 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46943 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137319 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41019 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36723 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->