### PR TITLE
[GTK] Fix some broken references in GTK 4 migration guide

### DIFF
--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -24,13 +24,13 @@ time to start looking into webkitgtk-6.0.
 All APIs that were previously deprecated in webkit2gtk-4.0 and webkit2gtk-4.1
 have been removed. This includes the original JavaScriptCore API (e.g.
 `JSContextRef` and `JSObjectRef`), which has been replaced by the GObject-style
-JavaScriptCore API (e.g. [type@JSC.Context] and [type@JSC.Object]) that is
-available since 2.22. It also includes the entire GObject DOM API (e.g.
+JavaScriptCore API (e.g. [type@JavaScriptCore.Context] and [type@JavaScriptCore.Value])
+that is available since 2.22. It also includes the entire GObject DOM API (e.g.
 `WebKitDOMDocument`), which has been removed without replacement. Use JavaScript
 to interact with and manipulate the DOM instead, perhaps via
 [method@WebKit.WebView.evaluate_javascript] or
 [method@WebKit.WebView.call_async_javascript_function] in the UI process, or
-[method@JSC.ValueObject.invoke_method] in the web process.
+[method@JavaScriptCore.Value.object_invoke_method] in the web process.
 
 Run your application with the environment variable `G_ENABLE_DIAGNOSTIC=1` to
 notice use of deprecated signals and properties.
@@ -150,7 +150,7 @@ now all use a filesystem path rather than a URI. All uses must be updated accord
 ## JavaScript Results
 
 WebKitJavascriptResult has been removed. [signal@WebKit.UserContentManager::script-message-received]
-now directly returns a [class@JSC.Value] instead.
+now directly returns a [class@JavaScriptCore.Value] instead.
 
 ## Web Process Extension
 


### PR DESCRIPTION
#### 100e814ad647c8839d7bf1ed6dccf72187b34637
<pre>
[GTK] Fix some broken references in GTK 4 migration guide
<a href="https://bugs.webkit.org/show_bug.cgi?id=296883">https://bugs.webkit.org/show_bug.cgi?id=296883</a>

Reviewed by Adrian Perez de Castro.

Fix broken links.

Canonical link: <a href="https://commits.webkit.org/298207@main">https://commits.webkit.org/298207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c8bbccc36d899f1bae56b2546acae4ae02bdc58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87119 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42027 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27057 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95935 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/41996 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99113 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24380 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18720 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47008 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41083 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->