### PR TITLE
[WebXR + WebGPU] Support HDR with WebXR + WebGPU

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -315,6 +315,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/WebGPU/InternalAPI/WebGPUXRSubImage.h
     Modules/WebGPU/InternalAPI/WebGPUXRView.h
 
+    Modules/webxr/XRCanvasConfiguration.h
+
     Modules/airplay/PlaybackTargetClientContextIdentifier.h
 
     Modules/applepay/ApplePayLogoSystemImage.h

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp
@@ -28,6 +28,7 @@
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
 
+#include "PlatformXR.h"
 #include "WebGPUConvertToBackingContext.h"
 #include "WebGPUDevice.h"
 #include "WebGPUTextureFormat.h"

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "PlatformXR.h"
 #include "WebGPUTextureFormat.h"
 #include "WebGPUTextureUsage.h"
 #include "WebGPUXREye.h"

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -54,6 +54,7 @@ class WebCoreOpaqueRoot;
 class WebXRSystem;
 class WebXRView;
 class WebXRViewerSpace;
+struct XRCanvasConfiguration;
 struct XRRenderStateInit;
 
 class WebXRSession final : public RefCounted<WebXRSession>, public EventTarget, public ActiveDOMObject, public PlatformXR::TrackingAndRenderingClient {
@@ -113,6 +114,8 @@ public:
 #if ENABLE(WEBXR_HANDS)
     bool isHandTrackingEnabled() const;
 #endif
+
+    void initializeTrackingAndRendering(std::optional<XRCanvasConfiguration>&&);
 
 private:
     WebXRSession(Document&, WebXRSystem&, XRSessionMode, PlatformXR::Device&, FeatureList&&);

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -120,7 +120,7 @@ private:
     private:
         DummyInlineDevice(ScriptExecutionContext&);
 
-        void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) final { }
+        void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<XRCanvasConfiguration>&&) final { }
         void shutDownTrackingAndRendering() final { }
         void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final { }
 

