### PR TITLE
Move ShadowRoot from ElementRareData to Element

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -185,6 +185,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Element);
 struct SameSizeAsElement : public ContainerNode {
     QualifiedName tagName;
     void* elementData;
+    void* shadowRoot;
 };
 
 static_assert(sizeof(Element) == sizeof(SameSizeAsElement), "Element should stay small");
@@ -3261,7 +3262,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
         if (renderer() || hasDisplayContents())
             RenderTreeUpdater::tearDownRenderersForShadowRootInsertion(*this);
 
-        ensureElementRareData().setShadowRoot(WTFMove(newShadowRoot));
+        m_shadowRoot = WTFMove(newShadowRoot);
 
         shadowRoot->setHost(*this);
         shadowRoot->setParentTreeScope(treeScope());
@@ -3288,7 +3289,7 @@ void Element::removeShadowRootSlow(ShadowRoot& oldRoot)
 
     ASSERT(!oldRoot.renderer());
 
-    elementRareData()->clearShadowRoot();
+    m_shadowRoot = nullptr;
 
     oldRoot.setHost(nullptr);
     oldRoot.setParentTreeScope(document());

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -420,7 +420,7 @@ public:
     virtual bool rendererIsNeeded(const RenderStyle&);
     virtual bool isReplaced(const RenderStyle&) const { return false; }
 
-    inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
+    ShadowRoot* shadowRoot() const { return m_shadowRoot.get(); }
     RefPtr<ShadowRoot> shadowRootForBindings(JSC::JSGlobalObject&) const;
     RefPtr<ShadowRoot> openOrClosedShadowRoot() const;
     RefPtr<Element> resolveReferenceTarget() const;
@@ -968,7 +968,7 @@ private:
     void cloneShadowTreeIfPossible(Element& newHost) const;
     virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const;
 
-    inline void removeShadowRoot(); // Defined in ElementRareData.h.
+    inline void removeShadowRoot(); // Defined in ShadowRoot.h
     void removeShadowRootSlow(ShadowRoot&);
 
     enum class ResolveComputedStyleMode : uint8_t { Normal, RenderedOnly, Editability };
@@ -1026,6 +1026,7 @@ private:
 
     QualifiedName m_tagName;
     RefPtr<ElementData> m_elementData;
+    RefPtr<ShadowRoot> m_shadowRoot;
 };
 
 inline void Element::setSavedLayerScrollPosition(const ScrollPosition& position)

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -31,6 +31,7 @@
 #include "ElementData.h"
 #include "HTMLNames.h"
 #include "RenderStyleInlines.h"
+#include "ShadowRoot.h"
 #include "StyleChange.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -40,7 +40,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     IntPoint savedLayerScrollPosition;
     HashMap<std::optional<Style::PseudoElementIdentifier>, std::unique_ptr<ElementAnimationRareData>> animationRareData;
     HashMap<std::optional<Style::PseudoElementIdentifier>, AtomString> viewTransitionCapture;
-    void* pointers[18];
+    void* pointers[17];
     void* intersectionObserverData;
     void* typedOMData[2];
     void* resizeObserverData;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -70,10 +70,6 @@ public:
     void setChildIndex(unsigned index) { m_childIndex = index; }
     static constexpr ptrdiff_t childIndexMemoryOffset() { return OBJECT_OFFSETOF(ElementRareData, m_childIndex); }
 
-    void clearShadowRoot() { m_shadowRoot = nullptr; }
-    ShadowRoot* shadowRoot() const { return m_shadowRoot.get(); }
-    void setShadowRoot(RefPtr<ShadowRoot>&& shadowRoot) { m_shadowRoot = WTFMove(shadowRoot); }
-
     CustomElementReactionQueue* customElementReactionQueue() { return m_customElementReactionQueue.get(); }
     void setCustomElementReactionQueue(std::unique_ptr<CustomElementReactionQueue>&& queue) { m_customElementReactionQueue = WTFMove(queue); }
 
@@ -180,8 +176,6 @@ public:
             result.add(UseType::Dataset);
         if (m_classList)
             result.add(UseType::ClassList);
-        if (m_shadowRoot)
-            result.add(UseType::ShadowRoot);
         if (m_customElementReactionQueue)
             result.add(UseType::CustomElementReactionQueue);
         if (m_customElementDefaultARIA)
@@ -239,7 +233,6 @@ private:
     AtomString m_effectiveLang;
     const std::unique_ptr<DatasetDOMStringMap> m_dataset;
     const std::unique_ptr<DOMTokenList> m_classList;
-    RefPtr<ShadowRoot> m_shadowRoot;
     std::unique_ptr<CustomElementReactionQueue> m_customElementReactionQueue;
     std::unique_ptr<CustomElementDefaultARIA> m_customElementDefaultARIA;
     const std::unique_ptr<FormAssociatedCustomElement> m_formAssociatedCustomElement;
