### PR TITLE
Add platform-specific test expectations for general Content Security Policy WPT tests.

### DIFF
--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+PASS Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.
+FAIL Content Security Policy: Expects blocked for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation assert_equals: One violation event should be fired expected 1 but got 0
+

--- a/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and keep-origin redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to cross-http origin and swap-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and keep-origin redirection from http context.: securitypolicyviolation
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and no-redirect redirection from http context.: securitypolicyviolation
+FAIL Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context. promise_test: Unhandled rejection with value: object "[object Event]"
+PASS Content Security Policy: Expects allowed for sharedworker-import to same-http origin and swap-origin redirection from http context.: securitypolicyviolation
+


### PR DESCRIPTION
#### ec93a663d1290d35dfc420f7e1566595d09f821c
<pre>
Add platform-specific test expectations for general Content Security Policy WPT tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296981">https://bugs.webkit.org/show_bug.cgi?id=296981</a>
<a href="https://rdar.apple.com/157611241">rdar://157611241</a>

Reviewed by Ryan Reno.

Resync’d tests are only compatible with internal webkit builds (aka Cheer). We are going to use separate test expectations for external, and the separate test expectations will use the older WPT test results that they passed with / are compatible with.

* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sequoia-wk2/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-self/sharedworker-import.http-expected.txt: Added.
* LayoutTests/platform/mac-sonoma/imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/sharedworker-import.http-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/298301@main">https://commits.webkit.org/298301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a8ca9e877d3afe84a6605dca093fd208bc6826d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65608 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4760d01e-b93a-4a54-91d2-a3f516b57e3b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87336 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42176 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4d4008cb-753f-45b6-846e-2ddf79337e58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67731 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21311 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95920 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37955 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18408 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41791 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43084 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->