### PR TITLE
Add ability for user to manually override userAgentData

### DIFF
--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -50,6 +50,7 @@ template<typename CharacterType> constexpr bool isASCIIHexDigit(CharacterType);
 template<typename CharacterType> constexpr bool isASCIILower(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIGraphic(CharacterType);
 template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType);
 template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType);
@@ -132,6 +133,11 @@ template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType 
 template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType character)
 {
     return character >= ' ' && character <= '~';
+}
+
+template<typename CharacterType> constexpr bool isASCIIGraphic(CharacterType character)
+{
+    return character >= '!' && character <= '~';
 }
 
 template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType character)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2208,6 +2208,7 @@ page/UndoManager.cpp
 page/UserContentController.cpp
 page/UserContentProvider.cpp
 page/UserContentURLPattern.cpp
+page/UserAgentStringParser.cpp
 page/UserScript.cpp
 page/UserStyleSheet.cpp
 page/VisitedLinkStore.cpp

--- a/Source/WebCore/page/NavigatorUAData.h
+++ b/Source/WebCore/page/NavigatorUAData.h
@@ -35,10 +35,12 @@ namespace WebCore {
 struct NavigatorUABrandVersion;
 struct UADataValues;
 struct UALowEntropyJSON;
+struct UserAgentStringData;
 
 class NavigatorUAData : public RefCounted<NavigatorUAData> {
 public:
     static Ref<NavigatorUAData> create();
+    static Ref<NavigatorUAData> create(Ref<UserAgentStringData>&&);
     const Vector<NavigatorUABrandVersion>& brands() const;
     bool mobile() const;
     String platform() const;
@@ -50,7 +52,14 @@ public:
 
 private:
     NavigatorUAData();
+    NavigatorUAData(Ref<UserAgentStringData>&&);
     static String createArbitraryVersion();
     static String createArbitraryBrand();
+
+    bool overrideFromUserAgentString { false };
+    bool mobileOverride { false };
+    inline static LazyNeverDestroyed<Vector<NavigatorUABrandVersion>> m_brands;
+
+    String platformOverride;
 };
 }

--- a/Source/WebCore/page/UserAgentStringData.h
+++ b/Source/WebCore/page/UserAgentStringData.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+struct UserAgentStringData : public RefCounted<UserAgentStringData> {
+public:
+    String browserName;
+    String browserVersion;
+    String platform;
+    String laytoutEngine;
+    String laytoutEngineVersion;
+    bool mobile { false };
+
+    static Ref<UserAgentStringData> create()
+    {
+        return adoptRef(*new UserAgentStringData);
+    }
+
+private:
+    UserAgentStringData() = default;
+};
+}

