### PR TITLE
[iOS] Add test coverage for mouse availability based gating of pointer lock

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1595,6 +1595,24 @@ TEST_F(PointerLockTests, ClientDisplaysAlertSheetWhilePointerLockActive)
 }
 #endif
 
-// FIXME: <https://webkit.org/b/296956> [iOS] Add test coverage for mouse availability based gating of pointer lock.
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+
+TEST_F(PointerLockTests, DeniedWithoutMouseDevice)
+{
+    setHasMouseDeviceForTesting(false);
+
+    click(200, 200);
+
+    __block bool done = false;
+
+    [webView() _doAfterProcessingAllPendingMouseEvents:^{
+        EXPECT_FALSE([pointerLockDelegate() didEngagePointerLock]);
+        done = true;
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+}
+
+#endif
 
 #endif


### PR DESCRIPTION
#### 9c6b996f3a4be6c5971b3038a49c53c0aba12c45
<pre>
[iOS] Add test coverage for mouse availability based gating of pointer lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=296956">https://bugs.webkit.org/show_bug.cgi?id=296956</a>
<a href="https://rdar.apple.com/157595899">rdar://157595899</a>

Reviewed by Aditya Keerthi.

This patch adds an API test for 298248@main.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((PointerLockTests, DeniedWithoutMouseDevice)):

Canonical link: <a href="https://commits.webkit.org/298289@main">https://commits.webkit.org/298289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/286828eeee3ce3b9de6b31f3469bb21f98495745

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/114982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65635 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee30af5e-cef2-49bc-bd30-d226dffbe949) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87367 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55241b3d-3284-42fd-905c-03b85304f12d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67763 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64754 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124292 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96166 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95952 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/18993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37979 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41830 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43112 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->