### PR TITLE
FragmentedSharedBuffer should always be immutable.

### DIFF
--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -74,12 +74,9 @@ std::optional<Ref<FragmentedSharedBuffer>> FragmentedSharedBuffer::fromIPCData(I
             return std::nullopt;
 
         if (useUnixDomainSockets || size < minimumPageSize) {
-            if (data.size() == 1)
-                return SharedBuffer::create(data[0]);
-            Ref sharedMemoryBuffer = FragmentedSharedBuffer::create();
-            for (auto span : data)
-                sharedMemoryBuffer->append(span);
-            return sharedMemoryBuffer;
+            SharedBufferBuilder builder;
+            builder.appendSpans(data);
+            return builder.take();
         }
         return std::nullopt;
     }, [](std::optional<WebCore::SharedMemoryHandle>&& handle) -> std::optional<Ref<FragmentedSharedBuffer>> {
@@ -93,13 +90,20 @@ std::optional<Ref<FragmentedSharedBuffer>> FragmentedSharedBuffer::fromIPCData(I
     });
 }
 
-FragmentedSharedBuffer::FragmentedSharedBuffer() = default;
-
-FragmentedSharedBuffer::FragmentedSharedBuffer(Ref<const DataSegment>&& segment, Contiguous contiguous)
+FragmentedSharedBuffer::FragmentedSharedBuffer(Ref<const DataSegment>&& segment)
     : m_size(segment->size())
     , m_segments(DataSegmentVector::from(DataSegmentVectorEntry { 0, WTFMove(segment) }))
-    , m_contiguous(contiguous == Contiguous::Yes)
+    , m_contiguous(true)
 {
+}
+
+FragmentedSharedBuffer::FragmentedSharedBuffer(size_t size, const DataSegmentVector& segments)
+    : m_size(size)
+    , m_segments(WTF::map<1>(segments, [](auto& element) {
+        return DataSegmentVectorEntry { element.beginPosition, element.segment.copyRef() };
+    }))
+{
+    ASSERT(internallyConsistent());
 }
 
 static Vector<uint8_t> combineSegmentsData(const FragmentedSharedBuffer::DataSegmentVector& segments, size_t size)
@@ -152,7 +156,7 @@ Vector<uint8_t> FragmentedSharedBuffer::takeData()
         return { };
 
     Vector<uint8_t> combinedData;
-    if (hasOneSegment() && std::holds_alternative<Vector<uint8_t>>(m_segments[0].segment->m_immutableData) && m_segments[0].segment->hasOneRef())
+    if (segmentsCount() == 1 && std::holds_alternative<Vector<uint8_t>>(m_segments[0].segment->m_immutableData) && m_segments[0].segment->hasOneRef())
         combinedData = std::exchange(std::get<Vector<uint8_t>>(const_cast<DataSegment&>(m_segments[0].segment.get()).m_immutableData), Vector<uint8_t>());
     else
         combinedData = combineSegmentsData(m_segments, m_size);
@@ -228,34 +232,6 @@ RefPtr<ArrayBuffer> FragmentedSharedBuffer::tryCreateArrayBuffer() const
     return arrayBuffer;
 }
 
