### PR TITLE
[Flex][Baseline Alignment] Fix flexbox-align-self-vert-rtl-* tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5190,11 +5190,6 @@ webkit.org/b/233196 imported/w3c/web-platform-tests/css/css-flexbox/percentage-h
 # align baseline in flexbox.
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/dynamic-baseline-change-nested.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/dynamic-baseline-change.html [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-rtl-001.xhtml [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-rtl-002.xhtml [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-rtl-003.xhtml [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-rtl-004.xhtml [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-vert-rtl-005.xhtml [ ImageOnlyFailure ]
 
 # Flex item's min|max content contributions
 webkit.org/b/230747 imported/w3c/web-platform-tests/css/css-flexbox/flex-container-max-content-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -128,8 +128,11 @@ LayoutUnit BaselineAlignmentState::synthesizedBaseline(const RenderBox& box, Fon
         boxSize += lineDirection == LineDirection::Horizontal ? box.verticalMarginExtent() : box.horizontalMarginExtent();
 
     if (baselineType == FontBaseline::Alphabetic) {
-        auto shouldTreatAsHorizontal = lineDirection == LineDirection::Horizontal
-            || (writingModeForSynthesis.isSidewaysOrientation() && writingModeForSynthesis.computedWritingMode() == StyleWritingMode::VerticalRl);
+        // When synthesizing the alphabetic baseline for a box we are determining the distance
+        // to the line-under edge. For a box with vertical-lr writing mode the location
+        // of the line-under edge should be the same as the box's block-start edge. For
+        // vertical-rl writing mode we need the box's size since they are on opposiate sides.
+        auto shouldTreatAsHorizontal = lineDirection == LineDirection::Horizontal || writingModeForSynthesis.computedWritingMode() == StyleWritingMode::VerticalRl;
         return shouldTreatAsHorizontal ? boxSize : LayoutUnit();
     }
     return boxSize / 2;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1612,8 +1612,10 @@ LayoutUnit RenderFlexibleBox::marginBoxAscentForFlexItem(const RenderBox& flexIt
 
     if (!mainAxisIsFlexItemInlineAxis(flexItem)) {
         auto flexboxWritingMode = style().writingMode();
+        auto alignmentContextAxis = style().isRowFlexDirection() ? LogicalBoxAxis::Inline : LogicalBoxAxis::Block;
+        auto writingModeForSynthesis = BaselineAlignmentState::usedWritingModeForBaselineAlignment(alignmentContextAxis, flexboxWritingMode, flexItem.writingMode());
         return BaselineAlignmentState::synthesizedBaseline(flexItem, BaselineAlignmentState::dominantBaseline(flexboxWritingMode),
-            flexboxWritingMode, direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
+            writingModeForSynthesis, direction, BaselineSynthesisEdge::BorderBox) + flowAwareMarginBeforeForFlexItem(flexItem);
     }
     auto ascent = alignmentForFlexItem(flexItem) == ItemPosition::LastBaseline ? flexItem.lastLineBaseline() : flexItem.firstLineBaseline();
     if (!ascent) {


### PR DESCRIPTION
#### 25f1db8380ce52433b580f30c232243e0bc07cf7
<pre>
[Flex][Baseline Alignment] Fix flexbox-align-self-vert-rtl-* tests
<a href="https://rdar.apple.com/157516386">rdar://157516386</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296908">https://bugs.webkit.org/show_bug.cgi?id=296908</a>

Reviewed by Alan Baradlay.

Consider the following flex content with baseline alignment which we
currently fail to align correctly:

&lt;div style=&quot;display: flex; width: 200px; flex-direction: column; direction: rtl; align-items: baseline; outline: 1px solid black;&quot;&gt;
  &lt;div style=&quot;background-color: blue;&quot;&gt;foo&lt;/div&gt;
  &lt;div style=&quot;background-color: magenta;&quot;&gt;foobarbaz&lt;/div&gt;
&lt;/div&gt;

When determining the ascent for this flex item, we call into
BaselineAlignmentState::synthesizedBaseline since we need to
synthesize a baseline for this content. This ends up returning
an incorrect value of 0 for both flex items. This baseline comes from
the fact that:

1.) We ask synthesizedBaseline to compute the alphabetic baseline since
the flexbox&apos;s writing mode is horizontal-tb.
2.) shouldTreatAsHorizontal is false since the LineDirection is
Vertical, the writing mode (which is the flexbox&apos;s writing mode) does not
have sideways orientation, and the writing mode is horizontal-tb.

In order to fix this bug, we need to make two main changes:

1.) Instead of passing in the flexbox&apos;s writing mode to
synthesizedBaseline, we should use BaselineAlignmentState::usedWritingModeForBaselineAlignment.
This is because the writing mode to determine the line under/over edges
needs to come from the CSS-align rules in
<a href="https://drafts.csswg.org/css-align-3/#baseline-export">https://drafts.csswg.org/css-align-3/#baseline-export</a>

2.) Remove the logic that checks for sideways orientation out of this
function. I introduced this logic in 257239@main and it seems like it was
used to determine which type of baseline (i.e. Alphabetic or Central) to
synthesize. Over time, this logic has moved around the function a bit and
from what I can tell, it no longer needs to live here. The type of
baseline to synthesize is now passed into the function and primarily
comes from BaselineAlignmentState::dominantBaseline.

Canonical link: <a href="https://commits.webkit.org/298667@main">https://commits.webkit.org/298667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efd554e7ce05c11722a524d0428aa71acb80aaaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66731 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba296f8f-e559-4f38-b1db-f74593b02ae8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88261 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/110fd951-d4a4-42c4-a9e5-94290d8f167c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68672 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65910 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125378 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96990 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96774 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39013 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48545 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42420 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->