### PR TITLE
[Screen Time] Screen Time Website Data may not be cleared properly with multiple Safari profiles

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm
@@ -44,7 +44,7 @@ void getScreenTimeURLs(std::optional<WTF::UUID> identifier, CompletionHandler<vo
 {
     RetainPtr<NSString> profileIdentifier;
     if (identifier)
-        profileIdentifier = identifier->toString().createNSString();
+        profileIdentifier = [identifier->createNSUUID() UUIDString];
 
     RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 
@@ -71,7 +71,7 @@ void removeScreenTimeData(const HashSet<URL>& websitesToRemove, const WebsiteDat
 {
     RetainPtr<NSString> profileIdentifier;
     if (configuration.identifier())
-        profileIdentifier = configuration.identifier()->toString().createNSString();
+        profileIdentifier = [configuration.identifier()->createNSUUID() UUIDString];
 
     RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 
@@ -97,7 +97,7 @@ void removeScreenTimeDataWithInterval(WallTime modifiedSince, const WebsiteDataS
 {
     RetainPtr<NSString> profileIdentifier;
     if (configuration.identifier())
-        profileIdentifier = configuration.identifier()->toString().createNSString();
+        profileIdentifier = [configuration.identifier()->createNSUUID() UUIDString];
 
     RetainPtr webHistory = adoptNS([PAL::allocSTWebHistoryInstance() initWithProfileIdentifier:profileIdentifier.get()]);
 


### PR DESCRIPTION
#### 03b9ff4426f9b538c940880f0d2c8d36aadbd499
<pre>
[Screen Time] Screen Time Website Data may not be cleared properly with multiple Safari profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=296967">https://bugs.webkit.org/show_bug.cgi?id=296967</a>
<a href="https://rdar.apple.com/157267710">rdar://157267710</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Website Data is not removed properly because the STWebpageController&apos;s
profile identifier and the STWebHistory&apos;s profile identifier are
case-sensitive.

Thus, we saw a case where the STWebpageController&apos;s profile identifier
was in uppercase but the STWebHistory&apos;s profile identifier was in lowercase.
This is because getting the string for a NSUUID is uppercase (STWebpageController)
but getting the string for UUID returns it in lowercase (STWebHistory).

To fix this, we make both profile identifiers the same case for now.
In the future, we should find a way to get the identifier strings in
such a way that does not change the case.

Change the IdentifierString test to match IdentifierStringWithRemoveData.

* Source/WebKit/UIProcess/WebsiteData/Cocoa/ScreenTimeWebsiteDataSupport.mm:
(WebKit::ScreenTimeWebsiteDataSupport::getScreenTimeURLs):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeData):
(WebKit::ScreenTimeWebsiteDataSupport::removeScreenTimeDataWithInterval):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, IdentifierString)):
(TEST(ScreenTime, IdentifierStringWithRemoveData)):

Canonical link: <a href="https://commits.webkit.org/298310@main">https://commits.webkit.org/298310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21f5ba4e212ee8425af25b8d0436f990b805c45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65734 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc106b26-2ed2-4ff4-89bd-dabd8a0cc070) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87460 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f11706cd-bf5b-4c96-8c36-31c41220fce8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67856 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64862 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96257 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96043 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19082 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18414 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47474 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41478 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44797 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->