-void FragmentedSharedBuffer::append(const FragmentedSharedBuffer& data)
-{
-    ASSERT(!m_contiguous || segmentsCount() + data.segmentsCount() <= 1);
-    m_segments.appendContainerWithMapping(data.m_segments, [&](auto& element) {
-        DataSegmentVectorEntry entry { m_size, element.segment.copyRef() };
-        m_size += element.segment->size();
-        return entry;
-    });
-    ASSERT(internallyConsistent());
-}
-
-void FragmentedSharedBuffer::append(std::span<const uint8_t> data)
-{
-    ASSERT(!m_contiguous || !segmentsCount());
-    m_segments.append({ m_size, DataSegment::create(data) });
-    m_size += data.size();
-    ASSERT(internallyConsistent());
-}
-
-void FragmentedSharedBuffer::append(Vector<uint8_t>&& data)
-{
-    ASSERT(!m_contiguous || !segmentsCount());
-    auto dataSize = data.size();
-    m_segments.append({ m_size, DataSegment::create(WTFMove(data)) });
-    m_size += dataSize;
-    ASSERT(internallyConsistent());
-}
-
 void FragmentedSharedBuffer::clear()
 {
     m_size = 0;
@@ -267,14 +243,7 @@ Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::copy() const
 {
     if (m_contiguous)
         return m_segments.size() ? SharedBuffer::create(m_segments[0].segment.copyRef()) : SharedBuffer::create();
-    Ref<FragmentedSharedBuffer> clone = adoptRef(*new FragmentedSharedBuffer);
-    clone->m_size = m_size;
-    clone->m_segments = WTF::map<1>(m_segments, [](auto& element) {
-        return DataSegmentVectorEntry { element.beginPosition, element.segment.copyRef() };
-    });
-    ASSERT(clone->internallyConsistent());
-    ASSERT(internallyConsistent());
-    return clone;
+    return adoptRef(*new FragmentedSharedBuffer(m_size, m_segments));
 }
 
 void FragmentedSharedBuffer::forEachSegment(NOESCAPE const Function<void(std::span<const uint8_t>)>& apply) const
@@ -400,13 +369,18 @@ bool FragmentedSharedBuffer::internallyConsistent() const
 {
     if (isContiguous() && segmentsCount() > 1)
         return false;
+    return internallyConsistent(m_size, m_segments);
+}
+
+bool FragmentedSharedBuffer::internallyConsistent(size_t size, const DataSegmentVector& segments)
+{
     size_t position = 0;
-    for (const auto& element : m_segments) {
+    for (const auto& element : segments) {
         if (element.beginPosition != position)
             return false;
         position += element.segment->size();
     }
-    return position == m_size;
+    return position == size;
 }
 #endif // ASSERT_ENABLED
 
@@ -623,26 +597,26 @@ SharedBufferBuilder& SharedBufferBuilder::operator=(RefPtr<FragmentedSharedBuffe
 void SharedBufferBuilder::initialize(Ref<FragmentedSharedBuffer>&& buffer)
 {
     ASSERT(!m_buffer);
-    // We do not want to take a reference to the SharedBuffer as all SharedBuffer should be immutable
-    // once created.
-    if (buffer->hasOneRef()) {
-        m_buffer = WTFMove(buffer);
-        return;
-    }
+    m_segments.reserveInitialCapacity(buffer->segmentsCount());
     append(buffer);
 }
 
 RefPtr<ArrayBuffer> SharedBufferBuilder::tryCreateArrayBuffer() const
 {
-    RefPtr buffer = m_buffer;
-    return buffer ? buffer->tryCreateArrayBuffer() : ArrayBuffer::tryCreate();
+    if (isEmpty())
+        return ArrayBuffer::tryCreate();
+    updateBufferIfNeeded();
+    return RefPtr { m_buffer }->tryCreateArrayBuffer();
 }
 
 Ref<FragmentedSharedBuffer> SharedBufferBuilder::take()
 {
-    if (RefPtr buffer = std::exchange(m_buffer, { }))
-        return buffer.releaseNonNull();
-    return SharedBuffer::create();
+    if (isEmpty())
+        return SharedBuffer::create();
+    updateBufferIfNeeded();
+    Ref buffer = m_buffer.releaseNonNull();
+    reset();
+    return buffer;
 }
 
 Ref<SharedBuffer> SharedBufferBuilder::takeAsContiguous()
@@ -652,15 +626,94 @@ Ref<SharedBuffer> SharedBufferBuilder::takeAsContiguous()
 
 RefPtr<ArrayBuffer> SharedBufferBuilder::takeAsArrayBuffer()
 {
-    if (!m_buffer)
+    if (isEmpty())
         return ArrayBuffer::tryCreate();
     return take()->tryCreateArrayBuffer();
 }
 
-void SharedBufferBuilder::ensureBuffer(size_t segments)
+void SharedBufferBuilder::updateBufferIfNeeded() const
 {
-    if (!m_buffer)
-        m_buffer = segments > 1 ? FragmentedSharedBuffer::create() : static_cast<Ref<FragmentedSharedBuffer>>(SharedBuffer::create());
+    if (m_state == State::Null) {
+        ASSERT(!m_buffer);
+        return;
+    }
+    if (m_state == State::Fresh)
+        return;
+    m_buffer = createBuffer();
+    m_state = State::Fresh;
+}
+
+Ref<FragmentedSharedBuffer> SharedBufferBuilder::createBuffer() const
+{
+    if (isEmpty())
+        return SharedBuffer::create();
+    if (m_segments.size() == 1)
+        return SharedBuffer::create(m_segments[0].segment.copyRef());
+    return adoptRef(*new FragmentedSharedBuffer(m_size, m_segments));
+}
+
+void SharedBufferBuilder::appendDataSegment(Ref<DataSegment>&& segment)
+{
+    m_state = State::Stale;
+    size_t size = segment->size();
+    m_segments.append(SharedBuffer::DataSegmentVectorEntry { m_size, WTFMove(segment) });
+    m_size += size;
+}
+
+void SharedBufferBuilder::append(const FragmentedSharedBuffer& data)
+{
+    m_state = State::Stale;
+    m_segments.appendContainerWithMapping(data.m_segments, [&](auto& element) {
+        SharedBuffer::DataSegmentVectorEntry entry { m_size, element.segment.copyRef() };
+        m_size += element.segment->size();
+        return entry;
+    });
+    ASSERT(FragmentedSharedBuffer::internallyConsistent(m_size, m_segments));
+}
+
+void SharedBufferBuilder::append(std::span<const uint8_t> data)
+{
+    if (data.size())
+        appendDataSegment(DataSegment::create(data));
+}
+
+void SharedBufferBuilder::append(Vector<uint8_t>&& data)
+{
+    if (data.size())
+        appendDataSegment(DataSegment::create(WTFMove(data)));
+}
+
+void SharedBufferBuilder::appendSpans(const Vector<std::span<const uint8_t>>& spans)
+{
+    m_state = State::Stale;
+    m_segments.appendContainerWithMapping(spans, [&](auto& span) {
+        SharedBuffer::DataSegmentVectorEntry entry { m_size, DataSegment::create(span) };
+        m_size += span.size();
+        return entry;
+    });
+    ASSERT(FragmentedSharedBuffer::internallyConsistent(m_size, m_segments));
+}
+
+SharedBufferBuilder::SharedBufferBuilder(const SharedBufferBuilder& other)
+    : m_state(other.m_state)
+    , m_buffer(other.m_buffer)
+    , m_size(other.m_size)
+    , m_segments(WTF::map<1>(other.m_segments, [](auto& element) {
+        return SharedBuffer::DataSegmentVectorEntry { element.beginPosition, element.segment.copyRef() };
+    }))
+{
+}
+
+SharedBufferBuilder& SharedBufferBuilder::operator=(const SharedBufferBuilder& other)
+{
+    reset();
+    m_state = other.m_state;
+    m_buffer = other.m_buffer;
+    m_size = other.m_size;
+    m_segments.appendContainerWithMapping(other.m_segments, [&](auto& element) {
+        return SharedBuffer::DataSegmentVectorEntry { element.beginPosition, element.segment.copyRef() };
+    });
+    return *this;
 }
 
 SharedBufferDataView::SharedBufferDataView(Ref<const DataSegment>&& segment, size_t positionWithinSegment, std::optional<size_t> size)

--- a/Source/WebCore/platform/cf/SharedBufferCF.cpp
+++ b/Source/WebCore/platform/cf/SharedBufferCF.cpp
@@ -69,14 +69,10 @@ void FragmentedSharedBuffer::hintMemoryNotNeededSoon() const
     }
 }
 
-void FragmentedSharedBuffer::append(CFDataRef data)
+void SharedBufferBuilder::append(CFDataRef data)
 {
-    if (data) {
-        ASSERT(!m_contiguous || !segmentsCount());
-        m_segments.append({m_size, DataSegment::create(data)});
-        m_size += CFDataGetLength(data);
-    }
-    ASSERT(internallyConsistent());
+    if (data)
+        appendDataSegment(DataSegment::create(data));
 }
 
 }

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -98,7 +98,7 @@ Ref<SharedBuffer> SharedBuffer::create(NSData *data)
     return adoptRef(*new SharedBuffer(bridge_cast(data)));
 }
 