@@ -287,7 +280,6 @@ inline ElementRareData::ElementRareData()
 
 inline ElementRareData::~ElementRareData()
 {
-    ASSERT(!m_shadowRoot);
     ASSERT(!m_beforePseudoElement);
     ASSERT(!m_afterPseudoElement);
 }
@@ -362,31 +354,6 @@ inline ElementRareData* Element::elementRareData() const
 {
     ASSERT_WITH_SECURITY_IMPLICATION(hasRareData());
     return static_cast<ElementRareData*>(rareData());
-}
-
-inline ShadowRoot* Node::shadowRoot() const
-{
-    if (auto* element = dynamicDowncast<Element>(*this))
-        return element->shadowRoot();
-    return nullptr;
-}
-
-inline ShadowRoot* Element::shadowRoot() const
-{
-    return hasRareData() ? elementRareData()->shadowRoot() : nullptr;
-}
-
-inline RefPtr<ShadowRoot> Node::protectedShadowRoot() const
-{
-    return shadowRoot();
-}
-
-inline void Element::removeShadowRoot()
-{
-    RefPtr shadowRoot = this->shadowRoot();
-    if (!shadowRoot) [[likely]]
-        return;
-    removeShadowRootSlow(*shadowRoot);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -281,8 +281,8 @@ public:
     RefPtr<Element> protectedShadowHost() const;
     ShadowRoot* containingShadowRoot() const;
     RefPtr<ShadowRoot> protectedContainingShadowRoot() const;
-    inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
-    inline RefPtr<ShadowRoot> protectedShadowRoot() const; // Defined in ElementRareData.h
+    inline ShadowRoot* shadowRoot() const; // Defined in ShadowRoot.h
+    inline RefPtr<ShadowRoot> protectedShadowRoot() const; // Defined in ShadowRoot.h
     bool isClosedShadowHidden(const Node&) const;
 
     HTMLSlotElement* assignedSlot() const;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -220,6 +220,25 @@ inline RefPtr<ContainerNode> Node::protectedParentOrShadowHostNode() const
     return parentOrShadowHostNode();
 }
 
+inline ShadowRoot* Node::shadowRoot() const
+{
+    if (auto* element = dynamicDowncast<Element>(*this))
+        return element->shadowRoot();
+    return nullptr;
+}
+
+inline RefPtr<ShadowRoot> Node::protectedShadowRoot() const
+{
+    return shadowRoot();
+}
+
+inline void Element::removeShadowRoot()
+{
+    if (!m_shadowRoot) [[likely]]
+        return;
+    removeShadowRootSlow(*m_shadowRoot.copyRef());
+}
+
 inline bool hasShadowRootParent(const Node& node)
 {
     return node.parentNode() && node.parentNode()->isShadowRoot();


### PR DESCRIPTION
#### dcfc2a30ef9c615f5f7b8b22b5258416a10f0257
<pre>
Move ShadowRoot from ElementRareData to Element
<a href="https://bugs.webkit.org/show_bug.cgi?id=296897">https://bugs.webkit.org/show_bug.cgi?id=296897</a>

Reviewed by NOBODY (OOPS!).

There are many elements with UA shadow roots. Move this pointer from ElementRareData to Element
to eliminate the overhead of allocating ElementRareData for those elements.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
(WebCore::Element::removeShadowRootSlow):
* Source/WebCore/dom/Element.h:
(WebCore::Element::shadowRoot const):
* Source/WebCore/dom/ElementInlines.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::useTypes const):
(WebCore::ElementRareData::~ElementRareData):
(WebCore::ElementRareData::clearShadowRoot): Deleted.
(WebCore::ElementRareData::shadowRoot const): Deleted.
(WebCore::ElementRareData::setShadowRoot): Deleted.
(WebCore::Node::shadowRoot const): Deleted.
(WebCore::Element::shadowRoot const): Deleted.
(WebCore::Node::protectedShadowRoot const): Deleted.
(WebCore::Element::removeShadowRoot): Deleted.
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ShadowRoot.h:
(WebCore::Node::shadowRoot const):
(WebCore::Node::protectedShadowRoot const):
(WebCore::Element::removeShadowRoot):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcfc2a30ef9c615f5f7b8b22b5258416a10f0257

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65413 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a658a7bb-0254-4f9a-8c3c-d0a32017e8a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87164 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42082 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 60 failures. 18801 tests run. 60 failures; Uploaded test results; Exiting early after 60 failures. 18599 tests run. 60 failures; Compiled WebKit (cancelled)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53611d98-3dac-4491-bce7-6c977cf77733) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67552 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21110 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64512 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124038 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95980 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95762 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37770 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41560 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47072 "Found 1 new failure in dom/ShadowRoot.h") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44449 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->