### PR TITLE
[WGSL] All passes should return after encountering the first error

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
@@ -102,24 +102,23 @@ TEST(WGSLTypeCheckingTests, Attributes)
     expectTypeError("@compute @workgroup_size(1, 1u, 1i) fn f6() { }"_s, "@workgroup_size arguments must be of the same type, either i32 or u32"_s);
 
 
-    // FIXME: Attribute Validator should also return upon encountering the first error
-    // attribute validation
-    // expectTypeError("@group(0) var<private> x: i32;"_s, "@group attribute must only be applied to resource variables"_s);
-    // expectTypeError("@group(-1) var<uniform> x: i32;"_s, "@group value must be non-negative"_s);
-    // expectTypeError("@binding(0) var<private> x: i32;"_s, "@binding attribute must only be applied to resource variables"_s);
-    // expectTypeError("@binding(-1) var<uniform> x: i32;"_s, "@binding value must be non-negative"_s);
-    // expectTypeError("@id(-1) var<private> y: i32;"_s, "@id attribute must only be applied to override variables"_s);
-    // expectTypeError("@id(-1) override z: i32;"_s, "@id value must be non-negative"_s);
-    // expectTypeError("@must_use fn mustUseWithoutReturnType() { }"_s, "@must_use can only be applied to functions that return a value"_s);
-    // expectTypeError("fn f1() -> @builtin(position) i32 { return 0; }"_s, "@builtin is not valid for non-entry point function types"_s);
-    // expectTypeError("fn f2() -> @location(0) i32 { return 0; }"_s, "@location is not valid for non-entry point function types"_s);
-    // expectTypeError("@fragment fn f3() -> @location(-1) i32 { return 0; }"_s, "@location value must be non-negative"_s);
-    // expectTypeError("@compute fn f4() -> @location(0) i32 { return 0; }"_s, "@location may not be used in the compute shader stage"_s);
-    // expectTypeError("@fragment fn f5() -> @location(0) bool { return false; }"_s, "@location must only be applied to declarations of numeric scalar or numeric vector type"_s);
-    // expectTypeError("fn f6() -> @interpolate(flat) i32 { return 0; }"_s, "@interpolate is only allowed on declarations that have a @location attribute"_s);
-    // expectTypeError("fn f7() -> @invariant i32 { return 0; }"_s, "@invariant is only allowed on declarations that have a @builtin(position) attribute"_s);
-    // expectTypeError("@workgroup_size(1) fn f8() { }"_s, "@workgroup_size must only be applied to compute shader entry point function"_s);
-    // expectTypeError("@workgroup_size(-1) @compute fn f9() { }"_s, "@workgroup_size argument must be at least 1"_s);
+    // Attribute validation
+    expectTypeError("@group(0) var<private> x: i32;"_s, "@group attribute must only be applied to resource variables"_s);
+    expectTypeError("@group(-1) var<uniform> x: i32;"_s, "@group value must be non-negative"_s);
+    expectTypeError("@binding(0) var<private> x: i32;"_s, "@binding attribute must only be applied to resource variables"_s);
+    expectTypeError("@binding(-1) var<uniform> x: i32;"_s, "@binding value must be non-negative"_s);
+    expectTypeError("@id(-1) var<private> y: i32;"_s, "@id attribute must only be applied to override variables"_s);
+    expectTypeError("@id(-1) override z: i32;"_s, "@id value must be non-negative"_s);
+    expectTypeError("@must_use fn mustUseWithoutReturnType() { }"_s, "@must_use can only be applied to functions that return a value"_s);
+    expectTypeError("fn f1() -> @builtin(position) i32 { return 0; }"_s, "@builtin is not valid for non-entry point function types"_s);
+    expectTypeError("fn f2() -> @location(0) i32 { return 0; }"_s, "@location is not valid for non-entry point function types"_s);
+    expectTypeError("@fragment fn f3() -> @location(-1) i32 { return 0; }"_s, "@location value must be non-negative"_s);
+    expectTypeError("@compute fn f4() -> @location(0) i32 { return 0; }"_s, "@location may not be used in the compute shader stage"_s);
+    expectTypeError("@fragment fn f5() -> @location(0) bool { return false; }"_s, "@location must only be applied to declarations of numeric scalar or numeric vector type"_s);
+    expectTypeError("fn f6() -> @interpolate(flat) i32 { return 0; }"_s, "@interpolate is only allowed on declarations that have a @location attribute"_s);
+    expectTypeError("fn f7() -> @invariant i32 { return 0; }"_s, "@invariant is only allowed on declarations that have a @builtin(position) attribute"_s);
+    expectTypeError("@workgroup_size(1) fn f8() { }"_s, "@workgroup_size must only be applied to compute shader entry point function"_s);
+    expectTypeError("@workgroup_size(-1) @compute fn f9() { }"_s, "@workgroup_size argument must be at least 1"_s);
 
     // check that we don't crash by trying to read the size of S2, which won't have been computed
     expectNoError(


### PR DESCRIPTION
#### 636bcad83217fcf88c7e0596051421888b6c2b47
<pre>
[WGSL] All passes should return after encountering the first error
<a href="https://bugs.webkit.org/show_bug.cgi?id=296373">https://bugs.webkit.org/show_bug.cgi?id=296373</a>
<a href="https://rdar.apple.com/157547984">rdar://157547984</a>

Reviewed by Mike Wyrzykowski.

Relanding since the original patch (297800@main) broke a couple tests.

In 296795@main the type checker was converted to return after the first error,
this patch continues that work and changes the remaining passes (attribute
validation and visibility validation) to have the same behavior.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::validate):
(WGSL::AttributeValidator::visit):
(WGSL::AttributeValidator::validateAlignment):
(WGSL::AttributeValidator::parseBuiltin):
(WGSL::AttributeValidator::parseInterpolate):
(WGSL::AttributeValidator::parseInvariant):
(WGSL::AttributeValidator::parseLocation):
(WGSL::AttributeValidator::validateInterpolation):
(WGSL::AttributeValidator::validateInvariant):
(WGSL::AttributeValidator::update):
(WGSL::AttributeValidator::set):
(WGSL::AttributeValidator::error):
(WGSL::AttributeValidator::validateIO):
(WGSL::AttributeValidator::validateBuiltinIO):
(WGSL::AttributeValidator::validateLocationIO):
(WGSL::AttributeValidator::validateStructIO):
* Source/WebGPU/WGSL/VisibilityValidator.cpp:
(WGSL::VisibilityValidator::validate):
(WGSL::VisibilityValidator::visit):
(WGSL::VisibilityValidator::error):
* Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm:
(TestWGSLAPI::TEST(WGSLTypeCheckingTests, Attributes)):

Canonical link: <a href="https://commits.webkit.org/298286@main">https://commits.webkit.org/298286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f9d896329aceee765ea276d157875fadd0ef03e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65455 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/216969d4-853d-40d7-a9c9-558322224952) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87233 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42102 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33aad87e-7a89-437a-a1a6-6e102f8863cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67623 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21186 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64604 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124137 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96041 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95826 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24426 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41004 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18849 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37833 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41659 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47173 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41221 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44536 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->