-void FragmentedSharedBuffer::append(NSData *data)
+void SharedBufferBuilder::append(NSData *data)
 {
     return append(bridge_cast(data));
 }
@@ -128,7 +128,7 @@ RetainPtr<CMBlockBufferRef> FragmentedSharedBuffer::createCMBlockBuffer() const
         return adoptCF(partialBuffer);
     };
 
-    if (hasOneSegment() && !isEmpty())
+    if (isContiguous() && !isEmpty())
         return segmentToCMBlockBuffer(m_segments[0].segment);
 
     CMBlockBufferRef rawBlockBuffer = nullptr;

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -79,7 +79,7 @@ String ScriptBuffer::toString() const
 
 bool ScriptBuffer::containsSingleFileMappedSegment() const
 {
-    return m_buffer && m_buffer.get()->hasOneSegment() && m_buffer.get()->begin()->segment->containsMappedFileData();
+    return m_buffer.hasOneSegment() && m_buffer.begin()->segment->containsMappedFileData();
 }
 
 void ScriptBuffer::append(const String& string)

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -225,6 +225,26 @@ TEST_F(FragmentedSharedBufferTest, builder)
     EXPECT_TRUE(builder2.isEmpty());
 }
 
+TEST_F(FragmentedSharedBufferTest, builderEmptyFollowedByGet)
+{
+    SharedBufferBuilder builder;
+    EXPECT_TRUE(!builder.get());
+    builder.empty();
+    EXPECT_FALSE(!builder.get());
+}
+
+TEST_F(FragmentedSharedBufferTest, builderInPlace)
+{
+    SharedBufferBuilder builder(std::in_place, "Hello"_span, "GoodBye"_span);
+    EXPECT_FALSE(builder.isNull());
+    EXPECT_FALSE(builder.isEmpty());
+    EXPECT_FALSE(builder.isContiguous());
+    EXPECT_EQ(builder.take()->segmentsCount(), 2u);
+    EXPECT_TRUE(builder.isNull());
+    EXPECT_TRUE(builder.isEmpty());
+    EXPECT_TRUE(builder.isContiguous());
+}
+
 static void checkBufferWithLength(const uint8_t* buffer, size_t bufferLength, const char* expected, size_t length)
 {
     ASSERT_EQ(length, bufferLength);
@@ -381,7 +401,7 @@ TEST_F(FragmentedSharedBufferTest, extractData)
     auto vector = copy->extractData();
     EXPECT_TRUE(copy->isEmpty());
     EXPECT_FALSE(original->isEmpty());
-    ASSERT_TRUE(original->hasOneSegment());
+    ASSERT_EQ(original->segmentsCount(), 1u);
     EXPECT_GT(original->begin()->segment->size(), 0u);
 }
 