--- a/Source/WebCore/page/UserAgentStringParser.cpp
+++ b/Source/WebCore/page/UserAgentStringParser.cpp
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "UserAgentStringParser.h"
+
+#include "RFC7230.h"
+#include "UserAgentStringData.h"
+#include <optional>
+#include <wtf/ASCIICType.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringCommon.h>
+#include <wtf/text/StringImpl.h>
+#include <wtf/text/WTFString.h>
+
+/*
+ * GRAMMAR:
+ * https://www.rfc-editor.org/rfc/rfc9110#name-user-agent
+ * User-Agent      = product *( RWS ( product / comment ) )
+ * product         = token ["/" product-version]
+ * product-version = token
+ * token           = 1*tchar
+ * tchar           = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters
+ * RWS             = 1*( SP / HTAB ); required whitespace
+ * comment         = "(" *( ctext / quoted-pair / comment ) ")"
+ * ctext           = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
+ * quoted-pair     = "\" ( HTAB / SP / VCHAR / obs-text )
+ * obs-text        = %x80-FF
+ * HTAB            = <ASCII horizontal tab %x09, aka '\t'>
+ * SP              = <ASCII space, i.e. " ">
+ * VCHAR           = <any visible US-ASCII character>
+ *
+ * REFERENCE:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent#syntax
+ *
+ * NOTE:
+ * User agent strings come in many different forms, but most browsers conform to a common pattern.
+ * This class is attempting to determine attributes about the user agent by expecting common forms
+ * of user agent strings. There is a link below that contains a list of of these strings grouped
+ * by platform, browser, layout engine, etc. I tried to pick the most frequent ones to parse out
+ * viable information.
+ *
+ * https://explore.whatismybrowser.com/useragents/explore/
+ *
+ * Some user agent strings, while valid grammatically, list their info in odd locations.
+ * This parser will not be able to pick out the correct information from those.
+ */
+
+namespace WebCore {
+UserAgentStringParser::UserAgentStringParser(const String& userAgentString)
+    : m_userAgentString(userAgentString)
+    , data(UserAgentStringData::create()) { };
+
+Ref<UserAgentStringParser> UserAgentStringParser::create(const String& userAgentString)
+{
+    return adoptRef(*new UserAgentStringParser(userAgentString));
+}
+
+std::optional<Ref<UserAgentStringData>> UserAgentStringParser::parse()
+{
+    data = UserAgentStringData::create();
+
+    if (atEnd())
+        return { };
+
+    consumeProduct();
+
+    while (!atEnd()) {
+        if (!isTabOrSpace(peek()))
+            return { };
+
+        consumeRWS();
+        start = pos;
+        if (peek() == '(')
+            consumeComment();
+        else
+            consumeProduct();
+
+        if (malformed)
+            return { };
+    }
+
+    populateUserAgentData();
+    return data;
+}
+
+void UserAgentStringParser::consumeProduct()
+{
+    consumeToken();
+    if (malformed)
+        return;
+
+    auto product = Product { .name = getSubstring(), .version = { } };
+    if (!atEnd() && peek() == '/') {
+        increment();
+        start = pos;
+        consumeToken();
+        if (malformed)
+            return;
+        product.version = getSubstring();
+    }
+    start = pos;
+    segments.append(product);
+}
+
+void UserAgentStringParser::consumeRWS()
+{
+    while (!atEnd() && isTabOrSpace(peek()))
+        increment();
+}
+
+void UserAgentStringParser::consumeComment()
+{
+    ASSERT(peek() == '(');
+    increment(); // pass first '('
+    start = pos;
+
+    if (atEnd()) {
+        malformed = true;
+        return;
+    }
+
+    auto c = peek();
+    while (!atEnd() && c != ')') {
+        if (c == '(')
+            consumeComment();
+        else if (c == '\\')
+            consumeQuotedPair();
+        else if (RFC7230::isCommentText(c))
+            increment();
+
+        if (malformed)
+            return;
+
+        c = peek();
+    }
+
+    if (atEnd()) {
+        malformed = true;
+        return;
+    }
+
+    auto s = getSubstring();
+    if (!s.isEmpty()) {
+        auto comment = Comment { .parts = s.split(';') };
+        segments.append(comment);
+    }
+    increment();
+    start = pos;
+    // malformed user agent string
+}
+
+void UserAgentStringParser::consumeToken()
+{
+    if (!RFC7230::isTokenCharacter(peek())) {
+        malformed = true;
+        return;
+    }
+
+    do {
+        increment();
+    } while (!atEnd() && RFC7230::isTokenCharacter(peek()));
+}
+
+void UserAgentStringParser::consumeQuotedPair()
+{
+    ASSERT(peek() == '\\');
+    increment(); // pass '\'
+
+    if (RFC7230::isQuotedPairSecondOctet(peek())) {
+        increment();
+        return;
+    }
+
+    malformed = true;
+}
+
+inline char16_t UserAgentStringParser::peek()
+{
+    return m_userAgentString[this->pos];
+}
+
+inline void UserAgentStringParser::increment()
+{
+    this->pos++;
+}
+
+inline bool UserAgentStringParser::atEnd()
+{
+    return this->pos >= this->m_userAgentString.length();
+}
+
+inline String UserAgentStringParser::getSubstring()
+{
+    return m_userAgentString.substring(start, pos - start);
+}
+
+struct BrowsersSeen {
+    bool brave : 1;
+    bool firefox : 1;
+    bool chrome : 1;
+    bool safari : 1;
+    bool opera : 1;
+    bool edge : 1;
+    String braveVersion;
+    String firefoxVersion;
+    String chromeVersion;
+    String safariVersion;
+    String operaVersion;
+    String edgeVersion;
+};
+
+void UserAgentStringParser::populateUserAgentData()
+{
+    BrowsersSeen browsersSeen;
+    auto weakThis = WeakPtr { *this };
+    bool linuxSeen { false };
+    for (const auto& segment : segments) {
+        WTF::switchOn(segment, [&browsersSeen, weakThis](const Product& p) {
+            if (p.name == "Mobile") {
+                weakThis->data->mobile = true;
+                return;
+            }
+            if (p.name == "Brave") {
+                browsersSeen.braveVersion = p.version;
+                browsersSeen.brave = true;
+                return;
+            }
+            if (p.name == "Firefox" || p.name == "fxiOS") {
+                browsersSeen.firefoxVersion = p.version;
+                browsersSeen.firefox = true;
+                return;
+            }
+            if (p.name == "Chrome") {
+                browsersSeen.chromeVersion = p.version;
+                browsersSeen.chrome = true;
+                return;
+            }
+            if (p.name == "Safari") {
+                browsersSeen.firefoxVersion = p.version;
+                browsersSeen.safari = true;
+                return;
+            }
+            if (p.name == "OPR") {
+                browsersSeen.operaVersion = p.version;
+                browsersSeen.opera = true;
+                return;
+            }
+            if (p.name.contains("Edg")) {
+                browsersSeen.edgeVersion = p.version;
+                browsersSeen.edge = true;
+                return;
+            } }, [weakThis, &linuxSeen](const Comment& c) {
+            for (const auto& part : c.parts) {
+                if (part.contains("Windows")) {
+                    weakThis->data->platform = "Windows"_s;
+                    return;
+                }
+                if (part == "Macintosh") {
+                    weakThis->data->platform = "macOS"_s;
+                    return;
+                }
+                if (part == "iPhone") {
+                    weakThis->data->platform = "iOS"_s;
+                    return;
+                }
+                if (part == "iPad") {
+                    weakThis->data->platform = "iOS"_s;
+                    return;
+                }
+                if (part.contains("Android")) {
+                    weakThis->data->platform = "Android"_s;
+                    return;
+                }
+                if (part.contains("Linux")) {
+                    linuxSeen = true;
+                    return;
+                }
+                if (part.contains("CrOS")) {
+                    weakThis->data->platform = "ChromeOS"_s;
+                    return;
+                }
+            } });
+    }
+
+    // android user agents sometimes list linux and android, but linux user agents don't list androids
+    if (linuxSeen && data->platform.isEmpty())
+        data->platform = "Linux"_s;
+
+    // both chrome and firefox sometimes list safari in their user agent strings
+    if (browsersSeen.safari && !browsersSeen.chrome && !browsersSeen.firefox) {
+        data->browserName = "Safari"_s;
+        data->browserVersion = browsersSeen.safariVersion;
+        return;
+    }
+
+    // no other browser typically list firefox
+    if (browsersSeen.firefox) {
+        data->browserName = "Firefox"_s;
+        data->browserVersion = browsersSeen.firefoxVersion;
+    }
+
+    // chrome based browsers typically list chrome
+    if (browsersSeen.chrome) {
+        if (browsersSeen.edge) {
+            data->browserName = "Edge"_s;
+            data->browserVersion = browsersSeen.edgeVersion;
+        } else if (browsersSeen.brave) {
+            data->browserName = "Brave"_s;
+            data->browserVersion = browsersSeen.braveVersion;
+        } else if (browsersSeen.opera) {
+            data->browserName = "Opera"_s;
+            data->browserVersion = browsersSeen.operaVersion;
+        } else {
+            data->browserName = "Chrome"_s;
+            data->browserVersion = browsersSeen.chromeVersion;
+        }
+    }
+}
+};

