### PR TITLE
Restrict location.protocol setter to HTTP(S) schemes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -556,7 +556,7 @@ imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/failure-check-sequence.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/redirect-to-data.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/top-level-data-url.window.html [ DumpJSConsoleLogInStdErr ]
-imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken.html [ DumpJSConsoleLogInStdErr Failure Pass ]
+imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken-weird.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/origin/cross-origin-objects/cross-origin-objects.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/html/browsers/sandboxing/sandbox-disallow-popups.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9879,7 +9879,6 @@
         "web-platform-tests/html/browsers/history/the-location-interface/reload_document_open_write-1.html",
         "web-platform-tests/html/browsers/history/the-location-interface/reload_document_write-1.html",
         "web-platform-tests/html/browsers/history/the-location-interface/reload_document_write_onload-1.html",
-        "web-platform-tests/html/browsers/history/the-location-interface/reload_post_1-1.html",
         "web-platform-tests/html/browsers/history/the-location-interface/same_origin_frame.html",
         "web-platform-tests/html/browsers/history/the-location-interface/scripted_click_assign_during_load-1.html",
         "web-platform-tests/html/browsers/history/the-location-interface/scripted_click_assign_during_load-2.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html
@@ -16,7 +16,7 @@
           t.done();
         }
         window.addEventListener('message', t.step_func(on_message), false);
-        window.addEventListener('load', function () { 
+        window.addEventListener('load', function () {
             iframe.contentDocument.querySelector("iframe").contentWindow.location.replace("/resources/blank.html");
         }, false);
       }, "Browser sends Referer header in nested iframe request when location.replace is called on an iframe");
@@ -27,7 +27,7 @@
           t.done();
         }
         window.addEventListener('message', t.step_func(on_message), false);
-        window.addEventListener('load', function () { 
+        window.addEventListener('load', function () {
             iframe.contentDocument.querySelector("iframe").contentWindow.location.replace("/resources/blank.html");
         }, false);
       }, "Browser sends Referer header in nested iframe request when location.assign is called on an iframe");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken-expected.txt
@@ -2,7 +2,7 @@
 PASS Set HTTP URL frame location.protocol to x
 PASS Set data URL frame location.protocol to x
 PASS Set HTTP URL frame location.protocol to data
-FAIL Set data URL frame location.protocol to data The object can not be cloned.
+PASS Set data URL frame location.protocol to data
 PASS Set HTTP URL frame location.protocol to file
 PASS Set data URL frame location.protocol to file
 PASS Set HTTP URL frame location.protocol to ftp

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hash_set_empty_string-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hash_set_empty_string-expected.txt
@@ -1,0 +1,3 @@
+
+PASS window.location.hash is an empty string
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set window.location.hash to an empty string</title>
+<link rel="author" href="mailto:cristianb@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-location-hash">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const orig_location = window.location.href;
+
+window.location.hash = '';
+
+test(() => {
+    assert_true(window.location.hash === '');
+    assert_true(window.location.href === orig_location);
+}, 'window.location.hash is an empty string');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting window.location.hash to same value while handling hashchange event shouldn't cause an infinite loop.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set window.location.hash to same value while handling event hashchange</title>
+<link rel="author" href="mailto:cristianb@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-location-hash">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let count = 0;
+
+window.onhashchange = () => {
+    count += 1;
+    window.location.hash = 'running';
+}
+
+promise_test(async t => {
+    window.location.hash = 'running';
+
+    await t.step_wait(() => count === 1);
+}, 'Setting window.location.hash to same value while handling hashchange event shouldn\'t cause an infinite loop.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/w3c-import.log
@@ -14,6 +14,10 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-postmessage-to-parent-parent.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-with-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/post-your-origin.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/post-your-protocol.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/reload_post_1-1.py
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/replace-or-assign-call-on-iframe.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/w3c-import.log
@@ -15,6 +15,9 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/allow_prototype_cycle_through_location.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load-1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load-2.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign_after_load.html
@@ -29,6 +32,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-prevent-extensions.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken-weird.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-non-broken.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-sameish.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-protocol-setter.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-prototype-no-toString-valueOf.html
@@ -45,6 +49,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_assign_about_blank-1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_assign_about_blank.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hash.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_host.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_hostname.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location_href.html
@@ -65,6 +71,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/reload_document_write.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/reload_document_write_onload-1.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/reload_document_write_onload.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same_origin_frame.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/scripted_click_assign_during_load-1.html

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -160,6 +160,8 @@ ExceptionOr<void> Location::setProtocol(LocalDOMWindow& incumbentWindow, LocalDO
     URL url = localFrame->document()->url();
     if (!url.setProtocol(protocol))
         return Exception { ExceptionCode::SyntaxError };
+    if (!url.protocolIsInHTTPFamily())
+        return { };
     return setLocation(incumbentWindow, firstWindow, url.string());
 }
 


### PR DESCRIPTION
#### 8bc5fdc4f9897b714d6627c48b5d6f0c54c735e5
<pre>
Restrict location.protocol setter to HTTP(S) schemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=296972">https://bugs.webkit.org/show_bug.cgi?id=296972</a>
<a href="https://rdar.apple.com/157607342">rdar://157607342</a>

Reviewed by Alex Christensen.

As of 292443@main you can no longer change a URL&apos;s scheme from special
to non-special and vice versa. As a side effect of disallowing
non-special to special we would end up navigating to the current
scheme, which would not always work.

So instead let&apos;s align with the HTML standard and return early if the
resulting scheme is not an HTTP(S) scheme, which are essentially the
only two schemes for which switching between them makes sense when it
comes to navigation.

As part of this we synchronize WPT
html/browsers/history/the-location-interface and mark the relevant test
that regressed as passing.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3c34dafeba8c993b3e32ad06450fe4b50499c02e">https://github.com/web-platform-tests/wpt/commit/3c34dafeba8c993b3e32ad06450fe4b50499c02e</a>

Canonical link: <a href="https://commits.webkit.org/298349@main">https://commits.webkit.org/298349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38024409d1bcae329f7045c9fc61c61559bc0dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65807 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8446d3c3-9267-472f-ba98-0d2274ecb4f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3af9f20-bff8-4829-a3d6-f2433359572a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67919 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21529 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64954 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124482 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96321 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38113 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41553 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44877 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43281 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->