### PR TITLE
[CSS] Support :visited as the scoping root selectors

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7077,9 +7077,6 @@ imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-update.html [ Skip ]
 imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-bounds-update.html [ Skip ]
 
-# CSS @scope
-imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]
-
 webkit.org/b/263923 animations/transition-and-animation-2.html [ Failure Pass ]
 
 # CloseWatcher related timeouts

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt
@@ -4,11 +4,11 @@ PASS :visited as scoped selector
 PASS :not(:link) as scoped selector
 PASS :not(:visited) as scoped selector
 PASS :link as scoping root
-FAIL :visited as scoping root assert_equals: visited expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
+PASS :visited as scoping root
 PASS :not(:visited) as scoping root
 PASS :not(:link) as scoping root
 PASS :link as scoping root, :scope
-FAIL :visited as scoping root, :scope assert_equals: visited expected "rgb(255, 255, 255)" but got "rgb(0, 128, 0)"
+PASS :visited as scoping root, :scope
 PASS :not(:visited) as scoping root, :scope
 PASS :not(:link) as scoping root, :scope
 PASS :link as scoping limit

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-expected.html
@@ -91,6 +91,8 @@
   // Insert inner <a> with JS, since the parser can't produce this result.
   let inner_a = document.createElement('a');
   inner_a.setAttribute('href', '');
+  inner_a.setAttribute('class', 'with_class_inner');
+  inner_a.setAttribute('style', 'color: green');
   inner_a.textContent = 'Visited2';
   outer_visited.append(inner_a);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-ref.html
@@ -91,6 +91,8 @@
   // Insert inner <a> with JS, since the parser can't produce this result.
   let inner_a = document.createElement('a');
   inner_a.setAttribute('href', '');
+  inner_a.setAttribute('class', 'with_class_inner');
+  inner_a.setAttribute('style', 'color: green');
   inner_a.textContent = 'Visited2';
   outer_visited.append(inner_a);
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html
@@ -186,7 +186,7 @@
   <template shadowrootmode=open>
     <main>
       Main
-      <a href="">
+      <a href="" class="with_class_outer">
         Visited1
       </a>
     </main>
@@ -198,6 +198,17 @@
       @scope (:visited) {
         :scope > :visited { background-color: coral; }
       }
+      @scope (:visited) {
+        :visited > :scope { background-color: lightgrey; }
+      }
+      @scope(.with_class_inner) {
+        :visited > :scope { color: yellow;  }
+      }
+
+      /* Should match */
+      @scope(.with_class_outer) {
+        :scope > :visited { color: green; }
+      }
     </style>
   </template>
 </div>
@@ -207,8 +218,10 @@
     // Insert the inner :visited link with JS, since the parser
     // can't produce this.
     let outer_a = visited_in_visited.shadowRoot.querySelector('main > a');
+
     let inner_a = document.createElement('a');
     inner_a.setAttribute('href', '');
+    inner_a.setAttribute('class', 'with_class_inner');
     inner_a.textContent = 'Visited2';
     outer_a.append(inner_a);
   }

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -898,9 +898,8 @@ bool CSSSelector::hasExplicitNestingParent() const
 bool CSSSelector::hasExplicitPseudoClassScope() const
 {
     return visitSimpleSelectors([] (const CSSSelector& selector) {
-        if (selector.match() == Match::PseudoClass && selector.pseudoClass() == PseudoClass::Scope)
+        if (selector.isScopePseudoClass())
             return true;
-
         return false;
     }, VisitFunctionalPseudoClasses::Yes);
 }
