### PR TITLE
[Form control refresh] Submit buttons should not use bold text on iOS

### DIFF
--- a/LayoutTests/platform/ios-18/editing/selection/3690703-2-expected.txt
+++ b/LayoutTests/platform/ios-18/editing/selection/3690703-2-expected.txt
@@ -83,14 +83,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (189,0) size 400x42 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 400x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                   RenderBR {BR} at (399,-1) size 1x19
-                  RenderButton {INPUT} at (86,21) size 106x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 82x14
-                      RenderText at (0,0) size 82x14
-                        text run at (0,0) width 82: "Google Search"
-                  RenderButton {INPUT} at (191,21) size 123x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 98x14
-                      RenderText at (0,0) size 98x14
-                        text run at (0,0) width 98: "I'm Feeling Lucky"
+                  RenderButton {INPUT} at (91,21) size 102x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 77x14
+                      RenderText at (0,0) size 77x14
+                        text run at (0,0) width 77: "Google Search"
+                  RenderButton {INPUT} at (192,21) size 116x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 92x14
+                      RenderText at (0,0) size 92x14
+                        text run at (0,0) width 92: "I'm Feeling Lucky"
                 RenderTableCell {TD} at (588,0) size 193x39 [r=0 c=2 rs=1 cs=1]
                   RenderInline {FONT} at (0,0) size 76x38
                     RenderText {#text} at (0,0) size 5x12

--- a/LayoutTests/platform/ios-18/editing/selection/3690703-expected.txt
+++ b/LayoutTests/platform/ios-18/editing/selection/3690703-expected.txt
@@ -85,14 +85,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (189,0) size 400x42 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 400x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                   RenderBR {BR} at (399,-1) size 1x19
-                  RenderButton {INPUT} at (86,21) size 106x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 82x14
-                      RenderText at (0,0) size 82x14
-                        text run at (0,0) width 82: "Google Search"
-                  RenderButton {INPUT} at (191,21) size 123x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 98x14
-                      RenderText at (0,0) size 98x14
-                        text run at (0,0) width 98: "I'm Feeling Lucky"
+                  RenderButton {INPUT} at (91,21) size 102x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 77x14
+                      RenderText at (0,0) size 77x14
+                        text run at (0,0) width 77: "Google Search"
+                  RenderButton {INPUT} at (192,21) size 116x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 92x14
+                      RenderText at (0,0) size 92x14
+                        text run at (0,0) width 92: "I'm Feeling Lucky"
                 RenderTableCell {TD} at (588,0) size 193x39 [r=0 c=2 rs=1 cs=1]
                   RenderInline {FONT} at (0,0) size 76x38
                     RenderText {#text} at (0,0) size 5x12

--- a/LayoutTests/platform/ios-18/editing/selection/3690719-expected.txt
+++ b/LayoutTests/platform/ios-18/editing/selection/3690719-expected.txt
@@ -77,14 +77,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (189,0) size 400x42 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 400x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                   RenderBR {BR} at (399,-1) size 1x19
-                  RenderButton {INPUT} at (86,21) size 106x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 82x14
-                      RenderText at (0,0) size 82x14
-                        text run at (0,0) width 82: "Google Search"
-                  RenderButton {INPUT} at (191,21) size 123x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 98x14
-                      RenderText at (0,0) size 98x14
-                        text run at (0,0) width 98: "I'm Feeling Lucky"
+                  RenderButton {INPUT} at (91,21) size 102x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 77x14
+                      RenderText at (0,0) size 77x14
+                        text run at (0,0) width 77: "Google Search"
+                  RenderButton {INPUT} at (192,21) size 116x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 92x14
+                      RenderText at (0,0) size 92x14
+                        text run at (0,0) width 92: "I'm Feeling Lucky"
                 RenderTableCell {TD} at (588,0) size 193x39 [r=0 c=2 rs=1 cs=1]
                   RenderInline {FONT} at (0,0) size 76x38
                     RenderText {#text} at (0,0) size 5x12

--- a/LayoutTests/platform/ios-18/editing/selection/4397952-expected.txt
+++ b/LayoutTests/platform/ios-18/editing/selection/4397952-expected.txt
@@ -13,11 +13,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 271: "This tests caret movement across buttons. "
           text run at (270,0) width 308: "The caret should be just after the second button."
       RenderBlock {DIV} at (0,36) size 784x20
-        RenderButton {INPUT} at (0,0) size 45x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 21x14
-            RenderText at (0,0) size 21x14
-              text run at (0,0) width 21: "Foo"
-        RenderButton {INPUT} at (44,0) size 43x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+        RenderButton {INPUT} at (0,0) size 44x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 20x14
+            RenderText at (0,0) size 20x14
+              text run at (0,0) width 20: "Foo"
+        RenderButton {INPUT} at (43,0) size 43x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
           RenderBlock (anonymous) at (12,3) size 18x14
             RenderText at (0,0) size 18x14
               text run at (0,0) width 18: "Bar"

--- a/LayoutTests/platform/ios-18/fast/css/margin-top-bottom-dynamic-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/css/margin-top-bottom-dynamic-expected.txt
@@ -35,16 +35,16 @@ layer at (0,0) size 800x600
             text run at (1,1) width 86: "Lorem ipsum"
       RenderBlock (anonymous) at (0,288) size 784x41
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 116x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 92x14
-            RenderText at (0,0) size 92x14
-              text run at (0,0) width 92: "Negative margin"
-        RenderText {#text} at (115,20) size 5x19
-          text run at (115,20) width 5: " "
-        RenderButton {INPUT} at (119,21) size 111x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 87x14
-            RenderText at (0,0) size 87x14
-              text run at (0,0) width 87: "Positive margin"
+        RenderButton {INPUT} at (0,21) size 110x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 86x14
+            RenderText at (0,0) size 86x14
+              text run at (0,0) width 86: "Negative margin"
+        RenderText {#text} at (109,20) size 5x19
+          text run at (109,20) width 5: " "
+        RenderButton {INPUT} at (113,21) size 105x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 81x14
+            RenderText at (0,0) size 81x14
+              text run at (0,0) width 81: "Positive margin"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,345) size 784x20
         RenderText {#text} at (0,0) size 458x19
@@ -58,14 +58,14 @@ layer at (0,0) size 800x600
             text run at (1,1) width 86: "Lorem ipsum"
       RenderBlock (anonymous) at (0,457) size 784x41
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 116x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 92x14
-            RenderText at (0,0) size 92x14
-              text run at (0,0) width 92: "Negative margin"
-        RenderText {#text} at (115,20) size 5x19
-          text run at (115,20) width 5: " "
-        RenderButton {INPUT} at (119,21) size 111x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 87x14
-            RenderText at (0,0) size 87x14
-              text run at (0,0) width 87: "Positive margin"
+        RenderButton {INPUT} at (0,21) size 110x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 86x14
+            RenderText at (0,0) size 86x14
+              text run at (0,0) width 86: "Negative margin"
+        RenderText {#text} at (109,20) size 5x19
+          text run at (109,20) width 5: " "
+        RenderButton {INPUT} at (113,21) size 105x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 81x14
+            RenderText at (0,0) size 81x14
+              text run at (0,0) width 81: "Positive margin"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios-18/fast/forms/001-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/001-expected.txt
@@ -43,12 +43,12 @@ layer at (0,0) size 800x695
         RenderTable {TABLE} at (0,0) size 784x86 [border: (2px outset #000000)]
           RenderTableSection {TBODY} at (2,2) size 780x82
             RenderTableRow {TR} at (0,0) size 780x82
-              RenderTableCell {TD} at (0,0) size 115x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 113x80 [color=#FFFFFF] [bgcolor=#007AFF] [border: (40px solid #FF0000)]
-                  RenderBlock (anonymous) at (46,40) size 21x14
-                    RenderText at (0,0) size 21x14
-                      text run at (0,0) width 21: "Foo"
-              RenderTableCell {TD} at (114,40) size 666x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (0,0) size 114x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 112x80 [color=#FFFFFF] [bgcolor=#007AFF] [border: (40px solid #FF0000)]
+                  RenderBlock (anonymous) at (46,40) size 20x14
+                    RenderText at (0,0) size 20x14
+                      text run at (0,0) width 20: "Foo"
+              RenderTableCell {TD} at (113,40) size 667x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
         RenderTable {TABLE} at (0,86) size 784x86 [border: (2px outset #000000)]
           RenderTableSection {TBODY} at (2,2) size 780x82
             RenderTableRow {TR} at (0,0) size 780x82

--- a/LayoutTests/platform/ios-18/fast/forms/blankbuttons-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/blankbuttons-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {INPUT} at (0,0) size 64x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,3) size 40x14
-          RenderText at (0,0) size 40x14
-            text run at (0,0) width 40: "Submit"
-      RenderBR {BR} at (63,-1) size 1x19
+      RenderButton {INPUT} at (0,0) size 61x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (12,3) size 37x14
+          RenderText at (0,0) size 37x14
+            text run at (0,0) width 37: "Submit"
+      RenderBR {BR} at (60,-1) size 1x19
       RenderButton {INPUT} at (0,20) size 54x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
         RenderBlock (anonymous) at (12,3) size 30x14
           RenderText at (0,0) size 30x14

--- a/LayoutTests/platform/ios-18/fast/forms/button-default-title-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/button-default-title-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 800x670
       RenderBlock (anonymous) at (0,77) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
           RenderBlock (anonymous) at (7,3) size 66x15
-            RenderText at (13,0) size 40x14
-              text run at (13,0) width 40: "Submit"
+            RenderText at (14,0) size 38x14
+              text run at (14,0) width 38: "Submit"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,114) size 784x21
         RenderText {#text} at (0,0) size 300x19
@@ -21,8 +21,8 @@ layer at (0,0) size 800x670
       RenderBlock (anonymous) at (0,150) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
           RenderBlock (anonymous) at (7,3) size 66x15
-            RenderText at (22,0) size 22x14
-              text run at (22,0) width 22: "Foo"
+            RenderText at (23,0) size 20x14
+              text run at (23,0) width 20: "Foo"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,187) size 784x21
         RenderText {#text} at (0,0) size 316x19

--- a/LayoutTests/platform/ios-18/fast/forms/formmove3-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/formmove3-expected.txt
@@ -11,15 +11,15 @@ layer at (0,0) size 800x600
           RenderInline {A} at (0,0) size 0x0
             RenderText {#text} at (0,0) size 0x0
         RenderBlock (anonymous) at (0,0) size 784x26
-          RenderTable {TABLE} at (0,0) size 73x26
-            RenderTableSection {TBODY} at (0,0) size 73x26
-              RenderTableRow {TR} at (0,2) size 73x22
+          RenderTable {TABLE} at (0,0) size 71x26
+            RenderTableSection {TBODY} at (0,0) size 71x26
+              RenderTableRow {TR} at (0,2) size 71x22
                 RenderTableCell {TD} at (2,12) size 2x2 [r=0 c=0 rs=1 cs=1]
-                RenderTableCell {TD} at (6,2) size 65x22 [r=0 c=1 rs=1 cs=1]
-                  RenderButton {INPUT} at (1,1) size 63x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 39x14
-                      RenderText at (0,0) size 39x14
-                        text run at (0,0) width 39: "Search"
+                RenderTableCell {TD} at (6,2) size 63x22 [r=0 c=1 rs=1 cs=1]
+                  RenderButton {INPUT} at (1,1) size 61x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 37x14
+                      RenderText at (0,0) size 37x14
+                        text run at (0,0) width 37: "Search"
         RenderBlock (anonymous) at (0,26) size 784x0
           RenderInline {A} at (0,0) size 0x0
           RenderInline {A} at (0,0) size 0x0 [color=#0000EE]

--- a/LayoutTests/platform/ios-18/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/input-appearance-height-expected.txt
@@ -59,12 +59,12 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (87,152) size 1x20
         RenderText {#text} at (0,173) size 48x20
           text run at (0,173) width 48: "submit "
-        RenderButton {INPUT} at (47,174) size 65x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 40x14
-            RenderText at (0,0) size 40x14
-              text run at (0,0) width 40: "Submit"
+        RenderButton {INPUT} at (47,174) size 62x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 37x14
+            RenderText at (0,0) size 37x14
+              text run at (0,0) width 37: "Submit"
         RenderText {#text} at (0,0) size 0x0
-        RenderBR {BR} at (111,173) size 1x20
+        RenderBR {BR} at (108,173) size 1x20
         RenderText {#text} at (0,194) size 51x20
           text run at (0,194) width 51: "isindex "
         RenderTextControl {INPUT} at (50,195) size 156x23 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]

--- a/LayoutTests/platform/ios-18/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/forms/targeted-frame-submission-expected.txt
@@ -4,10 +4,10 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {FORM} at (0,0) size 784x20
-        RenderButton {INPUT} at (0,0) size 51x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 27x14
-            RenderText at (0,0) size 27x14
-              text run at (0,0) width 27: "form"
+        RenderButton {INPUT} at (0,0) size 49x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 25x14
+            RenderText at (0,0) size 25x14
+              text run at (0,0) width 25: "form"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,36) size 784x40
         RenderText {#text} at (0,0) size 778x39

--- a/LayoutTests/platform/ios-18/fast/replaced/width100percent-button-expected.txt
+++ b/LayoutTests/platform/ios-18/fast/replaced/width100percent-button-expected.txt
@@ -33,21 +33,21 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,84) size 784x24
         RenderTableSection {TBODY} at (0,0) size 784x24
           RenderTableRow {TR} at (0,1) size 784x22
-            RenderTableCell {TD} at (1,1) size 77x22 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 75x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 51x14
-                  RenderText at (0,0) size 51x14
-                    text run at (0,0) width 51: "New Mail"
-            RenderTableCell {TD} at (78,1) size 58x22 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 56x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 32x14
-                  RenderText at (0,0) size 32x14
-                    text run at (0,0) width 32: "Reply"
-            RenderTableCell {TD} at (136,1) size 76x22 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 73x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 49x14
-                  RenderText at (0,0) size 49x14
-                    text run at (0,0) width 49: "Reply All"
-            RenderTableCell {TD} at (212,1) size 571x22 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (1,1) size 74x22 [r=0 c=0 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 72x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 48x14
+                  RenderText at (0,0) size 48x14
+                    text run at (0,0) width 48: "New Mail"
+            RenderTableCell {TD} at (75,1) size 56x22 [r=0 c=1 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 54x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 30x14
+                  RenderText at (0,0) size 30x14
+                    text run at (0,0) width 30: "Reply"
+            RenderTableCell {TD} at (131,1) size 73x22 [r=0 c=2 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 70x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 46x14
+                  RenderText at (0,0) size 46x14
+                    text run at (0,0) width 46: "Reply All"
+            RenderTableCell {TD} at (204,1) size 579x22 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x19
                 text run at (1,1) width 4: " "

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug1188-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug1188-expected.txt
@@ -12,24 +12,24 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (0,0) size 0x0
             RenderTableRow {TR} at (0,48) size 600x55
               RenderTableCell {TD} at (2,55) size 595x41 [bgcolor=#99CCCC] [r=1 c=0 rs=1 cs=3]
-                RenderInline {FONT} at (48,11) size 128x16
-                  RenderInline {B} at (48,11) size 128x16
-                    RenderText {#text} at (48,11) size 128x16
-                      text run at (48,4) width 128: "Search the Web with"
-                RenderText {#text} at (175,8) size 5x20
-                  text run at (175,1) width 5: " "
-                RenderMenuList {SELECT} at (179,9) size 75x21 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderInline {FONT} at (49,11) size 128x16
+                  RenderInline {B} at (49,11) size 128x16
+                    RenderText {#text} at (49,11) size 128x16
+                      text run at (49,4) width 128: "Search the Web with"
+                RenderText {#text} at (176,8) size 5x20
+                  text run at (176,1) width 5: " "
+                RenderMenuList {SELECT} at (180,9) size 75x21 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                   RenderBlock (anonymous) at (6,3) size 62x14
                     RenderText at (0,0) size 50x14
                       text run at (0,0) width 50: "Netscape"
-                RenderTextControl {INPUT} at (253,9) size 226x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-                RenderText {#text} at (478,8) size 5x20
-                  text run at (478,1) width 5: " "
-                RenderButton {INPUT} at (482,9) size 64x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 39x14
-                    RenderText at (0,0) size 39x14
-                      text run at (0,0) width 39: "Search"
-                RenderBR {BR} at (545,8) size 1x20
+                RenderTextControl {INPUT} at (254,9) size 226x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+                RenderText {#text} at (479,8) size 5x20
+                  text run at (479,1) width 5: " "
+                RenderButton {INPUT} at (483,9) size 62x21 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 37x14
+                    RenderText at (0,0) size 37x14
+                      text run at (0,0) width 37: "Search"
+                RenderBR {BR} at (544,8) size 1x20
                 RenderInline {SMALL} at (13,30) size 568x16
                   RenderInline {A} at (13,30) size 101x16 [color=#0000EE]
                     RenderText {#text} at (13,30) size 101x16
@@ -137,5 +137,5 @@ layer at (0,0) size 800x600
                       RenderTableCell {TD} at (0,0) size 0x0 [r=0 c=0 rs=1 cs=1]
 layer at (8,8) size 602x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 602x2 [color=#808080] [border: (1px inset #808080)]
-layer at (270,78) size 211x14
+layer at (271,78) size 211x14
   RenderBlock {DIV} at (6,3) size 213x15

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug1318-expected.txt
@@ -18,32 +18,32 @@ layer at (0,0) size 800x600
                 RenderBR {BR} at (392,61) size 1x19
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,82) size 784x24
-            RenderTableCell {TD} at (0,85) size 534x18 [r=1 c=0 rs=1 cs=1]
-              RenderInline {FONT} at (392,4) size 141x15
-                RenderText {#text} at (392,4) size 141x15
-                  text run at (392,1) width 141: "I agree with the program"
+            RenderTableCell {TD} at (0,85) size 538x18 [r=1 c=0 rs=1 cs=1]
+              RenderInline {FONT} at (395,4) size 142x15
+                RenderText {#text} at (395,4) size 142x15
+                  text run at (395,1) width 142: "I agree with the program"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (533,82) size 77x24 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (537,82) size 78x24 [r=1 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (3,4) size 16x16 [bgcolor=#FFFFFF03]
           RenderTableRow {TR} at (0,106) size 784x24
-            RenderTableCell {TD} at (0,109) size 534x18 [r=2 c=0 rs=1 cs=1]
-              RenderInline {FONT} at (380,4) size 153x15
-                RenderText {#text} at (380,4) size 153x15
-                  text run at (380,1) width 153: "I think vouchers are wrong"
+            RenderTableCell {TD} at (0,109) size 538x18 [r=2 c=0 rs=1 cs=1]
+              RenderInline {FONT} at (384,4) size 153x15
+                RenderText {#text} at (384,4) size 153x15
+                  text run at (384,1) width 153: "I think vouchers are wrong"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (533,106) size 77x24 [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (537,106) size 78x24 [r=2 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (3,4) size 16x16 [bgcolor=#FFFFFF03]
           RenderTableRow {TR} at (0,130) size 784x22
-            RenderTableCell {TD} at (0,132) size 610x18 [r=3 c=0 rs=1 cs=2]
-              RenderInline {A} at (267,0) size 76x19 [color=#0000EE]
-                RenderInline {FONT} at (267,3) size 76x15
-                  RenderText {#text} at (267,3) size 76x15
-                    text run at (267,1) width 76: "View Results"
-              RenderInline {FONT} at (342,3) size 0x15
+            RenderTableCell {TD} at (0,132) size 615x18 [r=3 c=0 rs=1 cs=2]
+              RenderInline {A} at (269,0) size 76x19 [color=#0000EE]
+                RenderInline {FONT} at (269,3) size 76x15
+                  RenderText {#text} at (269,3) size 76x15
+                    text run at (269,1) width 76: "View Results"
+              RenderInline {FONT} at (344,3) size 0x15
                 RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (609,130) size 176x22 [r=3 c=2 rs=1 cs=2]
-              RenderButton {INPUT} at (62,1) size 50x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 25x14
-                  RenderText at (0,0) size 25x14
-                    text run at (0,0) width 25: "vote"
+            RenderTableCell {TD} at (614,130) size 171x22 [r=3 c=2 rs=1 cs=2]
+              RenderButton {INPUT} at (61,1) size 48x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 23x14
+                  RenderText at (0,0) size 23x14
+                    text run at (0,0) width 23: "vote"
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug138725-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug138725-expected.txt
@@ -3,32 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 162x54
-        RenderTableSection {TBODY} at (0,0) size 162x54
-          RenderTableRow {TR} at (0,2) size 162x50
-            RenderTableCell {TD} at (2,2) size 158x50 [r=0 c=0 rs=1 cs=1]
-              RenderBlock (anonymous) at (1,1) size 156x0
+      RenderTable {TABLE} at (0,0) size 153x54
+        RenderTableSection {TBODY} at (0,0) size 153x54
+          RenderTableRow {TR} at (0,2) size 153x50
+            RenderTableCell {TD} at (2,2) size 149x50 [r=0 c=0 rs=1 cs=1]
+              RenderBlock (anonymous) at (1,1) size 147x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,1) size 156x48
-                RenderTable {TABLE} at (0,0) size 156x48
-                  RenderTableSection {TBODY} at (0,0) size 156x48
-                    RenderTableRow {TR} at (0,2) size 156x44
-                      RenderTableCell {TD} at (2,2) size 152x44 [r=0 c=0 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 150x42
-                          RenderTableSection {TBODY} at (0,0) size 150x42
-                            RenderTableRow {TR} at (0,2) size 150x38
-                              RenderTableCell {TD} at (2,2) size 146x38 [r=0 c=0 rs=1 cs=1]
-                                RenderBlock {FORM} at (1,1) size 144x20
-                                  RenderButton {INPUT} at (0,0) size 144x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                                    RenderBlock (anonymous) at (12,3) size 120x14
-                                      RenderText at (0,0) size 120x14
-                                        text run at (0,0) width 120: "ApplyForThisPosition"
+              RenderBlock (anonymous) at (1,1) size 147x48
+                RenderTable {TABLE} at (0,0) size 147x48
+                  RenderTableSection {TBODY} at (0,0) size 147x48
+                    RenderTableRow {TR} at (0,2) size 147x44
+                      RenderTableCell {TD} at (2,2) size 143x44 [r=0 c=0 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 141x42
+                          RenderTableSection {TBODY} at (0,0) size 141x42
+                            RenderTableRow {TR} at (0,2) size 141x38
+                              RenderTableCell {TD} at (2,2) size 137x38 [r=0 c=0 rs=1 cs=1]
+                                RenderBlock {FORM} at (1,1) size 135x20
+                                  RenderButton {INPUT} at (0,0) size 135x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                                    RenderBlock (anonymous) at (12,3) size 111x14
+                                      RenderText at (0,0) size 111x14
+                                        text run at (0,0) width 111: "ApplyForThisPosition"
                                   RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,49) size 156x0
+              RenderBlock (anonymous) at (1,49) size 147x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -85,10 +85,10 @@ layer at (0,0) size 800x792
             RenderTextControl {INPUT} at (394,17) size 155x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
           RenderText {#text} at (548,18) size 17x17
             text run at (548,18) width 17: " "
-          RenderButton {INPUT} at (564,17) size 65x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-            RenderBlock (anonymous) at (12,3) size 40x14
-              RenderText at (0,0) size 40x14
-                text run at (0,0) width 40: "Submit"
+          RenderButton {INPUT} at (564,17) size 62x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+            RenderBlock (anonymous) at (12,3) size 37x14
+              RenderText at (0,0) size 37x14
+                text run at (0,0) width 37: "Submit"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,621) size 784x18
         RenderText {#text} at (0,0) size 160x17

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -195,10 +195,10 @@ layer at (0,0) size 800x2667
             RenderTextControl {INPUT} at (71,22) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
           RenderText {#text} at (226,21) size 5x19
             text run at (226,21) width 5: " "
-          RenderButton {INPUT} at (230,22) size 65x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-            RenderBlock (anonymous) at (12,3) size 40x14
-              RenderText at (0,0) size 40x14
-                text run at (0,0) width 40: "Submit"
+          RenderButton {INPUT} at (230,22) size 62x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+            RenderBlock (anonymous) at (12,3) size 37x14
+              RenderText at (0,0) size 37x14
+                text run at (0,0) width 37: "Submit"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,2465) size 784x21
         RenderText {#text} at (0,0) size 64x19

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug33855-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug33855-expected.txt
@@ -7,29 +7,29 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (0,0) size 784x26
           RenderTableSection {TBODY} at (0,0) size 784x26
             RenderTableRow {TR} at (0,2) size 784x22 [bgcolor=#FFFFFF]
-              RenderTableCell {TD} at (2,2) size 78x22 [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 76x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 52x14
-                    RenderText at (0,0) size 52x14
-                      text run at (0,0) width 52: "Select all"
-              RenderTableCell {TD} at (81,2) size 63x22 [r=0 c=1 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 61x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 37x14
-                    RenderText at (0,0) size 37x14
-                      text run at (0,0) width 37: "Delete"
-              RenderTableCell {TD} at (145,2) size 95x22 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 92x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 68x14
-                    RenderText at (0,0) size 68x14
-                      text run at (0,0) width 68: "Empty trash"
-              RenderTableCell {TD} at (241,2) size 361x22 [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (1,1) size 4x19
-                  text run at (1,1) width 4: " "
-              RenderTableCell {TD} at (603,2) size 74x22 [r=0 c=4 rs=1 cs=1]
+              RenderTableCell {TD} at (2,2) size 74x22 [r=0 c=0 rs=1 cs=1]
                 RenderButton {INPUT} at (1,1) size 72x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
                   RenderBlock (anonymous) at (12,3) size 48x14
                     RenderText at (0,0) size 48x14
-                      text run at (0,0) width 48: "Move to:"
+                      text run at (0,0) width 48: "Select all"
+              RenderTableCell {TD} at (78,2) size 60x22 [r=0 c=1 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 58x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 34x14
+                    RenderText at (0,0) size 34x14
+                      text run at (0,0) width 34: "Delete"
+              RenderTableCell {TD} at (139,2) size 91x22 [r=0 c=2 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 88x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 64x14
+                    RenderText at (0,0) size 64x14
+                      text run at (0,0) width 64: "Empty trash"
+              RenderTableCell {TD} at (231,2) size 373x22 [r=0 c=3 rs=1 cs=1]
+                RenderText {#text} at (1,1) size 4x19
+                  text run at (1,1) width 4: " "
+              RenderTableCell {TD} at (605,2) size 72x22 [r=0 c=4 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 70x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 46x14
+                    RenderText at (0,0) size 46x14
+                      text run at (0,0) width 46: "Move to:"
               RenderTableCell {TD} at (679,2) size 103x22 [r=0 c=5 rs=1 cs=1]
                 RenderMenuList {SELECT} at (1,1) size 101x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                   RenderBlock (anonymous) at (6,3) size 89x14

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug39209-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug39209-expected.txt
@@ -6,19 +6,19 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 439x82 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 437x80
           RenderTableRow {TR} at (0,2) size 437x50
-            RenderTableCell {TD} at (2,15) size 132x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,15) size 136x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,15) size 31x19
                 text run at (2,2) width 31: "Blah"
-            RenderTableCell {TD} at (135,2) size 300x50 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (112,2) size 75x46 [border: (1px outset #000000)]
-                RenderTableSection {TBODY} at (1,1) size 72x44
-                  RenderTableRow {TR} at (0,2) size 72x40
-                    RenderTableCell {TD} at (2,2) size 68x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                      RenderBlock {FORM} at (2,2) size 64x20
-                        RenderButton {INPUT} at (0,0) size 64x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                          RenderBlock (anonymous) at (12,3) size 40x14
-                            RenderText at (0,0) size 40x14
-                              text run at (0,0) width 40: "Submit"
+            RenderTableCell {TD} at (139,2) size 296x50 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (112,2) size 72x46 [border: (1px outset #000000)]
+                RenderTableSection {TBODY} at (1,1) size 69x44
+                  RenderTableRow {TR} at (0,2) size 69x40
+                    RenderTableCell {TD} at (2,2) size 65x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                      RenderBlock {FORM} at (2,2) size 61x20
+                        RenderButton {INPUT} at (0,0) size 61x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                          RenderBlock (anonymous) at (12,3) size 37x14
+                            RenderText at (0,0) size 37x14
+                              text run at (0,0) width 37: "Submit"
                         RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,54) size 437x24
             RenderTableCell {TD} at (2,54) size 433x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=2]

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug4429-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug4429-expected.txt
@@ -11,8 +11,8 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (2,2) size 22x19
                   text run at (2,2) width 22: "foo"
         RenderBlock (anonymous) at (0,30) size 784x20
-          RenderButton {INPUT} at (0,0) size 64x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-            RenderBlock (anonymous) at (12,3) size 40x14
-              RenderText at (0,0) size 40x14
-                text run at (0,0) width 40: "Submit"
+          RenderButton {INPUT} at (0,0) size 61x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+            RenderBlock (anonymous) at (12,3) size 37x14
+              RenderText at (0,0) size 37x14
+                text run at (0,0) width 37: "Submit"
           RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug46368-1-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug46368-1-expected.txt
@@ -33,21 +33,21 @@ layer at (0,0) size 800x600
                 text run at (2,42) width 293: "Architecture, Bidi, Necko/Imglib, and more..."
       RenderBlock (anonymous) at (0,118) size 784x43
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 63x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 39x14
-            RenderText at (0,0) size 39x14
-              text run at (0,0) width 39: "Reload"
-        RenderText {#text} at (62,20) size 9x19
-          text run at (62,20) width 9: "  "
-        RenderButton {INPUT} at (70,21) size 95x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 71x14
-            RenderText at (0,0) size 71x14
-              text run at (0,0) width 71: "Change Font"
-        RenderText {#text} at (164,20) size 9x19
-          text run at (164,20) width 9: "  "
-        RenderTextControl {INPUT} at (172,21) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+        RenderButton {INPUT} at (0,21) size 60x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 36x14
+            RenderText at (0,0) size 36x14
+              text run at (0,0) width 36: "Reload"
+        RenderText {#text} at (59,20) size 9x19
+          text run at (59,20) width 9: "  "
+        RenderButton {INPUT} at (67,21) size 92x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 67x14
+            RenderText at (0,0) size 67x14
+              text run at (0,0) width 67: "Change Font"
+        RenderText {#text} at (158,20) size 9x19
+          text run at (158,20) width 9: "  "
+        RenderTextControl {INPUT} at (166,21) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
         RenderText {#text} at (0,0) size 0x0
-layer at (187,150) size 141x14
+layer at (181,150) size 141x14
   RenderBlock {DIV} at (6,3) size 143x15
     RenderText {#text} at (0,0) size 8x14
       text run at (0,0) width 8: "6"

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug46368-2-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug46368-2-expected.txt
@@ -21,21 +21,21 @@ layer at (0,0) size 800x600
                 text run at (2,2) width 245: "foo bar foo bar foo bar foo bar foo bar"
       RenderBlock (anonymous) at (0,68) size 784x43
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 63x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 39x14
-            RenderText at (0,0) size 39x14
-              text run at (0,0) width 39: "Reload"
-        RenderText {#text} at (62,20) size 9x19
-          text run at (62,20) width 9: "  "
-        RenderButton {INPUT} at (70,21) size 95x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 71x14
-            RenderText at (0,0) size 71x14
-              text run at (0,0) width 71: "Change Font"
-        RenderText {#text} at (164,20) size 9x19
-          text run at (164,20) width 9: "  "
-        RenderTextControl {INPUT} at (172,21) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+        RenderButton {INPUT} at (0,21) size 60x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 36x14
+            RenderText at (0,0) size 36x14
+              text run at (0,0) width 36: "Reload"
+        RenderText {#text} at (59,20) size 9x19
+          text run at (59,20) width 9: "  "
+        RenderButton {INPUT} at (67,21) size 92x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 67x14
+            RenderText at (0,0) size 67x14
+              text run at (0,0) width 67: "Change Font"
+        RenderText {#text} at (158,20) size 9x19
+          text run at (158,20) width 9: "  "
+        RenderTextControl {INPUT} at (166,21) size 156x22 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
         RenderText {#text} at (0,0) size 0x0
-layer at (187,100) size 141x14
+layer at (181,100) size 141x14
   RenderBlock {DIV} at (6,3) size 143x15
     RenderText {#text} at (0,0) size 8x14
       text run at (0,0) width 8: "6"

--- a/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug7342-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla/bugs/bug7342-expected.txt
@@ -58,10 +58,10 @@ layer at (0,0) size 800x600
                             RenderText {#text} at (0,0) size 0x0
                           RenderText {#text} at (0,0) size 0x0
                         RenderTableCell {TD} at (355,4) size 98x30 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                          RenderButton {INPUT} at (5,5) size 63x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                            RenderBlock (anonymous) at (12,3) size 39x14
-                              RenderText at (0,0) size 39x14
-                                text run at (0,0) width 39: "Search"
+                          RenderButton {INPUT} at (5,5) size 61x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                            RenderBlock (anonymous) at (12,3) size 37x14
+                              RenderText at (0,0) size 37x14
+                                text run at (0,0) width 37: "Search"
                           RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,39) size 457x31
                         RenderTableCell {TD} at (4,39) size 114x31 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/ios-18/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -23,10 +23,10 @@ layer at (0,0) size 800x600
                 RenderTableSection {TBODY} at (0,0) size 440x26
                   RenderTableRow {TR} at (0,2) size 440x22
                     RenderTableCell {TD} at (2,2) size 217x22 [r=0 c=0 rs=1 cs=1]
-                      RenderButton {INPUT} at (1,1) size 109x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                        RenderBlock (anonymous) at (12,3) size 85x14
-                          RenderText at (0,0) size 85x14
-                            text run at (0,0) width 85: "Submit Criteria"
+                      RenderButton {INPUT} at (1,1) size 103x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                        RenderBlock (anonymous) at (12,3) size 79x14
+                          RenderText at (0,0) size 79x14
+                            text run at (0,0) width 79: "Submit Criteria"
                     RenderTableCell {TD} at (221,2) size 217x22 [r=0 c=1 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 8x19
                         text run at (1,1) width 8: "4"

--- a/LayoutTests/platform/ios-18/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/ios-18/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -146,10 +146,10 @@ layer at (8,8) size 784x1513
                   RenderTextControl {INPUT} at (71,42) size 156x22 [color=#000000] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                 RenderText {#text} at (226,41) size 5x19
                   text run at (226,41) width 5: " "
-                RenderButton {INPUT} at (230,42) size 65x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 40x14
-                    RenderText at (0,0) size 40x14
-                      text run at (0,0) width 40: "Submit"
+                RenderButton {INPUT} at (230,42) size 62x20 [color=#FFFFFF] [bgcolor=#007AFF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 37x14
+                    RenderText at (0,0) size 37x14
+                      text run at (0,0) width 37: "Submit"
                 RenderText {#text} at (0,0) size 0x0
             RenderBlock {P} at (21,1346) size 442x23 [border: (1px dotted #FFFF00)]
               RenderInline {A} at (1,1) size 162x19 [color=#0000EE]

--- a/LayoutTests/platform/ios/editing/selection/3690703-2-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/3690703-2-expected.txt
@@ -83,14 +83,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (189,0) size 400x40 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 399x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                   RenderBR {BR} at (398,-1) size 1x19
-                  RenderButton {INPUT} at (85,20) size 107x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 82x14
-                      RenderText at (0,0) size 82x14
-                        text run at (0,0) width 82: "Google Search"
-                  RenderButton {INPUT} at (191,20) size 122x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 98x14
-                      RenderText at (0,0) size 98x14
-                        text run at (0,0) width 98: "I'm Feeling Lucky"
+                  RenderButton {INPUT} at (91,20) size 102x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 77x14
+                      RenderText at (0,0) size 77x14
+                        text run at (0,0) width 77: "Google Search"
+                  RenderButton {INPUT} at (192,20) size 116x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 92x14
+                      RenderText at (0,0) size 92x14
+                        text run at (0,0) width 92: "I'm Feeling Lucky"
                 RenderTableCell {TD} at (588,0) size 193x39 [r=0 c=2 rs=1 cs=1]
                   RenderInline {FONT} at (0,0) size 76x38
                     RenderText {#text} at (0,0) size 5x12

--- a/LayoutTests/platform/ios/editing/selection/3690703-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/3690703-expected.txt
@@ -85,14 +85,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (189,0) size 400x40 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 399x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                   RenderBR {BR} at (398,-1) size 1x19
-                  RenderButton {INPUT} at (85,20) size 107x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 82x14
-                      RenderText at (0,0) size 82x14
-                        text run at (0,0) width 82: "Google Search"
-                  RenderButton {INPUT} at (191,20) size 122x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 98x14
-                      RenderText at (0,0) size 98x14
-                        text run at (0,0) width 98: "I'm Feeling Lucky"
+                  RenderButton {INPUT} at (91,20) size 102x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 77x14
+                      RenderText at (0,0) size 77x14
+                        text run at (0,0) width 77: "Google Search"
+                  RenderButton {INPUT} at (192,20) size 116x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 92x14
+                      RenderText at (0,0) size 92x14
+                        text run at (0,0) width 92: "I'm Feeling Lucky"
                 RenderTableCell {TD} at (588,0) size 193x39 [r=0 c=2 rs=1 cs=1]
                   RenderInline {FONT} at (0,0) size 76x38
                     RenderText {#text} at (0,0) size 5x12

--- a/LayoutTests/platform/ios/editing/selection/3690719-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/3690719-expected.txt
@@ -77,14 +77,14 @@ layer at (0,0) size 800x600
                 RenderTableCell {TD} at (189,0) size 400x40 [r=0 c=1 rs=1 cs=1]
                   RenderTextControl {INPUT} at (0,0) size 399x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                   RenderBR {BR} at (398,-1) size 1x19
-                  RenderButton {INPUT} at (85,20) size 107x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 82x14
-                      RenderText at (0,0) size 82x14
-                        text run at (0,0) width 82: "Google Search"
-                  RenderButton {INPUT} at (191,20) size 122x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 98x14
-                      RenderText at (0,0) size 98x14
-                        text run at (0,0) width 98: "I'm Feeling Lucky"
+                  RenderButton {INPUT} at (91,20) size 102x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 77x14
+                      RenderText at (0,0) size 77x14
+                        text run at (0,0) width 77: "Google Search"
+                  RenderButton {INPUT} at (192,20) size 116x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 92x14
+                      RenderText at (0,0) size 92x14
+                        text run at (0,0) width 92: "I'm Feeling Lucky"
                 RenderTableCell {TD} at (588,0) size 193x39 [r=0 c=2 rs=1 cs=1]
                   RenderInline {FONT} at (0,0) size 76x38
                     RenderText {#text} at (0,0) size 5x12

--- a/LayoutTests/platform/ios/editing/selection/4397952-expected.txt
+++ b/LayoutTests/platform/ios/editing/selection/4397952-expected.txt
@@ -13,11 +13,11 @@ layer at (0,0) size 800x600
           text run at (0,0) width 271: "This tests caret movement across buttons. "
           text run at (270,0) width 308: "The caret should be just after the second button."
       RenderBlock {DIV} at (0,36) size 784x20
-        RenderButton {INPUT} at (0,0) size 45x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 21x14
-            RenderText at (0,0) size 21x14
-              text run at (0,0) width 21: "Foo"
-        RenderButton {INPUT} at (44,0) size 43x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+        RenderButton {INPUT} at (0,0) size 44x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 20x14
+            RenderText at (0,0) size 20x14
+              text run at (0,0) width 20: "Foo"
+        RenderButton {INPUT} at (43,0) size 43x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
           RenderBlock (anonymous) at (12,3) size 18x14
             RenderText at (0,0) size 18x14
               text run at (0,0) width 18: "Bar"

--- a/LayoutTests/platform/ios/fast/css/margin-top-bottom-dynamic-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/margin-top-bottom-dynamic-expected.txt
@@ -35,16 +35,16 @@ layer at (0,0) size 800x600
             text run at (1,1) width 86: "Lorem ipsum"
       RenderBlock (anonymous) at (0,288) size 784x41
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 116x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 92x14
-            RenderText at (0,0) size 92x14
-              text run at (0,0) width 92: "Negative margin"
-        RenderText {#text} at (115,20) size 5x19
-          text run at (115,20) width 5: " "
-        RenderButton {INPUT} at (119,21) size 111x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 87x14
-            RenderText at (0,0) size 87x14
-              text run at (0,0) width 87: "Positive margin"
+        RenderButton {INPUT} at (0,21) size 110x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 86x14
+            RenderText at (0,0) size 86x14
+              text run at (0,0) width 86: "Negative margin"
+        RenderText {#text} at (109,20) size 5x19
+          text run at (109,20) width 5: " "
+        RenderButton {INPUT} at (113,21) size 105x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 81x14
+            RenderText at (0,0) size 81x14
+              text run at (0,0) width 81: "Positive margin"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,345) size 784x20
         RenderText {#text} at (0,0) size 458x19
@@ -58,14 +58,14 @@ layer at (0,0) size 800x600
             text run at (1,1) width 86: "Lorem ipsum"
       RenderBlock (anonymous) at (0,457) size 784x41
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 116x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 92x14
-            RenderText at (0,0) size 92x14
-              text run at (0,0) width 92: "Negative margin"
-        RenderText {#text} at (115,20) size 5x19
-          text run at (115,20) width 5: " "
-        RenderButton {INPUT} at (119,21) size 111x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 87x14
-            RenderText at (0,0) size 87x14
-              text run at (0,0) width 87: "Positive margin"
+        RenderButton {INPUT} at (0,21) size 110x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 86x14
+            RenderText at (0,0) size 86x14
+              text run at (0,0) width 86: "Negative margin"
+        RenderText {#text} at (109,20) size 5x19
+          text run at (109,20) width 5: " "
+        RenderButton {INPUT} at (113,21) size 105x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 81x14
+            RenderText at (0,0) size 81x14
+              text run at (0,0) width 81: "Positive margin"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/forms/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/001-expected.txt
@@ -43,12 +43,12 @@ layer at (0,0) size 800x695
         RenderTable {TABLE} at (0,0) size 784x86 [border: (2px outset #000000)]
           RenderTableSection {TBODY} at (2,2) size 780x82
             RenderTableRow {TR} at (0,0) size 780x82
-              RenderTableCell {TD} at (0,0) size 115x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 113x80 [color=#FFFFFF] [bgcolor=#0088FF] [border: (40px solid #FF0000)]
-                  RenderBlock (anonymous) at (46,40) size 21x14
-                    RenderText at (0,0) size 21x14
-                      text run at (0,0) width 21: "Foo"
-              RenderTableCell {TD} at (114,40) size 666x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (0,0) size 114x82 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 112x80 [color=#FFFFFF] [bgcolor=#0088FF] [border: (40px solid #FF0000)]
+                  RenderBlock (anonymous) at (46,40) size 20x14
+                    RenderText at (0,0) size 20x14
+                      text run at (0,0) width 20: "Foo"
+              RenderTableCell {TD} at (113,40) size 667x2 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
         RenderTable {TABLE} at (0,86) size 784x86 [border: (2px outset #000000)]
           RenderTableSection {TBODY} at (2,2) size 780x82
             RenderTableRow {TR} at (0,0) size 780x82

--- a/LayoutTests/platform/ios/fast/forms/blankbuttons-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/blankbuttons-expected.txt
@@ -3,11 +3,11 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderButton {INPUT} at (0,0) size 64x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (12,3) size 40x14
-          RenderText at (0,0) size 40x14
-            text run at (0,0) width 40: "Submit"
-      RenderBR {BR} at (63,-1) size 1x19
+      RenderButton {INPUT} at (0,0) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (12,3) size 37x14
+          RenderText at (0,0) size 37x14
+            text run at (0,0) width 37: "Submit"
+      RenderBR {BR} at (60,-1) size 1x19
       RenderButton {INPUT} at (0,20) size 54x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
         RenderBlock (anonymous) at (12,3) size 30x14
           RenderText at (0,0) size 30x14

--- a/LayoutTests/platform/ios/fast/forms/button-default-title-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/button-default-title-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 800x670
       RenderBlock (anonymous) at (0,77) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
           RenderBlock (anonymous) at (7,3) size 66x15
-            RenderText at (13,0) size 40x14
-              text run at (13,0) width 40: "Submit"
+            RenderText at (14,0) size 38x14
+              text run at (14,0) width 38: "Submit"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,114) size 784x21
         RenderText {#text} at (0,0) size 300x19
@@ -21,8 +21,8 @@ layer at (0,0) size 800x670
       RenderBlock (anonymous) at (0,150) size 784x22
         RenderButton {INPUT} at (0,0) size 80x21 [color=#FFFFFF] [bgcolor=#008000] [border: (1px solid #FFFFFF)]
           RenderBlock (anonymous) at (7,3) size 66x15
-            RenderText at (22,0) size 22x14
-              text run at (22,0) width 22: "Foo"
+            RenderText at (23,0) size 20x14
+              text run at (23,0) width 20: "Foo"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,187) size 784x21
         RenderText {#text} at (0,0) size 316x19

--- a/LayoutTests/platform/ios/fast/forms/formmove3-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/formmove3-expected.txt
@@ -11,15 +11,15 @@ layer at (0,0) size 800x600
           RenderInline {A} at (0,0) size 0x0
             RenderText {#text} at (0,0) size 0x0
         RenderBlock (anonymous) at (0,0) size 784x26
-          RenderTable {TABLE} at (0,0) size 73x26
-            RenderTableSection {TBODY} at (0,0) size 73x26
-              RenderTableRow {TR} at (0,2) size 73x22
+          RenderTable {TABLE} at (0,0) size 71x26
+            RenderTableSection {TBODY} at (0,0) size 71x26
+              RenderTableRow {TR} at (0,2) size 71x22
                 RenderTableCell {TD} at (2,12) size 2x2 [r=0 c=0 rs=1 cs=1]
-                RenderTableCell {TD} at (6,2) size 65x22 [r=0 c=1 rs=1 cs=1]
-                  RenderButton {INPUT} at (1,1) size 63x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                    RenderBlock (anonymous) at (12,3) size 39x14
-                      RenderText at (0,0) size 39x14
-                        text run at (0,0) width 39: "Search"
+                RenderTableCell {TD} at (6,2) size 63x22 [r=0 c=1 rs=1 cs=1]
+                  RenderButton {INPUT} at (1,1) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                    RenderBlock (anonymous) at (12,3) size 37x14
+                      RenderText at (0,0) size 37x14
+                        text run at (0,0) width 37: "Search"
         RenderBlock (anonymous) at (0,26) size 784x0
           RenderInline {A} at (0,0) size 0x0
           RenderInline {A} at (0,0) size 0x0 [color=#0000EE]

--- a/LayoutTests/platform/ios/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-appearance-height-expected.txt
@@ -59,12 +59,12 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (87,150) size 1x19
         RenderText {#text} at (0,171) size 48x19
           text run at (0,171) width 48: "submit "
-        RenderButton {INPUT} at (47,172) size 65x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 40x14
-            RenderText at (0,0) size 40x14
-              text run at (0,0) width 40: "Submit"
+        RenderButton {INPUT} at (47,172) size 62x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 37x14
+            RenderText at (0,0) size 37x14
+              text run at (0,0) width 37: "Submit"
         RenderText {#text} at (0,0) size 0x0
-        RenderBR {BR} at (111,171) size 1x19
+        RenderBR {BR} at (108,171) size 1x19
         RenderText {#text} at (0,192) size 51x19
           text run at (0,192) width 51: "isindex "
         RenderTextControl {INPUT} at (50,193) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]

--- a/LayoutTests/platform/ios/fast/forms/input-first-letter-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-first-letter-expected.txt
@@ -6,8 +6,8 @@ layer at (0,0) size 800x600
       RenderText {#text} at (0,0) size 602x19
         text run at (0,0) width 602: "This test passes if it doesn't crash and if the Submit button does not honor the first-letter style."
       RenderBR {BR} at (601,0) size 1x19
-      RenderButton {INPUT} at (0,20) size 54x16 [color=#FFFFFF] [border: (1px solid #FFFFFF)]
-        RenderBlock (anonymous) at (7,1) size 40x14
-          RenderText at (0,0) size 40x14
-            text run at (0,0) width 40: "Submit"
+      RenderButton {INPUT} at (0,20) size 51x16 [color=#FFFFFF] [border: (1px solid #FFFFFF)]
+        RenderBlock (anonymous) at (7,1) size 37x14
+          RenderText at (0,0) size 37x14
+            text run at (0,0) width 37: "Submit"
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/forms/targeted-frame-submission-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/targeted-frame-submission-expected.txt
@@ -4,10 +4,10 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {FORM} at (0,0) size 784x20
-        RenderButton {INPUT} at (0,0) size 51x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 27x14
-            RenderText at (0,0) size 27x14
-              text run at (0,0) width 27: "form"
+        RenderButton {INPUT} at (0,0) size 49x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 25x14
+            RenderText at (0,0) size 25x14
+              text run at (0,0) width 25: "form"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,36) size 784x40
         RenderText {#text} at (0,0) size 778x39

--- a/LayoutTests/platform/ios/fast/replaced/width100percent-button-expected.txt
+++ b/LayoutTests/platform/ios/fast/replaced/width100percent-button-expected.txt
@@ -33,21 +33,21 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,84) size 784x24
         RenderTableSection {TBODY} at (0,0) size 784x24
           RenderTableRow {TR} at (0,1) size 784x22
-            RenderTableCell {TD} at (1,1) size 77x22 [r=0 c=0 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 75x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 51x14
-                  RenderText at (0,0) size 51x14
-                    text run at (0,0) width 51: "New Mail"
-            RenderTableCell {TD} at (78,1) size 58x22 [r=0 c=1 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 56x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 32x14
-                  RenderText at (0,0) size 32x14
-                    text run at (0,0) width 32: "Reply"
-            RenderTableCell {TD} at (136,1) size 76x22 [r=0 c=2 rs=1 cs=1]
-              RenderButton {INPUT} at (1,1) size 73x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 49x14
-                  RenderText at (0,0) size 49x14
-                    text run at (0,0) width 49: "Reply All"
-            RenderTableCell {TD} at (212,1) size 571x22 [r=0 c=3 rs=1 cs=1]
+            RenderTableCell {TD} at (1,1) size 74x22 [r=0 c=0 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 72x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 48x14
+                  RenderText at (0,0) size 48x14
+                    text run at (0,0) width 48: "New Mail"
+            RenderTableCell {TD} at (75,1) size 56x22 [r=0 c=1 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 54x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 30x14
+                  RenderText at (0,0) size 30x14
+                    text run at (0,0) width 30: "Reply"
+            RenderTableCell {TD} at (131,1) size 73x22 [r=0 c=2 rs=1 cs=1]
+              RenderButton {INPUT} at (1,1) size 70x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 46x14
+                  RenderText at (0,0) size 46x14
+                    text run at (0,0) width 46: "Reply All"
+            RenderTableCell {TD} at (204,1) size 579x22 [r=0 c=3 rs=1 cs=1]
               RenderText {#text} at (1,1) size 4x19
                 text run at (1,1) width 4: " "

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug1188-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug1188-expected.txt
@@ -12,24 +12,24 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (0,0) size 0x0
             RenderTableRow {TR} at (0,48) size 600x55
               RenderTableCell {TD} at (2,56) size 595x39 [bgcolor=#99CCCC] [r=1 c=0 rs=1 cs=3]
-                RenderInline {FONT} at (49,12) size 128x15
-                  RenderInline {B} at (49,12) size 128x15
-                    RenderText {#text} at (49,12) size 128x15
-                      text run at (49,4) width 128: "Search the Web with"
-                RenderText {#text} at (176,9) size 5x19
-                  text run at (176,1) width 5: " "
-                RenderMenuList {SELECT} at (180,10) size 75x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderInline {FONT} at (50,12) size 128x15
+                  RenderInline {B} at (50,12) size 128x15
+                    RenderText {#text} at (50,12) size 128x15
+                      text run at (50,4) width 128: "Search the Web with"
+                RenderText {#text} at (177,9) size 5x19
+                  text run at (177,1) width 5: " "
+                RenderMenuList {SELECT} at (181,10) size 75x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                   RenderBlock (anonymous) at (6,3) size 62x14
                     RenderText at (0,0) size 50x14
                       text run at (0,0) width 50: "Netscape"
-                RenderTextControl {INPUT} at (254,10) size 224x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-                RenderText {#text} at (477,9) size 5x19
-                  text run at (477,1) width 5: " "
-                RenderButton {INPUT} at (481,10) size 64x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 39x14
-                    RenderText at (0,0) size 39x14
-                      text run at (0,0) width 39: "Search"
-                RenderBR {BR} at (544,9) size 1x19
+                RenderTextControl {INPUT} at (255,10) size 225x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+                RenderText {#text} at (479,9) size 5x19
+                  text run at (479,1) width 5: " "
+                RenderButton {INPUT} at (483,10) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 37x14
+                    RenderText at (0,0) size 37x14
+                      text run at (0,0) width 37: "Search"
+                RenderBR {BR} at (543,9) size 1x19
                 RenderInline {SMALL} at (13,30) size 568x15
                   RenderInline {A} at (13,30) size 101x15 [color=#0000EE]
                     RenderText {#text} at (13,30) size 101x15
@@ -137,5 +137,5 @@ layer at (0,0) size 800x600
                       RenderTableCell {TD} at (0,0) size 0x0 [r=0 c=0 rs=1 cs=1]
 layer at (8,8) size 602x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 602x2 [color=#808080] [border: (1px inset #808080)]
-layer at (270,79) size 212x14
+layer at (271,79) size 212x14
   RenderBlock {DIV} at (6,3) size 212x14

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug1318-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug1318-expected.txt
@@ -18,32 +18,32 @@ layer at (0,0) size 800x600
                 RenderBR {BR} at (392,61) size 1x19
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,82) size 784x24
-            RenderTableCell {TD} at (0,85) size 534x18 [r=1 c=0 rs=1 cs=1]
-              RenderInline {FONT} at (392,4) size 141x15
-                RenderText {#text} at (392,4) size 141x15
-                  text run at (392,1) width 141: "I agree with the program"
+            RenderTableCell {TD} at (0,85) size 538x18 [r=1 c=0 rs=1 cs=1]
+              RenderInline {FONT} at (395,4) size 142x15
+                RenderText {#text} at (395,4) size 142x15
+                  text run at (395,1) width 142: "I agree with the program"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (533,82) size 77x24 [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (537,82) size 78x24 [r=1 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (3,4) size 16x16 [bgcolor=#FFFFFF03]
           RenderTableRow {TR} at (0,106) size 784x24
-            RenderTableCell {TD} at (0,109) size 534x18 [r=2 c=0 rs=1 cs=1]
-              RenderInline {FONT} at (380,4) size 153x15
-                RenderText {#text} at (380,4) size 153x15
-                  text run at (380,1) width 153: "I think vouchers are wrong"
+            RenderTableCell {TD} at (0,109) size 538x18 [r=2 c=0 rs=1 cs=1]
+              RenderInline {FONT} at (384,4) size 153x15
+                RenderText {#text} at (384,4) size 153x15
+                  text run at (384,1) width 153: "I think vouchers are wrong"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (533,106) size 77x24 [r=2 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (537,106) size 78x24 [r=2 c=1 rs=1 cs=1]
               RenderBlock {INPUT} at (3,4) size 16x16 [bgcolor=#FFFFFF03]
           RenderTableRow {TR} at (0,130) size 784x22
-            RenderTableCell {TD} at (0,132) size 610x18 [r=3 c=0 rs=1 cs=2]
-              RenderInline {A} at (267,0) size 76x19 [color=#0000EE]
-                RenderInline {FONT} at (267,3) size 76x15
-                  RenderText {#text} at (267,3) size 76x15
-                    text run at (267,1) width 76: "View Results"
-              RenderInline {FONT} at (342,3) size 0x15
+            RenderTableCell {TD} at (0,132) size 615x18 [r=3 c=0 rs=1 cs=2]
+              RenderInline {A} at (269,0) size 76x19 [color=#0000EE]
+                RenderInline {FONT} at (269,3) size 76x15
+                  RenderText {#text} at (269,3) size 76x15
+                    text run at (269,1) width 76: "View Results"
+              RenderInline {FONT} at (344,3) size 0x15
                 RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (609,130) size 176x22 [r=3 c=2 rs=1 cs=2]
-              RenderButton {INPUT} at (62,1) size 50x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                RenderBlock (anonymous) at (12,3) size 25x14
-                  RenderText at (0,0) size 25x14
-                    text run at (0,0) width 25: "vote"
+            RenderTableCell {TD} at (614,130) size 171x22 [r=3 c=2 rs=1 cs=2]
+              RenderButton {INPUT} at (61,1) size 48x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                RenderBlock (anonymous) at (12,3) size 23x14
+                  RenderText at (0,0) size 23x14
+                    text run at (0,0) width 23: "vote"
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug138725-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug138725-expected.txt
@@ -3,32 +3,32 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {TABLE} at (0,0) size 162x54
-        RenderTableSection {TBODY} at (0,0) size 162x54
-          RenderTableRow {TR} at (0,2) size 162x50
-            RenderTableCell {TD} at (2,2) size 158x50 [r=0 c=0 rs=1 cs=1]
-              RenderBlock (anonymous) at (1,1) size 156x0
+      RenderTable {TABLE} at (0,0) size 153x54
+        RenderTableSection {TBODY} at (0,0) size 153x54
+          RenderTableRow {TR} at (0,2) size 153x50
+            RenderTableCell {TD} at (2,2) size 149x50 [r=0 c=0 rs=1 cs=1]
+              RenderBlock (anonymous) at (1,1) size 147x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
                     RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,1) size 156x48
-                RenderTable {TABLE} at (0,0) size 156x48
-                  RenderTableSection {TBODY} at (0,0) size 156x48
-                    RenderTableRow {TR} at (0,2) size 156x44
-                      RenderTableCell {TD} at (2,2) size 152x44 [r=0 c=0 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 150x42
-                          RenderTableSection {TBODY} at (0,0) size 150x42
-                            RenderTableRow {TR} at (0,2) size 150x38
-                              RenderTableCell {TD} at (2,2) size 146x38 [r=0 c=0 rs=1 cs=1]
-                                RenderBlock {FORM} at (1,1) size 144x20
-                                  RenderButton {INPUT} at (0,0) size 144x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                                    RenderBlock (anonymous) at (12,3) size 120x14
-                                      RenderText at (0,0) size 120x14
-                                        text run at (0,0) width 120: "ApplyForThisPosition"
+              RenderBlock (anonymous) at (1,1) size 147x48
+                RenderTable {TABLE} at (0,0) size 147x48
+                  RenderTableSection {TBODY} at (0,0) size 147x48
+                    RenderTableRow {TR} at (0,2) size 147x44
+                      RenderTableCell {TD} at (2,2) size 143x44 [r=0 c=0 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 141x42
+                          RenderTableSection {TBODY} at (0,0) size 141x42
+                            RenderTableRow {TR} at (0,2) size 141x38
+                              RenderTableCell {TD} at (2,2) size 137x38 [r=0 c=0 rs=1 cs=1]
+                                RenderBlock {FORM} at (1,1) size 135x20
+                                  RenderButton {INPUT} at (0,0) size 135x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                                    RenderBlock (anonymous) at (12,3) size 111x14
+                                      RenderText at (0,0) size 111x14
+                                        text run at (0,0) width 111: "ApplyForThisPosition"
                                   RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (1,49) size 156x0
+              RenderBlock (anonymous) at (1,49) size 147x0
                 RenderInline {SPAN} at (0,0) size 0x0
                   RenderInline {SPAN} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-3-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-3-expected.txt
@@ -85,10 +85,10 @@ layer at (0,0) size 800x791
             RenderTextControl {INPUT} at (394,17) size 154x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
           RenderText {#text} at (547,18) size 17x17
             text run at (547,18) width 17: " "
-          RenderButton {INPUT} at (563,17) size 65x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-            RenderBlock (anonymous) at (12,3) size 40x14
-              RenderText at (0,0) size 40x14
-                text run at (0,0) width 40: "Submit"
+          RenderButton {INPUT} at (563,17) size 62x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+            RenderBlock (anonymous) at (12,3) size 37x14
+              RenderText at (0,0) size 37x14
+                text run at (0,0) width 37: "Submit"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,620) size 784x18
         RenderText {#text} at (0,0) size 160x17

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-4-expected.txt
@@ -195,10 +195,10 @@ layer at (0,0) size 800x2665
             RenderTextControl {INPUT} at (71,22) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
           RenderText {#text} at (225,21) size 5x19
             text run at (225,21) width 5: " "
-          RenderButton {INPUT} at (229,22) size 65x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-            RenderBlock (anonymous) at (12,3) size 40x14
-              RenderText at (0,0) size 40x14
-                text run at (0,0) width 40: "Submit"
+          RenderButton {INPUT} at (229,22) size 62x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+            RenderBlock (anonymous) at (12,3) size 37x14
+              RenderText at (0,0) size 37x14
+                text run at (0,0) width 37: "Submit"
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,2463) size 784x21
         RenderText {#text} at (0,0) size 64x19

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug33855-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug33855-expected.txt
@@ -7,29 +7,29 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (0,0) size 784x26
           RenderTableSection {TBODY} at (0,0) size 784x26
             RenderTableRow {TR} at (0,2) size 784x22 [bgcolor=#FFFFFF]
-              RenderTableCell {TD} at (2,2) size 78x22 [r=0 c=0 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 76x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 52x14
-                    RenderText at (0,0) size 52x14
-                      text run at (0,0) width 52: "Select all"
-              RenderTableCell {TD} at (81,2) size 63x22 [r=0 c=1 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 37x14
-                    RenderText at (0,0) size 37x14
-                      text run at (0,0) width 37: "Delete"
-              RenderTableCell {TD} at (145,2) size 95x22 [r=0 c=2 rs=1 cs=1]
-                RenderButton {INPUT} at (1,1) size 92x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 68x14
-                    RenderText at (0,0) size 68x14
-                      text run at (0,0) width 68: "Empty trash"
-              RenderTableCell {TD} at (241,2) size 361x22 [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (1,1) size 4x19
-                  text run at (1,1) width 4: " "
-              RenderTableCell {TD} at (603,2) size 74x22 [r=0 c=4 rs=1 cs=1]
+              RenderTableCell {TD} at (2,2) size 74x22 [r=0 c=0 rs=1 cs=1]
                 RenderButton {INPUT} at (1,1) size 72x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
                   RenderBlock (anonymous) at (12,3) size 48x14
                     RenderText at (0,0) size 48x14
-                      text run at (0,0) width 48: "Move to:"
+                      text run at (0,0) width 48: "Select all"
+              RenderTableCell {TD} at (78,2) size 60x22 [r=0 c=1 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 58x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 34x14
+                    RenderText at (0,0) size 34x14
+                      text run at (0,0) width 34: "Delete"
+              RenderTableCell {TD} at (139,2) size 91x22 [r=0 c=2 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 88x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 64x14
+                    RenderText at (0,0) size 64x14
+                      text run at (0,0) width 64: "Empty trash"
+              RenderTableCell {TD} at (231,2) size 373x22 [r=0 c=3 rs=1 cs=1]
+                RenderText {#text} at (1,1) size 4x19
+                  text run at (1,1) width 4: " "
+              RenderTableCell {TD} at (605,2) size 72x22 [r=0 c=4 rs=1 cs=1]
+                RenderButton {INPUT} at (1,1) size 70x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 46x14
+                    RenderText at (0,0) size 46x14
+                      text run at (0,0) width 46: "Move to:"
               RenderTableCell {TD} at (679,2) size 103x22 [r=0 c=5 rs=1 cs=1]
                 RenderMenuList {SELECT} at (1,1) size 101x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                   RenderBlock (anonymous) at (6,3) size 89x14

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug39209-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug39209-expected.txt
@@ -6,19 +6,19 @@ layer at (0,0) size 800x600
       RenderTable {TABLE} at (0,0) size 439x82 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 437x80
           RenderTableRow {TR} at (0,2) size 437x50
-            RenderTableCell {TD} at (2,15) size 132x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (2,15) size 136x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,15) size 31x19
                 text run at (2,2) width 31: "Blah"
-            RenderTableCell {TD} at (135,2) size 300x50 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderTable {TABLE} at (112,2) size 75x46 [border: (1px outset #000000)]
-                RenderTableSection {TBODY} at (1,1) size 72x44
-                  RenderTableRow {TR} at (0,2) size 72x40
-                    RenderTableCell {TD} at (2,2) size 68x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                      RenderBlock {FORM} at (2,2) size 64x20
-                        RenderButton {INPUT} at (0,0) size 64x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                          RenderBlock (anonymous) at (12,3) size 40x14
-                            RenderText at (0,0) size 40x14
-                              text run at (0,0) width 40: "Submit"
+            RenderTableCell {TD} at (139,2) size 296x50 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTable {TABLE} at (112,2) size 72x46 [border: (1px outset #000000)]
+                RenderTableSection {TBODY} at (1,1) size 69x44
+                  RenderTableRow {TR} at (0,2) size 69x40
+                    RenderTableCell {TD} at (2,2) size 65x40 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                      RenderBlock {FORM} at (2,2) size 61x20
+                        RenderButton {INPUT} at (0,0) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                          RenderBlock (anonymous) at (12,3) size 37x14
+                            RenderText at (0,0) size 37x14
+                              text run at (0,0) width 37: "Submit"
                         RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,54) size 437x24
             RenderTableCell {TD} at (2,54) size 433x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=2]

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug4429-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug4429-expected.txt
@@ -11,8 +11,8 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (2,2) size 22x19
                   text run at (2,2) width 22: "foo"
         RenderBlock (anonymous) at (0,30) size 784x20
-          RenderButton {INPUT} at (0,0) size 64x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-            RenderBlock (anonymous) at (12,3) size 40x14
-              RenderText at (0,0) size 40x14
-                text run at (0,0) width 40: "Submit"
+          RenderButton {INPUT} at (0,0) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+            RenderBlock (anonymous) at (12,3) size 37x14
+              RenderText at (0,0) size 37x14
+                text run at (0,0) width 37: "Submit"
           RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug46368-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug46368-1-expected.txt
@@ -33,21 +33,21 @@ layer at (0,0) size 800x600
                 text run at (2,42) width 293: "Architecture, Bidi, Necko/Imglib, and more..."
       RenderBlock (anonymous) at (0,118) size 784x41
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 63x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 39x14
-            RenderText at (0,0) size 39x14
-              text run at (0,0) width 39: "Reload"
-        RenderText {#text} at (62,20) size 9x19
-          text run at (62,20) width 9: "  "
-        RenderButton {INPUT} at (70,21) size 95x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 71x14
-            RenderText at (0,0) size 71x14
-              text run at (0,0) width 71: "Change Font"
-        RenderText {#text} at (164,20) size 9x19
-          text run at (164,20) width 9: "  "
-        RenderTextControl {INPUT} at (172,21) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+        RenderButton {INPUT} at (0,21) size 60x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 36x14
+            RenderText at (0,0) size 36x14
+              text run at (0,0) width 36: "Reload"
+        RenderText {#text} at (59,20) size 9x19
+          text run at (59,20) width 9: "  "
+        RenderButton {INPUT} at (67,21) size 92x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 67x14
+            RenderText at (0,0) size 67x14
+              text run at (0,0) width 67: "Change Font"
+        RenderText {#text} at (158,20) size 9x19
+          text run at (158,20) width 9: "  "
+        RenderTextControl {INPUT} at (166,21) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
         RenderText {#text} at (0,0) size 0x0
-layer at (187,150) size 142x14
+layer at (181,150) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
     RenderText {#text} at (0,0) size 8x14
       text run at (0,0) width 8: "6"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug46368-2-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug46368-2-expected.txt
@@ -21,21 +21,21 @@ layer at (0,0) size 800x600
                 text run at (2,2) width 245: "foo bar foo bar foo bar foo bar foo bar"
       RenderBlock (anonymous) at (0,68) size 784x41
         RenderBR {BR} at (0,0) size 0x19
-        RenderButton {INPUT} at (0,21) size 63x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 39x14
-            RenderText at (0,0) size 39x14
-              text run at (0,0) width 39: "Reload"
-        RenderText {#text} at (62,20) size 9x19
-          text run at (62,20) width 9: "  "
-        RenderButton {INPUT} at (70,21) size 95x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-          RenderBlock (anonymous) at (12,3) size 71x14
-            RenderText at (0,0) size 71x14
-              text run at (0,0) width 71: "Change Font"
-        RenderText {#text} at (164,20) size 9x19
-          text run at (164,20) width 9: "  "
-        RenderTextControl {INPUT} at (172,21) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+        RenderButton {INPUT} at (0,21) size 60x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 36x14
+            RenderText at (0,0) size 36x14
+              text run at (0,0) width 36: "Reload"
+        RenderText {#text} at (59,20) size 9x19
+          text run at (59,20) width 9: "  "
+        RenderButton {INPUT} at (67,21) size 92x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+          RenderBlock (anonymous) at (12,3) size 67x14
+            RenderText at (0,0) size 67x14
+              text run at (0,0) width 67: "Change Font"
+        RenderText {#text} at (158,20) size 9x19
+          text run at (158,20) width 9: "  "
+        RenderTextControl {INPUT} at (166,21) size 155x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
         RenderText {#text} at (0,0) size 0x0
-layer at (187,100) size 142x14
+layer at (181,100) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
     RenderText {#text} at (0,0) size 8x14
       text run at (0,0) width 8: "6"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug7342-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug7342-expected.txt
@@ -51,29 +51,29 @@ layer at (0,0) size 800x600
                   RenderTable {TABLE} at (4,27) size 459x74 [border: (1px outset #000000)]
                     RenderTableSection {TBODY} at (1,1) size 457x72
                       RenderTableRow {TR} at (0,4) size 457x30
-                        RenderTableCell {TD} at (4,4) size 347x30 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=3]
+                        RenderTableCell {TD} at (4,4) size 348x30 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=3]
                           RenderInline {FONT} at (5,6) size 301x16
                             RenderText {#text} at (0,0) size 0x0
                             RenderTextControl {INPUT} at (5,5) size 301x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                             RenderText {#text} at (0,0) size 0x0
                           RenderText {#text} at (0,0) size 0x0
-                        RenderTableCell {TD} at (354,4) size 99x30 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                          RenderButton {INPUT} at (5,5) size 63x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                            RenderBlock (anonymous) at (12,3) size 39x14
-                              RenderText at (0,0) size 39x14
-                                text run at (0,0) width 39: "Search"
+                        RenderTableCell {TD} at (355,4) size 98x30 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                          RenderButton {INPUT} at (5,5) size 61x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                            RenderBlock (anonymous) at (12,3) size 37x14
+                              RenderText at (0,0) size 37x14
+                                text run at (0,0) width 37: "Search"
                           RenderText {#text} at (0,0) size 0x0
                       RenderTableRow {TR} at (0,38) size 457x30
-                        RenderTableCell {TD} at (4,38) size 113x30 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                        RenderTableCell {TD} at (4,38) size 114x30 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 27x19
                             text run at (5,5) width 27: "asdf"
-                        RenderTableCell {TD} at (120,38) size 114x30 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                        RenderTableCell {TD} at (121,38) size 114x30 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 27x19
                             text run at (5,5) width 27: "asdf"
-                        RenderTableCell {TD} at (237,38) size 114x30 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                        RenderTableCell {TD} at (238,38) size 114x30 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 27x19
                             text run at (5,5) width 27: "asdf"
-                        RenderTableCell {TD} at (354,38) size 99x30 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                        RenderTableCell {TD} at (355,38) size 98x30 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                           RenderText {#text} at (5,5) size 27x19
                             text run at (5,5) width 27: "asdf"
 layer at (250,128) size 289x14 backgroundClip at (250,128) size 288x14 clip at (250,128) size 288x14

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1725-expected.txt
@@ -23,10 +23,10 @@ layer at (0,0) size 800x600
                 RenderTableSection {TBODY} at (0,0) size 440x26
                   RenderTableRow {TR} at (0,2) size 440x22
                     RenderTableCell {TD} at (2,2) size 217x22 [r=0 c=0 rs=1 cs=1]
-                      RenderButton {INPUT} at (1,1) size 109x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                        RenderBlock (anonymous) at (12,3) size 85x14
-                          RenderText at (0,0) size 85x14
-                            text run at (0,0) width 85: "Submit Criteria"
+                      RenderButton {INPUT} at (1,1) size 103x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                        RenderBlock (anonymous) at (12,3) size 79x14
+                          RenderText at (0,0) size 79x14
+                            text run at (0,0) width 79: "Submit Criteria"
                     RenderTableCell {TD} at (221,2) size 217x22 [r=0 c=1 rs=1 cs=1]
                       RenderText {#text} at (1,1) size 8x19
                         text run at (1,1) width 8: "4"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -146,10 +146,10 @@ layer at (8,8) size 784x1512
                   RenderTextControl {INPUT} at (71,42) size 155x20 [color=#000000] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
                 RenderText {#text} at (225,41) size 5x19
                   text run at (225,41) width 5: " "
-                RenderButton {INPUT} at (229,42) size 65x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
-                  RenderBlock (anonymous) at (12,3) size 40x14
-                    RenderText at (0,0) size 40x14
-                      text run at (0,0) width 40: "Submit"
+                RenderButton {INPUT} at (229,42) size 62x20 [color=#FFFFFF] [bgcolor=#0088FF] [border: (1px solid #FFFFFF)]
+                  RenderBlock (anonymous) at (12,3) size 37x14
+                    RenderText at (0,0) size 37x14
+                      text run at (0,0) width 37: "Submit"
                 RenderText {#text} at (0,0) size 0x0
             RenderBlock {P} at (21,1345) size 442x22 [border: (1px dotted #FFFF00)]
               RenderInline {A} at (1,1) size 162x19 [color=#0000EE]

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -846,7 +846,6 @@ button[type="submit"], button[type="submit"]:active,
 button[type="menu"], button[type="menu"]:active {
     background-color: -apple-system-blue;
     color: white;
-    font-weight: bold;
 }
 
 #endif


### PR DESCRIPTION
#### c9ff2b60570e45499e67a9cf5d72a7b567850a1f
<pre>
[Form control refresh] Submit buttons should not use bold text on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=296922">https://bugs.webkit.org/show_bug.cgi?id=296922</a>
<a href="https://rdar.apple.com/157545551">rdar://157545551</a>

Reviewed by Tim Nguyen.

Removed CSS style `font-weight: bold` for submit buttons on iOS.
Rebaselined tests to account for the updated control size.

* LayoutTests/platform/ios-18/editing/selection/3690703-2-expected.txt:
* LayoutTests/platform/ios-18/editing/selection/3690703-expected.txt:
* LayoutTests/platform/ios-18/editing/selection/3690719-expected.txt:
* LayoutTests/platform/ios-18/editing/selection/4397952-expected.txt:
* LayoutTests/platform/ios-18/fast/css/margin-top-bottom-dynamic-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/001-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/blankbuttons-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/button-default-title-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/formmove3-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/ios-18/fast/forms/targeted-frame-submission-expected.txt:
* LayoutTests/platform/ios-18/fast/replaced/width100percent-button-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug1188-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug138725-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug33855-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug39209-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug4429-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug46368-1-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug46368-2-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla/bugs/bug7342-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/ios-18/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* LayoutTests/platform/ios/editing/selection/3690703-2-expected.txt:
* LayoutTests/platform/ios/editing/selection/3690703-expected.txt:
* LayoutTests/platform/ios/editing/selection/3690719-expected.txt:
* LayoutTests/platform/ios/editing/selection/4397952-expected.txt:
* LayoutTests/platform/ios/fast/css/margin-top-bottom-dynamic-expected.txt:
* LayoutTests/platform/ios/fast/forms/001-expected.txt:
* LayoutTests/platform/ios/fast/forms/blankbuttons-expected.txt:
* LayoutTests/platform/ios/fast/forms/button-default-title-expected.txt:
* LayoutTests/platform/ios/fast/forms/formmove3-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-first-letter-expected.txt:
* LayoutTests/platform/ios/fast/forms/targeted-frame-submission-expected.txt:
* LayoutTests/platform/ios/fast/replaced/width100percent-button-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug1188-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug1318-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug138725-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-3-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug2479-4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug33855-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug39209-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug4429-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug46368-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug46368-2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug7342-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug1725-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:
* Source/WebCore/css/html.css:
(#if defined(WTF_PLATFORM_IOS_FAMILY) &amp;&amp; WTF_PLATFORM_IOS_FAMILY):

Canonical link: <a href="https://commits.webkit.org/299099@main">https://commits.webkit.org/299099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b32fcbf9412a4250963ca6c36bbbfe1a8602c553

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69854 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b118726d-f754-4714-b984-b2baba2030b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89419 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59046 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8a86d48-c891-45f5-a1e9-e82a792391e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69912 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/441214eb-70c4-416f-99e5-23bd7151e97f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23764 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67630 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127056 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98083 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50278 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44063 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45753 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->