### PR TITLE
Move implementation for methods using inline-declared methods out from headers

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GPUDevice.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "EventNames.h"
 #include "GPUBindGroup.h"
@@ -288,6 +289,11 @@ ExceptionOr<Ref<GPUSampler>> GPUDevice::createSampler(const std::optional<GPUSam
     if (!sampler)
         return Exception { ExceptionCode::InvalidStateError, "GPUDevice.createSampler: Unable to create sampler."_s };
     return GPUSampler::create(sampler.releaseNonNull());
+}
+
+ScriptExecutionContext* GPUDevice::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -160,7 +160,7 @@ private:
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::GPUDevice; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1163,6 +1163,11 @@ bool SourceBuffer::hasVideo() const
     return m_videoTracks && m_videoTracks->length();
 }
 
+ScriptExecutionContext* SourceBuffer::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 void SourceBuffer::videoTrackSelectedChanged(VideoTrack& track)
 {
     // 2.4.5 Changes to selected/enabled track state

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -120,7 +120,7 @@ public:
     bool active() const { return m_active; }
 
     // EventTarget
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     enum class AppendMode { Segments, Sequence };
     AppendMode mode() const { return m_mode; }

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -475,6 +475,11 @@ bool MediaDevices::virtualHasPendingActivity() const
     return hasEventListeners(m_eventNames.devicechangeEvent);
 }
 
+ScriptExecutionContext* MediaDevices::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 void MediaDevices::listenForDeviceChanges()
 {
     RefPtr document = this->document();

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -115,7 +115,7 @@ private:
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaDevices; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -401,6 +401,11 @@ Ref<MediaStreamPrivate> MediaStream::protectedPrivateStream()
     return m_private;
 }
 
+ScriptExecutionContext* MediaStream::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStream::logChannel() const
 {

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -102,7 +102,7 @@ public:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaStream; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void addTrackFromPlatform(Ref<MediaStreamTrack>&&);
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -349,6 +349,11 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, RTCD
     return channel;
 }
 
+ScriptExecutionContext* RTCDataChannel::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -103,7 +103,7 @@ private:
     void removeFromDataChannelLocalMapIfNeeded();
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDataChannel; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -64,6 +64,11 @@ RTCDtlsTransport::~RTCDtlsTransport()
     m_backend->unregisterClient();
 }
 
+ScriptExecutionContext* RTCDtlsTransport::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 Vector<Ref<JSC::ArrayBuffer>> RTCDtlsTransport::getRemoteCertificates()
 {
     return m_remoteCertificates;

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.h
@@ -62,7 +62,7 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDtlsTransport; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -289,6 +289,11 @@ bool RTCRtpSFrameTransform::virtualHasPendingActivity() const
     return (m_isAttached || m_hasWritable) && hasEventListeners();
 }
 
+ScriptExecutionContext* RTCRtpSFrameTransform::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -88,7 +88,7 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCRtpSFrameTransform; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
@@ -46,6 +46,11 @@ WebCodecsBase::WebCodecsBase(ScriptExecutionContext& context)
 
 WebCodecsBase::~WebCodecsBase() = default;
 