@@ -913,6 +912,15 @@ bool CSSSelector::isHostPseudoClass() const
 bool CSSSelector::isScopePseudoClass() const
 {
     return match() == Match::PseudoClass && pseudoClass() == PseudoClass::Scope;
+}
+
+bool CSSSelector::hasScope() const
+{
+    return visitSimpleSelectors([] (auto& selector) {
+        if (selector.isScopePseudoClass())
+            return true;
+        return false;
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -73,6 +73,7 @@ public:
 
     bool hasExplicitNestingParent() const;
     bool hasExplicitPseudoClassScope() const;
+    bool hasScope() const;
     void resolveNestingParentSelectors(const CSSSelectorList& parent);
     void replaceNestingParentByPseudoClassScope();
 

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -40,6 +40,7 @@ class CSSSelector;
 class Element;
 class RenderScrollbar;
 class RenderStyle;
+class StyleRuleScope;
 
 class SelectorChecker {
     WTF_MAKE_NONCOPYABLE(SelectorChecker);
@@ -94,6 +95,7 @@ public:
         RefPtr<const ContainerNode> scope;
         const Element* hasScope { nullptr };
         bool matchesAllHasScopes { false };
+        bool isEvaluatingScopingRoot { false };
         Style::ScopeOrdinal styleScopeOrdinal { Style::ScopeOrdinal::Element };
         Style::SelectorMatchingState* selectorMatchingState { nullptr };
 
@@ -102,6 +104,7 @@ public:
         PseudoIdSet pseudoIDSet;
         bool matchedInsideScope { false };
         bool disallowHasPseudoClass { false };
+        bool scopingRootMatchesVisited { false };
     };
 
     bool match(const CSSSelector&, const Element&, CheckingContext&) const;
@@ -112,7 +115,7 @@ public:
     static bool attributeSelectorMatches(const Element&, const QualifiedName&, const AtomString& attributeValue, const CSSSelector&);
 
     enum LinkMatchMask { MatchDefault = 0, MatchLink = 1, MatchVisited = 2, MatchAll = MatchLink | MatchVisited };
-    static unsigned determineLinkMatchType(const CSSSelector*);
+    static unsigned determineLinkMatchType(const CSSSelector*, const StyleRuleScope* = nullptr);
 
     struct LocalContext;
     

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -96,12 +96,13 @@ private:
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
     bool isFirstMatchModeAndHasMatchedAnyRules() const;
-    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, const ContainerNode* scopingRoot = nullptr);
-    bool containerQueriesMatch(const RuleData&, const MatchRequest&);
     struct ScopingRootWithDistance {
         RefPtr<const ContainerNode> scopingRoot;
         unsigned distance { std::numeric_limits<unsigned>::max() };
+        bool matchesVisited { false };
     };
+    bool ruleMatches(const RuleData&, unsigned& specificity, ScopeOrdinal, std::optional<ScopingRootWithDistance> scopingRoot = { });
+    bool containerQueriesMatch(const RuleData&, const MatchRequest&);
     std::pair<bool, std::optional<Vector<ScopingRootWithDistance>>> scopeRulesMatch(const RuleData&, const MatchRequest&);
 
     void sortMatchedRules();

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -139,7 +139,6 @@ RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned 
     , m_position(position)
     , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(*selector())))
     , m_canMatchPseudoElement(selectorCanMatchPseudoElement(*selector()))
-    , m_linkMatchType(SelectorChecker::determineLinkMatchType(selector()))
     , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
     , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
     , m_isEnabled(true)

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -64,6 +64,7 @@ public:
     bool canMatchPseudoElement() const { return m_canMatchPseudoElement; }
     MatchBasedOnRuleHash matchBasedOnRuleHash() const { return static_cast<MatchBasedOnRuleHash>(m_matchBasedOnRuleHash); }
     unsigned linkMatchType() const { return m_linkMatchType; }
+    void setLinkMatchType(unsigned value) { m_linkMatchType = value; }
     PropertyAllowlist propertyAllowlist() const { return static_cast<PropertyAllowlist>(m_propertyAllowlist); }
     IsStartingStyle isStartingStyle() const { return static_cast<IsStartingStyle>(m_isStartingStyle); }
     bool isEnabled() const { return m_isEnabled; }

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -160,6 +160,17 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     storeIdentifier(scopeRuleIdentifier, m_scopeRuleIdentifierForRulePosition);
 
     const auto& scopeRules = scopeRulesFor(ruleData);
+
+    auto computeLinkMatchType = [&] {
+        // General case: no @scope rule or current rule selector is not :scope.
+        if (scopeRules.isEmpty() || !ruleData.selector()->hasScope())
+            return SelectorChecker::determineLinkMatchType(ruleData.selector());
+        // When current rule is :scope, we need to take into account the @scope selectors to determine the link match type.
+        Ref scopeRule = scopeRules.last();
+        return SelectorChecker::determineLinkMatchType(ruleData.selector(), scopeRule.ptr());
+    };
+    ruleData.setLinkMatchType(computeLinkMatchType());
+
     m_features.collectFeatures(ruleData, scopeRules);
 
     unsigned classBucketSize = 0;


### PR DESCRIPTION
#### d6d238642bbc3cc3fd28823eb12552f9bf7a73d8
<pre>
[CSS] Support :visited as the scoping root selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=296947">https://bugs.webkit.org/show_bug.cgi?id=296947</a>
<a href="https://rdar.apple.com/157588890">rdar://157588890</a>

Reviewed by Antti Koivisto.

We statically take the scoping root selectors into account
to determine if we are potentially resolving visited/link style.

We track wheter we have match visited during scoping root matching, and
pass this result to normal style rule matching.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html:

Add slightly more complex case when the scoping root is a link, but the matching is done with class selector.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::hasExplicitPseudoClassScope const):
(WebCore::CSSSelector::hasScope const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):

Canonical link: <a href="https://commits.webkit.org/299560@main">https://commits.webkit.org/299560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38c43ccaad913ec40c867b77f3c21499e3960ef3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71481 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/490ec39b-0826-4fd7-bc8c-dd31d91bf015) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90734 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a20d8b4-cd57-46dd-ab3b-4d14b46a85d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71212 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7656f5aa-d050-483e-9c06-6d86dab54900) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69313 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128655 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99310 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99118 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25188 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22558 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46191 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51891 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49006 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47343 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->