### PR TITLE
[AutoFill Debugging] Part 2: Add new WKTextExtraction* types and properties

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -34,6 +34,19 @@
 namespace WebCore {
 namespace TextExtraction {
 
+enum class EventListenerCategory : uint16_t {
+    Click       = 1 << 0,
+    Hover       = 1 << 1,
+    Touch       = 1 << 2,
+    Wheel       = 1 << 3,
+    Gesture     = 1 << 4,
+    Pointer     = 1 << 5,
+    Keyboard    = 1 << 6,
+    Focus       = 1 << 7,
+    Form        = 1 << 8,
+    Media       = 1 << 9,
+};
+
 struct Editable {
     String label;
     String placeholder;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6377,7 +6377,7 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 #endif
             return rectInRootView;
         });
-        RetainPtr result = adoptNS([[WKTextExtractionResult alloc] initWithRootItem:rootItem.get()]);
+        RetainPtr result = adoptNS([[WKTextExtractionResult alloc] initWithRootItem:rootItem.get() popupMenu:nil]);
         completionHandler(result.get());
     });
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))


### PR DESCRIPTION
#### 7cfd9a324a9522418db499e24276d8cdff91232f
<pre>
[AutoFill Debugging] Part 2: Add new WKTextExtraction* types and properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=296966">https://bugs.webkit.org/show_bug.cgi?id=296966</a>

Reviewed by Abrar Rahman Protyasha.

More work in progress towards AutoFill debugging — add several new types of text extraction items,
as well as additional members (which are currently unused). The new types are:

- `WKTextExtractionTextFormControlItem`
- `WKTextExtractionContentEditableItem`
- `WKTextExtractionLinkItem`
- `WKTextExtractionPopupMenu`
- `WKTextExtractionSelectItem`

...and the new properties on all text extraction items are:

- `eventListeners` (representing a set of event listener types on the corresponding element)
- `ariaAttributes` (representing a subset of ARIA attributes)
- `accessibilityRole` (representing the `role` DOM attribute)
- `nodeIdentifier` (representing a nullable identifier string for the node)

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(eventListenerTypesAsArray(_:)):
(WKTextExtractionContentEditableItem.isFocused):
(WKTextExtractionTextFormControlItem.isSecure):
(WKTextExtractionTextFormControlItem.isFocused):
(WKTextExtractionTextFormControlItem.label):
(WKTextExtractionTextFormControlItem.placeholder):
(WKTextExtractionTextFormControlItem.isReadonly):
(WKTextExtractionTextFormControlItem.isDisabled):
(WKTextExtractionTextFormControlItem.isChecked):
(WKTextExtractionLinkItem.url):
(WKTextExtractionSelectItem.supportsMultiple):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::eventListenerTypes):
(WebKit::createWKEditable):
(WebKit::createItemWithChildren):
(WebKit::createWKTextItem): Deleted.

Canonical link: <a href="https://commits.webkit.org/298299@main">https://commits.webkit.org/298299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffdf2504986db89787ab274d7782b70bba0bcbbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65671 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5b58998-7f48-45b5-92d9-65328319a424) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87405 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ab27769-0b69-40fe-aeec-13e2dad33d83) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67801 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21384 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64794 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124332 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96205 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38006 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41870 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47405 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41414 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->