--- a/Source/WebCore/Modules/webxr/XRCanvasConfiguration.h
+++ b/Source/WebCore/Modules/webxr/XRCanvasConfiguration.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebGPUTextureFormat.h"
+
+namespace WebCore {
+
+struct XRCanvasConfiguration {
+    std::optional<WebGPU::TextureFormat> colorFormat;
+    std::optional<WebGPU::TextureFormat> depthStencilFormat;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.cpp
@@ -56,7 +56,7 @@ static WebGPU::XREye convertToBacking(XREye eye)
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(XRGPUBinding);
 
-XRGPUBinding::XRGPUBinding(const WebXRSession& session, GPUDevice& device)
+XRGPUBinding::XRGPUBinding(WebXRSession& session, GPUDevice& device)
     : m_backing(device.createXRBinding(session))
     , m_session(&session)
     , m_device(device)
@@ -70,8 +70,17 @@ GPUDevice& XRGPUBinding::device()
 
 ExceptionOr<Ref<XRProjectionLayer>> XRGPUBinding::createProjectionLayer(ScriptExecutionContext& scriptExecutionContext, std::optional<XRGPUProjectionLayerInit> init)
 {
-    if (!m_backing)
+    if (!m_backing || !m_session)
         return Exception { ExceptionCode::AbortError };
+
+    if (init) {
+        auto converted = init->convertToBacking();
+        m_session->initializeTrackingAndRendering(XRCanvasConfiguration {
+            .colorFormat = converted.colorFormat,
+            .depthStencilFormat = converted.depthStencilFormat
+        });
+    } else
+        m_session->initializeTrackingAndRendering(std::nullopt);
 
     WebGPU::XRProjectionLayerInit convertedInit;
     if (init)

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.h
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.h
@@ -57,10 +57,10 @@ class XRProjectionLayer;
 class XRQuadLayer;
 class XRGPUSubImage;
 
+struct XRCanvasConfiguration;
 struct XRCubeLayerInit;
 struct XRCylinderLayerInit;
 struct XREquirectLayerInit;
-struct XRGPUProjectionLayerInit;
 struct XRProjectionLayerInit;
 struct XRQuadLayerInit;
 
@@ -70,7 +70,7 @@ template<typename> class ExceptionOr;
 class XRGPUBinding : public RefCounted<XRGPUBinding> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(XRGPUBinding);
 public:
-    static Ref<XRGPUBinding> create(const WebXRSession& session, GPUDevice& device)
+    static Ref<XRGPUBinding> create(WebXRSession& session, GPUDevice& device)
     {
         return adoptRef(*new XRGPUBinding(session, device));
     }
@@ -90,10 +90,10 @@ public:
     // XREquirectLayer createEquirectLayer(optional XRGPUEquirectLayerInit init);
     // XRCubeLayer createCubeLayer(optional XRGPUCubeLayerInit init);
 private:
-    XRGPUBinding(const WebXRSession&, GPUDevice&);
+    XRGPUBinding(WebXRSession&, GPUDevice&);
 
     RefPtr<WebGPU::XRBinding> m_backing;
-    RefPtr<const WebXRSession> m_session;
+    RefPtr<WebXRSession> m_session;
     std::optional<XRGPUProjectionLayerInit> m_init;
     const Ref<GPUDevice> m_device;
 };

--- a/Source/WebCore/Modules/webxr/XRGPUProjectionLayerInit.h
+++ b/Source/WebCore/Modules/webxr/XRGPUProjectionLayerInit.h
@@ -25,12 +25,10 @@
 
 #pragma once
 
-#if ENABLE(WEBXR_LAYERS)
-
 #include "GPUTextureFormat.h"
 #include "GPUTextureUsage.h"
 #include "WebGPUXRProjectionLayer.h"
-#include "XRTextureType.h"
+#include "XRCanvasConfiguration.h"
 
 namespace WebCore {
 
@@ -56,5 +54,3 @@ struct XRGPUProjectionLayerInit {
 };
 
 } // namespace WebCore
-
-#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -39,6 +39,7 @@
 
 #if PLATFORM(COCOA)
 #include "IOSurface.h"
+#include <WebCore/XRGPUProjectionLayerInit.h>
 #include <wtf/MachSendRight.h>
 #endif
 
@@ -53,6 +54,8 @@ template<> struct IsDeprecatedWeakRefSmartPointerException<PlatformXR::TrackingA
 
 namespace WebCore {
 class SecurityOriginData;
+
+struct XRCanvasConfiguration;
 }
 
 namespace PlatformXR {
@@ -400,7 +403,7 @@ public:
     // the native resolution if the device supports supersampling.
     virtual double maxFramebufferScalingFactor() const { return nativeFramebufferScalingFactor(); }
 
-    virtual void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, SessionMode, const FeatureList&) = 0;
+    virtual void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, SessionMode, const FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) = 0;
     virtual void shutDownTrackingAndRendering() = 0;
     virtual void didCompleteShutdownTriggeredBySystem() { }
     TrackingAndRenderingClient* trackingAndRenderingClient() const { return m_trackingAndRenderingClient.get(); }

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -110,7 +110,7 @@ WebCore::IntSize SimulatedXRDevice::recommendedResolution(PlatformXR::SessionMod
     return IntSize(32, 32);
 }
 
-void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&)
+void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
 {
     if (m_trackingAndRenderingClient) {
         // WebXR FakeDevice waits for simulateInputConnection calls to add input sources-

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -43,6 +43,8 @@
 
 namespace WebCore {
 
+struct XRCanvasConfiguration;
+
 class GraphicsContextGL;
 template<typename> class ExceptionOr;
 
@@ -90,7 +92,7 @@ public:
     void addInputConnection(Ref<WebFakeXRInputController>&& input) { m_inputConnections.append(WTFMove(input)); };
 private:
     WebCore::IntSize recommendedResolution(PlatformXR::SessionMode) final;
-    void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) final;
+    void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) final;
     void shutDownTrackingAndRendering() final;
     bool supportsSessionShutdownNotification() const final { return m_supportsShutdownNotification; }
     void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final { }

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -31,6 +31,7 @@
 #include "PlatformXRSystemProxy.h"
 #include "XRDeviceInfo.h"
 #include <WebCore/SecurityOriginData.h>
+#include <WebCore/XRCanvasConfiguration.h>
 
 using namespace PlatformXR;
 
@@ -70,7 +71,7 @@ void XRDeviceProxy::updateSessionVisibilityState(PlatformXR::VisibilityState vis
         trackingAndRenderingClient()->updateSessionVisibilityState(visibilityState);
 }
 
-void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList& requestedFeatures)
+void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList& requestedFeatures, std::optional<WebCore::XRCanvasConfiguration>&& init)
 {
     if (!isImmersive(sessionMode))
         return;
@@ -79,7 +80,7 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     if (!xrSystem)
         return;
 
-    xrSystem->initializeTrackingAndRendering();
+    xrSystem->initializeTrackingAndRendering(WTFMove(init));
 
     // This is called from the constructor of WebXRSession. Since sessionDidInitializeInputSources()
     // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.h
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.h
@@ -35,6 +35,7 @@
 
 namespace WebCore {
 class SecurityOriginData;
+struct XRCanvasConfiguration;
 }
 
 namespace WebKit {
@@ -56,7 +57,7 @@ private:
 
     WebCore::IntSize recommendedResolution(PlatformXR::SessionMode) final { return m_recommendedResolution; }
     double minimumNearClipPlane() const final { return m_minimumNearClipPlane; }
-    void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) final;
+    void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) final;
     void shutDownTrackingAndRendering() final;
     void didCompleteShutdownTriggeredBySystem() final;
     bool supportsSessionShutdownNotification() const final { return true; }

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -66,6 +66,7 @@ enum class MediaProducerMediaState : uint32_t;
 struct FontAttributes;
 struct WindowFeatures;
 struct OrganizationStorageAccessPromptQuirk;
