### PR TITLE
Testing a new API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -1420,6 +1420,45 @@ UNIFIED_PDF_TEST(BackgroundDoesNotAdaptToColorSchemeOnEmbeddedDocuments)
 }
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+UNIFIED_PDF_TEST(PluginScrollViewIsNotHorizontallyScrollableForFullFramePDF)
+{
+    // Use width 391 specifically: for test.pdf (page width 129.6pt, contentWidth 161.6),
+    // the layout scale 391/161.6 produces a scaled width of ~391.000031 in float32,
+    // which expandedIntSize rounds up to 392 — a 1-pixel mismatch that makes the
+    // plugin's UIScrollView horizontally scrollable without the fix.
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 391, 800) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
+    [webView synchronouslyLoadRequest:request.get()];
+
+    // Wait for stable presentation to ensure the scrolling tree is fully committed
+    // and the plugin's WKChildScrollView has its geometry set.
+    __block bool stable = false;
+    [webView _doAfterNextStablePresentationUpdate:^{
+        stable = true;
+    }];
+    TestWebKitAPI::Util::run(&stable);
+
+    // The plugin's WKChildScrollView should not be horizontally scrollable.
+    // A rounding mismatch in contentsSize() could make contentSize.width
+    // 1 pixel larger than bounds.width, causing the plugin's scroll view
+    // to capture horizontal pan gestures and rubber-band (rdar://156854435).
+    UIView *childScrollView = [webView wkFirstSubviewWithClass:NSClassFromString(@"WKChildScrollView")];
+    EXPECT_NOT_NULL(childScrollView);
+    if (!childScrollView)
+        return;
+
+    auto *scrollView = dynamic_objc_cast<UIScrollView>(childScrollView);
+    EXPECT_NOT_NULL(scrollView);
+    if (!scrollView)
+        return;
+
+    EXPECT_GT(scrollView.contentSize.width, 0);
+    EXPECT_GT(scrollView.bounds.size.width, 0);
+    EXPECT_LE(scrollView.contentSize.width, scrollView.bounds.size.width);
+}
+#endif
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(UNIFIED_PDF)


### PR DESCRIPTION
#### 45c4f0ebff5f187857de4370e5671b78027d7f61
<pre>
Testing a new API test
<a href="https://rdar.apple.com/155886185">rdar://155886185</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295590">https://bugs.webkit.org/show_bug.cgi?id=295590</a>

Reviewed by NOBODY (OOPS!).

Test a new API test UNIFIED_PDF_TEST PluginScrollViewIsNotHorizontallyScrollableForFullFramePDF

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45c4f0ebff5f187857de4370e5671b78027d7f61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103363 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8e8f08c-3e5b-406a-bd2b-ab523bcede50) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115651 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82178 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4d76525-9038-4bad-b9c1-2e7c2334169e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134526 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96385 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/153c4174-adf4-4c8b-8234-d5dd9dda07b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16872 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14800 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6482 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126483 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.PluginScrollViewIsNotHorizontallyScrollableForFullFramePDF (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161113 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123659 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78698 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11002 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22058 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21845 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->