### PR TITLE
Unreviewed, reverting 298217@main (e5f31421894f)

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -274,10 +274,10 @@ static MTLPixelFormat metalPixelFormat(CVPixelBufferRef pixelBuffer, size_t plan
         return biplanarFormat(plane);
 
     case kCVPixelFormatType_422YpCbCr10:     /* Component Y'CbCr 10-bit 4:2:2 */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR8_422_1P) : biplanarFormat(plane);
 
     case kCVPixelFormatType_444YpCbCr10:     /* Component Y'CbCr 10-bit 4:4:4 */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_444_1P) : biplanarFormat(plane);
 
     case kCVPixelFormatType_420YpCbCr8Planar:   /* Planar Component Y'CbCr 8-bit 4:2:0.  baseAddr points to a big-endian CVPlanarPixelBufferInfo_YCbCrPlanar struct */
         return biplanarFormat(plane);
@@ -363,17 +363,17 @@ static MTLPixelFormat metalPixelFormat(CVPixelBufferRef pixelBuffer, size_t plan
         return MTLPixelFormatDepth32Float;
 
     case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange: /* 2 plane YCbCr10 4:2:0, each 10 bits in the MSBs of 16bits, video-range (luma=[64,940] chroma=[64,960]) */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_420_2P) : biplanarFormat(plane);
     case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange: /* 2 plane YCbCr10 4:2:2, each 10 bits in the MSBs of 16bits, video-range (luma=[64,940] chroma=[64,960]) */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P) : biplanarFormat(plane);
     case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange: /* 2 plane YCbCr10 4:4:4, each 10 bits in the MSBs of 16bits, video-range (luma=[64,940] chroma=[64,960]) */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_444_2P) : biplanarFormat(plane);
     case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange: /* 2 plane YCbCr10 4:2:0, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P) : biplanarFormat(plane);
     case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange: /* 2 plane YCbCr10 4:2:2, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P) : biplanarFormat(plane);
     case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange: /* 2 plane YCbCr10 4:4:4, each 10 bits in the MSBs of 16bits, full-range (Y range 0-1023) */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_444_2P) : biplanarFormat(plane);
     case kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar: /* first and second planes as per 420YpCbCr8BiPlanarVideoRange (420v), alpha 8 bits in third plane full-range.  No CVPlanarPixelBufferInfo struct. */
         return biplanarFormat(plane);
 
@@ -400,10 +400,10 @@ static MTLPixelFormat metalPixelFormat(CVPixelBufferRef pixelBuffer, size_t plan
         return biplanarFormat(plane);
 
     case kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange: /* Lossless-compressed-packed form of case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange.  No CVPlanarPixelBufferInfo struct. Format is compressed-packed with no padding bits between pixels. */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_420_2P_PACKED) : biplanarFormat(plane);
 
     case kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarVideoRange: /* Lossless-compressed form of case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange.  No CVPlanarPixelBufferInfo struct. Format is compressed-packed with no padding bits between pixels. */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P_PACKED) : biplanarFormat(plane);
 
     case kCVPixelFormatType_Lossy_32BGRA: /* Lossy-compressed form of case kCVPixelFormatType_32BGRA. No CVPlanarPixelBufferInfo struct.  */
         return MTLPixelFormatBGRA8Unorm;
@@ -413,17 +413,17 @@ static MTLPixelFormat metalPixelFormat(CVPixelBufferRef pixelBuffer, size_t plan
         return biplanarFormat(plane);
 
     case kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange: /* Lossy-compressed form of case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange.  No CVPlanarPixelBufferInfo struct. Format is compressed-packed with no padding bits between pixels. */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_420_2P_PACKED_PQ) : biplanarFormat(plane);
 
     case kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarVideoRange: /* Lossy-compressed form of kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange.  No CVPlanarPixelBufferInfo struct. Format is compressed-packed with no padding bits between pixels. */
-        return biplanarFormat(plane);
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P_PACKED) : biplanarFormat(plane);
 
     case kCVPixelFormatType_420YpCbCr10PackedBiPlanarVideoRange:
-        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_420_2P_PACKED) : MTLPixelFormatInvalid;
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_420_2P_PACKED) : biplanarFormat(plane);
     case kCVPixelFormatType_422YpCbCr10PackedBiPlanarVideoRange:
-        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P_PACKED) : MTLPixelFormatInvalid;
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_422_2P_PACKED) : biplanarFormat(plane);
     case kCVPixelFormatType_444YpCbCr10PackedBiPlanarVideoRange:
-        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_444_2P_PACKED) : MTLPixelFormatInvalid;
+        return !plane && supportsExtendedFormats ? static_cast<MTLPixelFormat>(MTLPixelFormatYCBCR10_444_2P_PACKED) : biplanarFormat(plane);
     }
 
     return MTLPixelFormatInvalid;
@@ -521,7 +521,7 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
         auto format0 = metalPixelFormat(pixelBuffer, 0, firstPlaneSwizzle, supportsExtendedFormats);
         if (format0 != MTLPixelFormatInvalid)
             status1 = CVMetalTextureCacheCreateTextureFromImage(nullptr, m_coreVideoTextureCache.get(), pixelBuffer, nullptr, format0, CVPixelBufferGetWidthOfPlane(pixelBuffer, 0), CVPixelBufferGetHeightOfPlane(pixelBuffer, 0), 0, &plane0);
