### PR TITLE
AX: fix broken and expensive ASSERTS in accessibility code

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -726,6 +726,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AXCoreObject.h
     accessibility/AXGeometryManager.h
     accessibility/AXLogger.h
+    accessibility/AXLoggerBase.h
     accessibility/AXObjectCache.h
     accessibility/AXSearchManager.h
     accessibility/AXTextMarker.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -555,6 +555,7 @@ Modules/webxr/XRWebGLSubImage.cpp
 accessibility/AXCoreObject.cpp
 accessibility/AXGeometryManager.cpp
 accessibility/AXLogger.cpp
+accessibility/AXLoggerBase.cpp
 accessibility/AXObjectCache.cpp
 accessibility/AXRemoteFrame.cpp
 accessibility/AXSearchManager.cpp

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "AXGeometryManager.h"
+#include "AXLoggerBase.h"
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 #include "AXIsolatedTree.h"
@@ -67,8 +68,8 @@ std::optional<IntRect> AXGeometryManager::cachedRectForID(AXID axID)
 void AXGeometryManager::cacheRect(std::optional<AXID> axID, IntRect&& rect)
 {
     // We shouldn't call this method on a geometry manager that has no page ID.
-    ASSERT(m_cache->pageID());
-    ASSERT(AXObjectCache::isIsolatedTreeEnabled());
+    AX_DEBUG_ASSERT(m_cache->pageID());
+    AX_DEBUG_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
 
     if (!axID)
         return;

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -30,6 +30,7 @@
 #include "IntRectHash.h"
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AXLogger.h
+++ b/Source/WebCore/accessibility/AXLogger.h
@@ -28,6 +28,8 @@
 #include "AXCoreObject.h"
 #include "AXObjectCache.h"
 #include <wtf/MonotonicTime.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AXLoggerBase.cpp
+++ b/Source/WebCore/accessibility/AXLoggerBase.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+static bool accessibilityLogChannelEnabled = false;
+
+void setAccessibilityLogChannelEnabled(bool enabled)
+{
+    accessibilityLogChannelEnabled = enabled;
+}
+
+bool isAccessibilityLogChannelEnabled()
+{
+    return accessibilityLogChannelEnabled;
+}

--- a/Source/WebCore/accessibility/AXLoggerBase.h
+++ b/Source/WebCore/accessibility/AXLoggerBase.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Assertions.h>
+
+// Called from the AXObjectCache constructor.
+void setAccessibilityLogChannelEnabled(bool);
+
+bool isAccessibilityLogChannelEnabled();
+
+// Use AX_BROKEN_ASSERT when a non-fatal assertion is failing even though it should never happen.
+// It will change it to a release log, but only if the accessibility log channel is enabled. On macOS:
+//     defaults write -g WebCoreLogging Accessibility
+// Monitor with:
+//     log stream --process Safari --predicate 'subsystem="com.apple.WebKit" AND category="Accessibility"'
+#define AX_BROKEN_ASSERT(assertion, ...) do { \
+    if (isAccessibilityLogChannelEnabled) { \
+        RELEASE_LOG_ERROR_IF(!(assertion), Accessibility, "BROKEN ASSERTION FAILED in %s(%d) : %s\n", __FILE__, __LINE__, WTF_PRETTY_FUNCTION); \
+    } \
+} while (0)
+
+// Enable this in order to get debug asserts, which are called too frequently to be enabled
+// by default.
+#define AX_DEBUG_ASSERTS_ENABLED 0
+
+#if AX_DEBUG_ASSERTS_ENABLED
+#define AX_DEBUG_ASSERT(assertion) ASSERT(assertion)
+#else
+#define AX_DEBUG_ASSERT(assertion) ((void)0)
+#endif

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -33,6 +33,7 @@
 #include "AXIsolatedObject.h"
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXRemoteFrame.h"
 #include "AXTextMarker.h"
 #include "AccessibilityAttachment.h"
@@ -286,6 +287,8 @@ AXObjectCache::AXObjectCache(Page& page, Document* document)
         AXLOG("No pageID.");
 #endif
     ASSERT(isMainThread());
+
+    setAccessibilityLogChannelEnabled(LOG_CHANNEL(Accessibility).state != logChannelStateOff);
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
     gAccessibilityThreadTextApisEnabled = DeprecatedGlobalSettings::accessibilityThreadTextApisEnabled();
@@ -693,7 +696,7 @@ bool hasAnyRole(Element& element, Vector<StringView>&& roles)
         return false;
 
     for (const auto& role : roles) {
-        ASSERT(!role.isEmpty());
+        AX_DEBUG_ASSERT(!role.isEmpty());
         if (SpaceSplitString::spaceSplitStringContainsValue(roleValue, role, SpaceSplitString::ShouldFoldCase::Yes))
             return true;
     }
@@ -1037,7 +1040,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
     Ref object = createObjectFromRenderer(renderer);
 
     // Will crash later if we have two objects for the same renderer.
