### PR TITLE
Increase FD limit for GPUProcess and NetworkProcess

### DIFF
--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -147,6 +147,8 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
     if (WKProcessExtension.sharedInstance)
         [WKProcessExtension.sharedInstance lockdownSandbox:@"2.0"];
 #endif
+
+    increaseFileDescriptorLimit();
 }
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -116,6 +116,8 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
         [NEFilterSource setDelegation:&auditToken.value()];
 #endif
     m_enableModernDownloadProgress = parameters.enableModernDownloadProgress;
+
+    increaseFileDescriptorLimit();
 }
 
 RetainPtr<CFDataRef> NetworkProcess::sourceApplicationAuditData() const

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -574,6 +574,7 @@
         "hw.product" ;; <rdar://problem/81334849>
         "kern.bootargs"
         "kern.hv_vmm_present"
+        "kern.maxfilesperproc"
 #if ASAN_ENABLED
         "kern.osrelease"
 #endif

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -178,6 +178,10 @@ protected:
     // IPC::Connection::Client.
     void didClose(IPC::Connection&) override;
 
+#if PLATFORM(COCOA)
+    void increaseFileDescriptorLimit();
+#endif
+
 private:
 #if ENABLE(CFPREFS_DIRECT_MODE)
     void handleAXPreferenceChange(const String& domain, const String& key, id value);


### PR DESCRIPTION
#### 1667e4506835aebe1431586c46888b3139db6e58
<pre>
Increase FD limit for GPUProcess and NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=296963">https://bugs.webkit.org/show_bug.cgi?id=296963</a>
<a href="https://rdar.apple.com/153040299">rdar://153040299</a>

Reviewed by Per Arne Vollan.

We are seeing some crashes where the GPUProcess bumps in to its low FD limit of 256. Bump this to
2560 to match the behavior of other similar processes in the system.

Also increase the limit for NetworkProcess, since that process can also run in to FD limits (due to
sharing file-backed blobs cross-process via NetworkCache).

* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::increaseFileDescriptorLimit):

Canonical link: <a href="https://commits.webkit.org/298272@main">https://commits.webkit.org/298272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bd11f763dafc3e90ef487e17d0873b6a95dbbbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121031 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/65582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7638e11c-3311-446d-a28a-2745581a43e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87312 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/65582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69f1613c-2dbe-42fa-b971-d56afa19cbd2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67705 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27275 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64688 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124224 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96112 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18932 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/37930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47287 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41311 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->