### PR TITLE
imported/w3c/web-platform-tests/service-workers/service-worker/skip-waiting-installed.https.html is a flakey text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/skip-waiting-installed-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/skip-waiting-installed-worker.js
@@ -1,8 +1,22 @@
-var saw_activate_event = false
+var saw_activate_event = false;
+var activate_event_resolvers = [];
 
 self.addEventListener('activate', function() {
     saw_activate_event = true;
+    while (activate_event_resolvers.length > 0) {
+      activate_event_resolvers.shift()();
+    }
   });
+
+function waitForActivateEvent() {
+  if (saw_activate_event) {
+    return Promise.resolve();
+  }
+  
+  return new Promise(function(resolve) {
+    activate_event_resolvers.push(resolve);
+  });
+}
 
 self.addEventListener('message', function(event) {
     var port = event.data.port;
@@ -12,7 +26,9 @@ self.addEventListener('message', function(event) {
             port.postMessage('FAIL: Promise should be resolved with undefined');
             return;
           }
-
+          return waitForActivateEvent();
+        })
+      .then(function() {
           if (!saw_activate_event) {
             port.postMessage(
                 'FAIL: Promise should be resolved after activate event is dispatched');

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/skip-waiting-installed.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/skip-waiting-installed.https.html
@@ -57,6 +57,9 @@ promise_test(function(t) {
           return wait_for_state(t, service_worker, 'installed');
         })
       .then(function() {
+          return wait_for_activation_on_sample_scope(t, self);
+        })
+      .then(function() {
           var channel = new MessageChannel();
           channel.port1.onmessage = t.step_func(onmessage);
           service_worker.postMessage({port: channel.port2}, [channel.port2]);


### PR DESCRIPTION
#### 9ac7913462ea6c0430cb69afb5ab4906563288ce
<pre>
imported/w3c/web-platform-tests/service-workers/service-worker/skip-waiting-installed.https.html is a flakey text failure
<a href="https://rdar.apple.com/156166158">rdar://156166158</a>

Reviewed by Jonathan Bedard.

Making the test more deterministic by fixing a race condition where the skipWaiting() promise could resolve before the activate event

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/skip-waiting-installed-worker.js:
(waitForActivateEvent):
(event.waitUntil.self.skipWaiting.then):
(then):
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/skip-waiting-installed.https.html:

Canonical link: <a href="https://commits.webkit.org/300261@main">https://commits.webkit.org/300261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/261be83b7243ea856e999b4213f03dd1434ac50b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65504 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e00bf7cc-1425-4394-a259-c8540f7e99ed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87159 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42780 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6acc19c3-76a6-45f3-8b78-f1772d7d5566) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/102975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67547 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64507 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124033 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95974 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37768 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41555 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41139 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->