### PR TITLE
SharedBufferBuilder copy constructor should not take reference of original FragmentedSharedBuffer

### DIFF
--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -105,7 +105,7 @@ private:
             return emptyString();
 
         if (!m_contiguousBuffer && (!m_containsOnlyASCII || *m_containsOnlyASCII))
-            m_contiguousBuffer = m_scriptBuffer.buffer()->makeContiguous();
+            m_contiguousBuffer = m_scriptBuffer.protectedBuffer()->makeContiguous();
         if (!m_containsOnlyASCII) {
             m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->span());
             if (*m_containsOnlyASCII)

--- a/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyScriptBufferSourceProvider.h
@@ -58,20 +58,14 @@ public:
         if (!m_buffer)
             return nullptr;
 
-        ASSERT(m_buffer->isContiguous());
-        return downcast<SharedBuffer>(*m_buffer).span().data();
+        return m_buffer->span().data();
     }
 
     void lockUnderlyingBufferImpl() final
     {
         ASSERT(!m_buffer);
-        m_buffer = m_scriptBuffer.buffer();
-
-        if (!m_buffer)
-            return;
-
-        if (!m_buffer->isContiguous())
-            m_buffer = m_buffer->makeContiguous();
+        if (RefPtr<const FragmentedSharedBuffer> buffer = m_scriptBuffer.buffer().get())
+            m_buffer = buffer->makeContiguous();
     }
 
     void unlockUnderlyingBufferImpl() final
@@ -100,7 +94,7 @@ private:
     }
 
     ScriptBuffer m_scriptBuffer;
-    RefPtr<const FragmentedSharedBuffer> m_buffer;
+    RefPtr<const SharedBuffer> m_buffer;
     String m_source;
 };
 

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -398,9 +398,18 @@ bool FragmentedSharedBuffer::operator==(const FragmentedSharedBuffer& other) con
     if (m_size != other.m_size)
         return false;
 
-    auto thisSpan = m_segments.span();
+    return haveIdenticalContent(m_segments, other.m_segments);
+}
+
+bool FragmentedSharedBuffer::haveIdenticalContent(const DataSegmentVector& a, const DataSegmentVector& b)
+{
+    // Fast comparison.
+    if (a == b)
+        return true;
+
+    auto thisSpan = a.span();
     size_t thisOffset = 0;
-    auto otherSpan = other.m_segments.span();
+    auto otherSpan = b.span();
     size_t otherOffset = 0;
 
     while (!thisSpan.empty() && !otherSpan.empty()) {
@@ -714,6 +723,17 @@ SharedBufferBuilder& SharedBufferBuilder::operator=(const SharedBufferBuilder& o
         return SharedBuffer::DataSegmentVectorEntry { element.beginPosition, element.segment.copyRef() };
     });
     return *this;
+}
+
+bool SharedBufferBuilder::operator==(const SharedBufferBuilder& other) const
+{
+    if (this == &other)
+        return true;
+
+    if (m_size != other.m_size)
+        return false;
+
+    return FragmentedSharedBuffer::haveIdenticalContent(m_segments, other.m_segments);
 }
 
 SharedBufferDataView::SharedBufferDataView(Ref<const DataSegment>&& segment, size_t positionWithinSegment, std::optional<size_t> size)

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -199,6 +199,8 @@ public:
     struct DataSegmentVectorEntry {
         size_t beginPosition;
         const Ref<const DataSegment> segment;
+
+        bool operator==(const DataSegmentVectorEntry&) const = default;
     };
     using DataSegmentVector = Vector<DataSegmentVectorEntry, 1>;
     DataSegmentVector::const_iterator begin() const LIFETIME_BOUND { return m_segments.begin(); }
@@ -240,6 +242,8 @@ private:
     // Combines all the segments into a Vector and returns that vector after clearing the FragmentedSharedBuffer.
     WEBCORE_EXPORT Vector<uint8_t> takeData();
     std::span<const DataSegmentVectorEntry> segmentForPosition(size_t position) const;
+
+    static bool haveIdenticalContent(const DataSegmentVector&, const DataSegmentVector&);
 
     size_t m_size { 0 };
     DataSegmentVector m_segments;
@@ -395,13 +399,12 @@ public:
     WEBCORE_EXPORT Ref<SharedBuffer> takeAsContiguous();
     WEBCORE_EXPORT RefPtr<ArrayBuffer> takeAsArrayBuffer();
 
+    WEBCORE_EXPORT bool operator==(const SharedBufferBuilder&) const;
+
 private:
     friend class ScriptBuffer;
     friend class FetchBodyConsumer;
-    // Copy constructor should make a copy of the underlying SharedBuffer
-    // This is prevented by ScriptBuffer and FetchBodyConsumer classes (bug 234215)
-    // For now let the default constructor/operator take a reference to the
-    // SharedBuffer.
+
     WEBCORE_EXPORT SharedBufferBuilder(const SharedBufferBuilder&);
     WEBCORE_EXPORT SharedBufferBuilder& operator=(const SharedBufferBuilder&);
 

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -42,7 +42,7 @@ static std::optional<ShareableResource::Handle> tryConvertToShareableResourceHan
     if (!script.containsSingleFileMappedSegment())
         return std::nullopt;
 
