### PR TITLE
Web Extensions: Clean up Mock Node and Tests for Get and Create for the Bookmarks API

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionBookmarksParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionBookmarksParameters.h
@@ -35,6 +35,7 @@ struct WebExtensionBookmarksParameters {
     uint64_t index;
     String title;
     std::optional<String> url;
+    WallTime dateAdded;
     std::optional<Vector<WebExtensionBookmarksParameters>> children;
 };
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionBookmarksParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionBookmarksParameters.serialization.in
@@ -28,6 +28,7 @@ struct WebKit::WebExtensionBookmarksParameters {
     uint64_t index;
     String title;
     std::optional<String> url;
+    WallTime dateAdded;
     std::optional<Vector<WebKit::WebExtensionBookmarksParameters>> children;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h
@@ -74,6 +74,13 @@ WK_SWIFT_UI_ACTOR
  */
 - (NSInteger)indexForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(index(for:));
 
+/*!
+ @abstract Called when the date the bookmark was added is needed.
+ @param context The context in which the web extension is running.
+ @return The date the bookmark was added. Should be `nil` for folders or separators.
+ */
+- (nullable NSDate *)dateAddedForWebExtensionContext:(WKWebExtensionContext * _Nonnull)context NS_SWIFT_NAME(dateAdded(for:));
+
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -784,7 +784,7 @@ private:
 #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
     bool isBookmarksMessageAllowed(IPC::Decoder&);
     void bookmarksCreate(const std::optional<String>& parentId, const std::optional<uint64_t>& index, const std::optional<String>& url, const std::optional<String>& title, CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&&);
-    void bookmarksGetTree(CompletionHandler<void(Expected<WebExtensionBookmarksParameters, WebExtensionError>&&)>&&);
+    void bookmarksGetTree(CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&&);
     void bookmarksGetSubTree(const String& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&&);
     void bookmarksGet(const Vector<String>& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&&);
     void bookmarksGetChildren(const String& bookmarkId, CompletionHandler<void(Expected<Vector<WebExtensionBookmarksParameters>, WebExtensionError>&&)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -53,7 +53,7 @@ messages -> WebExtensionContext {
     #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
     // Bookmarks APIs
     [Validator=isBookmarksMessageAllowed] BookmarksCreate(std::optional<String> parentId, std::optional<uint64_t> index, std::optional<String> url, std::optional<String> title) -> (Expected<WebKit::WebExtensionBookmarksParameters, WebKit::WebExtensionError> result)
-    [Validator=isBookmarksMessageAllowed] BookmarksGetTree() -> (Expected<WebKit::WebExtensionBookmarksParameters, WebKit::WebExtensionError> result)
+    [Validator=isBookmarksMessageAllowed] BookmarksGetTree() -> (Expected<Vector<WebKit::WebExtensionBookmarksParameters>, WebKit::WebExtensionError> result)
     [Validator=isBookmarksMessageAllowed] BookmarksGetSubTree(String bookmarkId) -> (Expected<Vector<WebKit::WebExtensionBookmarksParameters>, WebKit::WebExtensionError> result)
     [Validator=isBookmarksMessageAllowed] BookmarksGet(Vector<String> bookmarkId) -> (Expected<Vector<WebKit::WebExtensionBookmarksParameters>, WebKit::WebExtensionError> result)
     [Validator=isBookmarksMessageAllowed] BookmarksGetChildren(String bookmarkId) -> (Expected<Vector<WebKit::WebExtensionBookmarksParameters>, WebKit::WebExtensionError> result)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h
@@ -41,67 +41,6 @@ public:
         Folder
     };
 
-    struct CreateDetails {
-        std::optional<size_t> index;
-        String parentId;
-        String title;
-        std::optional<BookmarkTreeNodeType> type;
-        String url;
-    };
-
-    struct MockBookmarkNode: public CanMakeWeakPtr<MockBookmarkNode>, public RefCounted<MockBookmarkNode> {
-        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(MockBookmarkNode);
-
-    public:
-        template<typename... Args>
-        static Ref<MockBookmarkNode> create(Args&&... args)
-        {
-            return adoptRef(*new MockBookmarkNode(std::forward<Args>(args)...));
-        }
-
-        String id;
-        String parentId;
-        String title;
-        String url;
-        size_t index;
-        WallTime dateAdded;
-        BookmarkTreeNodeType type;
-        Vector<Ref<MockBookmarkNode>> children;
-
-        MockBookmarkNode(const MockBookmarkNode& other)
-            : id(other.id)
-            , parentId(other.parentId)
-            , title(other.title)
-            , url(other.url)
-            , index(other.index)
-            , dateAdded(other.dateAdded)
-            , type(other.type)
-            , children(other.children)
-        {
-
-        }
-
-        MockBookmarkNode& operator=(const MockBookmarkNode& other)
-        {
-            if (this == &other)
-                return *this;
-
-            id = other.id;
-            parentId = other.parentId;
-            title = other.title;
-            url = other.url;
-            index = other.index;
-            dateAdded = other.dateAdded;
-            type = other.type;
-            children = other.children;
-            return *this;
-        }
-
-        MockBookmarkNode() = default;
-    };
-
-    HashMap<String, Ref<MockBookmarkNode>> m_mockBookmarks;
-    void initializeMockBookmarksInternal();
 
 #if PLATFORM(COCOA)
     void createBookmark(NSDictionary *bookmark, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);


### PR DESCRIPTION
#### 60367f4ebf3c8581a95ce18db1a223da82b38d62
<pre>
Web Extensions: Clean up Mock Node and Tests for Get and Create for the Bookmarks API
and add getRecent
<a href="https://rdar.apple.com/157304875">rdar://157304875</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296813">https://bugs.webkit.org/show_bug.cgi?id=296813</a>

Reviewed by Brian Weinstein.

Moved all mock node implementation that was present in Create and getRecent in the Bookmarks API&apos;s WebProcess to the TestWebKitAPI space. Changed getTree to return a vector of its top level nodes instead of the root to be in line with MDN documentation. Implemented getRecent in WebProcess and UIProcess which included adding the dateAdded parameter to the BookmarkTreeNode list of parameters.

* Source/WebKit/Shared/Extensions/WebExtensionBookmarksParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionBookmarksParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionBookmarks.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::createParametersFromProtocolObject):
(WebKit::flattenAndConvertAllBookmarks):
(WebKit::WebExtensionContext::bookmarksGetTree):
(WebKit::WebExtensionContext::bookmarksGetRecent):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::toAPI):
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getRecent):
(WebKit::WebExtensionAPIBookmarks::getTree):
(WebKit::toWebAPI): Deleted.
(WebKit::WebExtensionAPIBookmarks::initializeMockBookmarksInternal): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIBookmarks.h:
(): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(-[_MockBookmarkNode dateAddedForWebExtensionContext:]):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureCreateBookmarkDelegate):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIgetRecent)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreate)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetTree)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateAndGetTree)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetSubTreeChildren)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIMockNodeWithgetRecent)): Deleted.
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPICreateParse)): Deleted.
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, CreateAndGetTree)): Deleted.
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, GetSubTree)): Deleted.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::createParametersFromProtocolObject):
(WebKit::WebExtensionContext::bookmarksGetRecent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::WebExtensionAPIBookmarks::createBookmark):
(WebKit::WebExtensionAPIBookmarks::getRecent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(-[_MockBookmarkNode bookmarkTypeForWebExtensionContext:]):
(-[_MockBookmarkNode childrenForWebExtensionContext:]):
(-[_MockBookmarkNode dateAddedForWebExtensionContext:]):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureCreateBookmarkDelegate):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIGetRecent)):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIgetRecent)): Deleted.

Canonical link: <a href="https://commits.webkit.org/298290@main">https://commits.webkit.org/298290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bfbc6faa92b43c62b68dd100e60e4b4fca40c8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87311 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42162 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21282 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64689 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124225 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96113 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95898 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24428 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18930 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37931 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47288 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->