+ScriptExecutionContext* WebCodecsBase::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 void WebCodecsBase::queueControlMessageAndProcess(WebCodecsControlMessage&& message)
 {
     if (m_isMessageQueueBlocked) {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     WebCodecsBase(ScriptExecutionContext&);
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void setState(WebCodecsCodecState state) { m_state = state; }
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
@@ -200,6 +200,11 @@ void DatabaseContext::databaseExceededQuota(const String& name, DatabaseDetails 
     ASSERT(context->isWorkerGlobalScope());
 }
 
+Document* DatabaseContext::document() const
+{
+    return downcast<Document>(ActiveDOMObject::scriptExecutionContext());
+}
+
 const SecurityOriginData& DatabaseContext::securityOrigin() const
 {
     return scriptExecutionContext()->securityOrigin()->data();

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -65,7 +65,7 @@ public:
     bool allowDatabaseAccess() const;
     void databaseExceededQuota(const String& name, DatabaseDetails);
 
-    Document* document() const { return downcast<Document>(ActiveDOMObject::scriptExecutionContext()); }
+    Document* document() const;
     const SecurityOriginData& securityOrigin() const;
 
     bool isContextThread() const;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6830,7 +6830,7 @@ sub GenerateCallbackHeaderContent
     push(@$contentRef, "        return adoptRef(*new ${className}(callback, globalObject));\n");
     push(@$contentRef, "    }\n\n");
 
-    push(@$contentRef, "    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }\n\n");
+    push(@$contentRef, "    ScriptExecutionContext* scriptExecutionContext() const;\n\n");
 
     push(@$contentRef, "    ~$className() final;\n");
 
@@ -7139,6 +7139,11 @@ sub GenerateCallbackImplementationContent
     push(@$contentRef, "        return jsNull();\n\n");
     push(@$contentRef, "    return static_cast<${className}&>(impl).callbackData()->callback();\n");
     push(@$contentRef, "}\n\n");
+
+    push(@$contentRef, "ScriptExecutionContext* ${className}::scriptExecutionContext() const\n");
+    push(@$contentRef, "{\n");
+    push(@$contentRef, "    return ContextDestructionObserver::scriptExecutionContext();\n");
+    push(@$contentRef, "}\n");
 }
 
 sub GenerateWriteBarriersForArguments

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -134,4 +134,8 @@ JSC::JSValue toJS(TestCallbackFunction& impl)
     return static_cast<JSTestCallbackFunction&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackFunction::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -34,7 +34,7 @@ public:
         return adoptRef(*new JSTestCallbackFunction(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackFunction() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -124,4 +124,8 @@ JSC::JSValue toJS(TestCallbackFunctionGenerateIsReachable& impl)
     return static_cast<JSTestCallbackFunctionGenerateIsReachable&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackFunctionGenerateIsReachable::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -35,7 +35,7 @@ public:
         return adoptRef(*new JSTestCallbackFunctionGenerateIsReachable(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackFunctionGenerateIsReachable() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -130,4 +130,8 @@ JSC::JSValue toJS(TestCallbackFunctionWithThisObject& impl)
     return static_cast<JSTestCallbackFunctionWithThisObject&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackFunctionWithThisObject::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -34,7 +34,7 @@ public:
         return adoptRef(*new JSTestCallbackFunctionWithThisObject(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackFunctionWithThisObject() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -132,4 +132,8 @@ JSC::JSValue toJS(TestCallbackFunctionWithTypedefs& impl)
     return static_cast<JSTestCallbackFunctionWithTypedefs&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackFunctionWithTypedefs::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -34,7 +34,7 @@ public:
         return adoptRef(*new JSTestCallbackFunctionWithTypedefs(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackFunctionWithTypedefs() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -137,4 +137,8 @@ JSC::JSValue toJS(TestCallbackFunctionWithVariadic& impl)
     return static_cast<JSTestCallbackFunctionWithVariadic&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackFunctionWithVariadic::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -36,7 +36,7 @@ public:
         return adoptRef(*new JSTestCallbackFunctionWithVariadic(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackFunctionWithVariadic() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -769,6 +769,10 @@ JSC::JSValue toJS(TestCallbackInterface& impl)
     return static_cast<JSTestCallbackInterface&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackInterface::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore
 
 #endif // ENABLE(TEST_CONDITIONAL)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -38,7 +38,7 @@ public:
         return adoptRef(*new JSTestCallbackInterface(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackInterface() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -132,4 +132,8 @@ JSC::JSValue toJS(TestCallbackWithFunctionOrDict& impl)
     return static_cast<JSTestCallbackWithFunctionOrDict&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestCallbackWithFunctionOrDict::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -34,7 +34,7 @@ public:
         return adoptRef(*new JSTestCallbackWithFunctionOrDict(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestCallbackWithFunctionOrDict() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -148,6 +148,10 @@ JSC::JSValue toJS(TestVoidCallbackFunction& impl)
     return static_cast<JSTestVoidCallbackFunction&>(impl).callbackData()->callback();
 }
 
+ScriptExecutionContext* JSTestVoidCallbackFunction::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
 } // namespace WebCore
 
 #endif // ENABLE(TEST_CONDITIONAL)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -36,7 +36,7 @@ public:
         return adoptRef(*new JSTestVoidCallbackFunction(callback, globalObject));
     }
 
-    ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const;
 
     ~JSTestVoidCallbackFunction() final;
     JSCallbackData* callbackData() { return m_data; }

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -1088,6 +1088,11 @@ void ViewTransition::stop()
         clearViewTransition();
 }
 
+Document* ViewTransition::document() const
+{
+    return downcast<Document>(scriptExecutionContext());
+}
+
 bool ViewTransition::documentElementIsCaptured() const
 {
     RefPtr document = this->document();

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -199,7 +199,7 @@ public:
     ViewTransitionPhase phase() const { return m_phase; }
     const OrderedNamedElementsMap& namedElements() const { return m_namedElements; };
 
-    Document* document() const { return downcast<Document>(scriptExecutionContext()); }
+    Document* document() const;
     RefPtr<Document> protectedDocument() const { return document(); }
 
     bool documentElementIsCaptured() const;

--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -104,6 +104,11 @@ bool MediaController::everyElement(Function<bool(Ref<HTMLMediaElement>&&)>&& fun
     return isNonEmpty;
 }
 
+ScriptExecutionContext* MediaController::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+};
+
 void MediaController::addMediaElement(HTMLMediaElement& element)
 {
     ASSERT(!m_mediaElements.contains(&element));

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -101,7 +101,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaController; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); };
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void addMediaElement(HTMLMediaElement&);
     void removeMediaElement(HTMLMediaElement&);

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -46,6 +46,11 @@ TrackListBase::TrackListBase(ScriptExecutionContext* context, Type type)
 
 TrackListBase::~TrackListBase() = default;
 
+ScriptExecutionContext* TrackListBase::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 void TrackListBase::didMoveToNewDocument(Document& newDocument)
 {
     ActiveDOMObject::didMoveToNewDocument(newDocument);

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -70,7 +70,7 @@ public:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const override = 0;
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void didMoveToNewDocument(Document&);
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -181,6 +181,11 @@ IntersectionObserver::~IntersectionObserver()
     disconnect();
 }
 
+Document* IntersectionObserver::trackingDocument() const
+{
+    return m_root ? &m_root->document() : m_implicitRootDocument.get();
+}
+
 String IntersectionObserver::rootMargin() const
 {
     StringBuilder stringBuilder;

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -81,7 +81,7 @@ public:
 
     ~IntersectionObserver();
 
-    Document* trackingDocument() const { return m_root ? &m_root->document() : m_implicitRootDocument.get(); }
+    Document* trackingDocument() const;
 
     ContainerNode* root() const { return m_root.get(); }
     String rootMargin() const;

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -85,6 +85,11 @@ void LegacyInlineBox::invalidateParentChildList()
 
 #endif
 
+const RenderStyle& LegacyInlineBox::lineStyle() const
+{
+    return m_bitfields.firstLine() ? renderer().firstLineStyle() : renderer().style();
+}
+
 void LegacyInlineBox::removeFromParent()
 { 
     if (parent())

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -214,7 +214,7 @@ public:
     void invalidateParentChildList();
 #endif
 
-    const RenderStyle& lineStyle() const { return m_bitfields.firstLine() ? renderer().firstLineStyle() : renderer().style(); }
+    const RenderStyle& lineStyle() const;
     
     const Style::VerticalAlign& verticalAlign() const { return lineStyle().verticalAlign(); }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -178,6 +178,11 @@ RenderMathMLOperator* RenderMathMLFraction::unembellishedOperator() const
     return mathMLBlock ? mathMLBlock->unembellishedOperator() : nullptr;
 }
 
+MathMLFractionElement& RenderMathMLFraction::element() const
+{
+    return static_cast<MathMLFractionElement&>(nodeForNonAnonymous());
+}
+
 void RenderMathMLFraction::computePreferredLogicalWidths()
 {
     ASSERT(needsPreferredLogicalWidthsUpdate());

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
@@ -57,7 +57,7 @@ private:
     RenderMathMLOperator* unembellishedOperator() const final;
     bool isMathContentCentered() const final { return true; }
 
-    MathMLFractionElement& element() const { return static_cast<MathMLFractionElement&>(nodeForNonAnonymous()); }
+    MathMLFractionElement& element() const;
 
     bool isValid() const;
     RenderBox& numerator() const;

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -46,6 +46,11 @@ RenderMathMLSpace::RenderMathMLSpace(MathMLSpaceElement& element, RenderStyle&& 
 
 RenderMathMLSpace::~RenderMathMLSpace() = default;
 
+MathMLSpaceElement& RenderMathMLSpace::element() const
+{
+    return static_cast<MathMLSpaceElement&>(nodeForNonAnonymous());
+}
+
 void RenderMathMLSpace::computePreferredLogicalWidths()
 {
     ASSERT(needsPreferredLogicalWidthsUpdate());

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
@@ -39,7 +39,7 @@ public:
     RenderMathMLSpace(MathMLSpaceElement&, RenderStyle&&);
     virtual ~RenderMathMLSpace();
 
-    MathMLSpaceElement& element() const { return static_cast<MathMLSpaceElement&>(nodeForNonAnonymous()); }
+    MathMLSpaceElement& element() const;
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLSpace"_s; }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
@@ -243,6 +243,11 @@ void BackgroundFetchRegistration::updateInformation(const BackgroundFetchInforma
     dispatchEvent(Event::create(eventNames().progressEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
+ScriptExecutionContext* BackgroundFetchRegistration::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 void BackgroundFetchRegistration::stop()
 {
 }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -78,7 +78,7 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::BackgroundFetchRegistration; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -162,4 +162,9 @@ void XMLHttpRequestProgressEventThrottle::resume()
     });
 }
 
+Ref<XMLHttpRequest> XMLHttpRequestProgressEventThrottle::protectedTarget()
+{
+    return m_target.get();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h
@@ -70,7 +70,7 @@ private:
     void flushProgressEvent();
     void dispatchEventWhenPossible(Event&);
 
-    Ref<XMLHttpRequest> protectedTarget() { return m_target.get(); }
+    Ref<XMLHttpRequest> protectedTarget();
 
     // Weak reference to our XMLHttpRequest object as it is the one holding us.
     WeakRef<XMLHttpRequest, WeakPtrImplWithEventTargetData> m_target;


### PR DESCRIPTION
#### 59cd2096d26ab40a0e1319f3d38c469a0cdc7d57
<pre>
Move implementation for methods using inline-declared methods out from headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=296934">https://bugs.webkit.org/show_bug.cgi?id=296934</a>

Reviewed by Ross Kirsling.

There are many, often trivial, methods implemented
in header files that are using methods from other classes
that are defined in a Inlines.h header file. The convention
in WebKit (enforced by the style-checker) is that one
should never include Inlines.h files in a header, as it has
a negative impact in build time.

The problem with this status-quo is that this obscures
the fact that those Inlines.h files are not always
included when needed, particularly in non-unified builds, but
also when the unified compilation units change. This causes
compilation warnings and/or of the likes of:

    error: inline function &apos;WebCore::ContextDestructionObserver::scriptExecutionContext&apos; is not defined

Since we don&apos;t want to include Inlines.h in headers,
the correct usage of the methods defined in those files
is to not use them in headers, but to have the implementations
using them defined in the CPP files instead.

This patch is an attempt to remedy this situation but
it&apos;s not exhaustive, but it fixes a lot of those errors.
Notably, it also modifies CodeGeneratorJS.pm to fix
this issue in generated-code as well.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::scriptExecutionContext const):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::scriptExecutionContext const):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
(WebCore::RTCDtlsTransport::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::RTCRtpSFrameTransform::scriptExecutionContext const):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp:
(WebCore::WebCodecsBase::scriptExecutionContext const):
* Source/WebCore/Modules/webcodecs/WebCodecsBase.h:
* Source/WebCore/Modules/webdatabase/DatabaseContext.cpp:
(WebCore::DatabaseContext::document const):
* Source/WebCore/Modules/webdatabase/DatabaseContext.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackHeaderContent):
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
(WebCore::JSTestCallbackFunction::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
(WebCore::JSTestCallbackFunctionGenerateIsReachable::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
(WebCore::JSTestCallbackFunctionWithThisObject::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
(WebCore::JSTestCallbackFunctionWithTypedefs::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
(WebCore::JSTestCallbackFunctionWithVariadic::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::JSTestCallbackInterface::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
(WebCore::JSTestCallbackWithFunctionOrDict::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
(WebCore::JSTestVoidCallbackFunction::scriptExecutionContext const):
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::document const):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::document const): Deleted.
* Source/WebCore/html/MediaController.cpp:
(WebCore::MediaController::scriptExecutionContext const):
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::scriptExecutionContext const):
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::trackingDocument const):
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::trackingDocument const): Deleted.
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::lineStyle const):
* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::lineStyle const): Deleted.
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::element const):
* Source/WebCore/rendering/mathml/RenderMathMLFraction.h:
* Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
(WebCore::RenderMathMLSpace::element const):
* Source/WebCore/rendering/mathml/RenderMathMLSpace.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchRegistration::scriptExecutionContext const):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::protectedTarget):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.h:
(WebCore::XMLHttpRequestProgressEventThrottle::protectedTarget): Deleted.

Canonical link: <a href="https://commits.webkit.org/298326@main">https://commits.webkit.org/298326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e19c3a2994f125510222b0087572ed45b55c35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87254 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42123 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21205 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37858 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47199 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->