--- a/Source/WebCore/page/UserAgentStringParser.h
+++ b/Source/WebCore/page/UserAgentStringParser.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <wtf/Forward.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/Variant.h>
+
+namespace WebCore {
+struct UserAgentStringData;
+/*
+ * This class takes in a user agent string and returns a UserAgentStringData class
+ */
+class UserAgentStringParser : public RefCountedAndCanMakeWeakPtr<UserAgentStringParser> {
+public:
+    static Ref<UserAgentStringParser> create(const String& userAgentString);
+    std::optional<Ref<UserAgentStringData>> parse();
+
+private:
+    UserAgentStringParser(const String& userAgentString);
+
+    void consumeProduct();
+    void consumeComment();
+    void consumeRWS();
+    void consumeToken();
+    void consumeQuotedPair();
+
+    void populateUserAgentData();
+
+    inline char16_t peek();
+    inline void increment();
+    inline bool atEnd();
+    inline String getSubstring();
+
+    bool malformed { false };
+    const String& m_userAgentString;
+    size_t pos { 0 };
+    size_t start { 0 };
+    Ref<UserAgentStringData> data;
+
+    struct Product {
+        String name;
+        String version;
+    };
+
+    struct Comment {
+        Vector<String> parts; // split on ;
+    };
+
+    using Segment = WTF::Variant<Product, Comment>;
+    Vector<Segment> segments;
+};
+}

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
 