-    ASSERT(!get(renderer));
+    AX_BROKEN_ASSERT(!get(renderer));
 
     cacheAndInitializeWrapper(object.get(), &renderer);
     // Compute the object's initial ignored status.

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -243,7 +243,7 @@ static void appendChildrenToArray(Ref<AXCoreObject> object, bool isForward, RefP
         // and we should never have created an isolated object from an ignored live object.
         // FIXME: This is not true for ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), fix this before shipping it.
         // FIXME: We hit this ASSERT on google.com. https://bugs.webkit.org/show_bug.cgi?id=293263
-        ASSERT(is<AccessibilityObject>(startObject));
+        AX_BROKEN_ASSERT(is<AccessibilityObject>(startObject));
         RefPtr newStartObject = dynamicDowncast<AccessibilityObject>(startObject.get());
         // Get the un-ignored sibling based on the search direction, and update the searchPosition.
         if (newStartObject && newStartObject->isIgnored())

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1163,7 +1163,7 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
                 ASSERT(adjacentRunIndex - runIndex == 2);
                 // This scenario really should only happen with single "entity" runs (where an entity could be an ASCII
                 // character, or a multi-byte emoji that occupies multiple indices but is one atomic entity).
-                ASSERT(!currentRuns->containsOnlyASCII || (currentRuns->runLength(runIndex) == 1 && currentRuns->runLength(adjacentRunIndex) == 1));
+                AX_BROKEN_ASSERT(!currentRuns->containsOnlyASCII || (currentRuns->runLength(runIndex) == 1 && currentRuns->runLength(adjacentRunIndex) == 1));
                 // The next line end is simply the adjacent marker with an upstream affinity (with an ASSERT to verify this).
                 ASSERT(currentRuns->indexForOffset(adjacentMarker.offset(), Affinity::Upstream) == runIndex + 1);
                 adjacentMarker.setAffinity(Affinity::Upstream);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityNodeObject.h"
 
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityLabel.h"
@@ -197,7 +198,7 @@ AccessibilityObject* AccessibilityNodeObject::nextSibling() const
 AccessibilityObject* AccessibilityNodeObject::ownerParentObject() const
 {
     auto owners = this->owners();
-    ASSERT(owners.size() <= 1);
+    AX_DEBUG_ASSERT(owners.size() <= 1);
     return owners.size() ? dynamicDowncast<AccessibilityObject>(owners.first().get()) : nullptr;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -74,6 +74,7 @@
 #include "HitTestResult.h"
 #include "LocalFrame.h"
 #include "LocalizedStrings.h"
+#include "Logging.h"
 #include "MathMLNames.h"
 #include "NodeList.h"
 #include "NodeName.h"
@@ -635,12 +636,10 @@ bool AccessibilityObject::isDescendantOfRole(AccessibilityRole role) const
     }) != nullptr;
 }
 
-#if ASSERT_ENABLED
 static bool isTableComponent(AXCoreObject& axObject)
 {
     return axObject.isTable() || axObject.isTableColumn() || axObject.isTableRow() || axObject.isTableCell();
 }
-#endif
 
 void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index, DescendIfIgnored descendIfIgnored)
 {
@@ -728,7 +727,7 @@ void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index
         // Table component child-parent relationships often don't line up properly, hence the need for methods
         // like parentTable() and parentRow(). Exclude them from this ASSERT.
         // FIXME: We hit this ASSERT on gmail.com. https://bugs.webkit.org/show_bug.cgi?id=293264
-        ASSERT(isTableComponent(child) || isTableComponent(*this) || child.parentObject() == this);
+        AX_BROKEN_ASSERT(isTableComponent(child) || isTableComponent(*this) || child.parentObject() == this);
         insert(Ref { child }, index);
     }
     

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityRenderObject.h"
 
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityListBox.h"
@@ -2736,7 +2737,7 @@ void AccessibilityRenderObject::addChildren()
     }
     // If the need to add more children in addition to existing children arises,
     // childrenChanged should have been called, leaving the object with no children.
