### PR TITLE
[Site Isolation] Make tooltips work with site isolation.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips-expected.txt
@@ -1,0 +1,12 @@
+Verifies that tooltips from iframes are correct.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS tooltips[0] is 'Test Main Frame'
+PASS tooltips[2] is 'Tooltip A'
+PASS tooltips[4] is 'Tooltip B'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Verifies that tooltips from iframes are correct.");
+jsTestIsAsync = true;
+
+var tooltips = [];
+function tooltipDidChangeCallback(tooltip)
+{
+    testRunner.installTooltipDidChangeCallback(tooltipDidChangeCallback);
+    tooltips.push(tooltip);
+}
+
+async function runTest() {
+
+    if (window.testRunner) {
+        testRunner.installTooltipDidChangeCallback(tooltipDidChangeCallback);
+
+        await eventSender.asyncMouseMoveTo(30, 30);
+        await eventSender.asyncMouseMoveTo(100, 100);
+        await eventSender.asyncMouseMoveTo(300, 300);
+
+        // If this test is run with another test before it, then
+        // we can get a 'clear' tooltip first. In order for this
+        // test to be able to run with other tests or independently
+        // we should slice off that first clear if it exists.
+
+        var firstTooltipIndex = 0;
+        if (tooltips[0] == "")
+            tooltips = tooltips.slice(1);
+
+        shouldBe("tooltips[0]", "'Test Main Frame'");
+        shouldBe("tooltips[2]", "'Tooltip A'");
+        shouldBe("tooltips[4]", "'Tooltip B'");
+
+        finishJSTest();
+    }
+}
+
+</script>
+<style>
+    .container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 800px;
+        height: 800px;
+        border: 2px solid #333;
+    }
+
+    #frame1 {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+        width: 400px;
+        height: 400px;
+        border-color: #e74c3c;
+        z-index: 1;
+    }
+    
+    #frame2 {
+        position: absolute;
+        top: 200px;
+        left: 200px;
+        width: 400px;
+        height: 400px;
+        border-color: #3498db;
+        z-index: 2;
+    }
+</style>
+<body onload="runTest()">
+    <div class="container" id="mainframe" title="Test Main Frame">
+        <iframe id="frame1" src='http://localhost:8000/site-isolation/mouse-events/resources/tooltip-subframe-a.html'></iframe>
+        <iframe id="frame2" src='http://localhost:8000/site-isolation/mouse-events/resources/tooltip-subframe-b.html'></iframe>
+    </div>
+</body>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/tooltip-subframe-a.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/tooltip-subframe-a.html
@@ -1,0 +1,16 @@
+<style>
+    .content {
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        width: 400px;
+        height: 400px;
+    }
+</style>
+<body>
+    <div class="content" title="Tooltip A">
+        <h1>Tooltip Test Page A</h1>
+    </div>
+    
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/tooltip-subframe-b.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/tooltip-subframe-b.html
@@ -1,0 +1,16 @@
+<style>
+    .content {
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        width: 400px;
+        height: 400px;
+    }
+</style>
+<body>
+    <div class="content" title="Tooltip B">
+        <h1>Tooltip Test Page B</h1>
+    </div>
+    
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2194,7 +2194,8 @@ HandleUserInputEventResult EventHandler::mouseMoved(const PlatformMouseEvent& ev
         return result;
 
     hitTestResult.setToNonUserAgentShadowAncestor();
-    page->chrome().mouseDidMoveOverElement(hitTestResult, event.modifiers());
+    if (!result.remoteUserInputEventData())
+        page->chrome().mouseDidMoveOverElement(hitTestResult, event.modifiers());
 
 #if ENABLE(IMAGE_ANALYSIS)
     if (event.syntheticClickType() == SyntheticClickType::NoTap && m_textRecognitionHoverTimer.isActive())

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -105,7 +105,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     , isActivePDFAnnotation(false)
     , elementType(elementTypeFromHitTestResult(hitTestResult))
     , frameInfo(frameInfoDataFromHitTestResult(hitTestResult))
-    , toolTipText(tooltipText)
+    , tooltipText(tooltipText)
     , hasEntireImage(hitTestResult.hasEntireImage())
     , allowsFollowingLink(hitTestResult.allowsFollowingLink())
     , allowsFollowingImageURL(hitTestResult.allowsFollowingImageURL())
@@ -143,13 +143,13 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     }
 }
 
-WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, const String& toolTipText)
-    : WebHitTestResultData(hitTestResult, toolTipText, false) { }
+WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, const String& tooltipText)
+    : WebHitTestResultData(hitTestResult, tooltipText, false) { }
 
 WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, bool includeImage)
     : WebHitTestResultData(hitTestResult, String(), includeImage) { }
 
-WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&& linkLocalResourceResponse,
+WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData, const String& lookupText, const String& tooltipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&& linkLocalResourceResponse,
 #if PLATFORM(MAC)
     const WebHitTestResultPlatformData& platformData,
 #endif
@@ -175,7 +175,7 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , frameInfo(frameInfo)
         , remoteUserInputEventData(remoteUserInputEventData)
         , lookupText(lookupText)
-        , toolTipText(toolTipText)
+        , tooltipText(tooltipText)
         , imageText(imageText)
         , imageBitmap(imageBitmap)
         , sourceImageMIMEType(sourceImageMIMEType)

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -91,7 +91,7 @@ struct WebHitTestResultData {
     std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData;
 
     String lookupText;
-    String toolTipText;
+    String tooltipText;
     String imageText;
     RefPtr<WebCore::SharedMemory> imageSharedMemory;
     RefPtr<WebCore::ShareableBitmap> imageBitmap;
@@ -115,9 +115,9 @@ struct WebHitTestResultData {
     WebHitTestResultData(const WebHitTestResultData&) = default;
     WebHitTestResultData& operator=(WebHitTestResultData&&) = default;
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
-    WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText);
+    WebHitTestResultData(const WebCore::HitTestResult&, const String& tooltipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&&,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, bool isActivePDFAnnotation, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, std::optional<WebCore::RemoteUserInputEventData>, const String& lookupText, const String& tooltipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, bool hasEntireImage, bool allowsFollowingLink, bool allowsFollowingImageURL, std::optional<WebCore::ResourceResponse>&&,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif
@@ -130,7 +130,7 @@ struct WebHitTestResultData {
 
     std::optional<WebCore::SharedMemory::Handle> getImageSharedMemoryHandle() const;
 private:
-    WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText, bool includeImage);
+    WebHitTestResultData(const WebCore::HitTestResult&, const String& tooltipText, bool includeImage);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -56,7 +56,7 @@ struct WebKit::WebHitTestResultData {
     std::optional<WebKit::FrameInfoData> frameInfo;
     std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData;
     String lookupText;
-    String toolTipText;
+    String tooltipText;
     String imageText;
     std::optional<WebCore::SharedMemoryHandle> getImageSharedMemoryHandle();
     RefPtr<WebCore::ShareableBitmap> imageBitmap;

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -118,6 +118,7 @@ public:
 
     virtual void setStatusText(WebKit::WebPageProxy*, const WTF::String&) { }
     virtual void mouseDidMoveOverElement(WebKit::WebPageProxy&, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEventModifier>, Object*) { }
+    virtual void tooltipDidChange(WebKit::WebPageProxy&, const WTF::String&) { }
 
     virtual void didNotHandleKeyEvent(WebKit::WebPageProxy*, const WebKit::NativeWebKeyboardEvent&) { }
     virtual void didNotHandleWheelEvent(WebKit::WebPageProxy*, const WebKit::NativeWebWheelEvent&) { }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1968,6 +1968,14 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             m_client.mouseDidMoveOverElement(toAPI(&page), toAPI(apiHitTestResult.ptr()), toAPI(modifiers), toAPI(userData), m_client.base.clientInfo);
         }
 
+        void tooltipDidChange(WebPageProxy& page, const String& tooltip) final
+        {
+            if (!m_client.tooltipDidChange)
+                return;
+
+            m_client.tooltipDidChange(toAPI(&page), toAPI(tooltip.impl()), m_client.base.clientInfo);
+        }
+
         void didNotHandleKeyEvent(WebPageProxy* page, const NativeWebKeyboardEvent& event) final
         {
             if (!m_client.didNotHandleKeyEvent)

--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -104,6 +104,7 @@ typedef void (*WKPageFocusCallback)(WKPageRef page, const void *clientInfo);
 typedef void (*WKPageUnfocusCallback)(WKPageRef page, const void *clientInfo);
 typedef void (*WKPageSetStatusTextCallback)(WKPageRef page, WKStringRef text, const void *clientInfo);
 typedef void (*WKPageMouseDidMoveOverElementCallback)(WKPageRef page, WKHitTestResultRef hitTestResult, WKEventModifiers modifiers, WKTypeRef userData, const void *clientInfo);
+typedef void (*WKPageTooltipDidChangeCallback)(WKPageRef page, WKStringRef toolTip, const void *clientInfo);
 typedef void (*WKPageDidNotHandleKeyEventCallback)(WKPageRef page, WKNativeEventPtr event, const void *clientInfo);
 typedef void (*WKPageDidNotHandleWheelEventCallback)(WKPageRef page, WKNativeEventPtr event, const void *clientInfo);
 typedef bool (*WKPageGetToolbarsAreVisibleCallback)(WKPageRef page, const void *clientInfo);
@@ -1942,6 +1943,7 @@ typedef struct WKPageUIClientV19 {
     WKUnlockScreenOrientationCallback                                   unlockScreenOrientation;
 
     WKPageAddMessageToConsoleCallback addMessageToConsole;
+    WKPageTooltipDidChangeCallback tooltipDidChange;
 } WKPageUIClientV19;
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9000,8 +9000,9 @@ void WebPageProxy::mouseDidMoveOverElement(WebHitTestResultData&& hitTestResultD
 #if PLATFORM(MAC)
     m_lastMouseMoveHitTestResult = API::HitTestResult::create(hitTestResultData, this);
 #endif
+
     m_uiClient->mouseDidMoveOverElement(*this, hitTestResultData, modifiers, protectedLegacyMainFrameProcess()->transformHandlesToObjects(userData.protectedObject().get()).get());
-    setToolTip(hitTestResultData.toolTipText);
+    setToolTip(hitTestResultData.tooltipText);
 }
 
 void WebPageProxy::setToolbarsAreVisible(bool toolbarsAreVisible)
@@ -10860,6 +10861,7 @@ void WebPageProxy::setToolTip(const String& toolTip)
     m_toolTip = toolTip;
     if (RefPtr pageClient = this->pageClient())
         pageClient->toolTipChanged(oldToolTip, m_toolTip);
+    m_uiClient->tooltipDidChange(*this, m_toolTip);
 }
 
 void WebPageProxy::setCursor(const WebCore::Cursor& cursor)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -898,7 +898,7 @@ void WebPageProxy::handleContextMenuLookUpImage()
     if (!imageBitmap)
         return;
 
-    showImageInQuickLookPreviewPanel(*imageBitmap, result.toolTipText, URL { result.absoluteImageURL }, QuickLookPreviewActivity::VisualSearch);
+    showImageInQuickLookPreviewPanel(*imageBitmap, result.tooltipText, URL { result.absoluteImageURL }, QuickLookPreviewActivity::VisualSearch);
 }
 
 void WebPageProxy::showImageInQuickLookPreviewPanel(ShareableBitmap& imageBitmap, const String& tooltip, const URL& imageURL, QuickLookPreviewActivity activity)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -289,6 +289,8 @@ interface TestRunner {
 
     unsigned long imageCountInGeneralPasteboard();
 
+    undefined installTooltipDidChangeCallback(object callback);
+
     // UI Process Testing
     undefined runUIScript(DOMString script, object callback);
     undefined runUIScriptImmediately(DOMString script, object callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -39,9 +39,11 @@
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WebKit2_C.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Logging.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextStream.h>
 
 namespace WTR {
 
@@ -273,6 +275,14 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
     if (WKStringIsEqualToUTF8CString(messageName, "NotifyDownloadDone")) {
         if (m_testRunner && m_testRunner->shouldFinishAfterDownload())
             m_testRunner->notifyDone();
+        return;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "CallTooltipDidChangeCallback")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        auto tooltipString = stringValue(messageBodyDictionary, "Tooltip");
+        if (m_testRunner)
+            m_testRunner->callTooltipDidChangeCallback(toJS(tooltipString).get());
         return;
     }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -605,6 +605,7 @@ enum {
     TextDidChangeInTextFieldCallbackID,
     TextFieldDidBeginEditingCallbackID,
     TextFieldDidEndEditingCallbackID,
+    ToolTipDidChangeCallbackID,
     FirstUIScriptCallbackID = 100
 };
 
@@ -1162,6 +1163,16 @@ void TestRunner::callDidEndSwipeCallback()
 void TestRunner::callDidRemoveSwipeSnapshotCallback()
 {
     callTestRunnerCallback(DidRemoveSwipeSnapshotCallbackID);
+}
+
+void TestRunner::installTooltipDidChangeCallback(JSContextRef context, JSValueRef callback)
+{
+    cacheTestRunnerCallback(context, ToolTipDidChangeCallbackID, callback);
+}
+
+void TestRunner::callTooltipDidChangeCallback(JSStringRef tooltip)
+{
+    callTestRunnerCallback(ToolTipDidChangeCallbackID, tooltip);
 }
 
 void TestRunner::clearStatisticsDataForDomain(JSStringRef domain)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -402,6 +402,9 @@ public:
     void callDidEndSwipeCallback();
     void callDidRemoveSwipeSnapshotCallback();
 
+    void installTooltipDidChangeCallback(JSContextRef, JSValueRef);
+    void callTooltipDidChangeCallback(JSStringRef tooltip);
+
     void clearTestRunnerCallbacks();
 
     void accummulateLogsForChannel(JSStringRef channel);

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -635,6 +635,9 @@ private:
     static void didUpdateHistoryTitle(WKContextRef, WKPageRef, WKStringRef title, WKURLRef, WKFrameRef, const void*);
     void didUpdateHistoryTitle(WKStringRef title, WKURLRef, WKFrameRef);
 
+    static void tooltipDidChange(WKPageRef, WKStringRef tooltip, const void*);
+    void tooltipDidChange(WKStringRef tooltip);
+
     static WKPageRef createOtherPage(WKPageRef, WKPageConfigurationRef, WKNavigationActionRef, WKWindowFeaturesRef, const void*);
     WKPageRef createOtherPage(PlatformWebView* parentView, WKPageConfigurationRef, WKNavigationActionRef, WKWindowFeaturesRef);
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -43,9 +43,11 @@
 #include <WebKit/WKWebsiteDataStoreRef.h>
 #include <climits>
 #include <cstdio>
+#include <wtf/Logging.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/TextStream.h>
 
 #if PLATFORM(MAC) && !PLATFORM(IOS_FAMILY)
 #include <Carbon/Carbon.h>
@@ -272,6 +274,13 @@ void TestInvocation::forceRepaintDoneCallback(WKErrorRef error, void* context)
 
     testInvocation->m_gotRepaint = true;
     TestController::singleton().notifyDone();
+}
+
+void TestInvocation::tooltipDidChange(WKStringRef toolTip)
+{
+    auto messageBody = adoptWK(WKMutableDictionaryCreate());
+    setValue(messageBody, "Tooltip", toolTip);
+    postPageMessage("CallTooltipDidChangeCallback", messageBody);
 }
 
 void TestInvocation::dumpResourceLoadStatisticsIfNecessary()

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -76,6 +76,8 @@ public:
 
     void notifyDownloadDone();
 
+    void tooltipDidChange(WKStringRef toolTip);
+
     void dumpResourceLoadStatistics();
 
     bool canOpenWindows() const { return m_canOpenWindows; }


### PR DESCRIPTION
#### a080b72f41e32c392811ef191c8c2a96e7560e38
<pre>
[Site Isolation] Make tooltips work with site isolation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296930">https://bugs.webkit.org/show_bug.cgi?id=296930</a>
<a href="https://rdar.apple.com/155247419">rdar://155247419</a>

Reviewed by Abrar Rahman Protyasha.

This is the fix and a test for tooltips to work correctly
with site isolation.

The fix is in EventHandler.cpp. In order to make sure that
mouse events get to the right process, currently first send
the event to the main frame web-process. If we are triggering in
a sub-frame, that information is passed onto a subframe in
the remoteUserInputEventData. If we have that data then we
know that the information is destined to head to another
process and we should not finish processing this
event in the main frame web process and returing to the
UI process. This check is all we need to circumvent
that.

Many of the rest of the changes are fixing capitalization of
toolTips to tooltips.

The rest is the plumbing needed to write a proper test.
Our current tooltip tests work by merely asking the web
process what tooltip we would expect for an element. That
is basically useless in a site isolated world. I have
added C API to allow for the passing back of the current
tooltip string when the tooltip changes. This is C API
only since the only use is for testing.

* LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/resources/tooltip-subframe-a.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/resources/tooltip-subframe-b.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::mouseMoved):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::tooltipDidChange):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/C/WKPageUIClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::mouseDidMoveOverElement):
(WebKit::WebPageProxy::setToolTip):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::handleContextMenuLookUpImage):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::tooltipDidChange):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setTooltipDidChangeCallback):
(WTR::TestController::tooltipDidChange):
(WTR::TestController::createOtherPlatformWebView):
(WTR::TestController::createWebViewWithOptions):
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::runTest):
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:

Canonical link: <a href="https://commits.webkit.org/298294@main">https://commits.webkit.org/298294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28de0370ac21711f231dbe356b98c4d7e86fc602

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121139 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65669 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e90094d-b1bd-4423-b226-deb143d7d15a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8f32f19-b5dc-4387-80f4-c5f6cf11b5a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67799 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21385 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64791 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124329 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96201 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24430 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38004 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47402 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41411 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->