### PR TITLE
[libpas] Add zeroed_with_alignment malloc variants to bmalloc.h

### DIFF
--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -145,6 +145,39 @@ BINLINE void* memalign(size_t alignment, size_t size, CompactAllocationMode mode
 }
 
 // Returns null on failure.
+BINLINE void* tryZeroedMemalign(size_t alignment, size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary)
+{
+#if BUSE(LIBPAS)
+    if (!isGigacage(kind))
+        return bmalloc_try_allocate_zeroed_with_alignment_inline(size, alignment, asPasAllocationMode(mode));
+    return bmalloc_try_allocate_auxiliary_zeroed_with_alignment_inline(
+        &heapForKind(gigacageKind(kind)), size, alignment, asPasAllocationMode(mode));
+#else
+    BUNUSED(mode);
+    auto* mem = Cache::tryAllocate(kind, alignment, size);
+    if (mem)
+        memset(mem, 0, size);
+    return mem;
+#endif
+}
+
+// Crashes on failure.
+BINLINE void* zeroedMemalign(size_t alignment, size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary)
+{
+#if BUSE(LIBPAS)
+    if (!isGigacage(kind))
+        return bmalloc_allocate_zeroed_with_alignment_inline(size, alignment, asPasAllocationMode(mode));
+    return bmalloc_allocate_auxiliary_zeroed_with_alignment_inline(
+        &heapForKind(gigacageKind(kind)), size, alignment, asPasAllocationMode(mode));
+#else
+    BUNUSED(mode);
+    auto* mem = Cache::allocate(kind, alignment, size);
+    memset(mem, 0, size);
+    return mem;
+#endif
+}
+
+// Returns null on failure.
 BINLINE void* tryRealloc(void* object, size_t newSize, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary)
 {
 #if BUSE(LIBPAS)

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
@@ -88,6 +88,11 @@ void* bmalloc_try_allocate_zeroed(size_t size, pas_allocation_mode allocation_mo
     return bmalloc_try_allocate_zeroed_inline(size, allocation_mode);
 }
 
+void* bmalloc_try_allocate_zeroed_with_alignment(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
+{
+    return bmalloc_try_allocate_zeroed_with_alignment_inline(size, alignment, allocation_mode);
+}
+
 void* bmalloc_allocate(size_t size, pas_allocation_mode allocation_mode)
 {
     return bmalloc_allocate_inline(size, allocation_mode);
@@ -101,6 +106,11 @@ void* bmalloc_allocate_with_alignment(size_t size, size_t alignment, pas_allocat
 void* bmalloc_allocate_zeroed(size_t size, pas_allocation_mode allocation_mode)
 {
     return bmalloc_allocate_zeroed_inline(size, allocation_mode);
+}
+
+void* bmalloc_allocate_zeroed_with_alignment(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
+{
+    return bmalloc_allocate_zeroed_with_alignment_inline(size, alignment, allocation_mode);
 }
 
 void* bmalloc_try_reallocate(void* old_ptr, size_t new_size,
@@ -343,6 +353,22 @@ void* bmalloc_allocate_auxiliary_with_alignment(pas_primitive_heap_ref* heap_ref
                                                 pas_allocation_mode allocation_mode)
 {
     return bmalloc_allocate_auxiliary_with_alignment_inline(heap_ref, size, alignment, allocation_mode);
+}
+
+void* bmalloc_try_allocate_auxiliary_zeroed_with_alignment(pas_primitive_heap_ref* heap_ref,
+                                                           size_t size,
+                                                           size_t alignment,
+                                                           pas_allocation_mode allocation_mode)
+{
+    return bmalloc_try_allocate_auxiliary_zeroed_with_alignment_inline(heap_ref, size, alignment, allocation_mode);
+}
+
+void* bmalloc_allocate_auxiliary_zeroed_with_alignment(pas_primitive_heap_ref* heap_ref,
+                                                       size_t size,
+                                                       size_t alignment,
+                                                       pas_allocation_mode allocation_mode)
+{
+    return bmalloc_allocate_auxiliary_zeroed_with_alignment_inline(heap_ref, size, alignment, allocation_mode);
 }
 
 void* bmalloc_try_reallocate_auxiliary(void* old_ptr,

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.h
@@ -41,6 +41,9 @@ PAS_API void* bmalloc_try_allocate_with_alignment(size_t size,
                                                   pas_allocation_mode allocation_mode);
 
 PAS_API void* bmalloc_try_allocate_zeroed(size_t size, pas_allocation_mode allocation_mode);
+PAS_API void* bmalloc_try_allocate_zeroed_with_alignment(size_t size,
+                                                         size_t alignment,
+                                                         pas_allocation_mode allocation_mode);
 
 PAS_API void* bmalloc_allocate(size_t size, pas_allocation_mode allocation_mode);
 PAS_API void* bmalloc_allocate_with_alignment(size_t size,
@@ -48,6 +51,9 @@ PAS_API void* bmalloc_allocate_with_alignment(size_t size,
                                               pas_allocation_mode allocation_mode);
 
 PAS_API void* bmalloc_allocate_zeroed(size_t size, pas_allocation_mode allocation_mode);
+PAS_API void* bmalloc_allocate_zeroed_with_alignment(size_t size,
+                                                     size_t alignment,
+                                                     pas_allocation_mode allocation_mode);
 
 PAS_API void* bmalloc_try_reallocate(void* old_ptr, size_t new_size,
                                      pas_allocation_mode allocation_mode,
@@ -122,6 +128,15 @@ PAS_API void* bmalloc_try_allocate_auxiliary_with_alignment(pas_primitive_heap_r
                                                             size_t alignment,
                                                             pas_allocation_mode allocation_mode);
 PAS_API void* bmalloc_allocate_auxiliary_with_alignment(pas_primitive_heap_ref* heap_ref,
+                                                        size_t size,
+                                                        size_t alignment,
+                                                        pas_allocation_mode allocation_mode);
+
+PAS_API void* bmalloc_try_allocate_auxiliary_zeroed_with_alignment(pas_primitive_heap_ref* heap_ref,
+                                                            size_t size,
+                                                            size_t alignment,
+                                                            pas_allocation_mode allocation_mode);
+PAS_API void* bmalloc_allocate_auxiliary_zeroed_with_alignment(pas_primitive_heap_ref* heap_ref,
                                                         size_t size,
                                                         size_t alignment,
                                                         pas_allocation_mode allocation_mode);


### PR DESCRIPTION
#### 2ea1c1850d3aa5725e6997f0a76ae5f4674c5f0d
<pre>
[libpas] Add zeroed_with_alignment malloc variants to bmalloc.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=296902">https://bugs.webkit.org/show_bug.cgi?id=296902</a>
<a href="https://rdar.apple.com/157510912">rdar://157510912</a>

Reviewed by Yusuke Suzuki.

Currently, we support both aligned allocations (e.g.
bmalloc_allocate_with_alignment) and zeroed allocations (e.g.
bmalloc_allocate_zeroed); however, we do not support
simultaneously-aligned-and-zeroed allocations (e.g.
bmalloc_allocate_zeroed_with_alignment). This patch implements those.

The consumer of the API can just zero it themselves, but libpas is
careful to optimize out that zeroing operation if it knows it’s not
necessary, e.g. if the page was newly mmap’d (c.f.
pas_allocation_result_zero).  This comes up when allocating wasm memory,
as we basically
  1. Ask for a huge allocation
  2. Mmap over it to ensure it’s zero
This is probably not itself a huge performance problem, but it does show
up when I tried to switch that #2 over to madvise(MADV_ZERO): normally
this would be preferable because this subsequent mmap would fragment the
backing vm-objects (and acquire more locks), but in the case that we’re
just replacing the entire vm-object anyways the first downside goes
away, after which presumably the actual effort of going page-by-page and
making sure they’re zeroed begins to dominate.

Creating this new bmalloc_allocate_zeroed_with_alignment family of
functions will thus allow us to avoid that unnecessary mmap and unblock
migrating it to use madvise(MADV_ZERO) instead.

Canonical link: <a href="https://commits.webkit.org/298428@main">https://commits.webkit.org/298428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4956b78719609f4d86ab8b441966d743b4417dca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115526 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121591 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6437c7f-b89f-41ee-a507-b23addd69210) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43777 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bf90fff-120c-4c80-8caa-61b8bdfb1c89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118474 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/103683 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/68161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65261 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/107692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21921 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114058 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/42440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/31803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/124751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/42807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99874 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24499 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42325 "Built successfully") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/41818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->