### PR TITLE
AX: Accessibility objects should live as long their DOM node, not as long as their renderer, which is destroyed and recreated frequently, causing unnecessary churn for ATs

### DIFF
--- a/LayoutTests/accessibility/display-contents/table-dynamic.html
+++ b/LayoutTests/accessibility/display-contents/table-dynamic.html
@@ -109,7 +109,9 @@ if (window.accessibilityController) {
             var tableOne = accessibilityController.accessibleElementById("t1");
             if (!tableZero || !tableOne)
                 return false;
-            return tableZero.rowCount >= 4 && tableOne.rowCount === 2;
+            if (tableZero.rowCount !== 4 || tableOne.rowCount !== 2)
+                return false;
+            return tableZero.cellForColumnAndRow(0, 3).role.toLowerCase().includes("cell");
         });
 
         dumpTable("t0", 4, 2, false /* useExpect */);

--- a/LayoutTests/accessibility/menu-list-crash2-expected.txt
+++ b/LayoutTests/accessibility/menu-list-crash2-expected.txt
@@ -1,7 +1,7 @@
 This tests that there's no crash if we hide menu list and then try to access accessibility information.
 
 Role before removal: AXRole: AXPopUpButton
-Role after removal: AXRole:
+Role after becoming ignored: AXRole: AXPopUpButton
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/menu-list-crash2.html
+++ b/LayoutTests/accessibility/menu-list-crash2.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../resources/accessibility-helper.js"></script>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
 </head>
 <body>
 
@@ -19,31 +20,31 @@ TEST
 TEST
 
 <script>
-    var testOutput = "This tests that there's no crash if we hide menu list and then try to access accessibility information.\n\n";
+var testOutput = "This tests that there's no crash if we hide menu list and then try to access accessibility information.\n\n";
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        const menulist = document.getElementById("menulist");
-        menulist.selectedIndex = 1;
+    const menulist = document.getElementById("menulist");
+    menulist.selectedIndex = 1;
 
-        const axMenulist = accessibilityController.accessibleElementById("menulist");
-        const initialRole = axMenulist.role;
-        testOutput += `Role before removal: ${initialRole}\n`;
+    var axMenulist = accessibilityController.accessibleElementById("menulist");
+    const initialRole = axMenulist.role;
+    testOutput += `Role before removal: ${initialRole}\n`;
 
