### PR TITLE
Use HashMap::ensure in SVGTextLayoutAttributesBuilder

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2010-2011. All rights reserved.
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -141,25 +141,25 @@ void SVGTextLayoutAttributesBuilder::buildCharacterDataMap(RenderSVGText& textRo
     TextPosition wholeTextPosition(outermostTextElement.get(), 0, m_textLength);
     fillCharacterDataMap(wholeTextPosition);
 
+    // Fill character data map using child text positioning elements in top-down order.
+    unsigned size = m_textPositions.size();
+    for (unsigned i = 0; i < size; ++i)
+        fillCharacterDataMap(m_textPositions[i]);
+
     // Handle x/y default attributes.
-    SVGCharacterDataMap::iterator it = m_characterDataMap.find(1);
-    if (it == m_characterDataMap.end()) {
+    auto addDataResult = m_characterDataMap.ensure((1), [] {
         SVGCharacterData data;
         data.x = 0;
         data.y = 0;
-        m_characterDataMap.set(1, data);
-    } else {
-        SVGCharacterData& data = it->value;
+        return data;
+    });
+    if (!addDataResult.isNewEntry) {
+        SVGCharacterData& data = addDataResult.iterator->value;
         if (SVGTextLayoutAttributes::isEmptyValue(data.x))
             data.x = 0;
         if (SVGTextLayoutAttributes::isEmptyValue(data.y))
             data.y = 0;
     }
-
-    // Fill character data map using child text positioning elements in top-down order. 
-    unsigned size = m_textPositions.size();
-    for (unsigned i = 0; i < size; ++i)
-        fillCharacterDataMap(m_textPositions[i]);
 }
 
 static inline void updateCharacterData(unsigned i, float& lastRotation, SVGCharacterData& data, const SVGLengthContext& lengthContext, const SVGLengthList* xList, const SVGLengthList* yList, const SVGLengthList* dxList, const SVGLengthList* dyList, const SVGNumberList* rotateList)
@@ -206,15 +206,10 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         if (!xListPtr && !yListPtr && !dxListPtr && !dyListPtr && !rotateListPtr)
             break;
 
-        SVGCharacterDataMap::iterator it = m_characterDataMap.find(position.start + i + 1);
-        if (it == m_characterDataMap.end()) {
-            SVGCharacterData data;
-            updateCharacterData(i, lastRotation, data, lengthContext, xListPtr, yListPtr, dxListPtr, dyListPtr, rotateListPtr);
-            m_characterDataMap.set(position.start + i + 1, data);
-            continue;
-        }
-
-        updateCharacterData(i, lastRotation, it->value, lengthContext, xListPtr, yListPtr, dxListPtr, dyListPtr, rotateListPtr);
+        auto& data = m_characterDataMap.ensure((position.start + i + 1), [] {
+            return SVGCharacterData();
+        }).iterator->value;
+        updateCharacterData(i, lastRotation, data, lengthContext, xListPtr, yListPtr, dxListPtr, dyListPtr, rotateListPtr);
     }
 
     // The last rotation value always spans the whole scope.
@@ -222,15 +217,10 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         return;
 
     for (unsigned i = rotateList.items().size(); i < position.length; ++i) {
-        SVGCharacterDataMap::iterator it = m_characterDataMap.find(position.start + i + 1);
-        if (it == m_characterDataMap.end()) {
-            SVGCharacterData data;
-            data.rotate = lastRotation;
-            m_characterDataMap.set(position.start + i + 1, data);
-            continue;
-        }
-
-        it->value.rotate = lastRotation;
+        auto& data = m_characterDataMap.ensure((position.start + i + 1), [] {
+            return SVGCharacterData();
+        }).iterator->value;
+        data.rotate = lastRotation;
     }
 }
 


### PR DESCRIPTION
#### 6736a4f2ca1ccc8a322e62f147c2556332548c55
<pre>
Use HashMap::ensure in SVGTextLayoutAttributesBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=278292">https://bugs.webkit.org/show_bug.cgi?id=278292</a>
&lt;<a href="https://rdar.apple.com/problem/134186468">rdar://problem/134186468</a>&gt;

Reviewed by Sammy Gill.

Inspired by: <a href="https://chromium.googlesource.com/chromium/src.git/+/0f6c84977fee3a56a328e9baa1134b668a316569">https://chromium.googlesource.com/chromium/src.git/+/0f6c84977fee3a56a328e9baa1134b668a316569</a>

This patch revives some work Ahmad Saleem started in 2024, and we sort of abandoned.
* Removes some redundancies and eliminates double-hashing.
* Do the update of default values last.

* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::SVGTextLayoutAttributesBuilder::buildCharacterDataMap):
(WebCore::SVGTextLayoutAttributesBuilder::fillCharacterDataMap):

Canonical link: <a href="https://commits.webkit.org/298339@main">https://commits.webkit.org/298339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c798e2a5fe649caea7a4d9e3acc20bccd4db9742

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121171 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65698 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b559e6f-a73e-494c-ae6d-b9b77e253361) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87429 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15f1280d-2605-4b66-b3bf-902ea7f6fcd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67825 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64823 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96226 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96011 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38030 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18429 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47436 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43177 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->