### PR TITLE
[Style] Support arbitrary keywords in Style::LengthWrapperBase

### DIFF
--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -35,6 +35,7 @@
 #include "RenderElementInlines.h"
 #include "RenderLayerModelObject.h"
 #include "RenderStyleInlines.h"
+#include "StyleLengthWrapper+Platform.h"
 #include "StyleOffsetAnchor.h"
 #include "StyleOffsetDistance.h"
 #include "StyleOffsetPath.h"

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -32,6 +32,7 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGPathData.h"
 #include "SVGPathElement.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -53,6 +53,7 @@
 #include "RenderTheme.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
+#include "StyleLengthWrapper+Platform.h"
 #include "StyleResolver.h"
 #include "TextRun.h"
 #include <math.h>

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -47,6 +47,7 @@
 #include "RenderScrollbar.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
+#include "StyleLengthWrapper+Platform.h"
 #include "StyleResolver.h"
 #include "TextControlInnerElements.h"
 #include "UnicodeBidi.h"

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -51,6 +51,7 @@
 #include "StyleExtractor.h"
 #include "StyleImage.h"
 #include "StyleInheritedData.h"
+#include "StyleLengthWrapper+Platform.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
 #include "StyleScrollSnapPoints.h"

--- a/Source/WebCore/style/StyleInterpolationFunctions.h
+++ b/Source/WebCore/style/StyleInterpolationFunctions.h
@@ -56,6 +56,7 @@
 #include "StyleImageWrapper.h"
 #include "StyleInterpolationClient.h"
 #include "StyleInterpolationContext.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StyleResolver.h"
 #include "StyleTextEdge.h"

