### PR TITLE
[WebCore] Remove Self Inclusions

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
@@ -29,7 +29,6 @@
 #include "WebGPUTextureFormat.h"
 #include "WebGPUTextureUsage.h"
 #include "WebGPUXREye.h"
-#include "WebGPUXRProjectionLayer.h"
 #include "WebGPUXRSubImage.h"
 
 #include <wtf/Ref.h>

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "AnimationEffect.h"
 #include "AnimationEffectTiming.h"
 #include "BasicEffectTiming.h"
 #include "ComputedEffectTiming.h"

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -4006,6 +4006,14 @@ def check_include_line(filename, file_extension, clean_lines, line_number, inclu
                   '%s Should be: config.h, primary header, blank line, and then alphabetically sorted.' %
                   error_message)
 
+    # Check to make sure there's no self inclusions
+    filename_regex = rf'(?:.*?/)?{re.escape(os.path.basename(filename))}'
+    if re.search(
+        rf'^#include\s*(<{filename_regex}>|\"{filename_regex}\")',
+        line,
+    ):
+        error(line_number, 'build/self_include', 4, 'Self include problem.')
+
 
 def check_language(filename, clean_lines, line_number, file_extension, include_state,
                    file_state, error):
@@ -4935,6 +4943,7 @@ class CppChecker(object):
         'build/webcore_export',
         'build/wk_api_available',
         'build/version_check',
+        'build/self_include',
         'build-speed/inlines',
         'legal/copyright',
         'policy/language',


### PR DESCRIPTION
#### eaaebba999c4a7e10ec7f999cbc134c506a05110
<pre>
[WebCore] Remove Self Inclusions
<a href="https://bugs.webkit.org/show_bug.cgi?id=296884">https://bugs.webkit.org/show_bug.cgi?id=296884</a>

Reviewed by Tim Nguyen.

Remove self inclusions

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h:
* Source/WebCore/animation/AnimationEffect.h:
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_include_line):
(CppChecker):

Canonical link: <a href="https://commits.webkit.org/298223@main">https://commits.webkit.org/298223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0057910514b9f5699445da076ab98ab855e5b5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87145 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42048 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67533 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/114017 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124011 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95960 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24388 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40905 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18752 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37754 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41533 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47045 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41119 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->