### PR TITLE
[WebIDL] Ensure [Reflect] extended attribute value is provided as a string when used with [Enumerated]

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -1126,7 +1126,7 @@ sub ContentAttributeName
     die "Do not use both [ReflectURL] and [ReflectSetter] on the same attribute" if $reflectURL && $reflectSetter;
     die "Do not use both [Reflect] and [ReflectSetter] on the same attribute" if $reflect && $reflectSetter;
 
-    my $contentAttributeName = UnquoteStringLiteral($getterOrSetter eq "setter" ? $reflect || $reflectURL || $reflectSetter : $reflect || $reflectURL);
+    my $contentAttributeName = UnquoteStringLiteral($generator, $getterOrSetter eq "setter" ? $reflect || $reflectURL || $reflectSetter : $reflect || $reflectURL);
     return undef if !$contentAttributeName;
 
     $contentAttributeName =~ s/-/_/g;
@@ -1141,7 +1141,7 @@ sub ContentAttributeName
 
 sub UnquoteStringLiteral
 {
-    my ($s) = @_;
+    my ($generator, $s) = @_;
     return $s if !$s;
     return $s if length($s) < 2;
     if (substr($s, 0, 1) ne '"' && substr($s, 0, 1) ne "'") {

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5679,8 +5679,15 @@ sub GenerateAttributeGetterBodyDefinition
         }
 
         if ($attribute->extendedAttributes->{Reflect} && $attribute->extendedAttributes->{Enumerated}) {
-            my $attributeName = $attribute->extendedAttributes->{Reflect};
-            $attributeName = $attribute->name if !$attributeName || $attributeName eq "VALUE_IS_MISSING";
+            my $reflect = $attribute->extendedAttributes->{Reflect};
+            my $attributeName;
+            if (!defined $reflect || $reflect eq "VALUE_IS_MISSING") {
+                $attributeName = $attribute->name;
+            } else {
+                $attributeName = $codeGenerator->UnquoteStringLiteral($reflect);
+                $attributeName =~ s/-/_/g;
+            }
+
             my $enumType = $attribute->extendedAttributes->{Enumerated};
             my $missingValueDefault;
             my $invalidValueDefault;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2305,6 +2305,10 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithInvalidAndMi
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterStringAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_reflectedSetterStringAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_reflectedSetterUSVStringAttr);
@@ -2644,7 +2648,7 @@ template<> void JSTestObjDOMConstructor::initializeProperties(VM& vm, JSDOMGloba
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 296> JSTestObjPrototypeTableValues {
+static const std::array<HashTableValue, 298> JSTestObjPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObjConstructor, 0 } },
     HashTableValue { "readOnlyLongAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyLongAttr, 0 } },
     HashTableValue { "readOnlyStringAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyStringAttr, 0 } },
@@ -2710,6 +2714,8 @@ static const std::array<HashTableValue, 296> JSTestObjPrototypeTableValues {
     HashTableValue { "reflectedNullableEnumWithInvalidValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr, setJSTestObj_reflectedNullableEnumWithInvalidValueDefaultStringAttr } },
     HashTableValue { "reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr, setJSTestObj_reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr } },
     HashTableValue { "reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr, setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr } },
+    HashTableValue { "reflectedNullableStringAttrIsSpecifiedWithQuotesAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttr, setJSTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttr } },
+    HashTableValue { "reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr, setJSTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr } },
     HashTableValue { "reflectedSetterStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterStringAttr, setJSTestObj_reflectedSetterStringAttr } },
     HashTableValue { "reflectedSetterUSVStringAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterUSVStringAttr, setJSTestObj_reflectedSetterUSVStringAttr } },
     HashTableValue { "reflectedSetterIntegralAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_reflectedSetterIntegralAttr, setJSTestObj_reflectedSetterIntegralAttr } },
@@ -5283,7 +5289,7 @@ static inline JSValue jsTestObj_reflectedCustomURLAttrGetter(JSGlobalObject& lex
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttributeForBindings(WebCore::HTMLNames::custom_conten_urlAttr))));
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLAtomStringAdaptor<IDLDOMString>>(lexicalGlobalObject, throwScope, impl.getURLAttributeForBindings(WebCore::HTMLNames::custom_content_urlAttr))));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedCustomURLAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
@@ -5301,7 +5307,7 @@ static inline bool setJSTestObj_reflectedCustomURLAttrSetter(JSGlobalObject& lex
     if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
         return false;
     invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::custom_conten_urlAttr, nativeValueConversionResult.releaseReturnValue());
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::custom_content_urlAttr, nativeValueConversionResult.releaseReturnValue());
     });
     return true;
 }
@@ -5506,6 +5512,88 @@ static inline bool setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQu
 JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::contentattributeAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        result = AtomString("value2"_s);
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::contentattributeAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableStringAttrIsSpecifiedWithQuotesAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    const AtomString& contentAttributeValue = impl.attributeWithoutSynchronization(WebCore::HTMLNames::content_attributeAttr);
+    AtomString result;
+    if (contentAttributeValue.isNull())
+        result = AtomString("value1"_s);
+    else if (auto value = parseEnumerationFromString<TestObj::EnumWithMissingAndInvalidValueDefault>(contentAttributeValue.convertToASCIILowercase()); value) [[likely]]
+        result = AtomString(convertEnumerationToString(*value));
+    else
+        result = AtomString("value2"_s);
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, throwScope, result)));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLNullable<IDLAtomStringAdaptor<IDLDOMString>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setAttributeWithoutSynchronization(WebCore::HTMLNames::content_attributeAttr, nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
 static inline JSValue jsTestObj_reflectedSetterStringAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -130,7 +130,7 @@ enum TestConfidence { "high", "kinda-low" };
     [Reflect="custom-content-string"] attribute DOMString reflectedStringAttr;
     [Reflect="custom-content-integral"] attribute long reflectedCustomIntegralAttr;
     [Reflect="custom-content-boolean"] attribute boolean reflectedCustomBooleanAttr;
-    [ReflectURL="custom-conten-url"] attribute DOMString reflectedCustomURLAttr;
+    [ReflectURL="custom-content-url"] attribute DOMString reflectedCustomURLAttr;
 
     // Reflected nullable IDL attributes
     [Reflect] attribute DOMString? reflectedNullableStringAttr;
@@ -138,6 +138,8 @@ enum TestConfidence { "high", "kinda-low" };
     [Reflect, Enumerated=TestEnumWithInvalidValueDefault] attribute DOMString? reflectedNullableEnumWithInvalidValueDefaultStringAttr;
     [Reflect, Enumerated=TestEnumWithMissingAndInvalidValueDefault] attribute DOMString? reflectedNullableEnumWithInvalidAndMissingValueDefaultStringAttr;
     [Reflect, Enumerated=TestEnumWithMissingValueDefaultNoQuotes] attribute DOMString? reflectedNullableEnumWithMissingValueDefaultNoQuotesStringAttr; 
+    [Reflect="contentattribute", Enumerated=TestEnumWithMissingAndInvalidValueDefault] attribute DOMString? reflectedNullableStringAttrIsSpecifiedWithQuotesAttr;
+    [Reflect="content-attribute", Enumerated=TestEnumWithMissingAndInvalidValueDefault] attribute DOMString? reflectedNullableStringHyphenatedAttrIsSpecifiedWithQuotesAttr;
 
     // Reflected for setter only IDL attributes
     [ReflectSetter] attribute DOMString reflectedSetterStringAttr;


### PR DESCRIPTION
#### fe2e7fecaef0f0be223945f38b2323ccdba013df
<pre>
[WebIDL] Ensure [Reflect] extended attribute value is provided as a string when used with [Enumerated]
<a href="https://bugs.webkit.org/show_bug.cgi?id=296861">https://bugs.webkit.org/show_bug.cgi?id=296861</a>

Reviewed by Darin Adler.

When [Reflect] is specified with [Enumerated] (e.g. [Reflect=&quot;someAttr&quot;]),
ensure the value is treated as a proper string. For hyphenated attribute values,
the value is normalized for getter/setter codegen (e.g. &quot;aria-orientation&quot;
becomes aria_orientationAttr).

This PR also updates CodeGenerator::UnquoteStringLiteral() to ensure arguments are
passed consistently.

* Source/WebCore/bindings/scripts/CodeGenerator.pm
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
* Source/WebCore/bindings/scripts/test/TestObj.idl

Canonical link: <a href="https://commits.webkit.org/298277@main">https://commits.webkit.org/298277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bed45236949faa4e49071cec06f8877abb24929

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43172 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87302 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96105 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95890 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24417 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41082 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18919 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37925 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47271 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->