-    auto& segment = script.buffer()->begin()->segment;
+    auto& segment = script.buffer().begin()->segment;
     auto sharedMemory = SharedMemory::wrapMap(segment->span(), SharedMemory::Protection::ReadOnly);
     if (!sharedMemory)
         return std::nullopt;
@@ -120,15 +120,6 @@ auto ScriptBuffer::ipcData() const -> IPCData
         return { WTFMove(*handle) };
 #endif
     return m_buffer.get();
-}
-
-bool operator==(const ScriptBuffer& a, const ScriptBuffer& b)
-{
-    if (a.buffer() == b.buffer())
-        return true;
-    if (!a.buffer() || !b.buffer())
-        return false;
-    return *a.buffer() == *b.buffer();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/ScriptBuffer.h
+++ b/Source/WebCore/workers/ScriptBuffer.h
@@ -49,8 +49,9 @@ public:
     WEBCORE_EXPORT explicit ScriptBuffer(const String&);
 
     String toString() const;
-    const FragmentedSharedBuffer* buffer() const { return m_buffer.get().get(); }
+    const SharedBufferBuilder& buffer() const { return m_buffer; }
     RefPtr<const FragmentedSharedBuffer> protectedBuffer() const { return m_buffer.get(); }
+    size_t size() const { return m_buffer.size(); }
 
     ScriptBuffer isolatedCopy() const { return ScriptBuffer(m_buffer ? RefPtr<FragmentedSharedBuffer>(m_buffer.copy()) : nullptr); }
     explicit operator bool() const { return !!m_buffer; }
@@ -69,10 +70,10 @@ public:
     WEBCORE_EXPORT static std::optional<ScriptBuffer> fromIPCData(IPCData&&);
     WEBCORE_EXPORT IPCData ipcData() const;
 
+    bool operator==(const ScriptBuffer& other) const { return m_buffer == other.m_buffer; }
+
 private:
     SharedBufferBuilder m_buffer; // Contains the UTF-8 encoded script.
 };
-
-bool operator==(const ScriptBuffer&, const ScriptBuffer&);
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -88,7 +88,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     auto scriptPath = this->scriptPath(registrationKey, scriptURL);
     FileSystem::makeAllDirectories(FileSystem::parentPath(scriptPath));
 
-    size_t size = script.buffer() ? script.buffer()->size() : 0;
+    size_t size = script.size();
 
     auto iterateOverBufferAndWriteData = [&](NOESCAPE const Function<bool(std::span<const uint8_t>)>& writeData) {
         script.protectedBuffer()->forEachSegment([&](std::span<const uint8_t> span) {


### PR DESCRIPTION
#### a3cfbbbccbd80ae28e843fa78b7fbb8c8e9c1cfb
<pre>
SharedBufferBuilder copy constructor should not take reference of original FragmentedSharedBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=234215">https://bugs.webkit.org/show_bug.cgi?id=234215</a>
<a href="https://rdar.apple.com/86699446">rdar://86699446</a>

Reviewed by Gerald Squelart.

in webkit.org/b/296798 we stopped using a SharedBuffer as storage backend
and instead used a dedicated Vector of DataSegment, removing the need to
store the FragmentedSharedBuffer when performing a copy.

We can further extend and never pass a SharedBuffer by pointer and instead
return a const reference in ScriptBuffer::buffer() and we remove all
use of unsafe pointers.

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::operator== const):
(WebCore::FragmentedSharedBuffer::haveIdenticalContent): Optimise the case
where the two shared buffers being compared have identical DataSegment instead
of performing a byte comparison over their entire content.
(WebCore::SharedBufferBuilder::operator== const): Add operator== to avoid having to create
an unnecessary temporary SharedBuffer.
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::tryConvertToShareableResourceHandle):
(WebCore::operator==): Deleted.
* Source/WebCore/workers/ScriptBuffer.h:
(WebCore::ScriptBuffer::buffer const): Return a const reference to the SharedBufferBuilder instead
so that we don&apos;t have to unnecessarily create a SharedBuffer unless actually needed.
(WebCore::ScriptBuffer::size const): Add shortcut to return the size without
having to create a SharedBuffer.
(WebCore::ScriptBuffer::operator== const):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store): Change storage type to SharedBuffer as the
content stored is always contiguous. Allows to remove unnecessary tests and conversions.

Canonical link: <a href="https://commits.webkit.org/298327@main">https://commits.webkit.org/298327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933cf5e74a37316713746d9984fe4822822a003a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65802 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cba4d30-43b2-460f-9dae-78b351f25e22) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87520 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c710df7e-1f1d-4101-a675-049dae316737) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67917 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21525 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64949 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124477 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96320 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96107 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38108 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42021 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->