### PR TITLE
[WPE] Allow building JavaScriptCore as a shared library

### DIFF
--- a/Source/JavaScriptCore/PlatformWPE.cmake
+++ b/Source/JavaScriptCore/PlatformWPE.cmake
@@ -10,6 +10,26 @@ list(APPEND JavaScriptCore_SYSTEM_INCLUDE_DIRECTORIES
     ${GLIB_INCLUDE_DIRS}
 )
 
+if (USE_SHARED_JSC)
+    set(JavaScriptCore_OUTPUT_NAME wpejavascriptcore-${WPE_API_VERSION})
+
+    configure_file(wpejavascriptcore.pc.in ${JavaScriptCore_PKGCONFIG_FILE} @ONLY)
+
+    if (EXISTS "${TOOLS_DIR}/glib/apply-build-revision-to-files.py")
+        add_custom_target(JavaScriptCore-build-revision
+            ${PYTHON_EXECUTABLE} "${TOOLS_DIR}/glib/apply-build-revision-to-files.py" ${JavaScriptCore_PKGCONFIG_FILE}
+            DEPENDS ${JavaScriptCore_PKGCONFIG_FILE}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} VERBATIM)
+        list(APPEND JavaScriptCore_DEPENDENCIES
+            JavaScriptCore-build-revision
+        )
+    endif ()
+
+    install(FILES "${CMAKE_BINARY_DIR}/Source/JavaScriptCore/wpejavascriptcore-${WPE_API_VERSION}.pc"
+        DESTINATION "${LIB_INSTALL_DIR}/pkgconfig"
+    )
+endif ()
+
 list(APPEND JavaScriptCore_PRIVATE_DEFINITIONS
     PKGLIBDIR="${CMAKE_INSTALL_FULL_LIBDIR}/wpe-webkit-${WPE_API_VERSION}"
 )
