### PR TITLE
[Form Control Refresh] `accent-color` should preserve control legibility

### DIFF
--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode-expected-mismatch.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+    <body style="background: black;">
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark">
+    </head>
+    <body style="background: black;">
+        <input type="checkbox" style="accent-color: black; zoom:5;" checked>
+        <input type="radio" style="accent-color: black; zoom:5;" checked>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode-expected-mismatch.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+    <input type="checkbox" style="accent-color: white; zoom:5;" checked>
+    <input type="radio" style="accent-color: white; zoom:5;" checked>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark">
+        <style>
+            input {
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <input type="progress">
+        <input type="checkbox" checked>
+        <input type="checkbox" switch checked>
+        <input type="radio" checked>
+        <input type="range" min="0" max="4" step="1" list="datalist">
+        <input type="text" list="datalist">
+        <input type="submit" value="Submit">
+        <datalist id="datalist">
+            <option>0</option>
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+        </datalist>
+        <script>
+            if (window.testRunner)
+                window.testRunner.setWindowIsKey(false);
+        </script>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="color-scheme" content="dark">
+        <style>
+            input {
+                accent-color: black;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <input type="progress">
+        <input type="checkbox" checked>
+        <input type="checkbox" switch checked>
+        <input type="radio" checked>
+        <input type="range" min="0" max="4" step="1" list="datalist">
+        <input type="text" list="datalist">
+        <input type="submit" value="Submit">
+        <datalist id="datalist">
+            <option>0</option>
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+        </datalist>
+        <script>
+            if (window.testRunner)
+                window.testRunner.setWindowIsKey(false);
+        </script>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            input {
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <input type="progress">
+        <input type="checkbox" checked>
+        <input type="checkbox" switch checked>
+        <input type="radio" checked>
+        <input type="range" min="0" max="4" step="1" list="datalist">
+        <input type="text" list="datalist">
+        <input type="submit" value="Submit">
+        <datalist id="datalist">
+            <option>0</option>
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+        </datalist>
+        <script>
+            if (window.testRunner)
+                window.testRunner.setWindowIsKey(false);
+        </script>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            input {
+                accent-color: white;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <input type="progress">
+        <input type="checkbox" checked>
+        <input type="checkbox" switch checked>
+        <input type="radio" checked>
+        <input type="range" min="0" max="4" step="1" list="datalist">
+        <input type="text" list="datalist">
+        <input type="submit" value="Submit">
+        <datalist id="datalist">
+            <option>0</option>
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+            <option>4</option>
+        </datalist>
+        <script>
+            if (window.testRunner)
+                window.testRunner.setWindowIsKey(false);
+        </script>
+    </body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear-expected-mismatch.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+    <input type="submit" style="accent-color: white; zoom:5;">
+</html>

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -263,7 +263,7 @@ public:
     virtual void adjustTextControlInnerPlaceholderStyle(RenderStyle&, const RenderStyle&, const Element*) const { }
     virtual void adjustTextControlInnerTextStyle(RenderStyle&, const RenderStyle&, const Element*) const { }
 
-    virtual Color disabledSubmitButtonTextColor() const { return Color::black; }
+    virtual Color submitButtonTextColor(const RenderObject&) const { return Color::black; }
 
     virtual bool mayNeedBleedAvoidance(const RenderStyle&) const { return true; }
 

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -101,10 +101,14 @@ TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderSty
         }
     }
 
-    if (lineStyle.insideDisabledSubmitButton()) {
+    if (lineStyle.insideSubmitButton()) {
         RefPtr page = renderer.frame().page();
-        if (page && page->focusController().isActive()) {
-            paintStyle.fillColor = RenderTheme::singleton().disabledSubmitButtonTextColor();
+        auto focusControllerActive = true;
+#if PLATFORM(MAC)
+        focusControllerActive = page && page->focusController().isActive();
+#endif
+        if (focusControllerActive) {
+            paintStyle.fillColor = RenderTheme::singleton().submitButtonTextColor(renderer);
             return paintStyle;
         }
     }

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -61,6 +61,7 @@ public:
     WEBCORE_EXPORT static RenderThemeCocoa& singleton();
 
 #if ENABLE(FORM_CONTROL_REFRESH)
+    Color controlTintColorWithContrast(const RenderStyle&, OptionSet<StyleColorOptions>) const;
     static std::optional<RoundedShape> shapeForInteractionRegion(const RenderBox&, const FloatRect&, ShouldComputePath);
     static FloatSize inflateRectForInteractionRegion(const RenderObject&, FloatRect&);
     bool controlSupportsTints(const RenderObject&) const override;
@@ -263,7 +264,8 @@ protected:
     bool adjustTextControlInnerTextStyleForVectorBasedControls(RenderStyle&, const RenderStyle&, const Element*) const;
 
     Color buttonTextColor(OptionSet<StyleColorOptions>, bool) const;
-    Color disabledSubmitButtonTextColor() const final;
+
+    Color submitButtonTextColor(const RenderObject&) const final;
 
     bool mayNeedBleedAvoidance(const RenderStyle&) const final;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -171,6 +171,29 @@ static void drawHighContrastOutline(GraphicsContext& context, Path path, OptionS
 }
 #endif
 
+static constexpr auto controlTintLuminanceThreshold = 0.5f;
+
+static Color foregroundColorForBackgroundColor(const Color& backgroundColor)
+{
+    return backgroundColor.luminance() <= controlTintLuminanceThreshold ? WebCore::Color::white : WebCore::Color::black;
+}
+
+static Color colorWithTargetLuminance(Color color, float targetLuminance)
+{
+    // Adjust the luminance of the color while preserving its hue by converting its
+    // type to XYZA so that its Y value, which represents luminance, can be easily changed.
+
+    const auto [x, y, z, alpha] = color.toColorTypeLossy<XYZA<float, WhitePoint::D65>>().resolved();
+
+    targetLuminance = std::clamp(0.f, targetLuminance, 1.f);
+    if (y > 0.0f) {
+        const auto scale = targetLuminance / y;
+        return Color(XYZA<float, WhitePoint::D65> { x * scale, targetLuminance, z * scale, alpha });
+    }
+
+    return Color(XYZA<float, WhitePoint::D65> { targetLuminance, targetLuminance, targetLuminance, alpha });
+}
+
 #endif
 
 }
@@ -670,14 +693,14 @@ static bool controlIsFocusedWithOutlineStyleAutoForVectorBasedControls(const Ren
 
 static constexpr auto checkboxRadioBorderDisabledOpacityForVectorBasedControls = 0.5f;
 
-static Color checkboxRadioIndicatorColorForVectorBasedControls(OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
+static Color checkboxRadioIndicatorColorForVectorBasedControls(const Color& tintColor, OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
 {
+    auto indicatorColor = foregroundColorForBackgroundColor(tintColor);
 #if PLATFORM(MAC)
     const auto isWindowActive = states.contains(ControlStyle::State::WindowActive);
-    auto indicatorColor = isWindowActive ? Color::white : RenderTheme::singleton().systemColor(CSSValueAppleSystemLabel, styleColorOptions);
+    indicatorColor = isWindowActive ? indicatorColor : RenderTheme::singleton().systemColor(CSSValueAppleSystemLabel, styleColorOptions);
 #else
     UNUSED_PARAM(styleColorOptions);
-    Color indicatorColor = Color::white;
 #endif
     const auto isEnabled = states.contains(ControlStyle::State::Enabled);
 
@@ -809,27 +832,35 @@ static Color checkboxRadioBorderColorForVectorBasedControls(OptionSet<ControlSty
     return defaultBorderColor;
 }
 
+static Color adjustCheckboxRadioBackgroundColorDisabledState(const Color& backgroundColor, OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions)
+{
+#if PLATFORM(IOS_FAMILY)
+    const auto isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
+    if (PAL::currentUserInterfaceIdiomIsVision()) {
+        auto disabledBackgroundColor = RenderTheme::singleton().systemColor(isEmpty ? CSSValueWebkitControlBackground : CSSValueAppleSystemOpaqueTertiaryFill, styleColorOptions);
+        return colorCompositedOverCanvasColor(disabledBackgroundColor, styleColorOptions);
+    }
+#else
+    UNUSED_PARAM(states);
+#endif
+    auto disabledBackgroundColor = backgroundColor.colorWithAlphaMultipliedBy(checkboxRadioBorderDisabledOpacityForVectorBasedControls);
+    return colorCompositedOverCanvasColor(disabledBackgroundColor, styleColorOptions);
+}
+
 Color RenderThemeCocoa::checkboxRadioBackgroundColorForVectorBasedControls(const RenderStyle& style, OptionSet<ControlStyle::State> states, OptionSet<StyleColorOptions> styleColorOptions) const
 {
     const auto isEmpty = !states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate });
-    const auto isEnabled = states.contains(ControlStyle::State::Enabled);
-    const auto isPressed = states.contains(ControlStyle::State::Pressed);
 
     Color backgroundColor = Color::white;
+    const auto tintColor = controlTintColorWithContrast(style, styleColorOptions);
 
 #if PLATFORM(IOS_FAMILY)
     if (PAL::currentUserInterfaceIdiomIsVision()) {
-        if (isEnabled) {
-            backgroundColor = isEmpty ? Color(DisplayP3<float> { 0.835, 0.835, 0.835 }) : controlTintColor(style, styleColorOptions);
-            if (isPressed)
-                backgroundColor = platformAdjustedColorForPressedState(backgroundColor, styleColorOptions);
-        } else
-            backgroundColor = RenderTheme::singleton().systemColor(isEmpty ? CSSValueWebkitControlBackground : CSSValueAppleSystemOpaqueTertiaryFill, styleColorOptions);
-
+        backgroundColor = isEmpty ? Color(DisplayP3<float> { 0.835, 0.835, 0.835 }) : tintColor;
         return colorCompositedOverCanvasColor(backgroundColor, styleColorOptions);
     }
 
-    backgroundColor = isEmpty ? systemColor(CSSValueWebkitControlBackground, styleColorOptions) : controlTintColor(style, styleColorOptions);
+    backgroundColor = isEmpty ? systemColor(CSSValueWebkitControlBackground, styleColorOptions) : tintColor;
 #else
     const auto isWindowActive = states.contains(ControlStyle::State::WindowActive);
 
@@ -838,13 +869,8 @@ Color RenderThemeCocoa::checkboxRadioBackgroundColorForVectorBasedControls(const
     else if (!isWindowActive)
         backgroundColor = systemColor(CSSValueAppleSystemTertiaryFill, styleColorOptions);
     else
-        backgroundColor = controlTintColor(style, styleColorOptions);
+        backgroundColor = tintColor;
 #endif
-
-    if (!isEnabled)
-        backgroundColor = backgroundColor.colorWithAlphaMultipliedBy(checkboxRadioBorderDisabledOpacityForVectorBasedControls);
-    else if (isPressed)
-        backgroundColor = platformAdjustedColorForPressedState(backgroundColor, styleColorOptions);
 
     return colorCompositedOverCanvasColor(backgroundColor, styleColorOptions);
 }
@@ -1063,7 +1089,16 @@ bool RenderThemeCocoa::paintCheckboxForVectorBasedControls(const RenderObject& b
     auto styleColorOptions = box.styleColorOptions();
     auto usedZoom = box.style().usedZoom();
 
+    const auto isEnabled = controlStates.contains(ControlStyle::State::Enabled);
+    const auto isPressed = controlStates.contains(ControlStyle::State::Pressed);
+
     auto backgroundColor = checkboxRadioBackgroundColorForVectorBasedControls(box.style(), controlStates, styleColorOptions);
+    const auto indicatorColor = checkboxRadioIndicatorColorForVectorBasedControls(backgroundColor, controlStates, styleColorOptions);
+
+    if (!isEnabled)
+        backgroundColor = adjustCheckboxRadioBackgroundColorDisabledState(backgroundColor, controlStates, styleColorOptions);
+    else if (isPressed)
+        backgroundColor = platformAdjustedColorForPressedState(backgroundColor, styleColorOptions);
 
     auto checked = controlStates.contains(ControlStyle::State::Checked);
     auto indeterminate = controlStates.contains(ControlStyle::State::Indeterminate);
@@ -1135,7 +1170,7 @@ bool RenderThemeCocoa::paintCheckboxForVectorBasedControls(const RenderObject& b
         glyphPath.transform(transform);
     }
 
-    context.setFillColor(checkboxRadioIndicatorColorForVectorBasedControls(controlStates, styleColorOptions));
+    context.setFillColor(indicatorColor);
     context.fillPath(glyphPath);
 
     return true;
@@ -1167,7 +1202,16 @@ bool RenderThemeCocoa::paintRadioForVectorBasedControls(const RenderObject& box,
     const auto styleColorOptions = box.styleColorOptions();
     const auto usedZoom = box.style().usedZoom();
 
-    const auto backgroundColor = checkboxRadioBackgroundColorForVectorBasedControls(box.style(), controlStates, styleColorOptions);
+    const auto isEnabled = controlStates.contains(ControlStyle::State::Enabled);
+    const auto isPressed = controlStates.contains(ControlStyle::State::Pressed);
+
+    auto backgroundColor = checkboxRadioBackgroundColorForVectorBasedControls(box.style(), controlStates, styleColorOptions);
+    const auto indicatorColor = checkboxRadioIndicatorColorForVectorBasedControls(backgroundColor, controlStates, styleColorOptions);
+
+    if (!isEnabled)
+        backgroundColor = adjustCheckboxRadioBackgroundColorDisabledState(backgroundColor, controlStates, styleColorOptions);
+    else if (isPressed)
+        backgroundColor = platformAdjustedColorForPressedState(backgroundColor, styleColorOptions);
 
     if (isVision) {
         context.save();
@@ -1190,7 +1234,7 @@ bool RenderThemeCocoa::paintRadioForVectorBasedControls(const RenderObject& box,
         innerCircleRect.inflateX(-innerCircleRect.width() * innerInverseRatio);
         innerCircleRect.inflateY(-innerCircleRect.height() * innerInverseRatio);
 
-        context.setFillColor(checkboxRadioIndicatorColorForVectorBasedControls(controlStates, styleColorOptions));
+        context.setFillColor(indicatorColor);
         context.fillEllipse(innerCircleRect);
     } else if (!isVision) {
         const auto borderColor = checkboxRadioBorderColorForVectorBasedControls(controlStates, styleColorOptions);
@@ -1223,14 +1267,14 @@ bool RenderThemeCocoa::paintButtonForVectorBasedControls(const RenderObject& box
     Color backgroundColor;
 
     if (box.theme().isDefault(box))
-        backgroundColor = controlTintColor(box.style(), styleColorOptions);
+        backgroundColor = controlTintColorWithContrast(box.style(), styleColorOptions);
     else {
         auto isWindowActive = true;
 #if PLATFORM(MAC)
         isWindowActive = states.contains(ControlStyle::State::WindowActive);
 #endif
         if (RefPtr input = dynamicDowncast<HTMLInputElement>(box.node()); input && input->isSubmitButton() && isWindowActive)
-            backgroundColor = controlTintColor(box.style(), styleColorOptions);
+            backgroundColor = controlTintColorWithContrast(box.style(), styleColorOptions);
         else
             backgroundColor = colorCompositedOverCanvasColor(CSSValueAppleSystemOpaqueSecondaryFill, styleColorOptions);
     }
@@ -2354,14 +2398,9 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(RenderStyle& styl
     const auto styleColorOptions = element->document().styleColorOptions(&style);
 
     auto adjustStyleForSubmitButton = [&] {
+        style.setInsideSubmitButton(true);
 #if PLATFORM(MAC)
         style.setColor(buttonTextColor(styleColorOptions, isEnabled));
-        if (isEnabled)
-            style.setInsideDefaultButton(true);
-        else
-            style.setInsideDisabledSubmitButton(true);
-#else
-        style.setColor(isEnabled ? Color::white : disabledSubmitButtonTextColor());
 #endif
     };
 
@@ -2662,6 +2701,21 @@ static PathWithSize listButtonIndicatorPath(ControlSize controlSize)
     }
 }
 
+Color RenderThemeCocoa::controlTintColorWithContrast(const RenderStyle& style, const OptionSet<StyleColorOptions> styleColorOptions) const
+{
+    const auto tintColor = controlTintColor(style, styleColorOptions);
+    if (style.hasAutoAccentColor())
+        return tintColor;
+
+    const auto isDarkMode = styleColorOptions.contains(StyleColorOptions::UseDarkAppearance);
+    const auto luminance = tintColor.luminance();
+
+    if ((isDarkMode && luminance <= controlTintLuminanceThreshold) || (!isDarkMode && luminance > controlTintLuminanceThreshold))
+        return colorWithTargetLuminance(tintColor, controlTintLuminanceThreshold);
+
+    return tintColor;
+}
+
 bool RenderThemeCocoa::paintListButtonForVectorBasedControls(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
 {
     if (!formControlRefreshEnabled(box))
@@ -2709,13 +2763,14 @@ bool RenderThemeCocoa::paintListButtonForVectorBasedControls(const RenderObject&
     const auto styleColorOptions = box.styleColorOptions();
 
 #if PLATFORM(MAC)
-    auto backgroundColor = systemColor(CSSValueAppleSystemOpaqueFill, styleColorOptions);
     const auto effectiveCornerRadius = listButtonCornerRadius(controlSize) * usedZoom;
 
     const auto isWindowActive = states.contains(ControlStyle::State::WindowActive);
-    auto indicatorColor = isWindowActive ? controlTintColor(style, styleColorOptions) : systemColor(CSSValueAppleSystemSecondaryLabel, styleColorOptions);
+    auto indicatorColor = isWindowActive ? controlTintColorWithContrast(style, styleColorOptions) : systemColor(CSSValueAppleSystemSecondaryLabel, styleColorOptions);
+
+    auto backgroundColor = systemColor(CSSValueAppleSystemQuaternaryLabel, styleColorOptions);
 #else
-    auto indicatorColor = controlTintColor(style, styleColorOptions);
+    auto indicatorColor = controlTintColorWithContrast(style, styleColorOptions);
 #endif
 
     if (!isEnabled) {
@@ -2852,7 +2907,7 @@ bool RenderThemeCocoa::paintProgressBarForVectorBasedControls(const RenderObject
     }
 
     FloatRect barRect(barInlineStart, barBlockStart, barInlineSize, barBlockSize);
-    context.fillRoundedRect(FloatRoundedRect(isHorizontalWritingMode ? barRect : barRect.transposedRect(), barCornerRadii), controlTintColor(renderer.style(), styleColorOptions).colorWithAlphaMultipliedBy(alpha));
+    context.fillRoundedRect(FloatRoundedRect(isHorizontalWritingMode ? barRect : barRect.transposedRect(), barCornerRadii), controlTintColorWithContrast(renderer.style(), styleColorOptions).colorWithAlphaMultipliedBy(alpha));
 
     return true;
 }
@@ -2885,7 +2940,7 @@ constexpr auto tickLengthForVectorBasedControls = trackThicknessForVectorBasedCo
 constexpr auto defaultSliderTickRadius = trackThicknessForVectorBasedControls / 8.0;
 constexpr FloatSize sliderThumbSize = { 24.f, 16.f };
 
-static void paintSliderTicksForVectorBasedControls(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect, bool isThumbVisible)
+static void paintSliderTicksForVectorBasedControls(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect, bool isThumbVisible, const Color& tickColorOn, const Color& tickColorOff)
 {
     // FIXME: RenderTheme{Mac,IOS}::sliderTickSize() and RenderThemeIOS{Mac,IOS}::sliderTickOffsetFromTrackCenter() need to be updated.
 
@@ -2917,7 +2972,6 @@ static void paintSliderTicksForVectorBasedControls(const RenderObject& box, cons
     GraphicsContextStateSaver stateSaver(context);
 
     auto value = input->valueAsNumber();
-    auto styleColorOptions = box.styleColorOptions();
 
     bool isInlineFlipped = (!isHorizontal && box.writingMode().isHorizontal()) || box.writingMode().isInlineFlipped();
     FloatRect layoutRectForTicks(rect);
@@ -2936,11 +2990,7 @@ static void paintSliderTicksForVectorBasedControls(const RenderObject& box, cons
         layoutRectForTicks.setY(rect.y() + tickMargin);
     }
 
-    Color tickColorOff = styleColorOptions.contains(StyleColorOptions::UseDarkAppearance) ? SRGBA<uint8_t> { 80, 80, 80 } : SRGBA<uint8_t> { 173, 173, 174 };
-
-    float alpha = 1.0f;
-    if (!RenderTheme::singleton().isEnabled(box))
-        alpha = kDisabledControlAlpha;
+    float alpha = RenderTheme::singleton().isEnabled(box) ? 1.0f : kDisabledControlAlpha;
 
     for (auto& optionElement : dataList->suggestions()) {
         if (auto optionValue = input->listOptionValueAsDouble(optionElement)) {
@@ -2967,7 +3017,7 @@ static void paintSliderTicksForVectorBasedControls(const RenderObject& box, cons
             else
                 tickRect.setWidth(tickRect.height());
 
-            const auto tickColor = (value >= *optionValue) ? Color::white : tickColorOff;
+            const auto tickColor = (value >= *optionValue) ? tickColorOn : tickColorOff;
             context.setFillColor(tickColor.colorWithAlphaMultipliedBy(alpha));
             context.fillEllipse(tickRect);
         }
@@ -3046,10 +3096,11 @@ bool RenderThemeCocoa::paintSliderTrackForVectorBasedControls(const RenderObject
 
 #if PLATFORM(MAC)
     const auto isWindowActive = states.contains(ControlStyle::State::WindowActive);
-    auto fillColor = isWindowActive ? controlTintColor(box.style(), styleColorOptions) : systemColor(CSSValueAppleSystemTertiaryLabel, styleColorOptions);
+    auto fillColor = isWindowActive ? controlTintColorWithContrast(box.style(), styleColorOptions) : systemColor(CSSValueAppleSystemTertiaryLabel, styleColorOptions);
 #else
-    auto fillColor = controlTintColor(box.style(), styleColorOptions);
+    auto fillColor = controlTintColorWithContrast(box.style(), styleColorOptions);
 #endif
+    auto unadjustedFillColor = fillColor;
 
     if (!isEnabled) {
         trackColor = trackColor.colorWithAlphaMultipliedBy(kDisabledControlAlpha);
@@ -3110,8 +3161,15 @@ bool RenderThemeCocoa::paintSliderTrackForVectorBasedControls(const RenderObject
 
     FloatRoundedRect fillRect(trackClip, fillCornerRadii);
     context.fillRoundedRect(fillRect, fillColor);
-    if (hasTicks)
-        paintSliderTicksForVectorBasedControls(box, paintInfo, rect, isThumbVisible);
+    if (hasTicks) {
+        auto tickColorOn = foregroundColorForBackgroundColor(unadjustedFillColor);
+        tickColorOn = isEnabled ? tickColorOn : tickColorOn.colorWithAlphaMultipliedBy(kDisabledControlAlpha);
+
+        const auto cssValueForTickOffColor = isEnabled ? CSSValueAppleSystemTertiaryLabel : CSSValueAppleSystemQuaternaryLabel;
+        const auto tickColorOff = systemColor(cssValueForTickOffColor, box.styleColorOptions());
+
+        paintSliderTicksForVectorBasedControls(box, paintInfo, rect, isThumbVisible, tickColorOn, tickColorOff);
+    }
 
     return true;
 }
@@ -3662,9 +3720,21 @@ bool RenderThemeCocoa::adjustTextControlInnerTextStyleForVectorBasedControls(Ren
     return true;
 }
 
-Color RenderThemeCocoa::disabledSubmitButtonTextColor() const
+Color RenderThemeCocoa::submitButtonTextColor(const RenderObject& box) const
 {
-    static constexpr auto textColor = SRGBA<uint8_t> { 255, 255, 255, 204 }; // opacity 0.8f
+    auto isEnabled = true;
+    if (CheckedPtr controlRenderer = box.parent()) {
+        if ((controlRenderer = controlRenderer->parent())) {
+            const auto states = extractControlStyleStatesForRenderer(*controlRenderer.get());
+            isEnabled = states.contains(ControlStyle::State::Enabled);
+        }
+    }
+
+    const auto tintColor = controlTintColorWithContrast(box.style(), box.styleColorOptions());
+    auto textColor = foregroundColorForBackgroundColor(tintColor);
+    if (!isEnabled)
+        textColor = textColor.colorWithAlphaMultipliedBy(textColor != Color::white ? 0.3f : 0.6f);
+
     return textColor;
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1279,7 +1279,7 @@ static bool rareInheritedDataChangeRequiresRepaint(const StyleRareInheritedData&
         || first.imageRendering != second.imageRendering
         || first.accentColor != second.accentColor
         || first.insideDefaultButton != second.insideDefaultButton
-        || first.insideDisabledSubmitButton != second.insideDisabledSubmitButton
+        || first.insideSubmitButton != second.insideSubmitButton
 #if ENABLE(DARK_MODE_CSS)
         || first.colorScheme != second.colorScheme
 #endif

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2373,8 +2373,8 @@ public:
     inline bool insideDefaultButton() const;
     inline void setInsideDefaultButton(bool);
 
-    inline bool insideDisabledSubmitButton() const;
-    inline void setInsideDisabledSubmitButton(bool);
+    inline bool insideSubmitButton() const;
+    inline void setInsideSubmitButton(bool);
 
 private:
     struct NonInheritedFlags {

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -897,7 +897,7 @@ inline Style::Color RenderStyle::tapHighlightColor() const { return m_rareInheri
 
 inline bool RenderStyle::insideDefaultButton() const { return m_rareInheritedData->insideDefaultButton; }
 
-inline bool RenderStyle::insideDisabledSubmitButton() const { return m_rareInheritedData->insideDisabledSubmitButton; }
+inline bool RenderStyle::insideSubmitButton() const { return m_rareInheritedData->insideSubmitButton; }
 
 inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) const
 {

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -400,7 +400,7 @@ inline void RenderStyle::setTapHighlightColor(Style::Color&& color) { SET(m_rare
 
 inline void RenderStyle::setInsideDefaultButton(bool value) { SET(m_rareInheritedData, insideDefaultButton, value); }
 
-inline void RenderStyle::setInsideDisabledSubmitButton(bool value) { SET(m_rareInheritedData, insideDisabledSubmitButton, value); }
+inline void RenderStyle::setInsideSubmitButton(bool value) { SET(m_rareInheritedData, insideSubmitButton, value); }
 
 inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(PseudoIdSet pseudoIdSet)
 {

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -147,7 +147,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , usedContentVisibility(static_cast<unsigned>(ContentVisibility::Visible))
     , autoRevealsWhenFound(false)
     , insideDefaultButton(false)
-    , insideDisabledSubmitButton(false)
+    , insideSubmitButton(false)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(static_cast<unsigned>(AppleVisualEffect::None))
 #endif
@@ -251,7 +251,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , usedContentVisibility(o.usedContentVisibility)
     , autoRevealsWhenFound(o.autoRevealsWhenFound)
     , insideDefaultButton(o.insideDefaultButton)
-    , insideDisabledSubmitButton(o.insideDisabledSubmitButton)
+    , insideSubmitButton(o.insideSubmitButton)
 #if HAVE(CORE_MATERIAL)
     , usedAppleVisualEffectForSubtree(o.usedAppleVisualEffectForSubtree)
 #endif
@@ -383,7 +383,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && effectiveInert == o.effectiveInert
         && usedContentVisibility == o.usedContentVisibility
         && insideDefaultButton == o.insideDefaultButton
-        && insideDisabledSubmitButton == o.insideDisabledSubmitButton
+        && insideSubmitButton == o.insideSubmitButton
 #if HAVE(CORE_MATERIAL)
         && usedAppleVisualEffectForSubtree == o.usedAppleVisualEffectForSubtree
 #endif
@@ -512,7 +512,7 @@ void StyleRareInheritedData::dumpDifferences(TextStream& ts, const StyleRareInhe
     LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, usedContentVisibility);
 
     LOG_IF_DIFFERENT_WITH_CAST(bool, insideDefaultButton);
-    LOG_IF_DIFFERENT_WITH_CAST(bool, insideDisabledSubmitButton);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, insideSubmitButton);
 
 #if HAVE(CORE_MATERIAL)
     LOG_IF_DIFFERENT_WITH_CAST(AppleVisualEffect, usedAppleVisualEffectForSubtree);

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -191,7 +191,7 @@ public:
     PREFERRED_TYPE(ContentVisibility) unsigned usedContentVisibility : 2;
     PREFERRED_TYPE(bool) unsigned autoRevealsWhenFound : 1;
     PREFERRED_TYPE(bool) unsigned insideDefaultButton : 1;
-    PREFERRED_TYPE(bool) unsigned insideDisabledSubmitButton : 1;
+    PREFERRED_TYPE(bool) unsigned insideSubmitButton : 1;
 #if HAVE(CORE_MATERIAL)
     PREFERRED_TYPE(AppleVisualEffect) unsigned usedAppleVisualEffectForSubtree : 4;
 #endif


### PR DESCRIPTION
#### 4f0c0eb24e9b1b2d4d6e69d6f2b6b60a8420a0e8
<pre>
[Form Control Refresh] `accent-color` should preserve control legibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=244233">https://bugs.webkit.org/show_bug.cgi?id=244233</a>
<a href="https://rdar.apple.com/99018889">rdar://99018889</a>

Reviewed by Aditya Keerthi.

When form control refresh is enabled, controls with tint color now preserve
legibility regardless of any set `accent-color`. To ensure that all controls can display
the same accent-colors, while also taking into account the fact that some controls
may not be able to use certain accent-colors without extensive changes to other parts
of the contol, the visual accent-color is bounded based on whether light mode or dark
mode is being used. In light mode, accent-colors with a luminance greater than 0.5
will have their luminance lowered to 0.5. In dark mode, accent-colors with a luminance
less than or equal to 0.5 will have their luminance increased to 0.5. For both
operations, the color&apos;s hue is preserved.

Additionally, checkboxes and radio buttons will now use a dark indicator in
cases where the accent-color luminance is greater than 0.5.

The threshold of 0.5 luminance was chosen to match AppKit&apos;s threshold for switching
indicator colors for checkboxes and radio buttons.

`setInsideDisabledSubmitButton` is now `setInsideSubmitButton` and is applied to
all submit buttons, regardless of enabled/disabled state in order to properly set
the text color based on enablement, the window active state, and the controls tint
color in order to preserve contrast.

Affected controls:
* &lt;input type=range&gt; (sliders)
* &lt;input type=checkbox&gt;
* &lt;input type=radio&gt;
* &lt;input type=text list=somedatalist&gt; (list buttons)
* &lt;input type=&quot;submit&quot;&gt;
* &lt;progress&gt;

* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-dark-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-checkbox-radio-do-not-disappear-light-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode-expected.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode-expected.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html: Added.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::submitButtonTextColor const):
(WebCore::RenderTheme::disabledSubmitButtonTextColor const): Deleted.
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::foregroundColorForBackgroundColor):
(WebCore::colorWithTargetLuminance):
(WebCore::checkboxRadioIndicatorColorForVectorBasedControls):
(WebCore::adjustCheckboxRadioBackgroundColorDisabledState):
(WebCore::RenderThemeCocoa::checkboxRadioBackgroundColorForVectorBasedControls const):
(WebCore::RenderThemeCocoa::paintCheckboxForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintRadioForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::adjustButtonStyleForVectorBasedControls const):
(WebCore::RenderThemeCocoa::controlTintColorWithContrast const):
(WebCore::RenderThemeCocoa::paintListButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintProgressBarForVectorBasedControls):
(WebCore::paintSliderTicksForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintSliderTrackForVectorBasedControls):
(WebCore::RenderThemeCocoa::submitButtonTextColor const):
(WebCore::RenderThemeCocoa::disabledSubmitButtonTextColor const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareInheritedDataChangeRequiresRepaint):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::insideSubmitButton const):
(WebCore::RenderStyle::insideDisabledSubmitButton const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setInsideSubmitButton):
(WebCore::RenderStyle::setInsideDisabledSubmitButton): Deleted.
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
(WebCore::StyleRareInheritedData::dumpDifferences const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/298318@main">https://commits.webkit.org/298318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a8e48e24c5eedf197daa1d36ae30de5ba9438a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25346 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121260 "Failed to checkout and rebase branch from PR 48944") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/65774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea0cabec-d8a2-47f3-a163-298d490a8e70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43423 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/121260 "Failed to checkout and rebase branch from PR 48944") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/65774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eec31269-1d26-4507-a071-14eed1e99ab2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118097 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/28307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/103378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/121260 "Failed to checkout and rebase branch from PR 48944") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/27475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/21498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64915 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/97691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/21615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42110 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/31502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/124446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42481 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/99568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/41287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18417 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47529 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/41518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/44840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->