### PR TITLE
Incorrect rule selected when nth-child selector used

### DIFF
--- a/LayoutTests/fast/css/css3-nth-child-bug-296807-expected.html
+++ b/LayoutTests/fast/css/css3-nth-child-bug-296807-expected.html
@@ -1,0 +1,42 @@
+<html>
+  <head>
+    <title>CSS selectors corner case (bug 296807)</title>
+    <link rel="author" title="Paweł Lampe" href="mailto:plampe@igalia.com">
+    <link rel="help" href="https://www.w3.org/TR/selectors-3/#nth-child-pseudo">
+    <link rel="help" href="https://www.w3.org/TR/selectors-4/#has-pseudo">
+    <style>
+      .container {
+          padding: 10px;
+          background: orange;
+      }
+      .container > div {
+          background: lightgray;
+      }
+      .container:has(:nth-child(1)) > div:nth-child(1) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(1) {
+          background: green;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(2) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(1) {
+          background: red;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(2) {
+          background: green;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(3) {
+          background: lightblue;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div>Red</div>
+      <div>Green</div>
+      <div>Blue</div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/fast/css/css3-nth-child-bug-296807.html
+++ b/LayoutTests/fast/css/css3-nth-child-bug-296807.html
@@ -1,0 +1,50 @@
+<html>
+  <head>
+    <title>CSS selectors corner case (bug 296807)</title>
+    <link rel="author" title="Paweł Lampe" href="mailto:plampe@igalia.com">
+    <link rel="help" href="https://www.w3.org/TR/selectors-3/#nth-child-pseudo">
+    <link rel="help" href="https://www.w3.org/TR/selectors-4/#has-pseudo">
+    <style>
+      .container {
+          padding: 10px;
+          background: orange;
+      }
+      .container > div {
+          background: lightgray;
+      }
+      .container:has(:nth-child(1)) > div:nth-child(1) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(1) {
+          background: green;
+      }
+      .container:has(:nth-child(2)) > div:nth-child(2) {
+          background: lightblue;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(1) {
+          background: red;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(2) {
+          background: green;
+      }
+      .container:has(:nth-child(3)) > div:nth-child(3) {
+          background: lightblue;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div>Green</div>
+      <div>Blue</div>
+    </div>
+    <script>
+      requestAnimationFrame(() => {
+          const container = document.getElementsByClassName("container")[0];
+          let newElement = document.createElement("div");
+          newElement.innerText = 'Red';
+          const referenceElement = container.children[0];
+          container.insertBefore(newElement, referenceElement);
+      });
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -170,6 +170,14 @@ static inline bool NODELETE isLastOfType(const Element& element, const Qualified
     return true;
 }
 
+static inline int countElementsBeforeSlow(const Element& element)
+{
+    int count = 0;
+    for (const Element* sibling = ElementTraversal::previousSibling(element); sibling; sibling = ElementTraversal::previousSibling(*sibling))
+        count++;
+    return count;
+}
+
 static inline int NODELETE countElementsBefore(const Element& element)
 {
     int count = 0;
@@ -181,6 +189,7 @@ static inline int NODELETE countElementsBefore(const Element& element)
         }
         count++;
     }
+    ASSERT(count == countElementsBeforeSlow(element));
     return count;
 }
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -690,6 +690,19 @@ ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& ref
     return { };
 }
 
+static inline void invalidateChildIndices(Node* firstSiblingWithAffectedIndex)
+{
+    CheckedPtr siblingWithAffectedIndex = firstSiblingWithAffectedIndex;
+    while (siblingWithAffectedIndex) {
+        if (CheckedPtr siblingElementWithAffectedIndex = dynamicDowncast<Element>(siblingWithAffectedIndex)) {
+            if (!siblingElementWithAffectedIndex->childIndex())
+                break;
+            siblingElementWithAffectedIndex->setChildIndex(0);
+        }
+        siblingWithAffectedIndex = siblingWithAffectedIndex->nextSibling();
+    }
+}
+
 void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
@@ -715,6 +728,8 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
     newChild.setParentNode(this);
     newChild.setPreviousSibling(previousSibling);
     newChild.setNextSibling(&nextChild);
+
+    invalidateChildIndices(&nextChild);
 }
 
 void ContainerNode::appendChildCommon(Node& child)
@@ -903,6 +918,8 @@ void ContainerNode::removeBetween(Node* previousChild, Node* nextChild, Node& ol
     oldChild.setParentNode(nullptr);
 
     oldChild.setTreeScopeRecursively(document());
+
+    invalidateChildIndices(nextChild);
 }
 
 void ContainerNode::parserRemoveChild(Node& oldChild)

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -184,7 +184,7 @@ private:
     void removeBetween(Node* previousChild, Node* nextChild, Node& oldChild);
     ExceptionOr<void> appendChildWithoutPreInsertionValidityCheck(Node&);
 
-    void NODELETE insertBeforeCommon(Node& nextChild, Node& oldChild);
+    void insertBeforeCommon(Node& nextChild, Node& oldChild);
     void NODELETE appendChildCommon(Node&);
 
     void rebuildSVGExtensionsElementsIfNecessary();


### PR DESCRIPTION
#### 8806751df6c0059be695bff269e999fc046da0ab
<pre>
Incorrect rule selected when nth-child selector used
<a href="https://bugs.webkit.org/show_bug.cgi?id=296807">https://bugs.webkit.org/show_bug.cgi?id=296807</a>

Reviewed by NOBODY (OOPS!).

This change effectively fixes incorrect has(nth-child) selector
matching by properly invalidating incorrect childIndex-es after
adding or removing a node thus making the countElementsBefore
function yielding correct values during matching.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8806751df6c0059be695bff269e999fc046da0ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191700 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141643 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98288 "4 flakes 13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44001 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42271 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41916 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2861 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55780 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150751 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45329 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128063 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123681 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54296 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53678 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->