### PR TITLE
Fix Speedometer3 regression from 297895@main

### DIFF
--- a/Source/WTF/wtf/TZoneMalloc.h
+++ b/Source/WTF/wtf/TZoneMalloc.h
@@ -40,6 +40,7 @@
 
 // struct allocators with FastMalloc fallback if TZoneHeap is disabled.
 #define WTF_MAKE_STRUCT_TZONE_ALLOCATED(name) WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(name)
+#define WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(name, exportMacro) WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(name)
 
 // template allocators with FastMalloc fallback if TZoneHeap is disabled.
 #define WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(name) WTF_DEPRECATED_MAKE_FAST_ALLOCATED(name)
@@ -153,6 +154,7 @@
 
 // struct allocators with FastMalloc fallback if TZoneHeap is enabled.
 #define WTF_MAKE_STRUCT_TZONE_ALLOCATED(name) MAKE_STRUCT_BTZONE_MALLOCED(name, NonCompact, WTF_NOEXPORT)
+#define WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(name, exportMacro) MAKE_STRUCT_BTZONE_MALLOCED(name, NonCompact, exportMacro)
 
 // template allocators with FastMalloc fallback if TZoneHeap is enabled.
 #define WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(name) MAKE_BTZONE_MALLOCED_TEMPLATE(name, NonCompact, WTF_NOEXPORT)