-    ASSERT(!m_childrenInitialized); 
+    AX_DEBUG_ASSERT(!m_childrenInitialized);
     m_childrenInitialized = true;
 
     auto clearDirtySubtree = makeScopeExit([&] {

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -31,12 +31,14 @@
 #include "AXGeometryManager.h"
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXSearchManager.h"
 #include "AXTextMarker.h"
 #include "AXTextRun.h"
 #include "AccessibilityNodeObject.h"
 #include "DateComponents.h"
 #include "HTMLNames.h"
+#include "Logging.h"
 #include "RenderObject.h"
 #include <wtf/text/MakeString.h>
 
@@ -70,7 +72,7 @@ Ref<AXIsolatedObject> AXIsolatedObject::create(IsolatedObjectData&& data)
 
 AXIsolatedObject::~AXIsolatedObject()
 {
-    ASSERT(!wrapper());
+    AX_BROKEN_ASSERT(!wrapper());
 }
 
 String AXIsolatedObject::debugDescriptionInternal(bool verbose, std::optional<OptionSet<AXDebugStringOption>> debugOptions) const
@@ -261,7 +263,7 @@ void AXIsolatedObject::setChildrenIDs(Vector<AXID>&& ids)
 const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool updateChildrenIfNeeded)
 {
 #if USE(APPLE_INTERNAL_SDK)
-    ASSERT(_AXSIsolatedTreeModeFunctionIsAvailable() && ((_AXSIsolatedTreeMode_Soft() == AXSIsolatedTreeModeSecondaryThread && !isMainThread())
+    AX_DEBUG_ASSERT(_AXSIsolatedTreeModeFunctionIsAvailable() && ((_AXSIsolatedTreeMode_Soft() == AXSIsolatedTreeModeSecondaryThread && !isMainThread())
         || (_AXSIsolatedTreeMode_Soft() == AXSIsolatedTreeModeMainThread && isMainThread())));
 #elif USE(ATSPI)
     ASSERT(!isMainThread());
@@ -282,7 +284,7 @@ const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool
         m_unresolvedChildrenIDs = WTFMove(unresolvedIDs);
         // Having any unresolved children IDs at this point means we should've had a child / children, but they didn't
         // exist in tree()->objectForID(), so we were never able to hydrate it into an object.
-        ASSERT(m_unresolvedChildrenIDs.isEmpty());
+        AX_BROKEN_ASSERT(m_unresolvedChildrenIDs.isEmpty());
 
 #ifndef NDEBUG
         verifyChildrenIndexInParent();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1521,7 +1521,7 @@ AXTreePtr findAXTree(Function<bool(AXTreePtr)>&& match)
 
 void AXIsolatedTree::queueNodeUpdate(AXID objectID, const NodeUpdateOptions& options)
 {
-    ASSERT(isMainThread());
+    AX_DEBUG_ASSERT(isMainThread());
 
     if (!options.shouldUpdateNode && options.properties.size()) {
         // If we're going to recompute all properties for the node (i.e., the node is in m_needsUpdateNode),

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -28,6 +28,7 @@
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 #include "AXCoreObject.h"
+#include "AXLoggerBase.h"
 #include "AXTextMarker.h"
 #include "AXTextRun.h"
 #include "AXTreeStore.h"
@@ -425,7 +426,7 @@ public:
 
     inline AXIsolatedObject* objectForID(AXID axID) const
     {
-        ASSERT(!isMainThread());
+        AX_DEBUG_ASSERT(!isMainThread());
 
         auto iterator = m_readerThreadNodeMap.find(axID);
         if (iterator != m_readerThreadNodeMap.end())
@@ -698,7 +699,7 @@ std::optional<AXPropertyFlag> convertToPropertyFlag(AXProperty);
 
 inline AXObjectCache* AXIsolatedTree::axObjectCache() const
 {
-    ASSERT(isMainThread());
+    AX_DEBUG_ASSERT(isMainThread());
     return m_axObjectCache.get();
 }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -31,6 +31,7 @@
 
 #import "AXCoreObject.h"
 #import "AXIsolatedObject.h"
+#import "AXLoggerBase.h"
 #import "AXObjectCache.h"
 #import "AXRemoteFrame.h"
 #import "AXSearchManager.h"
@@ -397,7 +398,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
         return m_axObject.get();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    ASSERT(AXObjectCache::isIsolatedTreeEnabled());
+    AX_DEBUG_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
     return m_isolatedObject.get();
 #else
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### ab66a869bd96849bae619d4743ed46d30ad52149
<pre>
AX: fix broken and expensive ASSERTS in accessibility code
<a href="https://bugs.webkit.org/show_bug.cgi?id=296895">https://bugs.webkit.org/show_bug.cgi?id=296895</a>
<a href="https://rdar.apple.com/157501091">rdar://157501091</a>

Reviewed by Tyler Wilcock.

We have ~100 ASSERTS in WebCore/accessibility, and of those I found 6
that are broken - they&apos;re asserting on live pages - and about 10 that
are called way too often, hundreds of thousands of times per minute.

Add AX_BROKEN_ASSERT that does a release log of the assertion failure -
but only if the accessibility log channel is enabled - and then
add AX_DEBUG_ASSERT for the really expensive ones and require
manually enabling those by the developer.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cacheRect):
* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/accessibility/AXLogger.h:
* Source/WebCore/accessibility/AXLoggerBase.cpp: Added.
(setAccessibilityLogChannelEnabled):
(isAccessibilityLogChannelEnabled):
* Source/WebCore/accessibility/AXLoggerBase.h: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::hasAnyRole):
(WebCore::AXObjectCache::getOrCreate):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendChildrenToArray):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findLine const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::ownerParentObject const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::isTableComponent):
(WebCore::AccessibilityObject::insertChild):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addChildren):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::~AXIsolatedObject):
(WebCore::AXIsolatedObject::children):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::queueNodeUpdate):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::objectForID const):
(WebCore::AXIsolatedTree::axObjectCache const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase axBackingObject]):

Canonical link: <a href="https://commits.webkit.org/298252@main">https://commits.webkit.org/298252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/033407f97e6183ae48748486a0e64bfd248c975f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120984 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65513 "Hash 033407f9 for PR 48918 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87274 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/65513 "Hash 033407f9 for PR 48918 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21229 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64651 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31255 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18891 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37876 "Hash 033407f9 for PR 48918 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47221 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->