### PR TITLE
[Refactor] Move Functions from RenderGrid to GridLayoutFunctions.

### DIFF
--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -79,6 +79,15 @@ ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(Style::GridTrackSizingDi
 
 unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPosition& alignment);
 
+bool hasAutoMarginsInColumnAxis(const RenderBox&, WritingMode parentWritingMode);
+bool hasAutoMarginsInRowAxis(const RenderBox&, WritingMode parentWritingMode);
+
+bool hasAutoSizeInColumnAxis(const RenderBox&, WritingMode parentWritingMode);
+bool hasAutoSizeInRowAxis(const RenderBox&, WritingMode parentWritingMode);
+
+bool allowedToStretchGridItemAlongColumnAxis(const RenderBox&, ItemPosition, WritingMode);
+bool allowedToStretchGridItemAlongRowAxis(const RenderBox&, ItemPosition, WritingMode);
+
 } // namespace GridLayoutFunctions
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -256,12 +256,6 @@ private:
     StyleSelfAlignmentData alignSelfForGridItem(const RenderBox&, StretchingMode = StretchingMode::Any, const RenderStyle* = nullptr) const;
     void applyStretchAlignmentToGridItemIfNeeded(RenderBox&, GridLayoutState&);
     void applySubgridStretchAlignmentToGridItemIfNeeded(RenderBox&);
-    bool hasAutoSizeInColumnAxis(const RenderBox& gridItem) const;
-    bool hasAutoSizeInRowAxis(const RenderBox& gridItem) const;
-    inline bool allowedToStretchGridItemAlongColumnAxis(const RenderBox& gridItem) const;
-    inline bool allowedToStretchGridItemAlongRowAxis(const RenderBox& gridItem) const;
-    bool hasAutoMarginsInColumnAxis(const RenderBox&) const;
-    bool hasAutoMarginsInRowAxis(const RenderBox&) const;
     void resetAutoMarginsAndLogicalTopInColumnAxis(RenderBox& child);
     void updateAutoMarginsInColumnAxisIfNeeded(RenderBox&);
     void updateAutoMarginsInRowAxisIfNeeded(RenderBox&);


### PR DESCRIPTION
#### ef8f859c84afc15959ae8a809b6af8102a210945
<pre>
[Refactor] Move Functions from RenderGrid to GridLayoutFunctions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296962">https://bugs.webkit.org/show_bug.cgi?id=296962</a>
&lt;<a href="https://rdar.apple.com/157505974">rdar://157505974</a>&gt;

Reviewed by Sammy Gill.

The purpose of this refactor is to clarify interactions between
the  RenderGrid and individual items within RenderBox.

* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::hasAutoMarginsInColumnAxis):
(WebCore::GridLayoutFunctions::hasAutoMarginsInRowAxis):
(WebCore::GridLayoutFunctions::hasAutoSizeInColumnAxis):
(WebCore::GridLayoutFunctions::hasAutoSizeInRowAxis):
(WebCore::GridLayoutFunctions::allowedToStretchGridItemAlongColumnAxis):
(WebCore::GridLayoutFunctions::allowedToStretchGridItemAlongRowAxis):
* Source/WebCore/rendering/GridLayoutFunctions.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::canSetColumnAxisStretchRequirementForItem const):
(WebCore::RenderGrid::applyStretchAlignmentToGridItemIfNeeded):
(WebCore::RenderGrid::isBaselineAlignmentForGridItem const):
(WebCore::RenderGrid::columnAxisOffsetForGridItem const):
(WebCore::RenderGrid::rowAxisOffsetForGridItem const):
(WebCore::RenderGrid::allowedToStretchGridItemAlongColumnAxis const):
(WebCore::RenderGrid::allowedToStretchGridItemAlongRowAxis const): Deleted.
(WebCore::RenderGrid::hasAutoMarginsInColumnAxis const): Deleted.
(WebCore::RenderGrid::hasAutoMarginsInRowAxis const): Deleted.
(WebCore::RenderGrid::hasAutoSizeInColumnAxis const): Deleted.
(WebCore::RenderGrid::hasAutoSizeInRowAxis const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/298420@main">https://commits.webkit.org/298420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e86a8809d6e2634cd1e2460a42b2fe47e155790a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66015 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/49d35e02-0c10-4748-922a-5987e141dde3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2fc0984-f92c-4a17-a038-904ea8130ba6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68106 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21745 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65183 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124692 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96492 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96278 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19369 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38277 "Failed to checkout and rebase branch from PR 48943") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47817 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->