### PR TITLE
[ARMv7] Always use gold to avoid running out of virtual memory.

### DIFF
--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -53,6 +53,14 @@ if (USE_LD_LLD)
     endif ()
 endif ()
 
+if (ARM_THUMB2_DETECTED AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+    set(USE_LD_LLD OFF)
+    # We run out of virtual memory easily, and gold seems to be the most reliable option.
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " -fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file")
+    string(APPEND CMAKE_MODULE_LINKER_FLAGS " -fuse-ld=gold -Wl,--no-map-whole-files -Wl,--no-keep-memory -Wl,--no-keep-files-mapped -Wl,--no-mmap-output-file")
+endif ()
+
 # Determine which linker is being used with the chosen linker flags.
 separate_arguments(LD_VERSION_COMMAND UNIX_COMMAND
     "${CMAKE_C_COMPILER} ${CMAKE_EXE_LINKER_FLAGS} -Wl,--version"

--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -572,7 +572,7 @@
                     "workernames": ["jsconly-linux-igalia-bot-2"]
                   },
                   {
-                    "name": "JSCOnly-Linux-ARMv7-Thumb2-Release", "factory": "BuildAndJSCTestsFactory",
+                    "name": "JSCOnly-Linux-ARMv7-Thumb2-Release", "factory": "BuildAndJSCTests32Factory",
                     "platform": "jsc-only", "configuration": "release", "architectures": ["armv7"],
                     "workernames": ["jsconly-linux-igalia-bot-3"]
                   },

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -150,13 +150,6 @@ class BuildAndTestLLINTCLoopFactory(Factory):
         self.addStep(RunLLINTCLoopTests())
 
 
-class BuildAndTest32bitJSCFactory(Factory):
-    def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None, **kwargs):
-        Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model, **kwargs)
-        self.addStep(Compile32bitJSC())
-        self.addStep(Run32bitJSCTests())
-
-
 class BuildAndNonLayoutTestFactory(BuildAndTestFactory):
     LayoutTestClass = None
 
@@ -165,6 +158,13 @@ class BuildAndJSCTestsFactory(Factory):
     def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None):
         Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model)
         self.addStep(CompileJSCOnly(timeout=60 * 60))
+        self.addStep(RunJavaScriptCoreTests(timeout=60 * 60))
+
+
+class BuildAndJSCTests32Factory(Factory):
+    def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None):
+        Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model)
+        self.addStep(CompileJSCOnly32(timeout=60 * 60))
         self.addStep(RunJavaScriptCoreTests(timeout=60 * 60))
 
 

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -509,9 +509,9 @@ class CompileLLINTCLoop(CompileWebKit):
     build_command = ["perl", "Tools/Scripts/build-jsc", "--cloop"]
 
 
-class Compile32bitJSC(CompileWebKit):
+class CompileJSCOnly32(CompileWebKit):
     name = 'compile-jsc-32bit'
-    build_command = ["perl", "Tools/Scripts/build-jsc", "--32-bit"]
+    build_command = ["linux32", "perl", "Tools/Scripts/build-jsc", "--32-bit"]
 
 
 class CompileJSCOnly(CompileWebKit):


### PR DESCRIPTION
#### 076da843bc1b128711f38f73dfc0f201e97f076c
<pre>
[ARMv7] Always use gold to avoid running out of virtual memory.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296949">https://bugs.webkit.org/show_bug.cgi?id=296949</a>

Reviewed by NOBODY (OOPS!).

LLD runs out of VA space when we aren&apos;t cross-compiling. We work around
this by forcing gold and not mapping whole files while linking.
* Source/cmake/OptionsCommon.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31f7c855359dd8f359f4274e2ad5a5889d3f8f04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87422 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42232 "Too many flaky failures: fast/dom/Range/compareBoundaryPoints-1.html, fast/forms/checkValidity-001.html, fast/harness/sample-mismatch-reftest.html, fast/html/adopt-parent-frame.html, fast/reporting/reporting-observer-callback-does-not-leak.html, imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html, js/arrowfunction-bind.html, js/bitops-type-tag.html, js/dom/array-tostring-ignore-separator.html, js/dom/call-link-info-recursion.html, performance-api/paint-timing/paint-timing-frames.html, resize-observer/element-leak.html, storage/indexeddb/intversion-two-opens-no-versions-private.html, storage/indexeddb/intversion-two-opens-no-versions.html, storage/indexeddb/intversion-upgrades.html, storage/indexeddb/invalid-keys-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-3d-r11f_g11f_b10f-rgb-float.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-3d-r11f_g11f_b10f-rgb-half_float.html, webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html, webgl/2.0.y/conformance/glsl/literals/overflow_leak.vert.html, webgl/2.0.y/conformance/glsl/misc/shader-with-non-reserved-words-6-of-8.html, webgl/2.0.y/conformance/ogles/GL/abs/abs_001_to_006.html, webgl/2.0.y/conformance/ogles/GL/log/log_009_to_012.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103286 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67818 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64816 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107326 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124354 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113590 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96222 "Passed tests") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/114477 "Failed build.webkit.org unit tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96007 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41207 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19048 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38025 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41892 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/138993 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile JSC; Compiled JSC (cancelled)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41436 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/138993 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile JSC; Compiled JSC (cancelled)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->