### PR TITLE
[Style] Remove unused integer value support from Style::LengthWrapperData

### DIFF
--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
@@ -73,27 +73,15 @@ LengthWrapperData::LengthWrapperData(const WebCore::Length& length)
     switch (length.type()) {
     case WebCore::LengthType::Fixed:
         m_type = LengthWrapperDataType::Fixed;
-        m_isFloat = length.isFloat();
-        if (m_isFloat)
-            m_floatValue = length.value();
-        else
-            m_intValue = length.intValue();
+        m_floatValue = length.value();
         return;
     case WebCore::LengthType::Percent:
         m_type = LengthWrapperDataType::Percent;
-        m_isFloat = length.isFloat();
-        if (m_isFloat)
-            m_floatValue = length.value();
-        else
-            m_intValue = length.intValue();
+        m_floatValue = length.value();
         return;
     case WebCore::LengthType::Relative:
         m_type = LengthWrapperDataType::Relative;
-        m_isFloat = length.isFloat();
-        if (m_isFloat)
-            m_floatValue = length.value();
-        else
-            m_intValue = length.intValue();
+        m_floatValue = length.value();
         return;
     case WebCore::LengthType::Calculated:
         m_type = LengthWrapperDataType::Calculated;
@@ -138,27 +126,15 @@ LengthWrapperData::LengthWrapperData(WebCore::Length&& length)
     switch (length.type()) {
     case WebCore::LengthType::Fixed:
         m_type = LengthWrapperDataType::Fixed;
-        m_isFloat = length.isFloat();
-        if (m_isFloat)
-            m_floatValue = length.value();
-        else
-            m_intValue = length.intValue();
+        m_floatValue = length.value();
         return;
     case WebCore::LengthType::Percent:
         m_type = LengthWrapperDataType::Percent;
-        m_isFloat = length.isFloat();
-        if (m_isFloat)
-            m_floatValue = length.value();
-        else
-            m_intValue = length.intValue();
+        m_floatValue = length.value();
         return;
     case WebCore::LengthType::Relative:
         m_type = LengthWrapperDataType::Relative;
-        m_isFloat = length.isFloat();
-        if (m_isFloat)
-            m_floatValue = length.value();
-        else
-            m_intValue = length.intValue();
+        m_floatValue = length.value();
         return;
     case WebCore::LengthType::Calculated:
         m_type = LengthWrapperDataType::Calculated;
@@ -202,17 +178,11 @@ WebCore::Length LengthWrapperData::toPlatform() const
 {
     switch (type()) {
     case LengthWrapperDataType::Fixed:
-        return m_isFloat
-            ? WebCore::Length(m_floatValue, WebCore::LengthType::Fixed, m_hasQuirk)
-            : WebCore::Length(m_intValue, WebCore::LengthType::Fixed, m_hasQuirk);
+        return WebCore::Length(m_floatValue, WebCore::LengthType::Fixed, m_hasQuirk);
     case LengthWrapperDataType::Percent:
-        return m_isFloat
-            ? WebCore::Length(m_floatValue, WebCore::LengthType::Percent)
-            : WebCore::Length(m_intValue, WebCore::LengthType::Percent);
+        return WebCore::Length(m_floatValue, WebCore::LengthType::Percent);
     case LengthWrapperDataType::Relative:
-        return m_isFloat
-            ? WebCore::Length(m_floatValue, WebCore::LengthType::Relative)
-            : WebCore::Length(m_intValue, WebCore::LengthType::Relative);
+        return WebCore::Length(m_floatValue, WebCore::LengthType::Relative);
     case LengthWrapperDataType::Calculated:
         return WebCore::Length(protectedCalculationValue());
     case LengthWrapperDataType::FillAvailable:
@@ -279,41 +249,14 @@ LengthWrapperData::LengthWrapperData(IPCData&& data)
 {
     WTF::switchOn(data,
         [&](const FixedData& data) {
-            WTF::switchOn(data.value,
-                [&](float value) {
-                    m_isFloat = true;
-                    m_floatValue = value;
-                },
-                [&](int value) {
-                    m_isFloat = false;
-                    m_intValue = value;
-                }
-            );
+            m_floatValue = data.value;
             m_hasQuirk = data.hasQuirk;
         },
         [&](const RelativeData& data) {
-            WTF::switchOn(data.value,
-                [&](float value) {
-                    m_isFloat = true;
-                    m_floatValue = value;
-                },
-                [&](int value) {
-                    m_isFloat = false;
-                    m_intValue = value;
-                }
-            );
+            m_floatValue = data.value;
         },
         [&](const PercentData& data) {
-            WTF::switchOn(data.value,
-                [&](float value) {
-                    m_isFloat = true;
-                    m_floatValue = value;
-                },
-                [&](int value) {
-                    m_isFloat = false;
-                    m_intValue = value;
-                }
-            );
+            m_floatValue = data.value;
         },
         []<typename EmptyData>(EmptyData) requires std::is_empty_v<EmptyData> { }
     );
@@ -327,11 +270,11 @@ auto LengthWrapperData::ipcData() const -> IPCData
     case LengthWrapperDataType::Normal:
         return NormalData { };
     case LengthWrapperDataType::Relative:
-        return RelativeData { floatOrInt() };
+        return RelativeData { value() };
     case LengthWrapperDataType::Percent:
-        return PercentData { floatOrInt() };
+        return PercentData { value() };
     case LengthWrapperDataType::Fixed:
-        return FixedData { floatOrInt(), m_hasQuirk };
+        return FixedData { value(), m_hasQuirk };
     case LengthWrapperDataType::Intrinsic:
         return IntrinsicData { };
     case LengthWrapperDataType::MinIntrinsic:
@@ -353,14 +296,6 @@ auto LengthWrapperData::ipcData() const -> IPCData
         return { };
     }
     RELEASE_ASSERT_NOT_REACHED();
-}
-
-auto LengthWrapperData::floatOrInt() const -> FloatOrInt
-{
-    ASSERT(m_type != LengthWrapperDataType::Calculated);
-    if (m_isFloat)
-        return m_floatValue;
-    return m_intValue;
 }
 
 float LengthWrapperData::nonNanCalculatedValue(float maxValue) const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3247,14 +3247,14 @@ header: <WebCore/StyleLengthWrapperData.h>
 [CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::NormalData {
 };
 [CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FixedData {
-    Variant<float, int> value
+    float value
     bool hasQuirk
 };
 [CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::RelativeData {
-    Variant<float, int> value
+    float value
 };
 [CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::PercentData {
-    Variant<float, int> value
+    float value
 };
 [CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::IntrinsicData {
 };


### PR DESCRIPTION
#### 195a9b6b23dd1027e3608f376c4590c3b8b352d2
<pre>
[Style] Remove unused integer value support from Style::LengthWrapperData
<a href="https://bugs.webkit.org/show_bug.cgi?id=296935">https://bugs.webkit.org/show_bug.cgi?id=296935</a>

Reviewed by Tim Nguyen.

Removes unused support for integer values from `Style::LengthWrapperData`. The
type is only ever created with `float` or `CalculationValue`.

* Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/298247@main">https://commits.webkit.org/298247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0288728999fe3ceba82f5645de8da49abf4845f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/120966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43107 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31235 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24404 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41689 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47203 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41251 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/42995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->