### PR TITLE
Handle scrollend events for select elements

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element-expected.txt
@@ -1,0 +1,9 @@
+
+Test scroll over content
+PASS overflowScrollendEventCount == 1 is true
+PASS windowScrollendEventCount == 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element.html
+++ b/LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+        }
+        .scroller {
+            position: absolute;
+            top: 310px;
+            left: 10px;
+            height: 300px;
+            width: 300px;
+            border: 20px solid gray;
+            padding: 5px;
+        }
+        .content {
+            width: 200%;
+            height: 300%;
+        }
+        
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var scroller;
+        var overflowScrollendEventCount = 0;
+        var windowScrollendEventCount = 0;
+
+        async function resetScrollPositions()
+        {
+            window.scrollTo(0, 300);
+            scroller.scrollTop = 0;
+            
+            // Wait for scroll events to fire.
+            await UIHelper.ensurePresentationUpdate();
+        }
+        
+        async function testScrollOverContent()
+        {
+            debug('');
+            debug('Test scroll over content');
+            await resetScrollPositions();
+            overflowScrollendEventCount = 0;
+            windowScrollendEventCount = 0;
+
+            const wheelEventSquence = {
+                "events" : [
+                    {
+                        type : "wheel",
+                        viewX : 100,
+                        viewY : 100,
+                        deltaY : -10,
+                        phase : "began"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : -100,
+                        phase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        phase : "ended"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : -100,
+                        momentumPhase : "began"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : -80,
+                        momentumPhase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        momentumPhase : "ended"
+                    }
+                ]
+            };
+            await UIHelper.mouseWheelSequence(wheelEventSquence);
+            await UIHelper.renderingUpdate();
+
+            shouldBe('overflowScrollendEventCount == 1', 'true');
+            shouldBe('windowScrollendEventCount == 0', 'true');
+        }
+
+        async function scrollTest()
+        {
+            await testScrollOverContent();
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            scroller = document.querySelector('.scroller');
+            scroller.addEventListener('scrollend', () => {
+                ++overflowScrollendEventCount;
+            }, false);
+
+            window.addEventListener('scrollend', () => {
+                ++windowScrollendEventCount;
+            }, false);
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <select id="mySelect" class="scroller" size="5">
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+        <option value="option4">Option 4</option>
+        <option value="option5">Option 5</option>
+        <option value="option6">Option 6</option>
+        <option value="option7">Option 7</option>
+        <option value="option8">Option 8</option>
+        <option value="option9">Option 9</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+        <option value="option10">Option 10</option>
+    </select>
+    <div class="overlapper"></div>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3503,6 +3503,11 @@ bool EventHandler::scrollableAreaCanHandleEvent(const PlatformWheelEvent& wheelE
     auto biasedDelta = wheelEvent.delta();
 #endif
 
+#if ENABLE(KINETIC_SCROLLING)
+    if (wheelEvent.phase() == PlatformWheelEventPhase::Ended || wheelEvent.momentumPhase() == PlatformWheelEventPhase::Ended)
+        return true;
+#endif
+
     auto verticalSide = ScrollableArea::targetSideForScrollDelta(-biasedDelta, ScrollEventAxis::Vertical);
     if (verticalSide && !scrollableArea.isPinnedOnSide(*verticalSide))
         return true;
@@ -3519,7 +3524,7 @@ bool EventHandler::scrollableAreaCanHandleEvent(const PlatformWheelEvent& wheelE
 bool EventHandler::handleWheelEventInScrollableArea(const PlatformWheelEvent& wheelEvent, ScrollableArea& scrollableArea, OptionSet<EventHandling> eventHandling)
 {
     auto gestureState = updateWheelGestureState(wheelEvent, eventHandling);
-    LOG_WITH_STREAM(Scrolling, stream << "EventHandler::handleWheelEventInScrollableArea() " << scrollableArea << " - eventHandling " << eventHandling << " -> gesture state " << gestureState);
+    LOG_WITH_STREAM(Scrolling, stream << "EventHandler::handleWheelEventInScrollableArea() " << scrollableArea << " - eventHandling " << eventHandling << " -> gesture state " << gestureState << " wheelEvent: " << wheelEvent);
     return scrollableArea.handleWheelEventForScrolling(wheelEvent, gestureState);
 }
 

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -182,6 +182,13 @@ bool ScrollAnimator::handleWheelEvent(const PlatformWheelEvent& wheelEvent)
 // "Stepped scrolling" is only used by RenderListBox. It's special in that it has no rubberbanding, and scroll deltas respect Scrollbar::pixelStep().
 bool ScrollAnimator::handleSteppedScrolling(const PlatformWheelEvent& wheelEvent)
 {
+#if ENABLE(KINETIC_SCROLLING)
+    if ((wheelEvent.phase() == PlatformWheelEventPhase::Ended && wheelEvent.momentumPhase() == PlatformWheelEventPhase::None) || wheelEvent.momentumPhase() == PlatformWheelEventPhase::Ended) {
+        m_scrollableArea.scrollDidEnd();
+        return true;
+    }
+#endif
+
     auto* horizontalScrollbar = m_scrollableArea.horizontalScrollbar();
     auto* verticalScrollbar = m_scrollableArea.verticalScrollbar();
 

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -1220,4 +1220,12 @@ std::optional<FrameIdentifier> RenderListBox::rootFrameID() const
     return view().frameView().frame().rootFrame().frameID();
 }
 
+void RenderListBox::scrollDidEnd()
+{
+    if (ScrollAnimator* scrollAnimator = existingScrollAnimator(); scrollAnimator && !scrollAnimator->isUserScrollInProgress() && !isAwaitingScrollend()) {
+        setIsAwaitingScrollend(false);
+        selectElement().protectedDocument()->addPendingScrollendEventTarget(selectElement());
+    }
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -75,6 +75,8 @@ public:
     bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint()) override;
     std::optional<FrameIdentifier> rootFrameID() const final;
 
+    void scrollDidEnd() final;
+
 private:
     bool isVisibleToHitTesting() const final;
 


### PR DESCRIPTION
#### ef277d5f855b6e8178298e2f68e5da6cf6557e39
<pre>
Handle scrollend events for select elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=296977">https://bugs.webkit.org/show_bug.cgi?id=296977</a>
<a href="https://rdar.apple.com/157610355">rdar://157610355</a>

Reviewed by Simon Fraser.

Handle scrollend events for select elements.

* LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrollend-event-on-select-element.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::scrollableAreaCanHandleEvent):
(WebCore::EventHandler::handleWheelEventInScrollableArea):
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::handleSteppedScrolling):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::scrollDidEnd):
* Source/WebCore/rendering/RenderListBox.h:

Canonical link: <a href="https://commits.webkit.org/298402@main">https://commits.webkit.org/298402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccdde34df2cd1b45477689d1f95acebec10bfc27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65910 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87609 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d921d873-c7b6-4b3a-bcb7-b0ea0dd9642e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68005 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21642 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65077 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124583 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96397 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24489 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38201 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42145 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47699 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43381 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->