### PR TITLE
[Navigation API] NavigateEvent for location.href needs to run before next microtask.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-canceled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-canceled-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for the location.href setter where the navigate event is canceled assert_array_equals: lengths differ, expected array ["navigate", "AbortSignal abort", "navigateerror", "promise microtask"] length 4, got ["promise microtask"] length 1
+PASS event and promise ordering for the location.href setter where the navigate event is canceled
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-double-intercept_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-double-intercept_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering when location.href is set repeatedly and handled by intercept() assert_array_equals: lengths differ, expected array ["navigate", "currententrychange", "handler run", "AbortSignal abort", "navigateerror", "navigate", "currententrychange", "handler run", "transition.finished rejected", "promise microtask", "navigatesuccess", "transition.finished fulfilled"] length 12, got ["promise microtask", "navigate", "currententrychange", "handler run", "navigatesuccess", "transition.finished fulfilled"] length 6
+PASS event and promise ordering when location.href is set repeatedly and handled by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-double-intercept_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-double-intercept_no-currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering when location.href is set repeatedly and handled by intercept() assert_array_equals: lengths differ, expected array ["navigate", "handler run", "AbortSignal abort", "navigateerror", "navigate", "handler run", "transition.finished rejected", "promise microtask", "navigatesuccess", "transition.finished fulfilled"] length 10, got ["promise microtask", "navigate", "handler run", "navigatesuccess", "transition.finished fulfilled"] length 5
+PASS event and promise ordering when location.href is set repeatedly and handled by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for the location.href setter intercepted by intercept() where we set location.href again inside the navigate handler assert_array_equals: lengths differ, expected array ["navigate", "AbortSignal abort", "navigateerror", "navigate", "currententrychange", "handler run", "promise microtask", "navigatesuccess", "transition.finished fulfilled"] length 9, got ["promise microtask", "navigate", "currententrychange", "handler run", "AbortSignal abort", "navigateerror", "navigate", "transition.finished rejected", "currententrychange", "handler run", "navigatesuccess", "transition.finished fulfilled"] length 12
+PASS event and promise ordering for the location.href setter intercepted by intercept() where we set location.href again inside the navigate handler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant_no-currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for the location.href setter intercepted by intercept() where we set location.href again inside the navigate handler assert_array_equals: lengths differ, expected array ["navigate", "AbortSignal abort", "navigateerror", "navigate", "handler run", "promise microtask", "navigatesuccess", "transition.finished fulfilled"] length 8, got ["promise microtask", "navigate", "handler run", "AbortSignal abort", "navigateerror", "navigate", "transition.finished rejected", "handler run", "navigatesuccess", "transition.finished fulfilled"] length 10
+PASS event and promise ordering for the location.href setter intercepted by intercept() where we set location.href again inside the navigate handler
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for location.href setter intercepted by passing a rejected promise to intercept() assert_array_equals: expected property 0 to be "navigate" but got "promise microtask" (expected array ["navigate", "currententrychange", "handler run", "promise microtask", "navigateerror", "transition.finished rejected"] got ["promise microtask", "navigate", "currententrychange", "handler run", "navigateerror", "transition.finished rejected"])
+PASS event and promise ordering for location.href setter intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_no-currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for location.href setter intercepted by passing a rejected promise to intercept() assert_array_equals: expected property 0 to be "navigate" but got "promise microtask" (expected array ["navigate", "handler run", "promise microtask", "navigateerror", "transition.finished rejected"] got ["promise microtask", "navigate", "handler run", "navigateerror", "transition.finished rejected"])
+PASS event and promise ordering for location.href setter intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept_currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for location.href setter intercepted by intercept() assert_array_equals: expected property 0 to be "navigate" but got "promise microtask" (expected array ["navigate", "currententrychange", "handler run", "promise microtask", "navigatesuccess", "transition.finished fulfilled"] got ["promise microtask", "navigate", "currententrychange", "handler run", "navigatesuccess", "transition.finished fulfilled"])
+PASS event and promise ordering for location.href setter intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept_no-currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for location.href setter intercepted by intercept() assert_array_equals: expected property 0 to be "navigate" but got "promise microtask" (expected array ["navigate", "handler run", "promise microtask", "navigatesuccess", "transition.finished fulfilled"] got ["promise microtask", "navigate", "handler run", "navigatesuccess", "transition.finished fulfilled"])
+PASS event and promise ordering for location.href setter intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled-expected.txt
@@ -1,5 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: oh no!
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Unhandled rejection: oh no!
 
-FAIL navigation.transition.finished must not trigger unhandled rejections null is not an object (evaluating 'navigation.transition.finished')
+FAIL navigation.transition.finished must not trigger unhandled rejections assert_unreached: unhandledrejection must not fire Reached unreachable code
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -129,6 +129,9 @@ public:
     bool isHandledByAboutSchemeHandler() const { return m_isHandledByAboutSchemeHandler; }
     void setIsHandledByAboutSchemeHandler(bool isHandledByAboutSchemeHandler) { m_isHandledByAboutSchemeHandler = isHandledByAboutSchemeHandler; }
 
+    bool skipNavigateEvent() const { return m_skipNavigateEvent; }
+    void setSkipNavigateEvent(bool value) { m_skipNavigateEvent = value; }
+
 private:
     Ref<Document> m_requester;
     Ref<SecurityOrigin> m_requesterSecurityOrigin;
@@ -156,6 +159,7 @@ private:
     NavigationHistoryBehavior m_navigationHistoryBehavior { NavigationHistoryBehavior::Auto };
     bool m_isFromNavigationAPI { false };
     bool m_isHandledByAboutSchemeHandler { false };
