### PR TITLE
Fix the defaults of the SVGFEConvolveMatrixElement properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Warning: feConvolveMatrix: problem parsing order="-1.5". Filtered element will not be displayed.
 
 PASS SVGAnimatedInteger interface - utilizing the targetX property of SVGFEConvolveMatrix
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-initial-values-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderX (remove) assert_equals: initial before expected 3 but got 0
-FAIL SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderX (invalid value) assert_equals: initial before expected 3 but got 0
-FAIL SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderY (remove) assert_equals: initial before expected 3 but got 0
-FAIL SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderY (invalid value) assert_equals: initial before expected 3 but got 0
+PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderX (remove)
+PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderX (invalid value)
+PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderY (remove)
+PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.orderY (invalid value)
 PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.targetX (remove)
 PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.targetX (invalid value)
 PASS SVGAnimatedInteger, initial values, SVGFEConvolveMatrixElement.prototype.targetY (remove)

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger.html
@@ -31,5 +31,18 @@ test(function() {
   assert_equals(feConvolveMatrix.targetX.baseVal, 0);
   feConvolveMatrix.targetX.baseVal = 300;
   assert_equals(feConvolveMatrix.targetX.baseVal, 300);
+
+  // Check initial orderX value.
+  assert_true(feConvolveMatrix.orderX instanceof SVGAnimatedInteger);
+  assert_equals(typeof(feConvolveMatrix.orderX.baseVal), "number");
+  assert_equals(feConvolveMatrix.orderX.baseVal, 3);
+
+  // Check assigning various valid and invalid values.
+  feConvolveMatrix.setAttribute("order", "5");
+  assert_equals(feConvolveMatrix.orderX.baseVal, 5);
+  feConvolveMatrix.setAttribute("order", "-1.5");
+  assert_equals(feConvolveMatrix.orderX.baseVal, -1);
+  feConvolveMatrix.orderX.baseVal = -2.7;
+  assert_equals(feConvolveMatrix.orderX.baseVal, -2); // Negative values are allowed from SVG DOM, but should lead to an error when rendering (disable the filter)
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Warning: feConvolveMatrix: problem parsing kernelUnitLength="". Filtered element will not be displayed.
-CONSOLE MESSAGE: Warning: feConvolveMatrix: problem parsing kernelUnitLength="foobar". Filtered element will not be displayed.
-CONSOLE MESSAGE: Warning: feConvolveMatrix: problem parsing kernelUnitLength="". Filtered element will not be displayed.
-CONSOLE MESSAGE: Warning: feConvolveMatrix: problem parsing kernelUnitLength="foobar". Filtered element will not be displayed.
 
 FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (remove) assert_equals: initial after expected 1 but got 0
 FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (invalid value) assert_equals: initial after expected 1 but got 0
@@ -21,14 +17,14 @@ PASS SVGAnimatedNumber, initial values, SVGFECompositeElement.prototype.k3 (remo
 PASS SVGAnimatedNumber, initial values, SVGFECompositeElement.prototype.k3 (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFECompositeElement.prototype.k4 (remove)
 PASS SVGAnimatedNumber, initial values, SVGFECompositeElement.prototype.k4 (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.divisor (remove) assert_equals: initial before expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.divisor (invalid value) assert_equals: initial before expected 1 but got 0
+PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.divisor (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.divisor (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.bias (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.bias (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (invalid value)
 FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (remove) assert_equals: initial after expected 1 but got 0
 FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (invalid value) assert_equals: initial after expected 1 but got 0
 FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (remove) assert_equals: initial after expected 1 but got 0

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -101,6 +101,10 @@ public:
 private:
     SVGFEConvolveMatrixElement(const QualifiedName&, Document&);
 
+    static constexpr int initialOrderValue = 3;
+    static constexpr float initialDivisorValue = 1;
+    static constexpr float initialKernelUnitLengthValue = 0;
+
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
@@ -111,10 +115,10 @@ private:
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
     Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
-    Ref<SVGAnimatedInteger> m_orderX { SVGAnimatedInteger::create(this) };
-    Ref<SVGAnimatedInteger> m_orderY { SVGAnimatedInteger::create(this) };
+    Ref<SVGAnimatedInteger> m_orderX { SVGAnimatedInteger::create(this, initialOrderValue) };
+    Ref<SVGAnimatedInteger> m_orderY { SVGAnimatedInteger::create(this, initialOrderValue) };
     Ref<SVGAnimatedNumberList> m_kernelMatrix { SVGAnimatedNumberList::create(this) };
-    Ref<SVGAnimatedNumber> m_divisor { SVGAnimatedNumber::create(this) };
+    Ref<SVGAnimatedNumber> m_divisor { SVGAnimatedNumber::create(this, initialDivisorValue) };
     Ref<SVGAnimatedNumber> m_bias { SVGAnimatedNumber::create(this) };
     Ref<SVGAnimatedInteger> m_targetX { SVGAnimatedInteger::create(this) };
     Ref<SVGAnimatedInteger> m_targetY { SVGAnimatedInteger::create(this) };


### PR DESCRIPTION
#### 5a05da2f822997ac3c1db8e00faa5cb5d8ebed9b
<pre>
Fix the defaults of the SVGFEConvolveMatrixElement properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=203770">https://bugs.webkit.org/show_bug.cgi?id=203770</a>
<a href="https://rdar.apple.com/122586298">rdar://122586298</a>

Reviewed by Nikolas Zimmermann.

The default of &apos;divisor&apos; property should be 1.
The default of &apos;orderX&apos; and &apos;orderY&apos; properties should be 3.

SVGFEConvolveMatrixElement::parseAttribute() should set the attributes to out of
range values and handle this as an error when building the filter effect in
SVGFEConvolveMatrixElement::build().

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger-initial-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedInteger.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
(WebCore::SVGFEConvolveMatrixElement::isValidTargetXOffset const):
(WebCore::SVGFEConvolveMatrixElement::isValidTargetYOffset const):
(WebCore::SVGFEConvolveMatrixElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:

Canonical link: <a href="https://commits.webkit.org/298250@main">https://commits.webkit.org/298250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/238cbdc05d6e0c1cef4c27e9a72dde7ed651699c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65473 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/995890e4-d7f7-4274-b9f9-bd364ab66a03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a83ebfb0-d9fe-4b05-8017-e0741f012de9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/27947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67574 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64538 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124070 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/95996 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95779 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24406 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/40950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37789 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47105 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41166 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->