### PR TITLE
NotificationJSONParser::parseNotificationPayload gets mutable from wrong object

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationJSONParser.cpp
@@ -140,7 +140,12 @@ ExceptionOr<NotificationPayload> NotificationJSONParser::parseNotificationPayloa
     std::optional<NotificationOptionsPayload> notificationOptions = optionsOrException.releaseReturnValue();
 
     bool isMutable = false;
-    if (auto value = protectedObject->getValue(mutableKey)) {
+    if (auto value = outerObject.getValue(mutableKey)) {
+        if (value->type() != JSON::Value::Type::Boolean)
+            return Exception { ExceptionCode::SyntaxError, makeString("Push message with Notification disposition: '"_s, mutableKey, "' member is specified but is not a boolean"_s) };
+        isMutable = *(value->asBoolean());
+    // FIXME: Eventually we should remove this branch as supporting mutable inside the notification object is non-standard (webkit.org/b/297389).
+    } else if (auto value = protectedObject->getValue(mutableKey)) {
         if (value->type() != JSON::Value::Type::Boolean)
             return Exception { ExceptionCode::SyntaxError, makeString("Push message with Notification disposition: '"_s, mutableKey, "' member is specified but is not a boolean"_s) };
         isMutable = *(value->asBoolean());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -2437,9 +2437,9 @@ static constexpr ASCIILiteral json35 = R"JSONRESOURCE(
     "web_push": 8030,
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "mutable": 39
-    }
+        "title": "Hello world!"
+    },
+    "mutable": 39
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json36 = R"JSONRESOURCE(
@@ -2447,9 +2447,9 @@ static constexpr ASCIILiteral json36 = R"JSONRESOURCE(
     "web_push": 8030,
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "mutable": { }
-    }
+        "title": "Hello world!"
+    },
+    "mutable": { }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json37 = R"JSONRESOURCE(
@@ -2457,9 +2457,9 @@ static constexpr ASCIILiteral json37 = R"JSONRESOURCE(
     "web_push": 8030,
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "mutable": "true"
-    }
+        "title": "Hello world!"
+    },
+    "mutable": "true"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json38 = R"JSONRESOURCE(
@@ -2468,8 +2468,8 @@ static constexpr ASCIILiteral json38 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
-        "mutable": true
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json39 = R"JSONRESOURCE(
@@ -2478,9 +2478,9 @@ static constexpr ASCIILiteral json39 = R"JSONRESOURCE(
     "app_badge": "12",
     "notification": {
         "navigate": "https://example.com/",
-        "title": "Hello world!",
-        "mutable": true
-    }
+        "title": "Hello world!"
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json40 = R"JSONRESOURCE(
@@ -2490,9 +2490,9 @@ static constexpr ASCIILiteral json40 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
-        "mutable": true,
         "tag": "title Gotcha!"
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json41 = R"JSONRESOURCE(
@@ -2502,9 +2502,9 @@ static constexpr ASCIILiteral json41 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
-        "mutable": true,
         "tag": "badge 1024"
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json42 = R"JSONRESOURCE(
@@ -2514,9 +2514,9 @@ static constexpr ASCIILiteral json42 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Hello world!",
-        "mutable": true,
         "tag": "titleandbadge ThisRules 4096"
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json43 = R"JSONRESOURCE(
@@ -2526,10 +2526,10 @@ static constexpr ASCIILiteral json43 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test the data object",
-        "mutable": true,
         "tag": "datatotitle",
         "data": "Raw string"
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json44 = R"JSONRESOURCE(
@@ -2539,10 +2539,10 @@ static constexpr ASCIILiteral json44 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test the data object",
-        "mutable": true,
         "tag": "datatotitle",
         "data": { "key": "value" }
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json45 = R"JSONRESOURCE(
@@ -2552,11 +2552,12 @@ static constexpr ASCIILiteral json45 = R"JSONRESOURCE(
     "notification": {
         "navigate": "https://example.com/",
         "title": "Test a default action URL override",
-        "mutable": true,
         "tag": "defaultactionurl https://webkit.org/"
-    }
+    },
+    "mutable": true
 }
 )JSONRESOURCE"_s;
+// Intentionally keep mutable as a child of notification here until we fix webkit.org/b/297389.
 static constexpr ASCIILiteral json46 = R"JSONRESOURCE(
 {
     "web_push": 8030,


### PR DESCRIPTION
#### 88f9bc0282fa36cd9b5eaebe216c087c997bf33d
<pre>
NotificationJSONParser::parseNotificationPayload gets mutable from wrong object
<a href="https://bugs.webkit.org/show_bug.cgi?id=296770">https://bugs.webkit.org/show_bug.cgi?id=296770</a>
<a href="https://rdar.apple.com/157475553">rdar://157475553</a>

Reviewed by Brady Eidson.

mutable is supposed to be a sibling of notification and app_badge, not
a child of notification.

Support both variants for now and once Declarative Web Push is more
widespread we can remove support for the incorrect variant (tracked via

<a href="https://bugs.webkit.org/show_bug.cgi?id=297389).">https://bugs.webkit.org/show_bug.cgi?id=297389).</a>
Canonical link: <a href="https://commits.webkit.org/298677@main">https://commits.webkit.org/298677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77c3d88c3c9c69b0ad3fdfc127314991c0342dea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72b9ecdb-27ac-46c0-a5be-3059e41202eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0edb5efe-7ade-47d7-b3f1-e216923fd159) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68777 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28330 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125523 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32448 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96847 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20034 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18575 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48690 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42565 "Failed to checkout and rebase branch from PR 48896") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->