### PR DESCRIPTION
#### 52383c657de22cc521391fd28d9a3fb97b283281
<pre>
FragmentedSharedBuffer should always be immutable.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296798">https://bugs.webkit.org/show_bug.cgi?id=296798</a>
<a href="https://rdar.apple.com/157282731">rdar://157282731</a>

Reviewed by Gerald Squelart.

Following this change, a FragmentedSharedBuffer is now always immutable
and can never be modified once created.

The SharedBufferBuilder is the object where DataSegmentVector is now kept
and updated.

Upon call to SharedBufferBuilder::take or get, the SharedBuffer or FragmentedSharedBuffer
shared buffer will be lazily created.
Due to how ScriptBuffer uses a SharedBufferBuilder::get() we have to keep this
SharedBuffer alive until the next time a segment is added (or cleared).
This dangerous will be rectified in a follow-up change.

Covered by existing API tests and more added to broaden coverage.

Canonical link: <a href="https://commits.webkit.org/298282@main">https://commits.webkit.org/298282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10a46ee0cdcb986aa71391c61b16b83da1f9d4be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65644 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/374f8704-8546-4afc-b99e-ba59194eb0ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90d94970-43c4-4b5b-aed9-ac0fcc42b203) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67776 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64766 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124304 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96185 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42339 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99430 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Skipped layout-tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95970 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24422 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19002 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47377 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44703 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->