--- a/Source/WebCore/dom/SerializedNode.cpp
+++ b/Source/WebCore/dom/SerializedNode.cpp
@@ -44,6 +44,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(SerializedNode);
+
 static void setAttributes(Element& element, Vector<SerializedNode::Element::Attribute>&& attributes)
 {
     element.parserSetAttributes(WTF::map(WTFMove(attributes), [] (auto&& attribute) {

--- a/Source/WebCore/dom/SerializedNode.h
+++ b/Source/WebCore/dom/SerializedNode.h
@@ -43,6 +43,7 @@ class JSDOMGlobalObject;
 enum class ClonedDocumentType : uint8_t;
 
 struct SerializedNode {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(SerializedNode, WEBCORE_EXPORT);
     struct QualifiedName {
         String prefix;
         String localName;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -44,15 +44,13 @@
 
 namespace WebKit {
 
-WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(JavaScriptEvaluationResult::Value);
-
-JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSObjectID root, HashMap<JSObjectID, UniqueRef<Value>>&& map)
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSObjectID root, HashMap<JSObjectID, Value>&& map)
     : m_map(WTFMove(map))
     , m_root(root) { }
 
 RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Value&& root)
 {
-    return WTF::switchOn(WTFMove(root.value), [] (EmptyType) -> RefPtr<API::Object> {
+    return WTF::switchOn(WTFMove(root), [] (EmptyType) -> RefPtr<API::Object> {
         return nullptr;
     }, [] (bool value) -> RefPtr<API::Object> {
         return API::Boolean::create(value);
@@ -72,7 +70,7 @@ RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Value&& root)
         return { WTFMove(dictionary) };
     }, [] (NodeInfo&&) -> RefPtr<API::Object> {
         return nullptr;
-    }, [] (WebCore::SerializedNode&&) -> RefPtr<API::Object> {
+    }, [] (UniqueRef<WebCore::SerializedNode>&&) -> RefPtr<API::Object> {
         return nullptr;
     });
 }
@@ -80,7 +78,7 @@ RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Value&& root)
 RefPtr<API::Object> JavaScriptEvaluationResult::toAPI()
 {
     for (auto&& [identifier, value] : std::exchange(m_map, { }))
-        m_instantiatedObjects.add(identifier, toAPI(WTFMove(value.get())));
+        m_instantiatedObjects.add(identifier, toAPI(WTFMove(value)));
     for (auto [vector, array] : std::exchange(m_arrays, { })) {
         for (auto identifier : vector) {
             if (RefPtr object = m_instantiatedObjects.get(identifier))
@@ -111,7 +109,7 @@ JSObjectID JavaScriptEvaluationResult::addObjectToMap(JSGlobalContextRef context
     if (!object) {
         if (!m_nullObjectID) {
             m_nullObjectID = JSObjectID::generate();
-            m_map.add(*m_nullObjectID, makeUniqueRef<Value>(Value { { EmptyType::Undefined } }));
+            m_map.add(*m_nullObjectID, Value { EmptyType::Undefined });
         }
         return *m_nullObjectID;
     }
@@ -123,7 +121,7 @@ JSObjectID JavaScriptEvaluationResult::addObjectToMap(JSGlobalContextRef context
 
     auto identifier = JSObjectID::generate();
     m_jsObjectsInMap.set(WTFMove(value), identifier);
-    m_map.add(identifier, makeUniqueRef<Value>(toValue(context, object)));
+    m_map.add(identifier, toValue(context, object));
     return identifier;
 }
 
@@ -157,51 +155,51 @@ auto JavaScriptEvaluationResult::toValue(JSGlobalContextRef context, JSValueRef 
 {
     if (!JSValueIsObject(context, value)) {
         if (JSValueIsBoolean(context, value))
-            return { JSValueToBoolean(context, value) };
+            return JSValueToBoolean(context, value);
         if (JSValueIsNumber(context, value)) {
             value = JSValueMakeNumber(context, JSValueToNumber(context, value, 0));
-            return { JSValueToNumber(context, value, 0) };
+            return JSValueToNumber(context, value, 0);
         }
         if (JSValueIsString(context, value)) {
             auto* globalObject = ::toJS(context);
             JSC::JSValue jsValue = ::toJS(globalObject, value);
-            return { jsValue.toWTFString(globalObject) };
+            return jsValue.toWTFString(globalObject);
         }
         if (JSValueIsNull(context, value))
-            return { EmptyType::Null };
-        return { EmptyType::Undefined };
+            return EmptyType::Null;
+        return EmptyType::Undefined;
     }
 
     JSObjectRef object = JSValueToObject(context, value, 0);
 
     if (auto* info = jsDynamicCast<WebCore::JSWebKitNodeInfo*>(::toJS(::toJS(context), object))) {
         Ref nodeInfo { info->wrapped() };
-        return { NodeInfo { nodeInfo->nodeIdentifier(), nodeInfo->contentFrameIdentifier() } };
+        return NodeInfo { nodeInfo->nodeIdentifier(), nodeInfo->contentFrameIdentifier() };
     }
 
     if (auto* node = jsDynamicCast<WebCore::JSWebKitSerializedNode*>(::toJS(::toJS(context), object))) {
         Ref serializedNode { node->wrapped() };
-        return { WebCore::SerializedNode { serializedNode->serializedNode() } };
+        return makeUniqueRef<WebCore::SerializedNode>(serializedNode->serializedNode());
     }
 
     if (JSValueIsDate(context, object))
-        return { Seconds(JSValueToNumber(context, object, 0) / 1000.0) };
+        return Seconds(JSValueToNumber(context, object, 0) / 1000.0);
 
     if (JSValueIsArray(context, object)) {
         SUPPRESS_UNCOUNTED_ARG JSValueRef lengthPropertyName = JSValueMakeString(context, adopt(JSStringCreateWithUTF8CString("length")).get());
         JSValueRef lengthValue = JSObjectGetPropertyForKey(context, object, lengthPropertyName, nullptr);
         double lengthDouble = JSValueToNumber(context, lengthValue, nullptr);
         if (lengthDouble < 0 || lengthDouble > static_cast<double>(std::numeric_limits<size_t>::max()))
-            return { EmptyType::Undefined };
+            return EmptyType::Undefined;
 
         size_t length = lengthDouble;
         Vector<JSObjectID> vector;
         if (!vector.tryReserveInitialCapacity(length))
-            return { EmptyType::Undefined };
+            return EmptyType::Undefined;
 
         for (size_t i = 0; i < length; ++i)
             vector.append(addObjectToMap(context, JSObjectGetPropertyAtIndex(context, object, i, nullptr)));
-        return { { WTFMove(vector) } };
+        return { WTFMove(vector) };
     }
 
     JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(context, object);
@@ -212,7 +210,7 @@ auto JavaScriptEvaluationResult::toValue(JSGlobalContextRef context, JSValueRef 
         SUPPRESS_UNCOUNTED_ARG map.add(addObjectToMap(context, JSValueMakeString(context, key.get())), addObjectToMap(context, JSObjectGetPropertyForKey(context, object, JSValueMakeString(context, key.get()), nullptr)));
     }
     JSPropertyNameArrayRelease(names);
-    return { { WTFMove(map) } };
+    return { WTFMove(map) };
 }
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSGlobalContextRef context, JSValueRef value)
@@ -233,7 +231,7 @@ JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Value&& 
         return std::make_tuple(lexicalGlobalObject, domGlobalObject, WTFMove(document));
     };
 
-    return WTF::switchOn(WTFMove(root.value), [&] (EmptyType emptyType) -> JSValueRef {
+    return WTF::switchOn(WTFMove(root), [&] (EmptyType emptyType) -> JSValueRef {
         switch (emptyType) {
         case EmptyType::Undefined:
             return JSValueMakeUndefined(context);
@@ -266,16 +264,16 @@ JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Value&& 
         if (document.get() != &node->document())
             return JSValueMakeUndefined(context);
         return ::toRef(lexicalGlobalObject, WebCore::toJS(lexicalGlobalObject, domGlobalObject, *node));
-    }, [&] (WebCore::SerializedNode&& serializedNode) -> JSValueRef {
+    }, [&] (UniqueRef<WebCore::SerializedNode>&& serializedNode) -> JSValueRef {
         auto [lexicalGlobalObject, domGlobalObject, document] = globalObjectTuple(context);
-        return ::toRef(lexicalGlobalObject, WebCore::SerializedNode::deserialize(WTFMove(serializedNode), lexicalGlobalObject, domGlobalObject, *document));
+        return ::toRef(lexicalGlobalObject, WebCore::SerializedNode::deserialize(WTFMove(serializedNode.get()), lexicalGlobalObject, domGlobalObject, *document));
     });
 }
 
 Protected<JSValueRef> JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
 {
     for (auto&& [identifier, value] : std::exchange(m_map, { }))
-        m_instantiatedJSObjects.add(identifier, Protected<JSValueRef>(context, toJS(context, WTFMove(value.get()))));
+        m_instantiatedJSObjects.add(identifier, Protected<JSValueRef>(context, toJS(context, WTFMove(value))));
     for (auto& [vector, array] : std::exchange(m_jsArrays, { })) {
         JSObjectRef jsArray = JSValueToObject(context, array.get(), 0);
         for (size_t index = 0; index < vector.size(); ++index) {
@@ -313,7 +311,7 @@ String JavaScriptEvaluationResult::toString() const
     auto it = m_map.find(m_root);
     if (it == m_map.end())
         return { };
-    auto* string = std::get_if<String>(&it->value->value);
+    auto* string = std::get_if<String>(&it->value);
     if (!string)
         return { };
     return *string;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -61,12 +61,9 @@ using JSObjectID = ObjectIdentifier<JSObjectIDType>;
 class JavaScriptEvaluationResult {
 public:
     enum class EmptyType : bool { Undefined, Null };
-    struct Value {
-        WTF_MAKE_STRUCT_TZONE_ALLOCATED(Value);
-        Variant<EmptyType, bool, double, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>, NodeInfo, WebCore::SerializedNode> value;
-    };
+    using Value = Variant<EmptyType, bool, double, String, Seconds, Vector<JSObjectID>, HashMap<JSObjectID, JSObjectID>, NodeInfo, UniqueRef<WebCore::SerializedNode>>;
 
-    JavaScriptEvaluationResult(JSObjectID, HashMap<JSObjectID, UniqueRef<Value>>&&);
+    JavaScriptEvaluationResult(JSObjectID, HashMap<JSObjectID, Value>&&);
     static std::optional<JavaScriptEvaluationResult> extract(JSGlobalContextRef, JSValueRef);
 
     JavaScriptEvaluationResult(JavaScriptEvaluationResult&&);
@@ -74,7 +71,7 @@ public:
     ~JavaScriptEvaluationResult();
 
     JSObjectID root() const { return m_root; }
-    const HashMap<JSObjectID, UniqueRef<Value>>& map() const { return m_map; }
+    const HashMap<JSObjectID, Value>& map() const { return m_map; }
 
     String toString() const;
 
@@ -139,7 +136,7 @@ private:
     Vector<std::pair<Vector<JSObjectID>, Protected<JSValueRef>>> m_jsArrays;
 
     // IPC representation
-    HashMap<JSObjectID, UniqueRef<Value>> m_map;
+    HashMap<JSObjectID, Value> m_map;
     JSObjectID m_root;
 };
 

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
@@ -25,13 +25,9 @@ struct WebKit::NodeInfo {
     Markable<WebCore::FrameIdentifier> contentFrameIdentifier;
 };
 
-[Nested] struct WebKit::JavaScriptEvaluationResult::Value {
-    Variant<WebKit::JavaScriptEvaluationResult::EmptyType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>, WebKit::NodeInfo, WebCore::SerializedNode> value;
-}
-
 class WebKit::JavaScriptEvaluationResult {
     WebKit::JSObjectID root()
-    HashMap<WebKit::JSObjectID, UniqueRef<WebKit::JavaScriptEvaluationResult::Value>> map()
+    HashMap<WebKit::JSObjectID, Variant<WebKit::JavaScriptEvaluationResult::EmptyType, bool, double, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>, WebKit::NodeInfo, UniqueRef<WebCore::SerializedNode>>> map()
 }
 
 [Nested] enum class WebKit::JavaScriptEvaluationResult::EmptyType : bool

--- a/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
+++ b/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
@@ -45,7 +45,7 @@ GRefPtr<JSCValue> JavaScriptEvaluationResult::toJSC()
 JSObjectID JavaScriptEvaluationResult::addObjectToMap(GVariant* variant)
 {
     auto identifier = JSObjectID::generate();
-    m_map.add(identifier, makeUniqueRef<Value>(toValue(variant)));
+    m_map.add(identifier, toValue(variant));
     return identifier;
 }
 
@@ -61,33 +61,33 @@ auto JavaScriptEvaluationResult::toValue(GVariant* variant) -> Value
             if (!key || !value)
                 continue;
             auto keyID = JSObjectID::generate();
-            m_map.add(keyID, makeUniqueRef<Value>(Value { { String::fromUTF8(key) } }));
+            m_map.add(keyID, String::fromUTF8(key));
             auto valueID = JSObjectID::generate();
-            m_map.add(valueID, makeUniqueRef<Value>(toValue(value)));
+            m_map.add(valueID, toValue(value));
             map.add(keyID, valueID);
         }
-        return { { WTFMove(map) } };
+        return { WTFMove(map) };
     }
 
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT32))
-        return { static_cast<double>(g_variant_get_uint32(variant)) };
+        return static_cast<double>(g_variant_get_uint32(variant));
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT32))
-        return { static_cast<double>(g_variant_get_int32(variant)) };
+        return static_cast<double>(g_variant_get_int32(variant));
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT64))
-        return { static_cast<double>(g_variant_get_uint64(variant)) };
+        return static_cast<double>(g_variant_get_uint64(variant));
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT64))
-        return { static_cast<double>(g_variant_get_int64(variant)) };
+        return static_cast<double>(g_variant_get_int64(variant));
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_INT16))
-        return { static_cast<double>(g_variant_get_int16(variant)) };
+        return static_cast<double>(g_variant_get_int16(variant));
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_UINT16))
-        return { static_cast<double>(g_variant_get_uint16(variant)) };
+        return static_cast<double>(g_variant_get_uint16(variant));
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_DOUBLE))
-        return { static_cast<double>(g_variant_get_double(variant)) };
+        return static_cast<double>(g_variant_get_double(variant));
 
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE_STRING))
-        return { String::fromUTF8(g_variant_get_string(variant, nullptr)) };
+        return String::fromUTF8(g_variant_get_string(variant, nullptr));
 
