### PR TITLE
Fix windows CI script by ignoring failures to remove existing directory contents

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -33,6 +33,7 @@ import shutil
 import subprocess
 import sys
 import zipfile
+import stat
 
 webkitTopAbsPath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -113,8 +114,23 @@ def determineWebKitBuildDirectories(platform, fullPlatform, configuration, cross
     return _topLevelBuildDirectory
 
 
+def fixFilePermissionsIfNeeded(dir):
+    for path, _, filenames in os.walk(dir):
+        for file in filenames:
+            fullpath = os.path.join(path, file)
+
+            if not os.path.isfile(fullpath):
+                continue
+            
+            if not os.access(fullpath, os.R_OK | os.W_OK):
+                os.chmod(fullpath, stat.S_IREAD | stat.S_IWRITE)
+
 def removeDirectoryIfExists(thinDirectory):
     if os.path.isdir(thinDirectory):
+        # We do this to try and guarantee a clean directory removal with rmtree. At some
+        # point the build bots ended up with some files with write-only permissions which
+        # lead to broken bots
+        fixFilePermissionsIfNeeded(thinDirectory)
         shutil.rmtree(thinDirectory)
 
 


### PR DESCRIPTION
#### 8533aea9d56f3f43828decbe275312741c3eac96
<pre>
Fix windows CI script by ignoring failures to remove existing directory contents
<a href="https://rdar.apple.com/157465828">rdar://157465828</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296877">https://bugs.webkit.org/show_bug.cgi?id=296877</a>

Reviewed by NOBODY (OOPS!).

Some of the bots got into a bad state where extracted files had write-only permissions, and were causing errors in CI scripts when trying to clean up these files. This change checks and adjusts file permissions if needed to allow for a clean removal.

* Tools/CISupport/built-product-archive:
(determineWebKitBuildDirectories):
(fixFilePermissionsIfNeeded):
(removeDirectoryIfExists):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8533aea9d56f3f43828decbe275312741c3eac96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65451 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1aeadbf-6df7-4037-8b5e-6d075137a6e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116658 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35143 "") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42104 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bda4adfb-8cab-4542-be00-7350996966b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117717 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/35143 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103055 "") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67617 "Passed tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/35143 "") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21177 "") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64599 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/35143 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21291 "") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124132 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41773 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31206 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96035 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42151 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99245 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95819 "Passed tests") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41003 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18840 "") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37830 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41654 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42962 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->