+struct XRCanvasConfiguration;
 using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 }
 
@@ -237,7 +238,7 @@ public:
     virtual void supportedXRSessionFeatures(PlatformXR::Device::FeatureList& vrFeatures, PlatformXR::Device::FeatureList& arFeatures) { }
 
 #if PLATFORM(IOS_FAMILY)
-    virtual void startXRSession(WebKit::WebPageProxy&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&& completionHandler) { completionHandler(nil, nil); }
+    virtual void startXRSession(WebKit::WebPageProxy&, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&& completionHandler) { completionHandler(nil, nil); }
     virtual void endXRSession(WebKit::WebPageProxy&, WebKit::PlatformXRSessionEndReason) { }
 #endif
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -302,7 +302,7 @@ struct UIEdgeInsets;
 - (BOOL)_webView:(WKWebView *)webView touchEventsMustRequireGestureRecognizerToFail:(UIGestureRecognizer *)gestureRecognizer WK_API_AVAILABLE(ios(15.0));
 - (BOOL)_webView:(WKWebView *)webView gestureRecognizerCanBePreventedByTouchEvents:(UIGestureRecognizer *)gestureRecognizer WK_API_AVAILABLE(ios(16.5));
 
-- (void)_webView:(WKWebView *)webView startXRSessionWithFeatures:(_WKXRSessionFeatureFlags)features completionHandler:(void (^)(id, UIViewController *))completionHandler WK_API_AVAILABLE(ios(17.4), visionos(1.1));
+- (void)_webView:(WKWebView *)webView startXRSessionWithFeatures:(_WKXRSessionFeatureFlags)features colorFormat:(MTLPixelFormat)pixelFormat depthFormat:(MTLPixelFormat)depthFormat completionHandler:(void (^)(id, UIViewController *))completionHandler WK_API_AVAILABLE(ios(17.4), visionos(1.1));
 
 - (void)_webViewDidEnterStandbyForTesting:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
 - (void)_webViewDidExitStandbyForTesting:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -48,6 +48,7 @@ class SecurityOrigin;
 namespace WebCore {
 class RegistrableDomain;
 struct OrganizationStorageAccessPromptQuirk;
+struct XRCanvasConfiguration;
 }
 
 namespace WebKit {
@@ -194,7 +195,7 @@ private:
         void requestPermissionOnXRSessionFeatures(WebPageProxy&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& /* granted */, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&) final;
         void supportedXRSessionFeatures(PlatformXR::Device::FeatureList&, PlatformXR::Device::FeatureList&) final;
 #if PLATFORM(IOS_FAMILY)
-        void startXRSession(WebPageProxy&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&&) final;
+        void startXRSession(WebPageProxy&, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&&) final;
         void endXRSession(WebPageProxy&, PlatformXRSessionEndReason) final;
 #endif
 #endif

--- a/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h
@@ -38,6 +38,8 @@
 
 namespace WebCore {
 class SecurityOriginData;
+
+struct XRCanvasConfiguration;
 }
 
 namespace WebKit {
@@ -70,7 +72,7 @@ public:
 #endif
 
     // Session creation/termination.
-    virtual void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) = 0;
+    virtual void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) = 0;
     virtual void endSessionIfExists(WebPageProxy&) = 0;
 
     // Session display loop.

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -37,6 +37,11 @@
 
 namespace WebCore {
 class SecurityOriginData;
+struct XRCanvasConfiguration;
+
+namespace WebGPU {
+enum class TextureFormat : uint8_t;
+}
 }
 
 namespace WebKit {
@@ -86,7 +91,7 @@ private:
     // Message handlers
     void enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&&);
     void requestPermissionOnSessionFeatures(IPC::Connection&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
-    void initializeTrackingAndRendering(IPC::Connection&);
+    void initializeTrackingAndRendering(IPC::Connection&, std::optional<WebCore::WebGPU::TextureFormat>, std::optional<WebCore::WebGPU::TextureFormat>);
     void shutDownTrackingAndRendering(IPC::Connection&);
     void requestFrame(IPC::Connection&, std::optional<PlatformXR::RequestData>&&, CompletionHandler<void(PlatformXR::FrameData&&)>&&);
 #if USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -34,7 +34,7 @@
 messages -> PlatformXRSystem {
     EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
     RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
-    InitializeTrackingAndRendering()
+    InitializeTrackingAndRendering(std::optional<WebCore::WebGPU::TextureFormat> colorFormat, std::optional<WebCore::WebGPU::TextureFormat> depthStencilFormat)
     ShutDownTrackingAndRendering()
     RequestFrame(struct std::optional<PlatformXR::RequestData> requestData) -> (struct PlatformXR::FrameData frameData)
 #if USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -38,6 +38,10 @@
 @class ARSession;
 @protocol WKARPresentationSession;
 
+namespace WebCore {
+struct XRCanvasConfiguration;
+}
+
 namespace WebKit {
 
 class ARKitCoordinator final : public PlatformXRCoordinator {
@@ -50,7 +54,7 @@ public:
     void getPrimaryDeviceInfo(WebPageProxy&, DeviceInfoCallback&&) override;
     void requestPermissionOnSessionFeatures(WebPageProxy&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, FeatureListCallback&&) override;
 
-    void startSession(WebPageProxy&, WeakPtr<SessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) override;
+    void startSession(WebPageProxy&, WeakPtr<SessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) override;
     void endSessionIfExists(WebPageProxy&) override;
 
     void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&) override;

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -108,7 +108,7 @@ void ARKitCoordinator::requestPermissionOnSessionFeatures(WebPageProxy& page, co
     });
 }
 
-void ARKitCoordinator::startSession(WebPageProxy& page, WeakPtr<SessionEventClient>&& sessionEventClient, const WebCore::SecurityOriginData&, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList&)
+void ARKitCoordinator::startSession(WebPageProxy& page, WeakPtr<SessionEventClient>&& sessionEventClient, const WebCore::SecurityOriginData&, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
 {
     RELEASE_LOG(XR, "ARKitCoordinator::startSession");
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -185,7 +185,7 @@ void OpenXRCoordinator::createLayerProjection(uint32_t width, uint32_t height, b
         m_layers.add(defaultLayerHandle(), WTFMove(layer));
 }
 
-void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoordinatorSessionEventClient>&& sessionEventClient, const WebCore::SecurityOriginData&, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList&)
+void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoordinatorSessionEventClient>&& sessionEventClient, const WebCore::SecurityOriginData&, PlatformXR::SessionMode sessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&)
 {
     ASSERT(RunLoop::isMain());
     LOG(XR, "OpenXRCoordinator::startSession");

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -52,7 +52,7 @@ public:
 
     void createLayerProjection(uint32_t, uint32_t, bool) override;
 
-    void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) override;
+    void startSession(WebPageProxy&, WeakPtr<PlatformXRCoordinatorSessionEventClient>&&, const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&) override;
     void endSessionIfExists(WebPageProxy&) override;
 
     void scheduleAnimationFrame(WebPageProxy&, std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback) override;

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/Page.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/Settings.h>
+#include <WebCore/XRCanvasConfiguration.h>
 #include <wtf/Vector.h>
 
 using namespace PlatformXR;
@@ -83,9 +84,15 @@ void PlatformXRSystemProxy::requestPermissionOnSessionFeatures(const WebCore::Se
     protectedPage()->sendWithAsyncReply(Messages::PlatformXRSystem::RequestPermissionOnSessionFeatures(securityOriginData, mode, granted, consentRequired, consentOptional, requiredFeaturesRequested, optionalFeaturesRequested), WTFMove(completionHandler));
 }
 
-void PlatformXRSystemProxy::initializeTrackingAndRendering()
+void PlatformXRSystemProxy::initializeTrackingAndRendering(std::optional<WebCore::XRCanvasConfiguration>&& optionalInit)
 {
-    protectedPage()->send(Messages::PlatformXRSystem::InitializeTrackingAndRendering());
+    std::optional<WebCore::WebGPU::TextureFormat> colorFormat;
+    std::optional<WebCore::WebGPU::TextureFormat> depthStencilFormat;
+    if (optionalInit) {
+        colorFormat = optionalInit->colorFormat;
+        depthStencilFormat = optionalInit->depthStencilFormat;
+    }
+    protectedPage()->send(Messages::PlatformXRSystem::InitializeTrackingAndRendering(WTFMove(colorFormat), WTFMove(depthStencilFormat)));
 }
 
 void PlatformXRSystemProxy::shutDownTrackingAndRendering()

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -49,7 +49,7 @@ public:
 
     void enumerateImmersiveXRDevices(CompletionHandler<void(const PlatformXR::Instance::DeviceList&)>&&);
     void requestPermissionOnSessionFeatures(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& /* granted */, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */,  CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
-    void initializeTrackingAndRendering();
+    void initializeTrackingAndRendering(std::optional<WebCore::XRCanvasConfiguration>&&);
     void shutDownTrackingAndRendering();
     void didCompleteShutdownTriggeredBySystem();
     void requestFrame(std::optional<PlatformXR::RequestData>&&, PlatformXR::Device::RequestFrameCallback&&);


### PR DESCRIPTION
#### 42c48d943df9620b88c027e1d86f0e5d03736eaa
<pre>
[WebXR + WebGPU] Support HDR with WebXR + WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=296675">https://bugs.webkit.org/show_bug.cgi?id=296675</a>
<a href="https://rdar.apple.com/157080294">rdar://157080294</a>

Reviewed by Dan Glastonbury.

In order to support HDR on WebXR + WebGPU sites, we must defer compositor
initialization until GPUDevice.configure(...) is called.

That allows us to pass the selected color and depth+(stencil) format to the
compositor as this is not possible to change without exiting and re-entering
the immersive session.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUXRProjectionLayerImpl.cpp:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUXRProjectionLayer.h:
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::WebXRSession):
(WebCore::WebXRSession::initializeTrackingAndRendering):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/Modules/webxr/XRGPUBinding.cpp:
(WebCore::XRGPUBinding::XRGPUBinding):
(WebCore::XRGPUBinding::createProjectionLayer):
* Source/WebCore/Modules/webxr/XRGPUBinding.h:
(WebCore::XRGPUBinding::create):
* Source/WebCore/Modules/webxr/XRGPUProjectionLayerInit.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
* Source/WebKit/Shared/XR/XRDeviceProxy.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::startXRSession):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::toMetalFormat):
(WebKit::UIDelegate::UIClient::startXRSession):
* Source/WebKit/UIProcess/XR/PlatformXRCoordinator.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::convertFromBacking):
(WebKit::PlatformXRSystem::initializeTrackingAndRendering):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::initializeTrackingAndRendering):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/298401@main">https://commits.webkit.org/298401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3c69702faa5f2e4261c7b599585b757030b6633

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65902 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8c02586-7def-4da0-a58b-173f711c5dca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87601 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ab4764d-0b37-4131-aaa4-694a96cc7086) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67997 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65068 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97821 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31638 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96393 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96178 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41405 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38193 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47690 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43373 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->