@@ -30,14 +30,16 @@
 #include "Chrome.h"
 #include "GPU.h"
 #include "JSDOMPromiseDeferred.h"
+#include "NavigatorUAData.h"
 #include "Page.h"
 #include "PushEvent.h"
 #include "ServiceWorkerGlobalScope.h"
+#include "UserAgentStringData.h"
+#include "UserAgentStringParser.h"
 #include "WorkerBadgeProxy.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerThread.h"
 #include <wtf/TZoneMallocInlines.h>
-#include "NavigatorUAData.h"
 
 namespace WebCore {
 
@@ -112,9 +114,14 @@ void WorkerNavigator::clearAppBadge(Ref<DeferredPromise>&& promise)
 
 NavigatorUAData& WorkerNavigator::userAgentData() const
 {
-    if (!m_navigatorUAData)
-        m_navigatorUAData = NavigatorUAData::create();
+    Ref parser = UserAgentStringParser::create(m_userAgent);
+    std::optional userAgentStringData = parser->parse();
+    if (userAgentStringData) {
+        m_navigatorUAData = NavigatorUAData::create(WTFMove(*userAgentStringData));
+        return *m_navigatorUAData;
+    }
 
+    m_navigatorUAData = NavigatorUAData::create();
     return *m_navigatorUAData;
 };
 

--- a/Source/WebCore/page/ios/DOMTimerHoldingTank.h
+++ b/Source/WebCore/page/ios/DOMTimerHoldingTank.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 
+#include "DOMTimer.h"
 #include "Timer.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>


### PR DESCRIPTION
#### 48b4c083dd541a67eba3a63adc8495144331f481
<pre>
Add ability for user to manually override userAgentData
<a href="https://bugs.webkit.org/show_bug.cgi?id=296982">https://bugs.webkit.org/show_bug.cgi?id=296982</a>
<a href="https://rdar.apple.com/157612451">rdar://157612451</a>

Reviewed by Brent Fulgham.

This patch checks for a manually selected user agent string and, if present, parses the string and populates the userAgentData data structure with the results.

* Source/WTF/wtf/ASCIICType.h:
(WTF::isASCIIGraphic):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::userAgentData const):
* Source/WebCore/page/NavigatorUAData.cpp:
(WebCore::NavigatorUAData::NavigatorUAData):
(WebCore::NavigatorUAData::create):
(WebCore::NavigatorUAData::brands const):
(WebCore::NavigatorUAData::mobile const):
(WebCore::NavigatorUAData::platform const):
* Source/WebCore/page/NavigatorUAData.h:
* Source/WebCore/page/UserAgentStringData.h: Copied from Source/WebCore/page/NavigatorUAData.h.
(WebCore::UserAgentStringData::create):
* Source/WebCore/page/UserAgentStringParser.cpp: Added.
(WebCore::UserAgentStringParser::UserAgentStringParser):
(WebCore::UserAgentStringParser::create):
(WebCore::UserAgentStringParser::parse):
(WebCore::UserAgentStringParser::consumeProduct):
(WebCore::UserAgentStringParser::consumeRWS):
(WebCore::UserAgentStringParser::consumeComment):
(WebCore::UserAgentStringParser::consumeToken):
(WebCore::UserAgentStringParser::consumeQuotedPair):
(WebCore::UserAgentStringParser::peek):
(WebCore::UserAgentStringParser::increment):
(WebCore::UserAgentStringParser::atEnd):
(WebCore::UserAgentStringParser::isDelimiter const):
(WebCore::UserAgentStringParser::isTchar const):
(WebCore::UserAgentStringParser::isCtext const):
(WebCore::UserAgentStringParser::isObsText const):
(WebCore::UserAgentStringParser::isVisibleChar const):
(WebCore::UserAgentStringParser::isRWS const):
* Source/WebCore/page/UserAgentStringParser.h: Copied from Source/WebCore/page/NavigatorUAData.h.

Canonical link: <a href="https://commits.webkit.org/298650@main">https://commits.webkit.org/298650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/934f1da9b0b72147d51e58ec50cd68c5be0d9ea6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44380 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68657 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65869 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108241 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125337 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114659 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96969 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96753 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19916 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38972 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48504 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143356 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42379 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36954 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->