### PR TITLE
Clear web process storage access state when WebKitTestRunner revokes permission

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
@@ -2,6 +2,6 @@ Blocked access to external URL https://www.localhost:9443/storage-access-api/res
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Grants have per-frame scope assert_false: frame1 should not have storage access initially. expected false got true
+FAIL Grants have per-frame scope assert_true: frame1 should now have cookie access. expected true got false
 TIMEOUT Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Workers don't inherit storage access assert_true: frame has access to cookies after request. expected true got false
-FAIL Workers don't observe parent's storage access assert_false: frame lacks storage access before request. expected false got true
+FAIL Workers don't observe parent's storage access assert_true: frame has access to cookies after request. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
@@ -7,9 +7,9 @@ FAIL Sec-Fetch-Storage-Access is active after retry with wildcard `allowed-origi
 FAIL 'Activate-Storage-Access: retry' is a no-op on a request without an `allowed-origin` value. assert_array_equals: value is undefined, expected array
 FAIL 'Activate-Storage-Access: retry' is a no-op on a request from an origin that does not match its `allowed-origin` value. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `retry` is a no-op on a request with a `none` Storage Access status. assert_array_equals: value is undefined, expected array
-PASS Activate-Storage-Access `load` header grants storage access to frame.
+FAIL Activate-Storage-Access `load` header grants storage access to frame. assert_true: frame should have storage access because of the `load` header expected true got false
 PASS Activate-Storage-Access `load` is honored for `active` cases.
-FAIL Activate-Storage-Access `load` header is a no-op for requests without storage access. assert_false: frame should not have received storage access. expected false got true
+PASS Activate-Storage-Access `load` header is a no-op for requests without storage access.
 FAIL Sec-Fetch-Storage-Access is `inactive` for ABA case. assert_array_equals: value is undefined, expected array
 FAIL Storage Access can be activated for ABA cases by retrying. assert_array_equals: value is undefined, expected array
 FAIL Sec-Fetch-Storage-Access maintains value on same-origin redirect. assert_array_equals: value is undefined, expected array

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -799,7 +799,12 @@ void WKWebsiteDataStoreResetResourceMonitorThrottler(WKWebsiteDataStoreRef dataS
 
 void WKWebsiteDataStoreSetStorageAccessPermissionForTesting(WKWebsiteDataStoreRef dataStoreRef, WKPageRef pageRef, bool granted, WKStringRef topFrame, WKStringRef subFrame, void* context, WKWebsiteDataStoreSetStorageAccessPermissionForTestingFunction completionHandler)
 {
-    WebKit::toProtectedImpl(dataStoreRef)->setStorageAccessPermissionForTesting(granted, WebKit::toImpl(pageRef)->identifier(), WebKit::toProtectedImpl(topFrame)->string(), WebKit::toProtectedImpl(subFrame)->string(), [context, completionHandler] {
+    Ref callbackAggregator = CallbackAggregator::create([context, completionHandler] {
         completionHandler(context);
     });
+
+    Ref store = *WebKit::toImpl(dataStoreRef);
+    if (!granted)
+        store->clearResourceLoadStatisticsInWebProcesses([callbackAggregator] { });
+    store->setStorageAccessPermissionForTesting(granted, WebKit::toImpl(pageRef)->identifier(), WebKit::toProtectedImpl(topFrame)->string(), WebKit::toProtectedImpl(subFrame)->string(), [callbackAggregator] { });
 }


### PR DESCRIPTION
#### 1b35f1430bb73049df29eb247ab43ec6803b5092
<pre>
Clear web process storage access state when WebKitTestRunner revokes permission
<a href="https://bugs.webkit.org/show_bug.cgi?id=296978">https://bugs.webkit.org/show_bug.cgi?id=296978</a>

Reviewed by Rupin Mittal.

If storage access permission is revoked using WKWebsiteDataStoreSetStorageAccessPermissionForTesting we
should clear the web process storage access state, like we already do in the network process.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt:
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreSetStorageAccessPermissionForTesting):

Canonical link: <a href="https://commits.webkit.org/298535@main">https://commits.webkit.org/298535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/854367a2a0b261661e7a2feee9a8fd034174c73b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4cb4f694-4378-4d79-9c3e-f8ad12994cf6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87331 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42175 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b954b274-df62-4e9b-8edc-d5c2dc159b21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67725 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64712 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124248 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96133 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95917 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37949 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18510 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47317 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44651 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43078 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->