### PR TITLE
[CSS] For style invalidation, :scope should always match

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL :focus via :scope in subject assert_equals: expected "1" but got "auto"
+PASS :focus via :scope in subject
 PASS :focus via :scope in non-subject
-FAIL :focus in limit, :scope in subject assert_equals: expected "auto" but got "1"
+PASS :focus in limit, :scope in subject
 PASS :focus in intermediate limit, :scope in subject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL :hover via :scope in subject assert_equals: expected "1" but got "auto"
+PASS :hover via :scope in subject
 PASS :hover via :scope in non-subject
-FAIL :hover in limit, :scope in subject assert_equals: expected "auto" but got "1"
+PASS :hover in limit, :scope in subject
 PASS :hover in intermediate limit, :scope in subject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -1,26 +1,26 @@
 
 PASS Element becoming scope root
 PASS Element becoming scope root (selector list)
-FAIL Element becoming scope root, with inner :scope rule assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Element becoming scope root, with inner :scope rule
 PASS Parent element becoming scope limit
 PASS Parent element becoming scope limit (selector list)
 PASS Subject element becoming scope limit
 PASS Parent element affecting scope limit
 PASS Sibling element affecting scope limit
 PASS Toggling inner/outer scope roots
-FAIL Element becoming root, with :scope in subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Element becoming root, with :scope in subject
 PASS Scope root with :has()
-FAIL Scope root with :has(), :scope subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Scope root with :has(), :scope both subject and non-subject assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Scope root with :has(), :scope subject
+PASS Scope root with :has(), :scope both subject and non-subject
 PASS Scope limit with :has()
-FAIL Element becoming root, with :scope selected by ~ combinator assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Element becoming root, with :scope selected by ~ combinator
 PASS Element becoming root via ~ combinator
 PASS Element becoming root via + combinator
 PASS :not(scope) in subject
 PASS :not(scope) in ancestor
 PASS :not(scope) in limit subject
 PASS :not(scope) in limit ancestor
-FAIL :nth-child() in scope root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS :nth-child() in scope root
 PASS :nth-child() in scope limit
 PASS Modifying selectorText invalidates affected elements
 PASS Modifying selectorText invalidates affected elements (>)

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -71,7 +71,13 @@ class SelectorChecker {
 
 public:
     enum class Mode : unsigned char {
-        ResolvingStyle = 0, CollectingRules, CollectingRulesIgnoringVirtualPseudoElements, QueryingRules
+        ResolvingStyle = 0,
+        CollectingRules,
+        // This is used for invalidation
+        // FIXME: Rename this to Mode::StyleInvalidation
+        CollectingRulesIgnoringVirtualPseudoElements,
+        // This is used for querySelector() API
+        QueryingRules
     };
 
     SelectorChecker(Document&);

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -654,7 +654,7 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
         return { true, { } };
 
     SelectorChecker checker(element().rootElement()->document());
-    SelectorChecker::CheckingContext context(SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements);
+    SelectorChecker::CheckingContext context(m_mode);
     context.styleScopeOrdinal = matchRequest.styleScopeOrdinal;
 
     Vector<ScopingRootWithDistance> scopingRoots;


### PR DESCRIPTION
#### 8e1c54e1fca87370217d851e8772798134ee33c1
<pre>
[CSS] For style invalidation, :scope should always match
<a href="https://bugs.webkit.org/show_bug.cgi?id=279225">https://bugs.webkit.org/show_bug.cgi?id=279225</a>
<a href="https://rdar.apple.com/135907710">rdar://135907710</a>

Reviewed by Antti Koivisto.

During style invalidation, we don&apos;t have the scoping root available to properly resolve :scope.
We can overestimate by matching always.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-focus-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-hover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/298335@main">https://commits.webkit.org/298335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c17067f735bb472bfcf1e12c15ec22faff1b207

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65823 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69d352d7-4c9f-4e7c-a38e-90f60ffebedc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43477 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4c7019e8-28ba-4e51-b9fb-a278e89d66a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67932 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64969 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124497 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31548 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19175 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47584 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41568 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44892 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->