--- a/Source/WebCore/style/values/align/StyleGapGutter.h
+++ b/Source/WebCore/style/values/align/StyleGapGutter.h
@@ -33,6 +33,8 @@ namespace Style {
 // https://drafts.csswg.org/css-align/#column-row-gap
 struct GapGutter : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Normal> {
     using Base::Base;
+
+    ALWAYS_INLINE bool isNormal() const { return holdsAlternative<CSS::Keyword::Normal>(); }
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.cpp
@@ -30,6 +30,7 @@
 #include "CSSBorderImageWidthValue.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/style/values/box/StyleMargin.h
+++ b/Source/WebCore/style/values/box/StyleMargin.h
@@ -33,8 +33,9 @@ namespace Style {
 // https://drafts.csswg.org/css-box/#margin-physical
 struct MarginEdge : LengthWrapperBase<LengthPercentage<>, CSS::Keyword::Auto> {
     using Base::Base;
+    using Base::hasQuirk;
 
-    ALWAYS_INLINE bool hasQuirk() const { return m_value.hasQuirk(); }
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
 };
 
 // <'margin'> = <'margin-top'>{1,4}

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
@@ -32,9 +32,14 @@ namespace Style {
 
 std::optional<PreferredSize> FlexBasis::tryPreferredSize() const
 {
-    if (isContent())
-        return { };
-    return PreferredSize { m_value };
+    return WTF::switchOn(*this,
+        [&](const CSS::Keyword::Content&) -> std::optional<PreferredSize> {
+            return { };
+        },
+        [&](const auto& value) -> std::optional<PreferredSize> {
+            return PreferredSize { value };
+        }
+    );
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -38,6 +38,38 @@ struct FlexBasis : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Ke
 
     // `FlexBasis` is a superset of `PreferredSize` and therefore this conversion can fail when type is `content`.
     std::optional<PreferredSize> tryPreferredSize() const;
+
+    ALWAYS_INLINE bool isContent() const { return holdsAlternative<CSS::Keyword::Content>(); }
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
+    ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
+    ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
+    ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
+    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
+    ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
+
+    ALWAYS_INLINE bool isIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>();
+    }
+    ALWAYS_INLINE bool isLegacyIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
+    }
+    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>()
+            || holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>()
+            || holdsAlternative<CSS::Keyword::Auto>();
+    }
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/grid/StyleGridTrackBreadth.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTrackBreadth.cpp
@@ -28,6 +28,7 @@
 
 #include "AnimationUtilities.h"
 #include "CSSPrimitiveValue.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/style/values/grid/StyleGridTrackBreadth.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackBreadth.h
@@ -43,6 +43,10 @@ using namespace CSS::Literals;
 
 struct GridTrackBreadthLength : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::Auto> {
     using Base::Base;
+
+    ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
+    ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
 };
 
 // <track-breadth> = <length-percentage [0,inf]> | <flex [0,inf]> | min-content | max-content | auto

--- a/Source/WebCore/style/values/inline/StyleVerticalAlign.cpp
+++ b/Source/WebCore/style/values/inline/StyleVerticalAlign.cpp
@@ -29,6 +29,7 @@
 #include "AnimationUtilities.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 

--- a/Source/WebCore/style/values/masking/StyleMaskBorderWidth.cpp
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderWidth.cpp
@@ -30,6 +30,7 @@
 #include "CSSBorderImageWidthValue.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/style/values/motion/StyleOffsetAnchor.cpp
+++ b/Source/WebCore/style/values/motion/StyleOffsetAnchor.cpp
@@ -28,6 +28,7 @@
 #include "CSSPositionValue.h"
 #include "RenderStyleInlines.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/style/values/position/StyleInset.h
+++ b/Source/WebCore/style/values/position/StyleInset.h
@@ -33,6 +33,8 @@ namespace Style {
 // https://drafts.csswg.org/css-position/#insets
 struct InsetEdge : LengthWrapperBase<LengthPercentage<>, CSS::Keyword::Auto> {
     using Base::Base;
+
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
 };
 
 // <'inset'> = <'top'>{1,4}

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AnimationUtilities.h"
+#include "CalculationValue.h"
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Blending
+
+template<LengthWrapperBaseDerived T> struct Blending<T> {
+    auto canBlend(const T& a, const T& b) -> bool
+    {
+        return a.hasSameType(b) || (a.isSpecified() && b.isSpecified());
+    }
+    auto requiresInterpolationForAccumulativeIteration(const T& a, const T& b) -> bool
+    {
+        return !a.hasSameType(b) || a.isCalculated() || b.isCalculated();
+    }
+    static Calculation::Child copyCalculation(const T& value)
+    {
+        if (value.isPercent())
+            return Calculation::percentage(value.m_value.value());
+        if (value.isCalculated())
+            return value.m_value.protectedCalculationValue()->copyRoot();
+        ASSERT(value.isFixed());
+        return Calculation::dimension(value.m_value.value());
+    }
+    T blendMixedSpecifiedTypes(const T& a, const T& b, const BlendingContext& context)
+    {
+        if (context.compositeOperation != CompositeOperation::Replace)
+            return typename T::Calc { Calculation::add(copyCalculation(a), copyCalculation(b)) };
+
+        if (!b.isCalculated() && !a.isPercent() && (context.progress == 1 || a.isZero())) {
+            if (b.isPercent())
+                return Style::blend(typename T::Percentage { 0 }, typename T::Percentage { b.m_value.value() }, context);
+            return Style::blend(typename T::Fixed { 0 }, typename T::Fixed { b.m_value.value() }, context);
+        }
+
+        if (!a.isCalculated() && !b.isPercent() && (!context.progress || b.isZero())) {
+            if (a.isPercent())
+                return Style::blend(typename T::Percentage { a.m_value.value() }, typename T::Percentage { 0 }, context);
+            return Style::blend(typename T::Fixed { a.m_value.value() }, typename T::Fixed { 0 }, context);
+        }
+
+        return typename T::Calc { Calculation::blend(copyCalculation(a), copyCalculation(b), context.progress) };
+    }
+    auto blend(const T& a, const T& b, const BlendingContext& context) -> T
+    {
+        if (!a.isSpecified() || !b.isSpecified())
+            return context.progress < 0.5 ? a : b;
+
+        if (a.isCalculated() || b.isCalculated() || !a.hasSameType(b))
+            return blendMixedSpecifiedTypes(a, b, context);
+
+        if (!context.progress && context.isReplace())
+            return a;
+
+        if (context.progress == 1 && context.isReplace())
+            return b;
+
+        auto resultType = b.m_value.type();
+
+        ASSERT(resultType == T::indexForPercentage || resultType == T::indexForFixed);
+
+        if (resultType == T::indexForPercentage) {
+            return Style::blend(
+                typename T::Percentage { a.m_value.value() },
+                typename T::Percentage { b.m_value.value() },
+                context
+            );
+        } else {
+            return Style::blend(
+                typename T::Fixed { a.m_value.value() },
+                typename T::Fixed { b.m_value.value() },
+                context
+            );
+        }
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+Platform.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+Platform.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CalculationValue.h"
+#include "StyleLengthWrapper.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - Platform
+
+template<LengthWrapperBaseDerived T> struct ToPlatform<T> {
+    auto operator()(const T& value) -> WebCore::Length
+    {
+        if (value.template holdsAlternative<typename T::Fixed>())
+            return WebCore::Length(value.m_value.value(), WebCore::LengthType::Fixed, value.m_value.hasQuirk());
+
+        if (value.template holdsAlternative<typename T::Percentage>())
+            return WebCore::Length(value.m_value.value(), WebCore::LengthType::Percent);
+
+        if (value.template holdsAlternative<typename T::Calc>())
+            return WebCore::Length(value.m_value.protectedCalculationValue());
+
+        if constexpr (T::SupportsAuto) {
+            if (value.template holdsAlternative<CSS::Keyword::Auto>())
+                return WebCore::Length(WebCore::LengthType::Auto);
+        }
+        if constexpr (T::SupportsContent) {
+            if (value.template holdsAlternative<CSS::Keyword::Content>())
+                return WebCore::Length(WebCore::LengthType::Content);
+        }
+        if constexpr (T::SupportsWebkitFillAvailable) {
+            if (value.template holdsAlternative<CSS::Keyword::WebkitFillAvailable>())
+                return WebCore::Length(WebCore::LengthType::FillAvailable);
+        }
+        if constexpr (T::SupportsFitContent) {
+            if (value.template holdsAlternative<CSS::Keyword::FitContent>())
+                return WebCore::Length(WebCore::LengthType::FitContent);
+        }
+        if constexpr (T::SupportsIntrinsic) {
+            if (value.template holdsAlternative<CSS::Keyword::Intrinsic>())
+                return WebCore::Length(WebCore::LengthType::Intrinsic);
+        }
+        if constexpr (T::SupportsMinContent) {
+            if (value.template holdsAlternative<CSS::Keyword::MinContent>())
+                return WebCore::Length(WebCore::LengthType::MinContent);
+        }
+        if constexpr (T::SupportsMaxContent) {
+            if (value.template holdsAlternative<CSS::Keyword::MaxContent>())
+                return WebCore::Length(WebCore::LengthType::MaxContent);
+        }
+        if constexpr (T::SupportsNormal) {
+            if (value.template holdsAlternative<CSS::Keyword::Normal>())
+                return WebCore::Length(WebCore::LengthType::Normal);
+        }
+        if constexpr (T::SupportsNone) {
+            if (value.template holdsAlternative<CSS::Keyword::None>())
+                return WebCore::Length(WebCore::LengthType::Undefined);
+        }
+
+        ASSERT_NOT_REACHED();
+        return WebCore::Length();
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -26,7 +26,6 @@
 
 #include "CSSPrimitiveKeywordList.h"
 #include "StyleLengthWrapperData.h"
-#include "StylePrimitiveNumericTypes+Platform.h"
 #include "StylePrimitiveNumericTypes.h"
 #include <wtf/text/TextStream.h>
 
@@ -40,6 +39,15 @@ template<typename> struct MinimumEvaluation;
 template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase {
     using Base = LengthWrapperBase<Numeric, Ks...>;
     using Keywords = CSS::PrimitiveKeywordList<Ks...>;
+
+    static constexpr bool hasKeywords = Keywords::count > 0;
+
+    static constexpr uint8_t indexForFirstKeyword       = 0;
+    static constexpr uint8_t indexForLastKeyword        = hasKeywords ? Keywords::count - 1: 0;
+    static constexpr uint8_t indexForFixed              = hasKeywords ? indexForLastKeyword + 1 : 0;
+    static constexpr uint8_t indexForPercentage         = indexForFixed + 1;
+    static constexpr uint8_t indexForCalc               = indexForFixed + 2;
+    static constexpr uint8_t maxIndex                   = indexForCalc;
 
     using Specified = Numeric;
     using Fixed = typename Specified::Dimension;
@@ -57,86 +65,32 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     static constexpr bool SupportsContent = Keywords::isValidKeyword(CSS::Keyword::Content { });
     static constexpr bool SupportsNone = Keywords::isValidKeyword(CSS::Keyword::None { });
 
-    LengthWrapperBase(CSS::Keyword::Auto) requires (SupportsAuto) : m_value(LengthWrapperDataType::Auto) { }
-    LengthWrapperBase(CSS::Keyword::Normal) requires (SupportsNormal) : m_value(LengthWrapperDataType::Normal) { }
-    LengthWrapperBase(CSS::Keyword::Intrinsic) requires (SupportsIntrinsic) : m_value(LengthWrapperDataType::Intrinsic) { }
-    LengthWrapperBase(CSS::Keyword::MinIntrinsic) requires (SupportsMinIntrinsic) : m_value(LengthWrapperDataType::MinIntrinsic) { }
-    LengthWrapperBase(CSS::Keyword::MinContent) requires (SupportsMinContent) : m_value(LengthWrapperDataType::MinContent) { }
-    LengthWrapperBase(CSS::Keyword::MaxContent) requires (SupportsMaxContent) : m_value(LengthWrapperDataType::MaxContent) { }
-    LengthWrapperBase(CSS::Keyword::WebkitFillAvailable) requires (SupportsWebkitFillAvailable) : m_value(LengthWrapperDataType::FillAvailable) { }
-    LengthWrapperBase(CSS::Keyword::FitContent) requires (SupportsFitContent) : m_value(LengthWrapperDataType::FitContent) { }
-    LengthWrapperBase(CSS::Keyword::Content) requires (SupportsContent) : m_value(LengthWrapperDataType::Content) { }
-    LengthWrapperBase(CSS::Keyword::None) requires (SupportsNone) : m_value(LengthWrapperDataType::Undefined) { }
+    LengthWrapperBase(CSS::ValidKeywordForList<Keywords> auto keyword) : m_value(Keywords::offsetForKeyword(keyword)) { }
 
-    LengthWrapperBase(Fixed fixed) : m_value(fixed.value, LengthWrapperDataType::Fixed) { }
-    LengthWrapperBase(Fixed fixed, bool hasQuirk) : m_value(fixed.value, LengthWrapperDataType::Fixed, hasQuirk) { }
-    LengthWrapperBase(Percentage percent) : m_value(percent.value, LengthWrapperDataType::Percent) { }
-    LengthWrapperBase(Calc&& calc) : m_value(calc.protectedCalculation()) { }
+    LengthWrapperBase(Fixed fixed) : m_value(indexForFixed, fixed.value) { }
+    LengthWrapperBase(Fixed fixed, bool hasQuirk) : m_value(indexForFixed, fixed.value, hasQuirk) { }
+    LengthWrapperBase(Percentage percent) : m_value(indexForPercentage, percent.value) { }
+    LengthWrapperBase(Calc&& calc) : m_value(indexForCalc, calc.protectedCalculation()) { }
     LengthWrapperBase(Specified&& specified) : m_value(toData(specified)) { }
     LengthWrapperBase(const Specified& specified) : m_value(toData(specified)) { }
 
-    LengthWrapperBase(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : m_value(static_cast<float>(literal.value), LengthWrapperDataType::Fixed) { }
-    LengthWrapperBase(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : m_value(static_cast<float>(literal.value), LengthWrapperDataType::Percent) { }
+    LengthWrapperBase(CSS::ValueLiteral<CSS::LengthUnit::Px> literal) : LengthWrapperBase(Fixed { literal }) { }
+    LengthWrapperBase(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal) : LengthWrapperBase(Percentage { literal }) { }
 
-    explicit LengthWrapperBase(WebCore::Length&& other) : m_value(WTFMove(other)) { validate(m_value); }
-    explicit LengthWrapperBase(const WebCore::Length& other) : m_value(other) { validate(m_value); }
-
-    explicit LengthWrapperBase(LengthWrapperData&& other) : m_value(WTFMove(other)) { validate(m_value); }
-    explicit LengthWrapperBase(const LengthWrapperData& other) : m_value(other) { validate(m_value); }
+    explicit LengthWrapperBase(WebCore::Length&& other) : m_value(toData(other)) { }
+    explicit LengthWrapperBase(const WebCore::Length& other) : m_value(toData(other)) { }
 
     explicit LengthWrapperBase(WTF::HashTableEmptyValueType token) : m_value(token) { }
 
     // IPC Support
-    explicit LengthWrapperBase(LengthWrapperData::IPCData&& data) : m_value { WTFMove(data) } { validate(m_value); }
+    explicit LengthWrapperBase(LengthWrapperData::IPCData&& data) : m_value { toData(WTFMove(data)) } { }
     LengthWrapperData::IPCData ipcData() const { return m_value.ipcData(); }
 
-    ALWAYS_INLINE bool isFixed() const { return m_value.type() == LengthWrapperDataType::Fixed; }
-    ALWAYS_INLINE bool isPercent() const { return m_value.type() == LengthWrapperDataType::Percent; }
-    ALWAYS_INLINE bool isCalculated() const { return m_value.type() == LengthWrapperDataType::Calculated; }
+    ALWAYS_INLINE bool isFixed() const { return holdsAlternative<Fixed>(); }
+    ALWAYS_INLINE bool isPercent() const { return holdsAlternative<Percentage>(); }
+    ALWAYS_INLINE bool isCalculated() const { return holdsAlternative<Calc>();}
     ALWAYS_INLINE bool isPercentOrCalculated() const { return isPercent() || isCalculated(); }
     ALWAYS_INLINE bool isSpecified() const { return isFixed() || isPercent() || isCalculated(); }
-
-    ALWAYS_INLINE bool isAuto() const requires (SupportsAuto) { return m_value.type() == LengthWrapperDataType::Auto; }
-    ALWAYS_INLINE bool isNormal() const requires (SupportsNormal) { return m_value.type() == LengthWrapperDataType::Normal; }
-    ALWAYS_INLINE bool isIntrinsicKeyword() const requires (SupportsIntrinsic) { return m_value.type() == LengthWrapperDataType::Intrinsic; }
-    ALWAYS_INLINE bool isMinIntrinsic() const requires (SupportsMinIntrinsic) { return m_value.type() == LengthWrapperDataType::MinIntrinsic; }
-    ALWAYS_INLINE bool isMinContent() const requires (SupportsMinContent) { return m_value.type() == LengthWrapperDataType::MinContent; }
-    ALWAYS_INLINE bool isMaxContent() const requires (SupportsMaxContent) { return m_value.type() == LengthWrapperDataType::MaxContent; }
-    ALWAYS_INLINE bool isFillAvailable() const requires (SupportsWebkitFillAvailable) { return m_value.type() == LengthWrapperDataType::FillAvailable; }
-    ALWAYS_INLINE bool isFitContent() const requires (SupportsFitContent) { return m_value.type() == LengthWrapperDataType::FitContent; }
-    ALWAYS_INLINE bool isContent() const requires (SupportsContent) { return m_value.type() == LengthWrapperDataType::Content; }
-    ALWAYS_INLINE bool isNone() const requires (SupportsNone) { return m_value.type() == LengthWrapperDataType::Undefined; }
-
-    // FIXME: This is misleadingly named. One would expect this function checks `type == LengthWrapperDataType::Intrinsic` but instead it checks `type = LengthWrapperDataType::MinContent || type == LengthWrapperDataType::MaxContent || type == LengthWrapperDataType::FillAvailable || type == LengthWrapperDataType::FitContent`.
-
-    static constexpr bool SupportsIsIntrinsic = SupportsMinContent || SupportsMaxContent || SupportsWebkitFillAvailable || SupportsFitContent;
-    static constexpr bool SupportsIsLegacyIntrinsic = SupportsIntrinsic || SupportsMinIntrinsic;
-
-    ALWAYS_INLINE bool isIntrinsic() const
-        requires (SupportsIsIntrinsic)
-    {
-        return (SupportsMinContent && m_value.type() == LengthWrapperDataType::MinContent)
-            || (SupportsMaxContent && m_value.type() == LengthWrapperDataType::MaxContent)
-            || (SupportsWebkitFillAvailable && m_value.type() == LengthWrapperDataType::FillAvailable)
-            || (SupportsFitContent && m_value.type() == LengthWrapperDataType::FitContent);
-    }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const
-        requires (SupportsIsLegacyIntrinsic)
-    {
-        return (SupportsIntrinsic && m_value.type() == LengthWrapperDataType::Intrinsic)
-            || (SupportsMinIntrinsic && m_value.type() == LengthWrapperDataType::MinIntrinsic);
-    }
-    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
-        requires (SupportsIsIntrinsic || SupportsIsLegacyIntrinsic || SupportsAuto)
-    {
-        return (SupportsMinContent && m_value.type() == LengthWrapperDataType::MinContent)
-            || (SupportsMinContent && m_value.type() == LengthWrapperDataType::MaxContent)
-            || (SupportsWebkitFillAvailable && m_value.type() == LengthWrapperDataType::FillAvailable)
-            || (SupportsFitContent && m_value.type() == LengthWrapperDataType::FitContent)
-            || (SupportsIntrinsic && m_value.type() == LengthWrapperDataType::Intrinsic)
-            || (SupportsMinIntrinsic && m_value.type() == LengthWrapperDataType::MinIntrinsic)
-            || (SupportsAuto && m_value.type() == LengthWrapperDataType::Auto);
-    }
 
     ALWAYS_INLINE bool isZero() const { return m_value.isZero(); }
     ALWAYS_INLINE bool isPositive() const { return m_value.isPositive(); }
@@ -146,92 +100,174 @@ template<typename Numeric, CSS::PrimitiveKeyword... Ks> struct LengthWrapperBase
     std::optional<Percentage> tryPercentage() const { return isPercent() ? std::make_optional(Percentage { m_value.value() }) : std::nullopt; }
     std::optional<Calc> tryCalc() const { return isCalculated() ? std::make_optional(Calc { m_value.calculationValue() }) : std::nullopt; }
 
+    std::optional<Specified> trySpecified() const
+    {
+        auto opaqueType = m_value.type();
+
+             if (opaqueType == indexForFixed)       return Specified(Fixed { m_value.value() });
+        else if (opaqueType == indexForPercentage)  return Specified(Percentage { m_value.value() });
+        else if (opaqueType == indexForCalc)        return Specified(Calc { m_value.calculationValue() });
+        else                                        return { };
+    }
+
     template<typename T> bool holdsAlternative() const
     {
-             if constexpr (std::same_as<T, Fixed>)                                                              return isFixed();
-        else if constexpr (std::same_as<T, Percentage>)                                                         return isPercent();
-        else if constexpr (std::same_as<T, Calc>)                                                               return isCalculated();
-        else if constexpr (std::same_as<T, CSS::Keyword::Auto> && SupportsAuto)                                 return isAuto();
-        else if constexpr (std::same_as<T, CSS::Keyword::Normal> && SupportsNormal)                             return isNormal();
-        else if constexpr (std::same_as<T, CSS::Keyword::Intrinsic> && SupportsIntrinsic)                       return isIntrinsicKeyword();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinIntrinsic> && SupportsMinIntrinsic)                 return isMinIntrinsic();
-        else if constexpr (std::same_as<T, CSS::Keyword::MinContent> && SupportsMinContent)                     return isMinContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::MaxContent> && SupportsMaxContent)                     return isMaxContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::WebkitFillAvailable> && SupportsWebkitFillAvailable)   return isFillAvailable();
-        else if constexpr (std::same_as<T, CSS::Keyword::FitContent> && SupportsFitContent)                     return isFitContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::Content> && SupportsContent)                           return isContent();
-        else if constexpr (std::same_as<T, CSS::Keyword::None> && SupportsNone)                                 return isNone();
+             if constexpr (CSS::ValidKeywordForList<T, Keywords>)   return m_value.type() == Keywords::offsetForKeyword(T { });
+        else if constexpr (std::same_as<T, Fixed>)                  return m_value.type() == indexForFixed;
+        else if constexpr (std::same_as<T, Percentage>)             return m_value.type() == indexForPercentage;
+        else if constexpr (std::same_as<T, Calc>)                   return m_value.type() == indexForCalc;
+        else if constexpr (std::same_as<T, Specified>)              return m_value.type() == indexForFixed || m_value.type() == indexForPercentage || m_value.type() == indexForCalc;
     }
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
-        switch (m_value.type()) {
-        case LengthWrapperDataType::Fixed:            return visitor(Fixed { m_value.value() });
-        case LengthWrapperDataType::Percent:          return visitor(Percentage { m_value.value() });
-        case LengthWrapperDataType::Calculated:       return visitor(Calc { m_value.calculationValue() });
-        case LengthWrapperDataType::Auto:             if constexpr (SupportsAuto) { return visitor(CSS::Keyword::Auto { }); } else { break; }
-        case LengthWrapperDataType::Intrinsic:        if constexpr (SupportsIntrinsic) { return visitor(CSS::Keyword::Intrinsic { }); } else { break; }
-        case LengthWrapperDataType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return visitor(CSS::Keyword::MinIntrinsic { }); } else { break; }
-        case LengthWrapperDataType::MinContent:       if constexpr (SupportsMinContent) { return visitor(CSS::Keyword::MinContent { }); } else { break; }
-        case LengthWrapperDataType::MaxContent:       if constexpr (SupportsMaxContent) { return visitor(CSS::Keyword::MaxContent { }); } else { break; }
-        case LengthWrapperDataType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return visitor(CSS::Keyword::WebkitFillAvailable { }); } else { break; }
-        case LengthWrapperDataType::FitContent:       if constexpr (SupportsFitContent) { return visitor(CSS::Keyword::FitContent { }); } else { break; }
-        case LengthWrapperDataType::Content:          if constexpr (SupportsContent) { return visitor(CSS::Keyword::Content { }); } else { break; }
-        case LengthWrapperDataType::Normal:           if constexpr (SupportsNormal) { return visitor(CSS::Keyword::Normal { }); } else { break; }
-        case LengthWrapperDataType::Undefined:        if constexpr (SupportsNone) { return visitor(CSS::Keyword::None { }); } else { break; }
-        case LengthWrapperDataType::Relative:
-            break;
+        auto opaqueType = m_value.type();
+
+        if constexpr (hasKeywords) {
+             if (opaqueType <= indexForLastKeyword)
+                return Keywords::visitKeywordAtOffset(opaqueType, visitor);
         }
+
+             if (opaqueType == indexForFixed)       return visitor(Fixed { m_value.value() });
+        else if (opaqueType == indexForPercentage)  return visitor(Percentage { m_value.value() });
+        else if (opaqueType == indexForCalc)        return visitor(Calc { m_value.calculationValue() });
+
         RELEASE_ASSERT_NOT_REACHED();
     }
+
+    bool hasQuirk() const { return m_value.hasQuirk(); }
 
     bool hasSameType(const LengthWrapperBase& other) const { return m_value.type() == other.m_value.type(); }
 
     bool operator==(const LengthWrapperBase&) const = default;
 
-protected:
+private:
     template<typename> friend struct ToPlatform;
     template<typename> friend struct Evaluation;
     template<typename> friend struct MinimumEvaluation;
     template<typename> friend struct Blending;
 
-    static void validate(const LengthWrapperData& length)
-    {
-        switch (length.type()) {
-        case LengthWrapperDataType::Fixed:            RELEASE_ASSERT(CSS::isWithinRange<Fixed::range>(length.value())); return;
-        case LengthWrapperDataType::Percent:          RELEASE_ASSERT(CSS::isWithinRange<Percentage::range>(length.value())); return;
-        case LengthWrapperDataType::Calculated:       return;
-        case LengthWrapperDataType::Auto:             if constexpr (SupportsAuto) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::Intrinsic:        if constexpr (SupportsIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::MinIntrinsic:     if constexpr (SupportsMinIntrinsic) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::MinContent:       if constexpr (SupportsMinContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::MaxContent:       if constexpr (SupportsMaxContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::FillAvailable:    if constexpr (SupportsWebkitFillAvailable) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::FitContent:       if constexpr (SupportsFitContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::Content:          if constexpr (SupportsContent) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::Normal:           if constexpr (SupportsNormal) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::Undefined:        if constexpr (SupportsNone) { return; } else { RELEASE_ASSERT_NOT_REACHED(); }
-        case LengthWrapperDataType::Relative:
-            break;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }
-
     static LengthWrapperData toData(const Specified& specified)
     {
         return WTF::switchOn(specified,
             [](const Fixed& fixed) {
-                return LengthWrapperData { fixed.value, LengthWrapperDataType::Fixed };
+                return LengthWrapperData { indexForFixed, fixed.value };
             },
             [](const Percentage& percentage) {
-                return LengthWrapperData { percentage.value, LengthWrapperDataType::Percent };
+                return LengthWrapperData { indexForPercentage, percentage.value };
             },
             [](const Calc& calc) {
-                return LengthWrapperData { calc.protectedCalculation() };
+                return LengthWrapperData { indexForCalc, calc.protectedCalculation() };
             }
         );
+    }
+
+    static LengthWrapperData toData(LengthWrapperData::IPCData&& ipcData)
+    {
+        RELEASE_ASSERT(ipcData.opaqueType <= maxIndex);
+        RELEASE_ASSERT(ipcData.opaqueType != indexForCalc);
+
+        if (ipcData.opaqueType == indexForFixed) {
+            RELEASE_ASSERT(CSS::isWithinRange<Fixed::range>(ipcData.value));
+        }
+        if (ipcData.opaqueType == indexForPercentage) {
+            RELEASE_ASSERT(CSS::isWithinRange<Percentage::range>(ipcData.value));
+        }
+
+        return LengthWrapperData { WTFMove(ipcData) };
+    }
+
+    static LengthWrapperData toData(const WebCore::Length& length)
+    {
+        switch (length.type()) {
+        case WebCore::LengthType::Fixed:
+            return LengthWrapperData(indexForFixed, CSS::clampToRange<Fixed::range, float>(length.value()), length.hasQuirk());
+        case WebCore::LengthType::Percent:
+            return LengthWrapperData(indexForPercentage, CSS::clampToRange<Percentage::range, float>(length.value()));
+        case WebCore::LengthType::Calculated:
+            return LengthWrapperData(indexForCalc, LengthWrapperData::LengthCalculation { length });
+        case WebCore::LengthType::Auto:
+            if constexpr (SupportsAuto) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::Auto { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::Content:
+            if constexpr (SupportsContent) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::Content { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::FillAvailable:
+            if constexpr (SupportsWebkitFillAvailable) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::WebkitFillAvailable { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::FitContent:
+            if constexpr (SupportsFitContent) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::FitContent { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::Intrinsic:
+            if constexpr (SupportsIntrinsic) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::Intrinsic { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::MinIntrinsic:
+            if constexpr (SupportsMinIntrinsic) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::MinIntrinsic { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::MinContent:
+            if constexpr (SupportsMinContent) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::MinContent { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::MaxContent:
+            if constexpr (SupportsMaxContent) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::MaxContent { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::Normal:
+            if constexpr (SupportsNormal) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::Normal { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::Undefined:
+            if constexpr (SupportsNone) {
+                return { Keywords::offsetForKeyword(CSS::Keyword::None { }) };
+            } else {
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        case WebCore::LengthType::Relative:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    LengthWrapperDataEvaluationKind evaluationKind() const
+    {
+        auto opaqueType = m_value.type();
+
+        if constexpr (hasKeywords) {
+             if (opaqueType <= indexForLastKeyword)
+                return LengthWrapperDataEvaluationKind::Flag;
+        }
+
+             if (opaqueType == indexForFixed)           return LengthWrapperDataEvaluationKind::Fixed;
+        else if (opaqueType == indexForPercentage)      return LengthWrapperDataEvaluationKind::Percentage;
+        else if (opaqueType == indexForCalc)            return LengthWrapperDataEvaluationKind::Calculation;
+
+        RELEASE_ASSERT_NOT_REACHED();
     }
 
     LengthWrapperData m_value;
@@ -241,33 +277,24 @@ protected:
 
 template<typename T> concept LengthWrapperBaseDerived = WTF::IsBaseOfTemplate<LengthWrapperBase, T>::value && VariantLike<T>;
 
-// MARK: - Platform
-
-template<LengthWrapperBaseDerived T> struct ToPlatform<T> {
-    auto operator()(const T& value) -> WebCore::Length
-    {
-        return value.m_value.toPlatform();
-    }
-};
-
 // MARK: - Evaluation
 
 template<LengthWrapperBaseDerived T> struct Evaluation<T> {
     auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor) -> LayoutUnit
     {
-        return valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, lazyMaximumValueFunctor);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor);
     }
     auto operator()(const T& value, NOESCAPE const Invocable<float()> auto& lazyMaximumValueFunctor) -> float
     {
-        return valueForLengthWrapperDataWithLazyMaximum<float, float>(value.m_value, lazyMaximumValueFunctor);
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), lazyMaximumValueFunctor);
     }
     auto operator()(const T& value, LayoutUnit maximumValue) -> LayoutUnit
     {
-        return valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
     }
     auto operator()(const T& value, float maximumValue) -> float
     {
-        return valueForLengthWrapperDataWithLazyMaximum<float, float>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+        return value.m_value.template valueForLengthWrapperDataWithLazyMaximum<float, float>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
     }
 };
 
@@ -279,34 +306,15 @@ template<typename StyleType, typename Reference> decltype(auto) evaluateMinimum(
 template<LengthWrapperBaseDerived T> struct MinimumEvaluation<T> {
     auto operator()(const T& value, NOESCAPE const Invocable<LayoutUnit()> auto& lazyMaximumValueFunctor) -> LayoutUnit
     {
-        return minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, lazyMaximumValueFunctor);
+        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), lazyMaximumValueFunctor);
     }
     auto operator()(const T& value, LayoutUnit maximumValue) -> LayoutUnit
     {
-        return minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
+        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return maximumValue; });
     }
     auto operator()(const T& value, float maximumValue) -> float
     {
-        return minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.m_value, [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); });
-    }
-};
-
-// MARK: - Blending
-
-template<LengthWrapperBaseDerived T> struct Blending<T> {
-    auto canBlend(const T& a, const T& b) -> bool
-    {
-        if (a.hasSameType(b))
-            return true;
-        return a.isSpecified() && b.isSpecified();
-    }
-    auto requiresInterpolationForAccumulativeIteration(const T& a, const T& b) -> bool
-    {
-        return a.isCalculated() || b.isCalculated() || !a.hasSameType(b);
-    }
-    auto blend(const T& a, const T& b, const BlendingContext& context) -> T
-    {
-        return T { blendLengthWrapperData(a.m_value, b.m_value, context, T::Fixed::range == CSS::Nonnegative ? ValueRange::NonNegative : ValueRange::All) };
+        return value.m_value.template minimumValueForLengthWrapperDataWithLazyMaximum<LayoutUnit, LayoutUnit>(value.evaluationKind(), [&] ALWAYS_INLINE_LAMBDA { return LayoutUnit(maximumValue); });
     }
 };
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
@@ -25,29 +25,30 @@
 #include "config.h"
 #include "StyleLengthWrapperData.h"
 
-#include "AnimationUtilities.h"
-#include "CalculationCategory.h"
-#include "CalculationTree.h"
 #include "CalculationValue.h"
 #include "CalculationValueMap.h"
-#include <wtf/ASCIICType.h>
-#include <wtf/StdLibExtras.h>
-#include <wtf/text/StringToIntegerConversion.h>
-#include <wtf/text/StringView.h>
-#include <wtf/text/TextStream.h>
+#include <cmath>
 
 namespace WebCore {
 namespace Style {
 
-LengthWrapperData::LengthWrapperData(Ref<CalculationValue>&& value)
-    : m_type(LengthWrapperDataType::Calculated)
+LengthWrapperData::LengthWrapperData(uint8_t opaqueType, LengthCalculation&& value)
+    : m_opaqueType { opaqueType }
+    , m_kind { LengthWrapperDataKind::Calculation }
+{
+    m_calculationValueHandle = CalculationValueMap::calculationValues().insert(value.length.protectedCalculationValue());
+}
+
+LengthWrapperData::LengthWrapperData(uint8_t opaqueType, Ref<CalculationValue>&& value)
+    : m_opaqueType { opaqueType }
+    , m_kind { LengthWrapperDataKind::Calculation }
 {
     m_calculationValueHandle = CalculationValueMap::calculationValues().insert(WTFMove(value));
 }
 
 CalculationValue& LengthWrapperData::calculationValue() const
 {
-    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    ASSERT(m_kind == LengthWrapperDataKind::Calculation);
     return CalculationValueMap::calculationValues().get(m_calculationValueHandle);
 }
 
@@ -58,249 +59,38 @@ Ref<CalculationValue> LengthWrapperData::protectedCalculationValue() const
 
 void LengthWrapperData::ref() const
 {
-    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    ASSERT(m_kind == LengthWrapperDataKind::Calculation);
     CalculationValueMap::calculationValues().ref(m_calculationValueHandle);
 }
 
 void LengthWrapperData::deref() const
 {
-    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    ASSERT(m_kind == LengthWrapperDataKind::Calculation);
     CalculationValueMap::calculationValues().deref(m_calculationValueHandle);
 }
 
-LengthWrapperData::LengthWrapperData(const WebCore::Length& length)
-{
-    switch (length.type()) {
-    case WebCore::LengthType::Fixed:
-        m_type = LengthWrapperDataType::Fixed;
-        m_floatValue = length.value();
-        return;
-    case WebCore::LengthType::Percent:
-        m_type = LengthWrapperDataType::Percent;
-        m_floatValue = length.value();
-        return;
-    case WebCore::LengthType::Relative:
-        m_type = LengthWrapperDataType::Relative;
-        m_floatValue = length.value();
-        return;
-    case WebCore::LengthType::Calculated:
-        m_type = LengthWrapperDataType::Calculated;
-        m_calculationValueHandle = CalculationValueMap::calculationValues().insert(length.protectedCalculationValue());
-        return;
-    case WebCore::LengthType::Auto:
-        m_type = LengthWrapperDataType::Auto;
-        return;
-    case WebCore::LengthType::Content:
-        m_type = LengthWrapperDataType::Content;
-        return;
-    case WebCore::LengthType::FillAvailable:
-        m_type = LengthWrapperDataType::FillAvailable;
-        return;
-    case WebCore::LengthType::FitContent:
-        m_type = LengthWrapperDataType::FitContent;
-        return;
-    case WebCore::LengthType::Intrinsic:
-        m_type = LengthWrapperDataType::Intrinsic;
-        return;
-    case WebCore::LengthType::MinIntrinsic:
-        m_type = LengthWrapperDataType::MinIntrinsic;
-        return;
-    case WebCore::LengthType::MinContent:
-        m_type = LengthWrapperDataType::MinContent;
-        return;
-    case WebCore::LengthType::MaxContent:
-        m_type = LengthWrapperDataType::MaxContent;
-        return;
-    case WebCore::LengthType::Normal:
-        m_type = LengthWrapperDataType::Normal;
-        return;
-    case WebCore::LengthType::Undefined:
-        m_type = LengthWrapperDataType::Undefined;
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-LengthWrapperData::LengthWrapperData(WebCore::Length&& length)
-{
-    switch (length.type()) {
-    case WebCore::LengthType::Fixed:
-        m_type = LengthWrapperDataType::Fixed;
-        m_floatValue = length.value();
-        return;
-    case WebCore::LengthType::Percent:
-        m_type = LengthWrapperDataType::Percent;
-        m_floatValue = length.value();
-        return;
-    case WebCore::LengthType::Relative:
-        m_type = LengthWrapperDataType::Relative;
-        m_floatValue = length.value();
-        return;
-    case WebCore::LengthType::Calculated:
-        m_type = LengthWrapperDataType::Calculated;
-        m_calculationValueHandle = CalculationValueMap::calculationValues().insert(length.protectedCalculationValue());
-        return;
-    case WebCore::LengthType::Auto:
-        m_type = LengthWrapperDataType::Auto;
-        return;
-    case WebCore::LengthType::Content:
-        m_type = LengthWrapperDataType::Content;
-        return;
-    case WebCore::LengthType::FillAvailable:
-        m_type = LengthWrapperDataType::FillAvailable;
-        return;
-    case WebCore::LengthType::FitContent:
-        m_type = LengthWrapperDataType::FitContent;
-        return;
-    case WebCore::LengthType::Intrinsic:
-        m_type = LengthWrapperDataType::Intrinsic;
-        return;
-    case WebCore::LengthType::MinIntrinsic:
-        m_type = LengthWrapperDataType::MinIntrinsic;
-        return;
-    case WebCore::LengthType::MinContent:
-        m_type = LengthWrapperDataType::MinContent;
-        return;
-    case WebCore::LengthType::MaxContent:
-        m_type = LengthWrapperDataType::MaxContent;
-        return;
-    case WebCore::LengthType::Normal:
-        m_type = LengthWrapperDataType::Normal;
-        return;
-    case WebCore::LengthType::Undefined:
-        m_type = LengthWrapperDataType::Undefined;
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-WebCore::Length LengthWrapperData::toPlatform() const
-{
-    switch (type()) {
-    case LengthWrapperDataType::Fixed:
-        return WebCore::Length(m_floatValue, WebCore::LengthType::Fixed, m_hasQuirk);
-    case LengthWrapperDataType::Percent:
-        return WebCore::Length(m_floatValue, WebCore::LengthType::Percent);
-    case LengthWrapperDataType::Relative:
-        return WebCore::Length(m_floatValue, WebCore::LengthType::Relative);
-    case LengthWrapperDataType::Calculated:
-        return WebCore::Length(protectedCalculationValue());
-    case LengthWrapperDataType::FillAvailable:
-        return WebCore::Length(WebCore::LengthType::FillAvailable);
-    case LengthWrapperDataType::Auto:
-        return WebCore::Length(WebCore::LengthType::Auto);
-    case LengthWrapperDataType::Normal:
-        return WebCore::Length(WebCore::LengthType::Normal);
-    case LengthWrapperDataType::Content:
-        return WebCore::Length(WebCore::LengthType::Content);
-    case LengthWrapperDataType::Intrinsic:
-        return WebCore::Length(WebCore::LengthType::Intrinsic);
-    case LengthWrapperDataType::MinIntrinsic:
-        return WebCore::Length(WebCore::LengthType::MinIntrinsic);
-    case LengthWrapperDataType::MinContent:
-        return WebCore::Length(WebCore::LengthType::MinContent);
-    case LengthWrapperDataType::MaxContent:
-        return WebCore::Length(WebCore::LengthType::MaxContent);
-    case LengthWrapperDataType::FitContent:
-        return WebCore::Length(WebCore::LengthType::FitContent);
-    case LengthWrapperDataType::Undefined:
-        return WebCore::Length(WebCore::LengthType::Undefined);
-    }
-    ASSERT_NOT_REACHED();
-    return WebCore::Length();
-}
-
-LengthWrapperDataType LengthWrapperData::typeFromIndex(const IPCData& data)
-{
-    static_assert(WTF::VariantSizeV<IPCData> == 13);
-    switch (data.index()) {
-    case WTF::alternativeIndexV<AutoData, IPCData>:
-        return LengthWrapperDataType::Auto;
-    case WTF::alternativeIndexV<NormalData, IPCData>:
-        return LengthWrapperDataType::Normal;
-    case WTF::alternativeIndexV<RelativeData, IPCData>:
-        return LengthWrapperDataType::Relative;
-    case WTF::alternativeIndexV<PercentData, IPCData>:
-        return LengthWrapperDataType::Percent;
-    case WTF::alternativeIndexV<FixedData, IPCData>:
-        return LengthWrapperDataType::Fixed;
-    case WTF::alternativeIndexV<IntrinsicData, IPCData>:
-        return LengthWrapperDataType::Intrinsic;
-    case WTF::alternativeIndexV<MinIntrinsicData, IPCData>:
-        return LengthWrapperDataType::MinIntrinsic;
-    case WTF::alternativeIndexV<MinContentData, IPCData>:
-        return LengthWrapperDataType::MinContent;
-    case WTF::alternativeIndexV<MaxContentData, IPCData>:
-        return LengthWrapperDataType::MaxContent;
-    case WTF::alternativeIndexV<FillAvailableData, IPCData>:
-        return LengthWrapperDataType::FillAvailable;
-    case WTF::alternativeIndexV<FitContentData, IPCData>:
-        return LengthWrapperDataType::FitContent;
-    case WTF::alternativeIndexV<ContentData, IPCData>:
-        return LengthWrapperDataType::Content;
-    case WTF::alternativeIndexV<UndefinedData, IPCData>:
-        return LengthWrapperDataType::Undefined;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 LengthWrapperData::LengthWrapperData(IPCData&& data)
-    : m_type(typeFromIndex(data))
+    : m_floatValue { data.value }
+    , m_opaqueType { data.opaqueType }
+    , m_kind { LengthWrapperDataKind::Default }
+    , m_hasQuirk { data.hasQuirk }
 {
-    WTF::switchOn(data,
-        [&](const FixedData& data) {
-            m_floatValue = data.value;
-            m_hasQuirk = data.hasQuirk;
-        },
-        [&](const RelativeData& data) {
-            m_floatValue = data.value;
-        },
-        [&](const PercentData& data) {
-            m_floatValue = data.value;
-        },
-        []<typename EmptyData>(EmptyData) requires std::is_empty_v<EmptyData> { }
-    );
 }
 
 auto LengthWrapperData::ipcData() const -> IPCData
 {
-    switch (m_type) {
-    case LengthWrapperDataType::Auto:
-        return AutoData { };
-    case LengthWrapperDataType::Normal:
-        return NormalData { };
-    case LengthWrapperDataType::Relative:
-        return RelativeData { value() };
-    case LengthWrapperDataType::Percent:
-        return PercentData { value() };
-    case LengthWrapperDataType::Fixed:
-        return FixedData { value(), m_hasQuirk };
-    case LengthWrapperDataType::Intrinsic:
-        return IntrinsicData { };
-    case LengthWrapperDataType::MinIntrinsic:
-        return MinIntrinsicData { };
-    case LengthWrapperDataType::MinContent:
-        return MinContentData { };
-    case LengthWrapperDataType::MaxContent:
-        return MaxContentData { };
-    case LengthWrapperDataType::FillAvailable:
-        return FillAvailableData { };
-    case LengthWrapperDataType::FitContent:
-        return FitContentData { };
-    case LengthWrapperDataType::Content:
-        return ContentData { };
-    case LengthWrapperDataType::Undefined:
-        return UndefinedData { };
-    case LengthWrapperDataType::Calculated:
-        ASSERT_NOT_REACHED();
-        return { };
-    }
-    RELEASE_ASSERT_NOT_REACHED();
+    ASSERT(m_kind == LengthWrapperDataKind::Default);
+
+    return IPCData {
+        .value = value(),
+        .opaqueType = m_opaqueType,
+        .hasQuirk = m_hasQuirk
+    };
 }
 
 float LengthWrapperData::nonNanCalculatedValue(float maxValue) const
 {
-    ASSERT(m_type == LengthWrapperDataType::Calculated);
+    ASSERT(m_kind == LengthWrapperDataKind::Calculation);
     float result = protectedCalculationValue()->evaluate(maxValue);
     if (std::isnan(result))
         return 0;
@@ -310,153 +100,6 @@ float LengthWrapperData::nonNanCalculatedValue(float maxValue) const
 bool LengthWrapperData::isCalculatedEqual(const LengthWrapperData& other) const
 {
     return calculationValue() == other.calculationValue();
-}
-
-static Calculation::Child lengthCalculation(const LengthWrapperData& length)
-{
-    if (length.type() == LengthWrapperDataType::Percent)
-        return Calculation::percentage(length.value());
-
-    if (length.type() == LengthWrapperDataType::Calculated)
-        return length.calculationValue().copyRoot();
-
-    ASSERT(length.type() == LengthWrapperDataType::Fixed);
-    return Calculation::dimension(length.value());
-}
-
-static LengthWrapperData makeLengthWrapperData(Calculation::Child&& root)
-{
-    // FIXME: Value range should be passed in.
-
-    // NOTE: category is always `LengthPercentage` as late resolved `LengthWrapperData` values defined by percentages is the only reason calculation value is needed by `LengthWrapperData`.
-    return LengthWrapperData(CalculationValue::create(Calculation::Category::LengthPercentage, Calculation::All, Calculation::Tree { WTFMove(root) }));
-}
-
-static LengthWrapperData blendLengthWrapperDataMixedTypes(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext& context)
-{
-    if (context.compositeOperation != CompositeOperation::Replace)
-        return makeLengthWrapperData(Calculation::add(lengthCalculation(from), lengthCalculation(to)));
-
-    if ((from.type() != LengthWrapperDataType::Fixed
-                && from.type() != LengthWrapperDataType::Percent
-                && from.type() != LengthWrapperDataType::Calculated
-                && from.type() != LengthWrapperDataType::Relative)
-        || (to.type() != LengthWrapperDataType::Fixed
-                && to.type() != LengthWrapperDataType::Percent
-                && to.type() != LengthWrapperDataType::Calculated
-                && to.type() != LengthWrapperDataType::Relative)) {
-        ASSERT(context.isDiscrete);
-        ASSERT(!context.progress || context.progress == 1);
-        return context.progress ? to : from;
-    }
-
-    if (from.type() == LengthWrapperDataType::Relative || to.type() == LengthWrapperDataType::Relative)
-        return { 0, LengthWrapperDataType::Fixed };
-
-    if (to.type() != LengthWrapperDataType::Calculated && from.type() != LengthWrapperDataType::Percent && (context.progress == 1 || from.isZero()))
-        return blendLengthWrapperData(LengthWrapperData(0, to.type()), to, context);
-
-    if (from.type() != LengthWrapperDataType::Calculated && to.type() != LengthWrapperDataType::Percent && (!context.progress || to.isZero()))
-        return blendLengthWrapperData(from, LengthWrapperData(0, from.type()), context);
-
-    return makeLengthWrapperData(Calculation::blend(lengthCalculation(from), lengthCalculation(to), context.progress));
-}
-
-LengthWrapperData blendLengthWrapperData(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext& context)
-{
-    if (from.type() == LengthWrapperDataType::Auto || to.type() == LengthWrapperDataType::Auto || from.type() == LengthWrapperDataType::Undefined || to.type() == LengthWrapperDataType::Undefined || from.type() == LengthWrapperDataType::Normal || to.type() == LengthWrapperDataType::Normal)
-        return context.progress < 0.5 ? from : to;
-
-    if (from.type() == LengthWrapperDataType::Calculated || to.type() == LengthWrapperDataType::Calculated || (from.type() != to.type()))
-        return blendLengthWrapperDataMixedTypes(from, to, context);
-
-    if (!context.progress && context.isReplace())
-        return from;
-
-    if (context.progress == 1 && context.isReplace())
-        return to;
-
-    auto resultType = to.type();
-    if (to.isZero())
-        resultType = from.type();
-
-    if (resultType == LengthWrapperDataType::Percent) {
-        float fromPercent = from.isZero() ? 0 : from.value();
-        float toPercent = to.isZero() ? 0 : to.value();
-        return LengthWrapperData(WebCore::blend(fromPercent, toPercent, context), LengthWrapperDataType::Percent);
-    }
-
-    float fromValue = from.isZero() ? 0 : from.value();
-    float toValue = to.isZero() ? 0 : to.value();
-    return LengthWrapperData(WebCore::blend(fromValue, toValue, context), resultType);
-}
-
-LengthWrapperData blendLengthWrapperData(const LengthWrapperData& from, const LengthWrapperData& to, const BlendingContext& context, ValueRange valueRange)
-{
-    auto blended = blendLengthWrapperData(from, to, context);
-    if (valueRange == ValueRange::NonNegative && blended.isNegative()) {
-        auto type = from.isZero() ? to.type() : from.type();
-        if (type != LengthWrapperDataType::Calculated)
-            return { 0, type };
-        return { 0, LengthWrapperDataType::Fixed };
-    }
-    return blended;
-}
-
-static TextStream& operator<<(TextStream& ts, LengthWrapperDataType type)
-{
-    switch (type) {
-    case LengthWrapperDataType::Auto: ts << "auto"_s; break;
-    case LengthWrapperDataType::Calculated: ts << "calc"_s; break;
-    case LengthWrapperDataType::Content: ts << "content"_s; break;
-    case LengthWrapperDataType::FillAvailable: ts << "fill-available"_s; break;
-    case LengthWrapperDataType::FitContent: ts << "fit-content"_s; break;
-    case LengthWrapperDataType::Fixed: ts << "fixed"_s; break;
-    case LengthWrapperDataType::Intrinsic: ts << "intrinsic"_s; break;
-    case LengthWrapperDataType::MinIntrinsic: ts << "min-intrinsic"_s; break;
-    case LengthWrapperDataType::MinContent: ts << "min-content"_s; break;
-    case LengthWrapperDataType::MaxContent: ts << "max-content"_s; break;
-    case LengthWrapperDataType::Normal: ts << "normal"_s; break;
-    case LengthWrapperDataType::Percent: ts << "percent"_s; break;
-    case LengthWrapperDataType::Relative: ts << "relative"_s; break;
-    case LengthWrapperDataType::Undefined: ts << "undefined"_s; break;
-    }
-    return ts;
-}
-
-TextStream& operator<<(TextStream& ts, const LengthWrapperData& length)
-{
-    switch (length.type()) {
-    case LengthWrapperDataType::Auto:
-    case LengthWrapperDataType::Content:
-    case LengthWrapperDataType::Normal:
-    case LengthWrapperDataType::Undefined:
-        ts << length.type();
-        break;
-    case LengthWrapperDataType::Fixed:
-        ts << TextStream::FormatNumberRespectingIntegers(length.value()) << "px"_s;
-        break;
-    case LengthWrapperDataType::Relative:
-    case LengthWrapperDataType::Intrinsic:
-    case LengthWrapperDataType::MinIntrinsic:
-    case LengthWrapperDataType::MinContent:
-    case LengthWrapperDataType::MaxContent:
-    case LengthWrapperDataType::FillAvailable:
-    case LengthWrapperDataType::FitContent:
-        ts << length.type() << ' ' << TextStream::FormatNumberRespectingIntegers(length.value());
-        break;
-    case LengthWrapperDataType::Percent:
-        ts << TextStream::FormatNumberRespectingIntegers(length.value()) << '%';
-        break;
-    case LengthWrapperDataType::Calculated:
-        ts << length.protectedCalculationValue();
-        break;
-    }
-
-    if (length.hasQuirk())
-        ts << " has-quirk"_s;
-
-    return ts;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/primitives/StylePosition.cpp
+++ b/Source/WebCore/style/values/primitives/StylePosition.cpp
@@ -31,6 +31,7 @@
 #include "LengthPoint.h"
 #include "RenderStyle.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Platform.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StylePrimitiveNumericTypes+Platform.h"

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.cpp
@@ -28,6 +28,7 @@
 #include "FloatRect.h"
 #include "GeometryUtilities.h"
 #include "Path.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include <numbers>

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -33,6 +33,7 @@
 #include "SVGPathByteStreamSource.h"
 #include "SVGPathParser.h"
 #include "SVGPathSource.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StylePathFunction.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -50,6 +50,36 @@ namespace Style {
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
 struct MaximumSize : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::None, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
+
+    ALWAYS_INLINE bool isNone() const { return holdsAlternative<CSS::Keyword::None>(); }
+    ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
+    ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
+    ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
+    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
+    ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
+
+    ALWAYS_INLINE bool isIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>();
+    }
+    ALWAYS_INLINE bool isLegacyIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
+    }
+    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>()
+            || holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
+    }
 };
 
 using MaximumSizePair = SpaceSeparatedSize<MaximumSize>;

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -53,6 +53,37 @@ struct PreferredSize;
 struct MinimumSize : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
+    ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
+    ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
+    ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
+    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
+    ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
+
+    ALWAYS_INLINE bool isIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>();
+    }
+    ALWAYS_INLINE bool isLegacyIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
+    }
+    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>()
+            || holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>()
+            || holdsAlternative<CSS::Keyword::Auto>();
+    }
+
 private:
     friend struct PreferredSize;
 };

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
@@ -33,12 +33,20 @@ namespace Style {
 
 MinimumSize PreferredSize::asMinimumSize() const
 {
-    return MinimumSize { m_value };
+    return WTF::switchOn(*this,
+        [&](const auto& value) {
+            return MinimumSize { value };
+        }
+    );
 }
 
 FlexBasis PreferredSize::asFlexBasis() const
 {
-    return FlexBasis { m_value };
+    return WTF::switchOn(*this,
+        [&](const auto& value) {
+            return FlexBasis { value };
+        }
+    );
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -60,6 +60,37 @@ struct PreferredSize : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS
     // `PreferredSize` is a structural subset of `FlexBasis` and therefore can be losslessly converted.
     FlexBasis asFlexBasis() const;
 
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
+    ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
+    ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
+    ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
+    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
+    ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
+
+    ALWAYS_INLINE bool isIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>();
+    }
+    ALWAYS_INLINE bool isLegacyIntrinsic() const
+    {
+        return holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
+    }
+    ALWAYS_INLINE bool isIntrinsicOrLegacyIntrinsicOrAuto() const
+    {
+        return holdsAlternative<CSS::Keyword::MinContent>()
+            || holdsAlternative<CSS::Keyword::MaxContent>()
+            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
+            || holdsAlternative<CSS::Keyword::FitContent>()
+            || holdsAlternative<CSS::Keyword::Intrinsic>()
+            || holdsAlternative<CSS::Keyword::MinIntrinsic>()
+            || holdsAlternative<CSS::Keyword::Auto>();
+    }
+
 private:
     friend struct FlexBasis;
     friend struct MinimumSize;

--- a/Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h
+++ b/Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h
@@ -34,6 +34,8 @@ namespace Style {
 // https://svgwg.org/svg2-draft/geometry.html#RY
 struct SVGRadiusComponent : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>, CSS::Keyword::Auto> {
     using Base::Base;
+
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.cpp
@@ -28,6 +28,7 @@
 #include "AnimationUtilities.h"
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp
@@ -31,6 +31,7 @@
 #include "FontMetrics.h"
 #include "RenderStyleInlines.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.h
@@ -34,6 +34,8 @@ namespace Style {
 struct TextUnderlineOffset : LengthWrapperBase<LengthPercentage<>, CSS::Keyword::Auto> {
     using Base::Base;
 
+    ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }
+
     float resolve(const RenderStyle&, float autoValue = 0.0f) const;
     float resolve(float fontSize, float autoValue = 0.0f) const;
 };

--- a/Source/WebCore/style/values/text/StyleTextIndent.cpp
+++ b/Source/WebCore/style/values/text/StyleTextIndent.cpp
@@ -26,6 +26,7 @@
 #include "StyleTextIndent.h"
 
 #include "StyleBuilderChecking.h"
+#include "StyleLengthWrapper+Blending.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3254,46 +3254,21 @@ using WebCore::Style::ShapeCommand = Variant<WebCore::Style::MoveCommand, WebCor
 };
 
 header: <WebCore/StyleLengthWrapperData.h>
-[CustomHeader] struct WebCore::Style::LengthWrapperData {
-    Variant<WebCore::Style::LengthWrapperData::AutoData, WebCore::Style::LengthWrapperData::NormalData, WebCore::Style::LengthWrapperData::RelativeData, WebCore::Style::LengthWrapperData::PercentData, WebCore::Style::LengthWrapperData::FixedData, WebCore::Style::LengthWrapperData::IntrinsicData, WebCore::Style::LengthWrapperData::MinIntrinsicData, WebCore::Style::LengthWrapperData::MinContentData, WebCore::Style::LengthWrapperData::MaxContentData, WebCore::Style::LengthWrapperData::FillAvailableData, WebCore::Style::LengthWrapperData::FitContentData, WebCore::Style::LengthWrapperData::ContentData, WebCore::Style::LengthWrapperData::UndefinedData> ipcData();
-}
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::AutoData {
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::IPCData {
+    float value;
+    uint8_t opaqueType;
+    bool hasQuirk;
 };
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::NormalData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FixedData {
-    float value
-    bool hasQuirk
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::RelativeData {
-    float value
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::PercentData {
-    float value
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::IntrinsicData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::MinIntrinsicData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::MinContentData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::MaxContentData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FillAvailableData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::FitContentData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::ContentData {
-};
-[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData::UndefinedData {
+[CustomHeader, Nested] struct WebCore::Style::LengthWrapperData {
+    WebCore::Style::LengthWrapperData::IPCData ipcData();
 };
 
 header: <WebCore/StylePosition.h>
 [CustomHeader, Nested] struct WebCore::Style::PositionX {
-    Variant<WebCore::Style::LengthWrapperData::AutoData, WebCore::Style::LengthWrapperData::NormalData, WebCore::Style::LengthWrapperData::RelativeData, WebCore::Style::LengthWrapperData::PercentData, WebCore::Style::LengthWrapperData::FixedData, WebCore::Style::LengthWrapperData::IntrinsicData, WebCore::Style::LengthWrapperData::MinIntrinsicData, WebCore::Style::LengthWrapperData::MinContentData, WebCore::Style::LengthWrapperData::MaxContentData, WebCore::Style::LengthWrapperData::FillAvailableData, WebCore::Style::LengthWrapperData::FitContentData, WebCore::Style::LengthWrapperData::ContentData, WebCore::Style::LengthWrapperData::UndefinedData> ipcData();
+    WebCore::Style::LengthWrapperData::IPCData ipcData();
 };
 [CustomHeader, Nested] struct WebCore::Style::PositionY {
-    Variant<WebCore::Style::LengthWrapperData::AutoData, WebCore::Style::LengthWrapperData::NormalData, WebCore::Style::LengthWrapperData::RelativeData, WebCore::Style::LengthWrapperData::PercentData, WebCore::Style::LengthWrapperData::FixedData, WebCore::Style::LengthWrapperData::IntrinsicData, WebCore::Style::LengthWrapperData::MinIntrinsicData, WebCore::Style::LengthWrapperData::MinContentData, WebCore::Style::LengthWrapperData::MaxContentData, WebCore::Style::LengthWrapperData::FillAvailableData, WebCore::Style::LengthWrapperData::FitContentData, WebCore::Style::LengthWrapperData::ContentData, WebCore::Style::LengthWrapperData::UndefinedData> ipcData();
+    WebCore::Style::LengthWrapperData::IPCData ipcData();
 };
 [CustomHeader, Nested] struct WebCore::Style::Position {
     WebCore::Style::PositionX x;


### PR DESCRIPTION
#### 9ced4cd71b219e691ca27ef7e7e2edb3f982e331
<pre>
[Style] Support arbitrary keywords in Style::LengthWrapperBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=296960">https://bugs.webkit.org/show_bug.cgi?id=296960</a>

Reviewed by Darin Adler.

Replaces the current data model for `Style::LengthWrapperData`, which
used an enum of potential values, with a new approach where the owner,
`Style::LengthWrapperBase` manages an opaque type index value for it. A
new kind field is used to manage what kind the type of the union is.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/rendering/PathOperation.cpp:
* Source/WebCore/rendering/RenderMenuList.cpp:
* Source/WebCore/rendering/RenderSearchField.cpp:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/style/StyleInterpolationFunctions.h:
* Source/WebCore/style/values/align/StyleGapGutter.h:
* Source/WebCore/style/values/backgrounds/StyleBorderImageWidth.cpp:
* Source/WebCore/style/values/box/StyleMargin.h:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.h:
* Source/WebCore/style/values/grid/StyleGridTrackBreadth.cpp:
* Source/WebCore/style/values/grid/StyleGridTrackBreadth.h:
* Source/WebCore/style/values/masking/StyleMaskBorderWidth.cpp:
* Source/WebCore/style/values/motion/StyleOffsetAnchor.cpp:
* Source/WebCore/style/values/position/StyleInset.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h: Added.
* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapper+Platform.h: Added.
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebCore/style/values/primitives/StylePosition.cpp:
* Source/WebCore/style/values/shapes/StyleCircleFunction.cpp:
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
* Source/WebCore/style/values/sizing/StyleMaximumSize.h:
* Source/WebCore/style/values/sizing/StyleMinimumSize.h:
* Source/WebCore/style/values/sizing/StylePreferredSize.cpp:
* Source/WebCore/style/values/sizing/StylePreferredSize.h:
* Source/WebCore/style/values/svg/StyleSVGRadiusComponent.h:
* Source/WebCore/style/values/svg/StyleSVGStrokeDasharray.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationThickness.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextUnderlineOffset.h:
* Source/WebCore/style/values/text/StyleTextIndent.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/298460@main">https://commits.webkit.org/298460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f366f349a38edd13ce5c42d4d79d64722e713879

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115476 "50 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121557 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87748 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21776 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65216 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124720 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31775 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96512 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96298 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19399 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38300 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47849 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41789 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->