### PR TITLE
[GStreamer][WebRTC] Set a couple DTLS-related Transport stats fields

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2645,12 +2645,16 @@ imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html [ 
 imported/w3c/web-platform-tests/webrtc/protocol/crypto-suite.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/dtls-fingerprint-validation.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/dtls-setup.https.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/protocol/ice-state.https.html [ Failure ]
-imported/w3c/web-platform-tests/webrtc/protocol/ice-ufragpwd.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/msid-parse.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/rtp-payloadtypes.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/h264-profile-levels.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel.html [ Failure ]
+
+# Expected to pass when our SDK ships GStreamer 1.28. See also:
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/80e663d5605124fbd7e4b69e69060749a541e491
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/ea69849cd89a9d1a69c98bd9c640452a5deb72c2
+imported/w3c/web-platform-tests/webrtc/protocol/ice-state.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/protocol/ice-ufragpwd.html [ Failure ]
 
 # Missing support for multiple MediaStreams per track/transceiver.
 # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3954


### PR DESCRIPTION
#### a9d2c3bb8980c625bd1f1ec5f570ef7aa68bab1a
<pre>
[GStreamer][WebRTC] Set a couple DTLS-related Transport stats fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=296993">https://bugs.webkit.org/show_bug.cgi?id=296993</a>

Reviewed by Xabier Rodriguez-Calvar.

That required changes in GStreamer, they will ship in version 1.28. Test expectations were
documented meanwhile.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::TransportStats::TransportStats):

Canonical link: <a href="https://commits.webkit.org/299090@main">https://commits.webkit.org/299090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37907ac2d6b61b3f2b184f78bc6dcbd9069cbb0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87395 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42213 "Too many flaky failures: fast/css/fullscreen-style-sharing-crash.html, fast/dom/connected-subframe-counter-overflow.html, fast/dom/document-contentType-data-uri.html, fast/events/device-orientation-crash.html, fast/events/event-targets.html, fast/forms/mailto/get-multiple-items-text-plain.html, fast/images/destroyed-image-load-event.html, fetch/fetch-worker-crash.html, imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html, imported/w3c/web-platform-tests/wasm/core/utf8-invalid-encoding.wast.js.html, js/arrowfunction-call.html, js/arrowfunction-constructor.html, js/arrowfunction-lexical-bind-arguments-non-strict.html, js/dom/array-sort-accessor-adds-two-elements.html, js/dom/array-sort-accessor-decreases-length.html, js/dom/array-sort-accessor-deletes-predecessor.html, performance-api/paint-timing/paint-timing-frames.html, storage/domstorage/events/basic-body-attribute.html, storage/domstorage/events/basic-setattribute.html, storage/domstorage/events/basic.html, storage/indexeddb/lazy-index-population.html, storage/indexeddb/modern/double-abort-private.html, storage/indexeddb/mozilla/odd-result-order-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, webgl/2.0.y/conformance/glsl/reserved/_webgl_field.vert.html, webgl/2.0.y/conformance2/reading/read-pixels-from-rgb8-into-pbo-bug.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67791 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21377 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124322 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/41985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96194 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/95979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/37999 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47395 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->