-        setTimeout(async function() {
-            menulist.style.display = "none";
-            gc();
+    setTimeout(async function() {
+        menulist.style.display = "none";
+        await UIHelper.renderingUpdate();
 
-            await waitFor(() => axMenulist.role !== initialRole);
+        await waitFor(() => axMenulist.isIgnored);
 
-            // Don't crash!
-            testOutput += `Role after removal: ${axMenulist.role}\n`;
+        // Don't crash!
+        testOutput += `Role after becoming ignored: ${axMenulist.role}\n`;
 
-            debug(testOutput);
-            finishJSTest();
-        }, 0);
-    }
+        debug(testOutput);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/slider-with-lost-renderer-expected.txt
+++ b/LayoutTests/accessibility/slider-with-lost-renderer-expected.txt
@@ -2,8 +2,9 @@ This test ensures that adding a child to a slider that has lost its renderer dyn
 
 Initial #slider role: AXRole: AXSlider
 Initial #slider children count: 1
+PASS: slider.isIgnored === true
 
-Final #slider role: AXRole:
+Final #slider role: AXRole: AXSlider
 Final #slider children count: 0
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/slider-with-lost-renderer.html
+++ b/LayoutTests/accessibility/slider-with-lost-renderer.html
@@ -3,40 +3,43 @@
 <head>
 <script src="../resources/accessibility-helper.js"></script>
 <script src="../resources/js-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
 </head>
 <body>
 
 <input type="range" id="slider" min="0" max="11">
 
 <script>
-    var testOutput = "This test ensures that adding a child to a slider that has lost its renderer dynamically doesn't crash.\n\n";
+var output = "This test ensures that adding a child to a slider that has lost its renderer dynamically doesn't crash.\n\n";
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        const slider = accessibilityController.accessibleElementById("slider");
-        testOutput += `Initial #slider role: ${slider.role}\n`;
-        testOutput += `Initial #slider children count: ${slider.childrenCount}\n`;
+    var slider = accessibilityController.accessibleElementById("slider");
+    output += `Initial #slider role: ${slider.role}\n`;
+    output += `Initial #slider children count: ${slider.childrenCount}\n`;
 
-        setTimeout(async function() {
-            // At the time of writing, WebKit handles "children changed for object" events
-            // on a deferred timer. So add a child to the slider to queue up a change.
-            document.getElementById("slider").appendChild(document.createTextNode("foo"));
-            // Force the slider to lose its renderer by changing it to display:contents.
-            document.getElementById("slider").style.display = "contents";
+    setTimeout(async function() {
+        // At the time of writing, WebKit handles "children changed for object" events
+        // on a deferred timer. So add a child to the slider to queue up a change.
+        document.getElementById("slider").appendChild(document.createTextNode("foo"));
+        // Force the slider to lose its renderer by changing it to display:contents.
+        document.getElementById("slider").style.display = "contents";
+        // Force layout and wait for rendering to complete.
+        document.getElementById("slider").offsetHeight;
+        await UIHelper.renderingUpdate();
 
-            await waitFor(() => {
-                return (!slider.role || !slider.role.includes("Slider")) && slider.childrenCount === 0;
-            });
+        // An input with no renderer should be ignored, so wait for that to happen.
+        output += await expectAsync("slider.isIgnored", "true");
 
-            // Accessing the slider again should not cause a crash after those changes.
-            testOutput += `\nFinal #slider role: ${slider.role}\n`;
-            testOutput += `Final #slider children count: ${slider.childrenCount}\n`;
+        // Accessing the slider again should not cause a crash after those changes.
+        output += `\nFinal #slider role: ${slider.role}\n`;
+        output += `Final #slider children count: ${slider.childrenCount}\n`;
 
-            debug(testOutput);
-            finishJSTest();
-        }, 0);
-    }
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/slotted-url-continuation-hang-expected.txt
+++ b/LayoutTests/accessibility/slotted-url-continuation-hang-expected.txt
@@ -1,0 +1,45 @@
+This test ensures we don't hang when traversing and getting the accessibility text of a link that is part of an inline continuation.
+
+
+{AXRole: AXWebArea
+	AXTitle:
+	AXDescription:
+	AXHelp:
+}
+
+{AXRole: AXHeading
+	AXTitle: Clickable
+	AXDescription:
+	AXHelp:
+}
+
+{AXRole: AXLink
+	AXTitle:
+	AXDescription:
+	AXHelp:
+}
+
+{AXRole: AXGroup
+	AXTitle:
+	AXDescription:
+	AXHelp:
+}
+
+{#link AXRole: AXLink
+	AXTitle: Clickable
+	AXDescription:
+	AXHelp:
+}
+
+{AXRole: AXStaticText AXValue: Clickable
+	AXTitle:
+	AXDescription:
+	AXHelp:
+}
+PASS: No hang.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Clickable
+

--- a/LayoutTests/accessibility/slotted-url-continuation-hang.html
+++ b/LayoutTests/accessibility/slotted-url-continuation-hang.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+<!-- Do not reformat this markup, as doing so can break the conditions required for the bug to reproduce. -->
+<div>
+<template shadowrootmode=open>
+  <h2>
+    <slot name=title></slot>
+  </h2>
+</template>
+<div slot=title>
+  <foo-link><template shadowrootmode=open>
+    <a href="#url">
+      <slot></slot>
+    </a></template>
+    <div>
+        <a id="link" href="#url">Clickable</a>
+    </div>
+  </foo-link>
+</div>
+<script>
+var output = "This test ensures we don't hang when traversing and getting the accessibility text of a link that is part of an inline continuation.\n\n";
+
+if (window.accessibilityController) {
+    output += dumpAXSearchTraversal(accessibilityController.rootElement, { includeAccessibilityText: true });
+    output += "PASS: No hang.\n";
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/accessibility/menu-list-crash2-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/menu-list-crash2-expected.txt
@@ -1,7 +1,7 @@
 This tests that there's no crash if we hide menu list and then try to access accessibility information.
 
 Role before removal: AXRole: AXComboBox
-Role after removal: AXRole: AXInvalid
+Role after becoming ignored: AXRole: AXComboBox
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/glib/accessibility/slider-with-lost-renderer-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/slider-with-lost-renderer-expected.txt
@@ -2,8 +2,9 @@ This test ensures that adding a child to a slider that has lost its renderer dyn
 
 Initial #slider role: AXRole: AXSlider
 Initial #slider children count: 0
+PASS: slider.isIgnored === true
 
-Final #slider role: AXRole: AXInvalid
+Final #slider role: AXRole: AXSlider
 Final #slider children count: 0
 
 PASS successfullyParsed is true

--- a/LayoutTests/platform/glib/accessibility/slotted-url-continuation-hang-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/slotted-url-continuation-hang-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we don't hang when traversing and getting the accessibility text of a link that is part of an inline continuation.
+
+PASS: No hang.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Clickable
+

--- a/LayoutTests/platform/ios/accessibility/menu-list-crash2-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/menu-list-crash2-expected.txt
@@ -1,7 +1,7 @@
 This tests that there's no crash if we hide menu list and then try to access accessibility information.
 
 Role before removal: PopUpButton
-Role after removal: null
+Role after becoming ignored: PopUpButton
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/ios/accessibility/slider-with-lost-renderer-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/slider-with-lost-renderer-expected.txt
@@ -2,8 +2,9 @@ This test ensures that adding a child to a slider that has lost its renderer dyn
 
 Initial #slider role: Slider
 Initial #slider children count: 1
+PASS: slider.isIgnored === true
 
-Final #slider role: null
+Final #slider role: Slider
 Final #slider children count: 0
 
 PASS successfullyParsed is true

--- a/LayoutTests/platform/mac-wk1/accessibility/slotted-url-continuation-hang-expected.txt
+++ b/LayoutTests/platform/mac-wk1/accessibility/slotted-url-continuation-hang-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we don't hang when traversing and getting the accessibility text of a link that is part of an inline continuation.
+
+PASS: No hang.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Clickable
+

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -29,11 +29,14 @@ function dumpAXTable(axElement, options) {
 //   * `excludeRoles`: Array of strings representing roles you don't want to include in the output.
 //                     Case insensitive, partial match is fine, e.g. "scrollbar" will exclude "AXScrollBar".
 //
-//   * `visibleOnly`: True if only elements in the viewport should be returned.
+//   * `visibleOnly`: Specify true if only elements visible in the viewport should be returned.
+//
+//   * `includeAccessibilityText`: Specify true if you want the accessibility text of each element to be included in the output.
 function dumpAXSearchTraversal(axElement, options = { }) {
     let output = "";
     let searchResult = null;
     const { visibleOnly = false } = options;
+    const { includeAccessibilityText = false } = options;
     while (true) {
         searchResult = axElement.uiElementForSearchPredicate(searchResult, /* directionIsNext */ true, "AXAnyTypeSearchKey", /* searchText */ "", visibleOnly);
         if (!searchResult)
@@ -58,6 +61,9 @@ function dumpAXSearchTraversal(axElement, options = { }) {
         let resultDescription = `${id ? `#${id} ` : ""}${role}`;
         if (role.includes("StaticText"))
             resultDescription += ` ${accessibilityController.platformName === "ios" ? searchResult.description : searchResult.stringValue}`;
+
+        if (includeAccessibilityText)
+            resultDescription += `\n${platformTextAlternatives(searchResult)}\n`;
 
         output += `\n{${resultDescription}}\n`;
     }

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1519,6 +1519,9 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::linkedObjects() const
     linkedObjects.appendVector(controlledObjects());
     linkedObjects.appendVector(ownedObjects());
 
+    linkedObjects.removeAllMatching([] (const auto& object) {
+        return object->isIgnored();
+    });
     return linkedObjects;
 }
 

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -65,15 +65,13 @@ std::optional<IntRect> AXGeometryManager::cachedRectForID(AXID axID)
     return std::nullopt;
 }
 
-void AXGeometryManager::cacheRect(std::optional<AXID> axID, IntRect&& rect)
+void AXGeometryManager::cacheRect(AXID axID, IntRect&& rect)
 {
     // We shouldn't call this method on a geometry manager that has no page ID.
     AX_DEBUG_ASSERT(m_cache->pageID());
     AX_DEBUG_ASSERT(AXObjectCache::isIsolatedTreeEnabled());
 
-    if (!axID)
-        return;
-    auto rectIterator = m_cachedRects.find(*axID);
+    auto rectIterator = m_cachedRects.find(axID);
 
     bool rectChanged = false;
     if (rectIterator != m_cachedRects.end()) {
@@ -82,7 +80,7 @@ void AXGeometryManager::cacheRect(std::optional<AXID> axID, IntRect&& rect)
             rectIterator->value = rect;
     } else {
         rectChanged = true;
-        m_cachedRects.set(*axID, rect);
+        m_cachedRects.set(axID, rect);
     }
 
     if (!rectChanged)
@@ -91,7 +89,7 @@ void AXGeometryManager::cacheRect(std::optional<AXID> axID, IntRect&& rect)
     RefPtr tree = AXIsolatedTree::treeForPageID(*m_cache->pageID());
     if (!tree)
         return;
-    tree->updateFrame(*axID, WTFMove(rect));
+    tree->updateFrame(axID, WTFMove(rect));
 }
 
 void AXGeometryManager::scheduleObjectRegionsUpdate(bool scheduleImmediately)

--- a/Source/WebCore/accessibility/AXGeometryManager.h
+++ b/Source/WebCore/accessibility/AXGeometryManager.h
@@ -52,7 +52,7 @@ public:
     void willUpdateObjectRegions();
     void scheduleObjectRegionsUpdate(bool /* scheduleImmediately */);
 
-    void cacheRect(std::optional<AXID>, IntRect&&);
+    void cacheRect(AXID, IntRect&&);
     // std::nullopt if there is no cached rect for the given ID (i.e. because it hasn't been cached yet via paint or otherwise, or cannot be painted / cached at all).
     std::optional<IntRect> cachedRectForID(AXID);
 

--- a/Source/WebCore/accessibility/AccessibilityLabel.cpp
+++ b/Source/WebCore/accessibility/AccessibilityLabel.cpp
@@ -38,11 +38,21 @@ AccessibilityLabel::AccessibilityLabel(AXID axID, RenderObject& renderer, AXObje
 {
 }
 
+AccessibilityLabel::AccessibilityLabel(AXID axID, Element& element, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, element, cache)
+{
+}
+
 AccessibilityLabel::~AccessibilityLabel() = default;
 
 Ref<AccessibilityLabel> AccessibilityLabel::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
     return adoptRef(*new AccessibilityLabel(axID, renderer, cache));
+}
+
+Ref<AccessibilityLabel> AccessibilityLabel::create(AXID axID, Element& element, AXObjectCache& cache)
+{
+    return adoptRef(*new AccessibilityLabel(axID, element, cache));
 }
 
 String AccessibilityLabel::stringValue() const

--- a/Source/WebCore/accessibility/AccessibilityLabel.h
+++ b/Source/WebCore/accessibility/AccessibilityLabel.h
@@ -35,11 +35,13 @@ namespace WebCore {
 class AccessibilityLabel final : public AccessibilityRenderObject {
 public:
     static Ref<AccessibilityLabel> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityLabel> create(AXID, Element&, AXObjectCache&);
     virtual ~AccessibilityLabel();
 
     bool containsOnlyStaticText() const final;
 private:
     explicit AccessibilityLabel(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityLabel(AXID, Element&, AXObjectCache&);
     bool computeIsIgnored() const final { return isIgnoredByDefault(); }
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Label; }

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -66,7 +66,7 @@ Ref<AccessibilityList> AccessibilityList::create(AXID axID, Node& node, AXObject
 
 bool AccessibilityList::computeIsIgnored() const
 {
-    return isIgnoredByDefault();
+    return m_renderer ? isIgnoredByDefault() : AccessibilityNodeObject::computeIsIgnored();
 }
 
 bool AccessibilityList::isUnorderedList() const

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -68,6 +68,7 @@
 #include "HTMLSelectElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLSummaryElement.h"
+#include "HTMLTableCellElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLTextFormControlElement.h"
 #include "HTMLVideoElement.h"
@@ -124,11 +125,6 @@ void AccessibilityNodeObject::init()
     m_initialized = true;
 #endif
     AccessibilityObject::init();
-}
-
-Ref<AccessibilityNodeObject> AccessibilityNodeObject::create(AXID axID, Node& node, AXObjectCache& cache)
-{
-    return adoptRef(*new AccessibilityNodeObject(axID, &node, cache));
 }
 
 void AccessibilityNodeObject::detachRemoteParts(AccessibilityDetachmentType detachmentType)
@@ -344,6 +340,9 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::Legend;
     if (elementName == ElementName::HTML_canvas)
         return AccessibilityRole::Canvas;
+
+    if (is<HTMLTableCellElement>(*element))
+        return Accessibility::layoutTableCellRole;
 
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element))
         return roleFromInputElement(*input);
@@ -709,7 +708,6 @@ bool AccessibilityNodeObject::computeIsIgnored() const
     if (!node)
         return true;
 
-    // Handle non-rendered text that is exposed through aria-hidden=false.
     if (node->isTextNode() && !renderer()) {
         RefPtr parent = node->parentNode();
         // Fallback content in iframe nodes should be ignored.

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -41,7 +41,6 @@ class Node;
 
 class AccessibilityNodeObject : public AccessibilityObject {
 public:
-    static Ref<AccessibilityNodeObject> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityNodeObject();
 
     void init() override;
@@ -232,6 +231,10 @@ namespace Accessibility {
 
 RefPtr<HTMLElement> controlForLabelElement(const HTMLLabelElement&);
 Vector<Ref<HTMLElement>> labelsForElement(Element*);
+
+// This value is what will be used if AccessibilityTableCell determines the cell
+// should not be treated as a cell (e.g. because it is in a layout table).
+static constexpr AccessibilityRole layoutTableCellRole = AccessibilityRole::TextGroup;
 
 } // namespace Accessibility
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -176,6 +176,8 @@ public:
     AccessibilityChildrenVector disclosedRows() override; // ARIATreeItem implementation. AccessibilityTableRow overrides this method for grid rows.
     AccessibilityObject* disclosedByRow() const override { return nullptr; }
 
+    void postMenuClosedNotificationIfNecessary() const;
+
     bool isFieldset() const override { return false; }
     virtual bool isImageMapLink() const { return false; }
     virtual bool isMenuList() const { return false; }
@@ -883,6 +885,11 @@ protected:
 
     void detachRemoteParts(AccessibilityDetachmentType) override;
     void detachPlatformWrapper(AccessibilityDetachmentType) final;
+#if PLATFORM(IOS_FAMILY)
+    void markPlatformWrapperIgnoredStateDirty() const;
+#else
+    void markPlatformWrapperIgnoredStateDirty() const { };
+#endif
 
     void setIsIgnoredFromParentData(AccessibilityIsIgnoredFromParentData& data) { m_isIgnoredFromParentData = data; }
     bool ignoredFromPresentationalRole() const;

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -41,9 +41,20 @@ AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, Render
     ASSERT(is<RenderProgress>(renderer) || is<RenderMeter>(renderer) || is<HTMLProgressElement>(renderer.node()) || is<HTMLMeterElement>(renderer.node()));
 }
 
+AccessibilityProgressIndicator::AccessibilityProgressIndicator(AXID axID, Element& element, AXObjectCache& cache)
+    : AccessibilityRenderObject(axID, element, cache)
+{
+    ASSERT(is<HTMLProgressElement>(element) || is<HTMLMeterElement>(element));
+}
+
 Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(AXID axID, RenderObject& renderer, AXObjectCache& cache)
 {
     return adoptRef(*new AccessibilityProgressIndicator(axID, renderer, cache));
+}
+
+Ref<AccessibilityProgressIndicator> AccessibilityProgressIndicator::create(AXID axID, Element& element, AXObjectCache& cache)
+{
+    return adoptRef(*new AccessibilityProgressIndicator(axID, element, cache));
 }
 
 bool AccessibilityProgressIndicator::computeIsIgnored() const

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.h
@@ -33,11 +33,13 @@ class RenderProgress;
 class AccessibilityProgressIndicator final : public AccessibilityRenderObject {
 public:
     static Ref<AccessibilityProgressIndicator> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityProgressIndicator> create(AXID, Element&, AXObjectCache&);
 
     bool isIndeterminate() const final;
 
 private:
     explicit AccessibilityProgressIndicator(AXID, RenderObject&, AXObjectCache&);
+    explicit AccessibilityProgressIndicator(AXID, Element&, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final;
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -55,7 +55,17 @@ class VisibleSelection;
 class AccessibilityRenderObject : public AccessibilityNodeObject {
 public:
     static Ref<AccessibilityRenderObject> create(AXID, RenderObject&, AXObjectCache&);
+    static Ref<AccessibilityRenderObject> create(AXID, Node&, AXObjectCache&);
     virtual ~AccessibilityRenderObject();
+
+    // Returns true if the renderer changed.
+    bool setRendererIfNeeded(RenderObject* renderer)
+    {
+        if (m_renderer == renderer)
+            return false;
+        m_renderer = renderer;
+        return true;
+    }
 
     FloatRect frameRect() const final;
     bool isNonLayerSVGObject() const final;

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -56,11 +56,22 @@ AccessibilitySVGObject::AccessibilitySVGObject(AXID axID, RenderObject& renderer
     m_isSVGRoot = isSVGRoot;
 }
 
+AccessibilitySVGObject::AccessibilitySVGObject(AXID axID, Element& element, AXObjectCache& cache, bool isSVGRoot)
+    : AccessibilityRenderObject(axID, element, cache)
+{
+    m_isSVGRoot = isSVGRoot;
+}
+
 AccessibilitySVGObject::~AccessibilitySVGObject() = default;
 
 Ref<AccessibilitySVGObject> AccessibilitySVGObject::create(AXID axID, RenderObject& renderer, AXObjectCache& cache, bool isSVGRoot)
 {
     return adoptRef(*new AccessibilitySVGObject(axID, renderer, cache, isSVGRoot));
+}
+
+Ref<AccessibilitySVGObject> AccessibilitySVGObject::create(AXID axID, Element& element, AXObjectCache& cache, bool isSVGRoot)
+{
+    return adoptRef(*new AccessibilitySVGObject(axID, element, cache, isSVGRoot));
 }
 
 AccessibilityObject* AccessibilitySVGObject::targetForUseElement() const

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.h
@@ -35,6 +35,7 @@ namespace WebCore {
 class AccessibilitySVGObject : public AccessibilityRenderObject {
 public:
     static Ref<AccessibilitySVGObject> create(AXID, RenderObject&, AXObjectCache&, bool isSVGRoot = false);
+    static Ref<AccessibilitySVGObject> create(AXID, Element&, AXObjectCache&, bool isSVGRoot = false);
     virtual ~AccessibilitySVGObject();
 
     AccessibilityObject* parentObject() const override;
@@ -46,6 +47,7 @@ public:
 
 protected:
     explicit AccessibilitySVGObject(AXID, RenderObject&, AXObjectCache&, bool isSVGRoot);
+    explicit AccessibilitySVGObject(AXID, Element&, AXObjectCache&, bool isSVGRoot);
     AccessibilityRole determineAriaRoleAttribute() const final;
 
 private:

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -73,6 +73,12 @@ String AccessibilityScrollView::ownerDebugDescription() const
     return makeString("owned by: "_s, renderer ? renderer->debugDescription() : m_frameOwnerElement->debugDescription());
 }
 
+String AccessibilityScrollView::extraDebugInfo() const
+{
+    Vector<String> debugStrings = { ownerDebugDescription(), AccessibilityObject::extraDebugInfo() };
+    return makeStringByJoining(debugStrings, ","_s);
+}
+
 void AccessibilityScrollView::detachRemoteParts(AccessibilityDetachmentType detachmentType)
 {
     AccessibilityObject::detachRemoteParts(detachmentType);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -50,7 +50,7 @@ public:
     RefPtr<AXRemoteFrame> remoteFrame() const { return m_remoteFrame; }
 
     String ownerDebugDescription() const;
-    String extraDebugInfo() const final { return ownerDebugDescription(); }
+    String extraDebugInfo() const final;
 
 private:
     explicit AccessibilityScrollView(AXID, ScrollView&, AXObjectCache&);

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -112,6 +112,11 @@ unsigned AccessibilityObject::accessibilitySecureFieldLength()
     return inputElement ? inputElement->value()->length() : 0;
 }
 
+void AccessibilityObject::markPlatformWrapperIgnoredStateDirty() const
+{
+    [wrapper() _clearCachedIsAccessibilityElementState];
+}
+
 bool AccessibilityObject::accessibilityIgnoreAttachment() const
 {
     return [[wrapper() attachmentView] accessibilityIsIgnored];

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
@@ -43,9 +43,11 @@ static NSString * const UIAccessibilityTextualContextSourceCode = @"UIAccessibil
 - (BOOL)accessibilityIsIgnored;
 @end
 
+enum class IsAccessibilityElement : uint8_t { No, Yes, Unknown };
+
 @interface WebAccessibilityObjectWrapper : WebAccessibilityObjectWrapperBase {
     // Cached data to avoid frequent re-computation.
-    int m_isAccessibilityElement;
+    IsAccessibilityElement m_isAccessibilityElement;
     uint64_t m_accessibilityTraitsFromAncestor;
 }
 
@@ -71,6 +73,9 @@ static NSString * const UIAccessibilityTextualContextSourceCode = @"UIAccessibil
 
 // This is called by the Accessibility system to relay back to the chrome.
 - (void)handleNotificationRelayToChrome:(NSString *)notificationName notificationData:(NSData *)notificationData;
+
+// Private methods:
+- (void)_clearCachedIsAccessibilityElementState;
 
 @end
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -236,7 +236,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
 
     // Initialize to a sentinel value.
     m_accessibilityTraitsFromAncestor = ULLONG_MAX;
-    m_isAccessibilityElement = -1;
+    m_isAccessibilityElement = IsAccessibilityElement::Unknown;
 
     return self;
 }
@@ -886,6 +886,9 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
 
     backingObject->updateBackingStore();
 
+    if (backingObject->isIgnored())
+        return NO;
+
     switch (backingObject->role()) {
     case AccessibilityRole::TextField:
     case AccessibilityRole::TextArea:
@@ -1062,10 +1065,22 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    if (m_isAccessibilityElement == -1)
-        m_isAccessibilityElement = [self determineIsAccessibilityElement];
+    if (m_isAccessibilityElement == IsAccessibilityElement::Unknown)
+        m_isAccessibilityElement = [self determineIsAccessibilityElement] ? IsAccessibilityElement::Yes : IsAccessibilityElement::No;
 
-    return m_isAccessibilityElement;
+    ASSERT(m_isAccessibilityElement != IsAccessibilityElement::Unknown);
+    switch (m_isAccessibilityElement) {
+    case IsAccessibilityElement::Yes:
+        return YES;
+    case IsAccessibilityElement::No:
+    case IsAccessibilityElement::Unknown:
+        return NO;
+    }
+}
+
+- (void)_clearCachedIsAccessibilityElementState
+{
+    m_isAccessibilityElement = IsAccessibilityElement::Unknown;
 }
 
 - (BOOL)stringValueShouldBeUsedInLabel

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1606,9 +1606,9 @@ void AXIsolatedTree::processQueuedNodeUpdates()
         updateRelations(cache->relations());
 
     if (m_mostRecentlyPaintedTextIsDirty) {
+        m_mostRecentlyPaintedTextIsDirty = false;
         Locker lock { m_changeLogLock };
         m_pendingMostRecentlyPaintedText = cache->mostRecentlyPaintedText();
-        m_mostRecentlyPaintedTextIsDirty = false;
     }
 
     queueRemovalsAndUnresolvedChanges();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3776,14 +3776,18 @@ void Document::clearAXObjectCache()
     // are made to access it during destruction.
     if (RefPtr page = this->page())
         page->clearAXObjectCache();
+    m_topAXObjectCache = nullptr;
 }
 
 AXObjectCache* Document::existingAXObjectCacheSlow() const
 {
     ASSERT(hasEverCreatedAnAXObjectCache);
+    if (m_topAXObjectCache)
+        return m_topAXObjectCache.get();
+
     if (RefPtr page = this->page())
-        return page->existingAXObjectCache();
-    return nullptr;
+        m_topAXObjectCache = page->existingAXObjectCache();
+    return m_topAXObjectCache.get();
 }
 
 AXObjectCache* Document::axObjectCache() const
@@ -3791,10 +3795,14 @@ AXObjectCache* Document::axObjectCache() const
     if (!AXObjectCache::accessibilityEnabled())
         return nullptr;
 
+    if (m_topAXObjectCache)
+        return m_topAXObjectCache.get();
+
     RefPtr page = this->page();
     if (!page)
         return nullptr;
-    return page->axObjectCache();
+    m_topAXObjectCache = page->axObjectCache();
+    return m_topAXObjectCache.get();
 }
 
 void Document::setVisuallyOrdered()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2742,6 +2742,8 @@ private:
     mutable std::unique_ptr<CSSParserContext> m_cachedCSSParserContext;
     mutable std::unique_ptr<PermissionsPolicy> m_permissionsPolicy;
 
+    // FIXME: This will need to be re-evaluated for site isolation.
+    mutable WeakPtr<AXObjectCache> m_topAXObjectCache;
     RefPtr<FrameMemoryMonitor> m_frameMemoryMonitor;
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -71,6 +71,11 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
         // Don't check whether this is the first summary element
         // since we don't know the answer when this function is called inside Element::removedFrom.
         didChangeSlot(summarySlotName(), shadowRoot);
+
+        if (RefPtr associatedDetails = dynamicDowncast<HTMLDetailsElement>(shadowRoot.host())) {
+            if (CheckedPtr cache = associatedDetails->protectedDocument()->existingAXObjectCache())
+                cache->onDetailsSummarySlotChange(*associatedDetails);
+        }
     } else
         didChangeSlot(NamedSlotAssignment::defaultSlotName(), shadowRoot);
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -154,7 +154,6 @@ void RenderObjectDeleter::operator() (RenderObject* renderer) const
 RenderObject::RenderObject(Type type, Node& node, OptionSet<TypeFlag> typeFlags, TypeSpecificFlags typeSpecificFlags)
     : CachedImageClient()
 #if ASSERT_ENABLED
-    , m_hasAXObject(false)
     , m_setNeedsLayoutForbidden(false)
 #endif
     , m_node(node)
@@ -173,7 +172,6 @@ RenderObject::RenderObject(Type type, Node& node, OptionSet<TypeFlag> typeFlags,
 RenderObject::~RenderObject()
 {
     clearLayoutBox();
-    ASSERT(!m_hasAXObject);
 #ifndef NDEBUG
     renderObjectCounter.decrement();
 #endif

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -406,11 +406,6 @@ public:
     WEBCORE_EXPORT bool useDarkAppearance() const;
     WEBCORE_EXPORT OptionSet<StyleColorOptions> styleColorOptions() const;
 
-#if ASSERT_ENABLED
-    void setHasAXObject(bool flag) { m_hasAXObject = flag; }
-    bool hasAXObject() const { return m_hasAXObject; }
-#endif
-
     // Creates a scope where this object will assert on calls to setNeedsLayout().
     class SetLayoutNeededForbiddenScope;
     
@@ -1185,10 +1180,6 @@ private:
 
 #if ASSERT_ENABLED
     void setNeedsLayoutIsForbidden(bool flag) const { m_setNeedsLayoutForbidden = flag; }
-#endif
-
-#if ASSERT_ENABLED
-    bool m_hasAXObject : 1;
     mutable bool m_setNeedsLayoutForbidden : 1;
 #endif
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7772,8 +7772,11 @@ AccessibilityObject* Internals::axObjectForElement(Element& element) const
         return nullptr;
     WebCore::AXObjectCache::enableAccessibility();
 
-    auto* cache = document->axObjectCache();
-    return cache ? cache->getOrCreate(element) : nullptr;
+    if (CheckedPtr cache = document->axObjectCache()) {
+        cache->performDeferredCacheUpdate(ForceLayout::No);
+        return cache->getOrCreate(element);
+    }
+    return nullptr;
 }
 
 String Internals::getComputedLabel(Element& element) const

--- a/Tools/DumpRenderTree/AccessibilityController.cpp
+++ b/Tools/DumpRenderTree/AccessibilityController.cpp
@@ -72,6 +72,15 @@ static JSValueRef logScrollingStartEventsCallback(JSContextRef ctx, JSObjectRef,
     return JSValueMakeUndefined(ctx);
 }
 
+#if PLATFORM(MAC)
+static JSValueRef printTreesCallback(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t, const JSValueRef[], JSValueRef*)
+{
+    AccessibilityController* controller = static_cast<AccessibilityController*>(JSObjectGetPrivate(thisObject));
+    controller->printTrees();
+    return JSValueMakeUndefined(context);
+}
+#endif // PLATFORM(MAC)
+
 static JSValueRef logAccessibilityEventsCallback(JSContextRef ctx, JSObjectRef, JSObjectRef thisObject, size_t, const JSValueRef[], JSValueRef*)
 {
     AccessibilityController* controller = static_cast<AccessibilityController*>(JSObjectGetPrivate(thisObject));
@@ -157,6 +166,9 @@ JSRetainPtr<JSClassRef> AccessibilityController::createJSClass()
         { "addNotificationListener", addNotificationListenerCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "removeNotificationListener", removeNotificationListenerCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "enableEnhancedAccessibility", enableEnhancedAccessibilityCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+#if PLATFORM(MAC)
+        { "printTrees", printTreesCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+#endif
         { 0, 0, 0 }
     };
     static constexpr JSStaticValue values[] = {

--- a/Tools/DumpRenderTree/AccessibilityController.h
+++ b/Tools/DumpRenderTree/AccessibilityController.h
@@ -73,6 +73,12 @@ public:
     void winNotificationReceived(PlatformUIElement, const std::string& eventName);
 #endif
 
+#if PLATFORM(MAC)
+    void printTrees();
+#else
+    void printTrees() { }
+#endif
+
 private:
     static JSRetainPtr<JSClassRef> createJSClass();
 

--- a/Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm
@@ -108,6 +108,11 @@ AccessibilityUIElement AccessibilityController::accessibleElementById(JSStringRe
     return nullptr;
 }
 
+void AccessibilityController::printTrees()
+{
+    [[mainFrame accessibilityRoot] accessibilityPerformAction:@"AXLogTrees"];
+}
+
 void AccessibilityController::setLogFocusEvents(bool)
 {
 }


### PR DESCRIPTION
#### 7bee0b21b7d3b68d6ef5ffd2219e3db3faf677a8
<pre>
AX: Accessibility objects should live as long their DOM node, not as long as their renderer, which is destroyed and recreated frequently, causing unnecessary churn for ATs
<a href="https://bugs.webkit.org/show_bug.cgi?id=296959">https://bugs.webkit.org/show_bug.cgi?id=296959</a>
<a href="https://rdar.apple.com/157598062">rdar://157598062</a>

Reviewed by Andres Gonzalez.

Prior to this commit, accessibility objects only lived as long as their renderer did. This is problematic because renderers
are destroyed and recreated constantly, as they exist to serve rendering. This can cause extreme instability for assistive
technologies, who get a reference to an object and try to use it, and find it has been destroyed, when really the renderer
was refreshed but the DOM node is still there. I have traced multiple bugs over the years to this behavior, e.g.
VoiceOver infinitely looping over content on reddit.com, allowing AT text searches to auto-expand details elements, etc.

With this commit, DOM nodes become the &quot;primary key&quot; for any accessibility object that has one. This required a slew
of changes to work around the fact that we can no longer rely on constantly throwing away and recreating objects to have
fresh (non-stale) state:

  - AXObjectCache::m_deferredRendererChangedList added to handle necessary updates to objects who lose or gain a renderer.

  - AXObjectCache::m_deferredRecomputeActiveSummaryList added to re-compute summary / details role and ignored state
    when the active summary changes (we used to rely on render tree updates destroying and recreating objects to update the accessibility tree)

  - Detect when menu elements become ignored (e.g. because of display:none) and post a notification

  - Update cached WebAccessibilityObjectWrapperIOS::m_isAccessibilityElement when an object changed ignored state

  - Add a case in AccessibilityRenderObject::nextSibling() to use the DOM to get the next sibling when we compute a next-sibling
    that is ourselves. This happens because continuations can result in multiple renderers sharing the same node, so if
    renderer-A computes renderer-B as its next sibling, and either are part of the same continuation, they&apos;ll compute to
    the same accessibility object, causing an infinite loop. New test slotted-url-continuation-hang.html added reproducing this bug.

  - Fix an existing bug where nodes / renderers deleted from iframes never result in a call to AXObjectCache::remove(Node/RenderObject&amp;).
    This happened because it seems sometimes iframe-documents can lose their m_frame, meaning they cannot access a Page, and thus
    cannot access an AXObjectCache, meaning the node / renderer removal never gets seen by the AXObjectCache. This again always
    existed, but manifested as a layout test failure with this PR, which lead me to the discovery. Resolve it by adding a new
    Document::m_topAXObjectCache field, which can stay alive even after the document&apos;s frame is inexplicably lost.

Beyond object-stability for ATs, this will likely have efficiency benefits for the isolated tree. When AXIsolatedTree::updateChildren
detects that children have changed (e.g. because a renderer subtree got blown away and recreated, meaning brand new objects, wrappers,
and AXIDs), we do a lot of work. That won&apos;t happen anymore.

* LayoutTests/accessibility/display-contents/table-dynamic.html:
* LayoutTests/accessibility/menu-list-crash2-expected.txt:
* LayoutTests/accessibility/menu-list-crash2.html:
* LayoutTests/accessibility/slider-with-lost-renderer-expected.txt:
* LayoutTests/accessibility/slider-with-lost-renderer.html:
* LayoutTests/accessibility/slotted-url-continuation-hang-expected.txt: Added.
* LayoutTests/accessibility/slotted-url-continuation-hang.html: Added.
* LayoutTests/platform/ios/accessibility/menu-list-crash2-expected.txt:
* LayoutTests/platform/ios/accessibility/slider-with-lost-renderer-expected.txt:
* LayoutTests/resources/accessibility-helper.js:
(dumpAXSearchTraversal):
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::linkedObjects const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::composedParentIgnoringDocumentFragments):
(WebCore::AXObjectCache::createFromNode):
(WebCore::AXObjectCache::cacheAndInitializeWrapper):
(WebCore::AXObjectCache::getOrCreate):
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::onRendererCreated):
(WebCore::AXObjectCache::onDetailsSummarySlotChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::onPaint const):
(WebCore::layoutTableCellRole):
(WebCore::AXObjectCache::get const): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::computeIsIgnored const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
(WebCore::AccessibilityNodeObject::computeIsIgnored const):
(WebCore::AccessibilityNodeObject::create): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::extraDebugInfo const):
(WebCore::AccessibilityObject::postMenuClosedNotificationIfNecessary const):
(WebCore::AccessibilityObject::detachRemoteParts):
(WebCore::AccessibilityObject::isContinuation const):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::markPlatformWrapperIgnoredStateDirty const):
(WebCore::AccessibilityObject::extraDebugInfo const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::create):
(WebCore::AccessibilityRenderObject::nextSibling const):
(WebCore::AccessibilityRenderObject::selectedText const):
(WebCore::AccessibilityRenderObject::selectedTextRange const):
(WebCore::AccessibilityRenderObject::insertionPointLineNumber const):
(WebCore::AccessibilityRenderObject::setSelectedTextRange):
(WebCore::AccessibilityRenderObject::visiblePositionForIndex const):
(WebCore::AccessibilityRenderObject::indexForVisiblePosition const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
(WebCore::AccessibilityRenderObject::setRenderer):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::extraDebugInfo const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AccessibilityObject::markPlatformWrapperIgnoredStateDirty const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
(-[WebAccessibilityObjectWrapper _clearCachedIsAccessibilityElementState]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::clearAXObjectCache):
(WebCore::Document::existingAXObjectCacheSlow const):
(WebCore::Document::axObjectCache const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::hostChildElementDidChange):

Canonical link: <a href="https://commits.webkit.org/298426@main">https://commits.webkit.org/298426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0a54bd3fefad10df61670830a3f6f1a78d10871

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66010 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87718 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68110 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124687 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96490 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96276 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24497 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38274 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47812 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41755 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->