### PR TITLE
Web Inspector: DOM element previews in Object Tree outlines show newlines and indentation

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
@@ -67,6 +67,10 @@
     color: hsl(0, 0%, 50%);
 }
 
+.formatted-node, .formatted-node-preview {
+    white-space: wrap;
+}
+
 .formatted-node > .tree-outline.dom {
     display: block !important;
     padding: 0;


### PR DESCRIPTION
#### 406af9d4a91730657dd53fdf98dcffd9d4f21f65
<pre>
Web Inspector: DOM element previews in Object Tree outlines show newlines and indentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=296753">https://bugs.webkit.org/show_bug.cgi?id=296753</a>
<a href="https://rdar.apple.com/157225532">rdar://157225532</a>

Reviewed by Devin Rousso.

Allow DOM node previews to wrap, ignoring any whitespace from the original markup.
This overrides the inherited `white-space:pre-wrap` from the styles of the console message body.

Without this patch, DOM node previews with newlines are rendered verbatim
creating the appearance that Web Inspector layout in the Console is broken.

* Source/WebInspectorUI/UserInterface/Views/FormattedValue.css:
(.formatted-node, .formatted-node-preview):

Canonical link: <a href="https://commits.webkit.org/298626@main">https://commits.webkit.org/298626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d88deb7df6f2f2c58012ca0c369eaafad2eecd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65347 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba9c6b50-208a-420e-a313-9e9ad43e3ba9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/34999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87131 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42033 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bea2567-8363-4ef6-908e-e65bd8511dec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67519 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21069 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64468 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21179 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/123993 "Hash 1d88deb7 for PR 48909 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31091 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/123993 "Hash 1d88deb7 for PR 48909 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99130 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/123993 "Hash 1d88deb7 for PR 48909 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40887 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18736 "") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37736 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18551 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41101 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44408 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->