### PR TITLE
[Absolute Positioning][Grid] align-self auto should resolve against the parent's align items when statically positioned.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: center;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+  align-items: center;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+  align-items: center;
+}
+.item {
+  width: 50px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-center-large-border-padding-ref.html">
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box when statically positioned and align-items: center in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-top: 74px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 500px;
+  background-color: blue;
+  background-clip: content-box;
+  align-items: center;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: center;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-center-ref.html">
+<meta name="assert" content="Center of the abspos child should be aligned within the center of the grid's content box when statically positioned and align-items: center in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: center;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: end in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: end in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-flex-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: flex-end in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-flex-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: flex-end in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: flex-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-self-end-large-border-padding-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: self-end in parent.">
+<style>
+.grid {
+  display: grid;
+  padding: 13px;
+  padding-bottom: 42px;
+  border: 23px solid black;
+  border-bottom-width: 45px;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.item {
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#align-abspos">
+<link rel="help" href="https://www.w3.org/TR/css-position-3/#staticpos-rect">
+<link rel="match" href="grid-abspos-staticpos-align-items-self-end-ref.html">
+<meta name="assert" content="Abspos child of grid is aligned to end of grid content box when statically positioned and align-items: self-end in parent.">
+<style>
+.grid {
+  display: grid;
+  border: 1px solid black;
+  width: 100px;
+  height: 100px;
+  align-items: self-end;
+}
+.abspos {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div class="abspos"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -125,6 +125,9 @@ private:
     Style::InsetEdge m_insetBefore;
     Style::InsetEdge m_insetAfter;
     bool m_useStaticPosition { false };
+#if ASSERT_ENABLED
+    mutable bool m_isEligibleForStaticRangeAlignment { false };
+#endif
 };
 
 inline bool PositionedLayoutConstraints::isOpposing() const


### PR DESCRIPTION
#### addd63ad0fb344eed25bbdc2a3427ad4e1620202
<pre>
[Absolute Positioning][Grid] align-self auto should resolve against the parent&apos;s align items when statically positioned.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296903">https://bugs.webkit.org/show_bug.cgi?id=296903</a>
<a href="https://rdar.apple.com/problem/157511193">rdar://problem/157511193</a>

Reviewed by Alan Baradlay.

One of the things we currently look at when determining a box&apos;s
eligibility for alignment in its static position rectangle is the value
of its align-self property. If we find that the value is auto then we
return false. This patch builds upon this case by resolving against the
parent&apos;s value of align-items in that case and then switching upon the
ItemPosition.

Instead of applying this logic inside of isEligibleForStaticRangeAlignment
directly, we need to add it inside of resolveAlignmentValue. This is
because this function is used by resolveAlignmentShift, which we use to
determine how much we need to move the box to satisfy its alignment, to
determine what the ItemPosition should be. We did not need to modify
this function previously since it was just returning the box&apos;s alignment
value which was on m_alignment. Now we resolve against the parent
instead of using ItemPosition::Normal which was occurring before.

When resolving self alignment against the parent we also need to provide
an ItemPosition as what the normal behavior should be. According to
css-align, this would either be &quot;start,&quot; or &quot;stretch,&quot; depending on the
type of the box with a link to css-position:
<a href="https://drafts.csswg.org/css-align-3/#align-abspos">https://drafts.csswg.org/css-align-3/#align-abspos</a>

From my reading of css-position, it seems like the only way this can be
Something other than start is if it has non-auto insets (i.e. is not
statically positioned). As a result, we provide ItemPosition::Start as
the normal behavior:
<a href="https://drafts.csswg.org/css-position-3/#abspos-layout">https://drafts.csswg.org/css-position-3/#abspos-layout</a>

resolveAlignmentValue is called indirectly in two different cases: the
first is when we are aligning a box that has fixed insets and fixed
margins into available space and the second is during out new alignment
codepath. Since the first case cannot happened when the box is
statically positioned we can constrain resolveAlignmentValue to only
contain logic that is applicable to cases when the box is statically
positioned and is eligible to be aligned within its static position
rectangle. This is kept in sync with a new member variable that keeps
track of when a box is eligible to take the new codepath. Currently only
compiled in debug builds since it is only used as a way to keep these
two pieces of code in sync.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-center.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-flex-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end-large-border-padding.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/abspos/grid-abspos-staticpos-align-items-self-end.html: Added.
The above tests were added to verify behavior and are the tests we added
in previous patches to test the respective values of align-self but are
not being tested via align-items on the parent.

Canonical link: <a href="https://commits.webkit.org/298287@main">https://commits.webkit.org/298287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0c9caeaf3c3c6548df574bdcdc17f6f7f64faa8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65577 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/080f1199-9d1c-43f6-a6fd-2178ed0f9dfc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87286 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42160 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (exception)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38d37333-e88c-460e-8a31-269df08e2a24) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67678 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21243 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64664 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124199 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96095 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24427 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41728 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47244 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41285 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43028 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->