### PR TITLE
[Form Control Refresh] Disabled checkbox and submit controls may fail to repaint for window inactive state

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1224,6 +1224,12 @@ bool RenderTheme::isIndeterminate(const RenderObject& renderer) const
     return input && input->isCheckbox() && input->matchesIndeterminatePseudoClass();
 }
 
+bool RenderTheme::isSubmitButton(const RenderObject& renderer) const
+{
+    RefPtr element = dynamicDowncast<HTMLFormControlElement>(renderer.node());
+    return element && element->isSubmitButton();
+}
+
 bool RenderTheme::isEnabled(const RenderObject& renderer) const
 {
     RefPtr element = dynamicDowncast<Element>(renderer.node());

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -414,6 +414,7 @@ public:
     bool isWindowActive(const RenderObject&) const;
     bool isChecked(const RenderObject&) const;
     bool isIndeterminate(const RenderObject&) const;
+    bool isSubmitButton(const RenderObject&) const;
     bool isEnabled(const RenderObject&) const;
     bool isFocused(const RenderObject&) const;
     bool isPressed(const RenderObject&) const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -63,6 +63,8 @@ public:
 #if ENABLE(FORM_CONTROL_REFRESH)
     static std::optional<RoundedShape> shapeForInteractionRegion(const RenderBox&, const FloatRect&, ShouldComputePath);
     static FloatSize inflateRectForInteractionRegion(const RenderObject&, FloatRect&);
+    bool controlSupportsTints(const RenderObject&) const override;
+    bool supportsControlTints() const override { return true; }
 #endif
 
     struct IconAndSize {

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -531,6 +531,32 @@ LayoutRect RenderThemeCocoa::adjustedPaintRect(const RenderBox& box, const Layou
 
 #if ENABLE(FORM_CONTROL_REFRESH)
 
+bool RenderThemeCocoa::controlSupportsTints(const RenderObject& box) const
+{
+#if PLATFORM(MAC)
+    switch (box.style().usedAppearance()) {
+    case StyleAppearance::Button:
+        return isSubmitButton(box);
+    case StyleAppearance::Checkbox:
+    case StyleAppearance::Radio:
+        return isChecked(box) || isIndeterminate(box);
+    case StyleAppearance::ListButton:
+    case StyleAppearance::ProgressBar:
+    case StyleAppearance::SliderHorizontal:
+    case StyleAppearance::SliderVertical:
+        return true;
+    case StyleAppearance::Switch:
+        return isChecked(box);
+    default:
+        break;
+    }
+#else
+    UNUSED_PARAM(box)
+#endif
+
+    return false;
+}
+
 enum class ControlSize : uint8_t {
     Micro,
     Mini,

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1157,6 +1157,10 @@ void RenderThemeMac::adjustRepaintRect(const RenderBox& renderer, FloatRect& rec
 
 bool RenderThemeMac::controlSupportsTints(const RenderObject& o) const
 {
+#if ENABLE(FORM_CONTROL_REFRESH)
+    if (o.settings().formControlRefreshEnabled())
+        return RenderThemeCocoa::controlSupportsTints(o);
+#endif
     // An alternate way to implement this would be to get the appropriate cell object
     // and call the private _needRedrawOnWindowChangedKeyState method. An advantage of
     // that would be that we would match AppKit behavior more closely, but a disadvantage


### PR DESCRIPTION
#### 124c73889ce00f7555e35adf4c2987eb8b7aa3ac
<pre>
[Form Control Refresh] Disabled checkbox and submit controls may fail to repaint for window inactive state
<a href="https://bugs.webkit.org/show_bug.cgi?id=296961">https://bugs.webkit.org/show_bug.cgi?id=296961</a>
<a href="https://rdar.apple.com/153576943">rdar://153576943</a>

Reviewed by Aditya Keerthi.

Implement `supportsControlTints` and `controlSupportsTints` in RenderThemeCocoa to return true
for all controls which have tint. These methods communicate whether or not a repaint should
occur when the window switches between the active and inactive state.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::isSubmitButton const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::controlSupportsTints const):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::controlSupportsTints const):

Canonical link: <a href="https://commits.webkit.org/298271@main">https://commits.webkit.org/298271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec26111dc062ada2feffe3644829efbbe3019826

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121028 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/65579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ea81b67-9b70-4d72-9b1e-c530fd9ce69c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/65579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/268f1592-b5c7-4901-b913-bf57e381e967) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67703 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64686 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124222 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31294 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95895 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24414 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41089 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18923 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47282 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41309 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->