-        auto format1 = metalPixelFormat(pixelBuffer, 1, firstPlaneSwizzle, supportsExtendedFormats);
+        auto format1 = metalPixelFormat(pixelBuffer, 1, secondPlaneSwizzle, supportsExtendedFormats);
         if (format1 != MTLPixelFormatInvalid)
             status2 = CVMetalTextureCacheCreateTextureFromImage(nullptr, m_coreVideoTextureCache.get(), pixelBuffer, nullptr, format1, CVPixelBufferGetWidthOfPlane(pixelBuffer, 1), CVPixelBufferGetHeightOfPlane(pixelBuffer, 1), 1, &plane1);
     }

--- a/Source/WebGPU/WebGPU/MetalSPI.h
+++ b/Source/WebGPU/WebGPU/MetalSPI.h
@@ -35,9 +35,50 @@ DECLARE_SYSTEM_HEADER
 #import <Metal/MTLResource_Private.h>
 #import <Metal/MTLTexture_Private.h>
 #else
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_420_2P = static_cast<MTLPixelFormat>(500);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_422_1P = static_cast<MTLPixelFormat>(501);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_422_2P = static_cast<MTLPixelFormat>(502);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_444_2P = static_cast<MTLPixelFormat>(503);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_1P = static_cast<MTLPixelFormat>(504);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_420_2P = static_cast<MTLPixelFormat>(505);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_422_2P = static_cast<MTLPixelFormat>(506);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P = static_cast<MTLPixelFormat>(507);
 constexpr MTLPixelFormat MTLPixelFormatYCBCR10_420_2P_PACKED = static_cast<MTLPixelFormat>(508);
 constexpr MTLPixelFormat MTLPixelFormatYCBCR10_422_2P_PACKED = static_cast<MTLPixelFormat>(509);
 constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P_PACKED = static_cast<MTLPixelFormat>(510);
+
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_420_2P_sRGB = static_cast<MTLPixelFormat>(520);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_422_1P_sRGB = static_cast<MTLPixelFormat>(521);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_422_2P_sRGB = static_cast<MTLPixelFormat>(522);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR8_444_2P_sRGB = static_cast<MTLPixelFormat>(523);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_1P_sRGB = static_cast<MTLPixelFormat>(524);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_420_2P_sRGB = static_cast<MTLPixelFormat>(525);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_422_2P_sRGB = static_cast<MTLPixelFormat>(526);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P_sRGB = static_cast<MTLPixelFormat>(527);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_420_2P_PACKED_sRGB = static_cast<MTLPixelFormat>(528);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_422_2P_PACKED_sRGB = static_cast<MTLPixelFormat>(529);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P_PACKED_sRGB = static_cast<MTLPixelFormat>(530);
+
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_1P_PQ = static_cast<MTLPixelFormat>(563);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_420_2P_PQ = static_cast<MTLPixelFormat>(564);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_422_2P_PQ = static_cast<MTLPixelFormat>(565);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P_PQ = static_cast<MTLPixelFormat>(566);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_420_2P_PACKED_PQ = static_cast<MTLPixelFormat>(567);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_422_2P_PACKED_PQ = static_cast<MTLPixelFormat>(568);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR10_444_2P_PACKED_PQ = static_cast<MTLPixelFormat>(569);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_420_2P = static_cast<MTLPixelFormat>(570);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_422_2P = static_cast<MTLPixelFormat>(571);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_444_2P = static_cast<MTLPixelFormat>(572);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_420_2P_PQ = static_cast<MTLPixelFormat>(573);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_422_2P_PQ = static_cast<MTLPixelFormat>(574);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_444_2P_PQ = static_cast<MTLPixelFormat>(575);
+
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_420_2P_PACKED = static_cast<MTLPixelFormat>(580);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_422_2P_PACKED = static_cast<MTLPixelFormat>(581);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_444_2P_PACKED = static_cast<MTLPixelFormat>(582);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_420_2P_PACKED_PQ = static_cast<MTLPixelFormat>(583);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_422_2P_PACKED_PQ = static_cast<MTLPixelFormat>(584);
+constexpr MTLPixelFormat MTLPixelFormatYCBCR12_444_2P_PACKED_PQ = static_cast<MTLPixelFormat>(585);
 
 @protocol MTLResourceSPI <MTLResource>
 @optional


### PR DESCRIPTION
#### b6a892080dd6855f16fce9958b1a61c96506e191
<pre>
Unreviewed, reverting 298217@main (e5f31421894f)
<a href="https://bugs.webkit.org/show_bug.cgi?id=296906">https://bugs.webkit.org/show_bug.cgi?id=296906</a>
<a href="https://rdar.apple.com/157515185">rdar://157515185</a>

Reland 298022@main with x86 regression fixed

Reverted change:

    Unreviewed, reverting 298022@main (29b363550378)
    <a href="https://bugs.webkit.org/show_bug.cgi?id=296881">https://bugs.webkit.org/show_bug.cgi?id=296881</a>
    <a href="https://rdar.apple.com/157477043">rdar://157477043</a>
    298217@main (e5f31421894f)

Canonical link: <a href="https://commits.webkit.org/298224@main">https://commits.webkit.org/298224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb2725978a8f374030ae4c0225064587a062d590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65396 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6290ee0f-a055-4abc-afcc-617ab8104875) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87183 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46be3210-b8c6-4803-a9be-d5459eca1ae5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67571 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27132 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124069 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95995 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24389 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37788 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41590 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47104 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41165 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44475 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->