+    bool m_skipNavigateEvent { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -468,7 +468,7 @@ private:
 
     void updateRequestAndAddExtraFields(Frame&, ResourceRequest&, IsMainResource, FrameLoadType, ShouldUpdateAppInitiatedValue, IsServiceWorkerNavigationLoad, WillOpenInNewWindow, Document*);
 
-    bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const AtomString&, NavigationHistoryBehavior, bool isSameDocument, FormState* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr, Element* sourceElement = nullptr);
+    bool dispatchNavigateEvent(FrameLoadType, const FrameLoadRequest&, bool isSameDocument, FormState* = nullptr, Event* = nullptr, SerializedScriptValue* classicHistoryAPIState = nullptr);
 
     WeakRef<LocalFrame> m_frame;
     const UniqueRef<LocalFrameLoaderClient> m_client;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -225,10 +225,11 @@ private:
 
 class ScheduledLocationChange : public ScheduledURLNavigation {
 public:
-    ScheduledLocationChange(Document& initiatingDocument, SecurityOrigin* securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool duringLoad, NavigationHistoryBehavior navigationHandling, CompletionHandler<void(bool)>&& completionHandler)
+    ScheduledLocationChange(Document& initiatingDocument, SecurityOrigin* securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool duringLoad, NavigationHistoryBehavior navigationHandling, bool hasDispatchedNavigateEvent, CompletionHandler<void(bool)>&& completionHandler)
         : ScheduledURLNavigation(initiatingDocument, 0.0, securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, true)
         , m_completionHandler(WTFMove(completionHandler))
         , m_navigationHistoryBehavior(navigationHandling)
+        , m_hasDispatchedNavigateEvent(hasDispatchedNavigateEvent)
     {
     }
 
@@ -249,6 +250,7 @@ public:
         frameLoadRequest.disableNavigationToInvalidURL();
         frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLs());
         frameLoadRequest.setNavigationHistoryBehavior(m_navigationHistoryBehavior);
+        frameLoadRequest.setSkipNavigateEvent(m_hasDispatchedNavigateEvent);
 
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
         frame.changeLocation(WTFMove(frameLoadRequest));
@@ -258,6 +260,7 @@ public:
 private:
     CompletionHandler<void(bool)> m_completionHandler;
     NavigationHistoryBehavior m_navigationHistoryBehavior;
+    bool m_hasDispatchedNavigateEvent { false };
 };
 
 class ScheduledRefresh : public ScheduledURLNavigation {
@@ -606,11 +609,33 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
         return completionHandler(ScheduleLocationChangeResult::Completed);
     }
 
+    // Fire Navigation API navigate event synchronously before scheduling navigation.
+    // This ensures proper event ordering where navigate event fires before microtasks.
+    // Only fire for same-origin navigations to avoid cross-origin issues.
+    bool hasDispatchedNavigateEvent = false;
+    if (localFrame && !url.protocolIsJavaScript()) {
+        RefPtr document = localFrame->document();
+        if (document && document->settings().navigationAPIEnabled() && document->securityOrigin().isSameOriginAs(securityOrigin)) {
+            if (RefPtr window = document->window()) {
+                if (RefPtr navigation = window->navigation()) {
+                    auto navigationType = (historyHandling == NavigationHistoryBehavior::Replace) ? NavigationNavigationType::Replace : NavigationNavigationType::Push;
+                    bool isSameDocument = false;
+                    FormState* formState = nullptr;
+
+                    if (!navigation->dispatchPushReplaceReloadNavigateEvent(url, navigationType, isSameDocument, formState))
+                        return completionHandler(ScheduleLocationChangeResult::Stopped);
+
+                    hasDispatchedNavigateEvent = true;
+                }
+            }
+        }
+    }
+
     // Handle a location change of a page with no document as a special case.
     // This may happen when a frame changes the location of another frame.
     bool duringLoad = loader && !loader->stateMachine().committedFirstRealDocumentLoad();
 
-    schedule(makeUnique<ScheduledLocationChange>(initiatingDocument, &securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, historyHandling, [completionHandler = WTFMove(completionHandler)] (bool hasStarted) mutable {
+    schedule(makeUnique<ScheduledLocationChange>(initiatingDocument, &securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, historyHandling, hasDispatchedNavigateEvent, [completionHandler = WTFMove(completionHandler)] (bool hasStarted) mutable {
         completionHandler(hasStarted ? ScheduleLocationChangeResult::Started : ScheduleLocationChangeResult::Stopped);
     }));
 }


### PR DESCRIPTION
#### db6e4c26e758915244eae2cf0f8d03ca66a59ec6
<pre>
[Navigation API] NavigateEvent for location.href needs to run before next microtask.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296945">https://bugs.webkit.org/show_bug.cgi?id=296945</a>
<a href="https://rdar.apple.com/157307363">rdar://157307363</a>

Reviewed by Alex Christensen.

When location.href or similar APIs trigger a navigation, the navigate event should fire
synchronously before any microtasks run. This ensures proper event ordering and allows
navigate event handlers to prevent the navigation if needed. The fix adds synchronous
NavigateEvent dispatch in scheduleLocationChange().

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-canceled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-double-intercept_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-double-intercept_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reentrant_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled-expected.txt:
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::skipNavigateEvent const):
(WebCore::FrameLoadRequest::setSkipNavigateEvent):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::dispatchNavigateEvent):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledLocationChange::ScheduledLocationChange):
(WebCore::NavigationScheduler::scheduleLocationChange):

Canonical link: <a href="https://commits.webkit.org/298445@main">https://commits.webkit.org/298445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4755d25e914aaa47282ff5d4ef8a40f8c2daa98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66056 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6fbac06-cdd9-466b-be17-e966673f0f0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b41bca31-4402-49b2-9477-3e67359ca7bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68140 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/114868 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21782 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65234 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124732 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31788 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24505 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19404 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47865 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41800 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45128 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->