-    return { EmptyType::Null };
+    return EmptyType::Null;
 }
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(GVariant* variant)


### PR DESCRIPTION
#### 75c2b6c6213dae60fe4823baa5b8b3d1272cd793
<pre>
Fix Speedometer3 regression from 297895@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=296904">https://bugs.webkit.org/show_bug.cgi?id=296904</a>
<a href="https://rdar.apple.com/157213758">rdar://157213758</a>

Reviewed by Ryosuke Niwa.

When running Speedometer3, approximately 6000 JavaScriptEvaluationResults are created.
Each JavaScriptEvaluationResult contains approximately 80 Value variants.
In 297895@main I introduced an allocation and several unnecessary copies of Value.
This undoes that and solves the problem a different way, by taking the large and
uncommon alternative of the Variant and making it a UniqueRef instead of the whole Variant.
This removes about a half million allocations and copies from Speedometer3.

* Source/WTF/wtf/TZoneMalloc.h:
* Source/WebCore/dom/SerializedNode.cpp:
* Source/WebCore/dom/SerializedNode.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::toAPI):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::toValue):
(WebKit::JavaScriptEvaluationResult::toJS):
(WebKit::JavaScriptEvaluationResult::toString const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
(WebKit::JavaScriptEvaluationResult::map const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::toID):
(WebKit::JavaScriptEvaluationResult::toValue):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
* Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in:
* Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp:
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::toValue):

Canonical link: <a href="https://commits.webkit.org/298219@main">https://commits.webkit.org/298219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03bf1214ae8d20d7321b581a916508436c961d45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65390 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d7ffafd-4df4-48dc-b8d8-46749465264a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/42996 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9de446a-bcc4-48df-b23d-69c3490c254d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67572 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21125 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64530 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107080 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124056 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113256 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31143 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95989 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95771 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18793 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37782 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47092 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137466 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41159 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36752 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->