@@ -22,3 +42,12 @@ install(FILES ${JavaScriptCore_INSTALLED_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wpe-webkit-${WPE_API_VERSION}/jsc"
     COMPONENT "Development"
 )
+
+if (USE_SHARED_JSC)
+    GI_INTROSPECT(JavaScriptCore ${WPE_API_VERSION} jsc/jsc.h
+        PACKAGE wpejavascriptcore
+        SYMBOL_PREFIX jsc
+        DEPENDENCIES GObject-2.0
+    )
+    GI_DOCGEN(JavaScriptCore API/glib/docs/jsc.toml.in)
+endif ()

--- a/Source/JavaScriptCore/wpejavascriptcore.pc.in
+++ b/Source/JavaScriptCore/wpejavascriptcore.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@LIB_INSTALL_DIR@
+includedir=${prefix}/include
+revision=@BUILD_REVISION@
+
+Name: WPEJavaScriptCore
+Description: WPE version of the JavaScriptCore engine
+Version: @PROJECT_VERSION@
+Requires: glib-2.0 gobject-2.0
+Libs: -L${libdir} -lwpejavascriptcore-@WPE_API_VERSION@
+Cflags: -I${includedir}/wpe-webkit-@WPE_API_VERSION@

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -695,30 +695,32 @@ install(FILES ${WPE_API_INSTALLED_HEADERS}
         COMPONENT "Development"
 )
 
-# XXX: Using ${JavaScriptCore_INSTALLED_HEADERS} here expands to nothing.
-GI_INTROSPECT(WPEJavaScriptCore ${WPE_API_VERSION} jsc/jsc.h
-    TARGET WebKit
-    PACKAGE wpe-javascriptcore
-    SYMBOL_PREFIX jsc
-    DEPENDENCIES GObject-2.0
-    OPTIONS
-        -I${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}
-        -I${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}
-    SOURCES
-        ${JAVASCRIPTCORE_DIR}/API/glib/JSCOptions.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCClass.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCContext.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCDefines.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCException.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCValue.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCVersion.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCVirtualMachine.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCWeakValue.h
-        ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/jsc.h
-        ${JAVASCRIPTCORE_DIR}/API/glib
-    NO_IMPLICIT_SOURCES
-)
-GI_DOCGEN(WPEJavaScriptCore "${JAVASCRIPTCORE_DIR}/API/glib/docs/jsc.toml.in")
+if (NOT USE_SHARED_JSC)
+    # XXX: Using ${JavaScriptCore_INSTALLED_HEADERS} here expands to nothing.
+    GI_INTROSPECT(WPEJavaScriptCore ${WPE_API_VERSION} jsc/jsc.h
+        TARGET WebKit
+        PACKAGE wpe-javascriptcore
+        SYMBOL_PREFIX jsc
+        DEPENDENCIES GObject-2.0
+        OPTIONS
+            -I${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}
+            -I${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}
+        SOURCES
+            ${JAVASCRIPTCORE_DIR}/API/glib/JSCOptions.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCClass.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCContext.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCDefines.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCException.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCValue.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCVersion.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCVirtualMachine.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/JSCWeakValue.h
+            ${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}/jsc/jsc.h
+            ${JAVASCRIPTCORE_DIR}/API/glib
+        NO_IMPLICIT_SOURCES
+    )
+    GI_DOCGEN(WPEJavaScriptCore "${JAVASCRIPTCORE_DIR}/API/glib/docs/jsc.toml.in")
+endif ()
 
 set(WPE_SOURCES_FOR_INTROSPECTION
     UIProcess/API/wpe/WebKitColor.cpp
@@ -734,10 +736,17 @@ else ()
     list(APPEND WPE_SOURCES_FOR_INTROSPECTION UIProcess/API/wpe/WebKitWebViewWPE1.cpp)
 endif ()
 
-set(WPE_LIBRARIES_FOR_INTROSPECTION
-    WPEJavaScriptCore
-    Soup-${SOUP_API_VERSION}:libsoup-${SOUP_API_VERSION}
-)
+if (NOT USE_SHARED_JSC)
+    set(WPE_LIBRARIES_FOR_INTROSPECTION
+        WPEJavaScriptCore
+        Soup-${SOUP_API_VERSION}:libsoup-${SOUP_API_VERSION}
+    )
+else ()
+    set(WPE_LIBRARIES_FOR_INTROSPECTION
+        JavaScriptCore
+        Soup-${SOUP_API_VERSION}:libsoup-${SOUP_API_VERSION}
+    )
+endif ()
 
 set(WPE_INCLUDE_DIRS_FOR_INTROSPECTION
     -I${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}
@@ -792,8 +801,7 @@ GI_INTROSPECT(${WPE_WEB_PROCESS_EXTENSION_API_NAME} ${WPE_API_VERSION} wpe/${WPE
     IDENTIFIER_PREFIX WebKit
     SYMBOL_PREFIX webkit
     DEPENDENCIES
-        WPEJavaScriptCore
-        Soup-${SOUP_API_VERSION}:libsoup-${SOUP_API_VERSION}
+        ${WPE_LIBRARIES_FOR_INTROSPECTION}
     OPTIONS
         -I${JavaScriptCoreGLib_FRAMEWORK_HEADERS_DIR}
         -I${JavaScriptCoreGLib_DERIVED_SOURCES_DIR}

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -113,6 +113,7 @@ WEBKIT_OPTION_DEFINE(USE_SYSPROF_CAPTURE "Whether to use libsysprof-capture for 
 WEBKIT_OPTION_DEFINE(USE_SYSTEM_SYSPROF_CAPTURE "Whether to use a system-provided libsysprof-capture" PRIVATE ON)
 WEBKIT_OPTION_DEFINE(USE_SYSTEM_UNIFDEF "Whether to use a system-provided unifdef" PRIVATE ON)
 WEBKIT_OPTION_DEFINE(ENABLE_JSC_RESTRICTED_OPTIONS_BY_DEFAULT "Whether to enable dangerous development options in JSC by default." PRIVATE OFF)
+WEBKIT_OPTION_DEFINE(USE_SHARED_JSC "Build JavaScriptCore as a shared library" PRIVATE OFF)
 
 WEBKIT_OPTION_CONFLICT(ENABLE_WPE_PLATFORM ENABLE_WPE_1_1_API)
 
@@ -196,7 +197,6 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 set(bmalloc_LIBRARY_TYPE OBJECT)
 set(WTF_LIBRARY_TYPE OBJECT)
-set(JavaScriptCore_LIBRARY_TYPE OBJECT)
 set(WebCore_LIBRARY_TYPE OBJECT)
 
 # These are shared variables, but we special case their definition so that we can use the
@@ -469,6 +469,14 @@ EXPOSE_STRING_VARIABLE_TO_BUILD(WPE_WEB_PROCESS_EXTENSION_PC_MODULE)
 
 set(WPEWebProcessExtension_PKGCONFIG_FILE ${CMAKE_BINARY_DIR}/${WPE_WEB_PROCESS_EXTENSION_PC_MODULE}.pc)
 set(WPEWebProcessExtension_Uninstalled_PKGCONFIG_FILE ${CMAKE_BINARY_DIR}/${WPE_WEB_PROCESS_EXTENSION_PC_MODULE}-uninstalled.pc)
+
+if (USE_SHARED_JSC)
+    set(JavaScriptCore_LIBRARY_TYPE SHARED)
+    set(SHOULD_INSTALL_JS_SHELL ON)
+    set(JavaScriptCore_PKGCONFIG_FILE ${CMAKE_BINARY_DIR}/Source/JavaScriptCore/wpejavascriptcore-${WPE_API_VERSION}.pc)
+else ()
+    set(JavaScriptCore_LIBRARY_TYPE OBJECT)
+endif ()
 
 include(BubblewrapSandboxChecks)
 include(GStreamerChecks)


### PR DESCRIPTION
#### 6567ad5fce642ebd51e8b11ca873aaa212c41ee5
<pre>
[WPE] Allow building JavaScriptCore as a shared library
<a href="https://bugs.webkit.org/show_bug.cgi?id=296879">https://bugs.webkit.org/show_bug.cgi?id=296879</a>

Reviewed by NOBODY (OOPS!).

This updates the WPE cmake machinery to allow optionally building
JavaScriptCore as a shared library, configuring and installing a
PackageConfig file in that case.

* Source/JavaScriptCore/PlatformWPE.cmake: Set a library name, configure
  a pc file and produce a GI target.
* Source/JavaScriptCore/wpejavascriptcore.pc.in: Added.
* Source/WebKit/PlatformWPE.cmake: Configure WebKit GI targets to use
  an alternate GI JavaScriptCore dependency when building JSC as a
  shared library.
* Source/cmake/OptionsWPE.cmake: Add a new private WPE option to build
  JSC as a shared library.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6567ad5fce642ebd51e8b11ca873aaa212c41ee5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65315 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34964 "") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42895 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87099 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117537 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/34964 "") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/102909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67490 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/34964 "") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/21036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/64435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/106982 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/34964 "") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/21149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123960 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113152 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41602 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95917 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41979 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/99099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95700 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40860 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/18705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41481 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/46991 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137367 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41067 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/36734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->