### PR TITLE
[WebGPU] Reduce usages of unsafe in Swift

### DIFF
--- a/Source/WTF/wtf/SwiftBridging.h
+++ b/Source/WTF/wtf/SwiftBridging.h
@@ -37,6 +37,10 @@
 #define SWIFT_ESCAPABLE
 #endif
 
+#ifndef SWIFT_RETURNS_UNRETAINED
+#define SWIFT_RETURNS_UNRETAINED
+#endif
+
 #ifndef SWIFT_ESCAPABLE_IF
 #define SWIFT_ESCAPABLE_IF(...)
 #endif

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -27,6 +27,7 @@
 #include <span>
 
 #include <wtf/Compiler.h>
+#include <wtf/SwiftBridging.h>
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringImpl.h>
 
@@ -313,7 +314,7 @@ private:
     WTF_EXPORT_PRIVATE explicit String(const char* characters);
 
     RefPtr<StringImpl> m_impl;
-};
+} SWIFT_ESCAPABLE;
 
 static_assert(sizeof(String) == sizeof(void*), "String should effectively be a pointer to a StringImpl, and efficient to pass by value");
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -123,7 +123,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
 
 RefPtr<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optional<ComputePassDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
+    String label = descriptor ? descriptor->label : emptyString();
 
     WGPUComputePassTimestampWrites timestampWrites {
         .querySet = (descriptor && descriptor->timestampWrites && descriptor->timestampWrites->querySet) ? m_convertToBackingContext->convertToBacking(*descriptor->timestampWrites->protectedQuerySet().get()) : nullptr,
@@ -133,7 +133,7 @@ RefPtr<ComputePassEncoder> CommandEncoderImpl::beginComputePass(const std::optio
 
     WGPUComputePassDescriptor backingDescriptor {
         .nextInChain = nullptr,
-        .label = label.data(),
+        .label = label,
         .timestampWrites = timestampWrites.querySet ? &timestampWrites : nullptr
     };
 
@@ -280,11 +280,9 @@ void CommandEncoderImpl::resolveQuerySet(
 
 RefPtr<CommandBuffer> CommandEncoderImpl::finish(const CommandBufferDescriptor& descriptor)
 {
-    auto label = descriptor.label.utf8();
-
     WGPUCommandBufferDescriptor backingDescriptor {
         nullptr,
-        label.data(),
+        descriptor.label,
     };
 
     return CommandBufferImpl::create(adoptWebGPU(wgpuCommandEncoderFinish(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);

--- a/Source/WebGPU/WebGPU/APIConversions.h
+++ b/Source/WebGPU/WebGPU/APIConversions.h
@@ -53,6 +53,7 @@
 #import "XRSubImage.h"
 #import "XRView.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/SwiftBridging.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebGPU {
@@ -169,7 +170,7 @@ inline PresentationContext& fromAPI(WGPUSwapChain swapChain)
     return static_cast<PresentationContext&>(*swapChain);
 }
 
-inline Texture& fromAPI(WGPUTexture texture)
+inline Texture& fromAPI(WGPUTexture texture) SWIFT_RETURNS_UNRETAINED
 {
     return static_cast<Texture&>(*texture);
 }

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -44,7 +44,9 @@
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 
-struct WGPUBufferImpl {
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(wgpuBufferReference, wgpuBufferRelease) WGPUBufferImpl {
 };
 
 namespace WebGPU {

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -102,7 +102,7 @@ public:
     void setLabel(String&&);
 
     Device& device() const { return m_device; }
-    Ref<Device> protectedDevice() const SWIFT_RETURNS_INDEPENDENT_VALUE { return m_device; }
+    Ref<Device> protectedDevice() const { return m_device; }
 
     bool isValid() const { return m_commandBuffer; }
     void lock(bool);

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -307,7 +307,7 @@ Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDe
 
     id<MTLComputeCommandEncoder> computeCommandEncoder = [m_commandBuffer computeCommandEncoderWithDescriptor:computePassDescriptor];
     setExistingEncoder(computeCommandEncoder);
-    computeCommandEncoder.label = fromAPI(descriptor.label).createNSString().get();
+    computeCommandEncoder.label = descriptor.label.createNSString().get();
 
     return ComputePassEncoder::create(computeCommandEncoder, descriptor, *this, m_device);
 }
@@ -2113,7 +2113,7 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
     m_commandBuffer = nil;
     m_existingCommandEncoder = nil;
 
-    commandBuffer.label = fromAPI(descriptor.label).createNSString().get();
+    commandBuffer.label = descriptor.label.createNSString().get();
 
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
     if (m_managedBuffers.count || m_managedTextures.count) {

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -49,6 +49,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/Ref.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/CString.h>
 
 using SpanConstUInt8 = std::span<const uint8_t>;
 using SpanUInt8 = std::span<uint8_t>;
@@ -70,10 +71,10 @@ class Range;
 
 namespace WebGPU_Internal {
 
-inline void logString(const char * input)
+inline void logString(const String& input)
 {
-    if (input)
-        RELEASE_LOG(WebGPUSwift, "%s", input);
+    if (!input.isEmpty())
+        RELEASE_LOG(WebGPUSwift, "%s", input.utf8().data());
 }
 
 using RefComputePassEncoder = Ref<WebGPU::ComputePassEncoder>;

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -39,7 +39,9 @@
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
-struct WGPUQuerySetImpl {
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(wgpuQuerySetReference, wgpuQuerySetRelease) WGPUQuerySetImpl {
 };
 
 namespace WebGPU {
@@ -80,7 +82,7 @@ public:
     uint32_t count() const { return m_count; }
     WGPUQueryType type() const { return m_type; }
     id<MTLBuffer> visibilityBuffer() const { return m_visibilityBuffer; }
-    const CounterSampleBuffer& counterSampleBufferWithOffset() const SWIFT_RETURNS_INDEPENDENT_VALUE;
+    CounterSampleBuffer counterSampleBufferWithOffset() const;
     [[noreturn]] id<MTLCounterSampleBuffer> counterSampleBuffer() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     void setCommandEncoder(CommandEncoder&) const;

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -149,7 +149,7 @@ void QuerySet::setCommandEncoder(CommandEncoder& commandEncoder) const
         commandEncoder.makeSubmitInvalid();
 }
 
-const QuerySet::CounterSampleBuffer& QuerySet::counterSampleBufferWithOffset() const
+QuerySet::CounterSampleBuffer QuerySet::counterSampleBufferWithOffset() const
 {
     return m_timestampBufferWithOffset;
 }

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -114,8 +114,11 @@ private:
     void removeMTLCommandBufferInternal(id<MTLCommandBuffer>);
 
     NSString* errorValidatingWriteTexture(const WGPUImageCopyTexture&, const WGPUTextureDataLayout&, const WGPUExtent3D&, size_t, const Texture&) const;
-    std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(std::span<uint8_t> data, bool noCopy);
 
+private PUBLIC_IN_WEBGPU_SWIFT:
+    std::pair<id<MTLBuffer>, uint64_t> newTemporaryBufferWithBytes(const std::span<uint8_t> data, bool noCopy);
+
+private:
     id<MTLCommandQueue> m_commandQueue { nil };
     id<MTLCommandBuffer> m_commandBuffer { nil };
     id<MTLBlitCommandEncoder> m_blitCommandEncoder { nil };

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -37,7 +37,9 @@
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
-struct WGPUTextureImpl {
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(wgpuTextureReference, wgpuTextureRelease) WGPUTextureImpl {
 };
 
 namespace WebGPU {

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -33,7 +33,9 @@
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
-struct WGPUTextureViewImpl {
+// FIXME(rdar://155970441): this annotation should be in WebGPU.h, move it once we support
+// annotating incomplete types
+struct __attribute__((swift_attr("@safe"))) SWIFT_SHARED_REFERENCE(wgpuTextureViewReference, wgpuTextureViewRelease) WGPUTextureViewImpl {
 };
 
 namespace WebGPU {

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -36,6 +36,9 @@
 #include <swift/bridging>
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+
 #ifdef __cplusplus
 
 #include <array>
@@ -783,12 +786,12 @@ typedef void (*WGPURequestDeviceCallback)(WGPURequestDeviceStatus status, WGPUDe
 typedef struct WGPUChainedStruct {
     struct WGPUChainedStruct const * next;
     WGPUSType sType;
-} WGPUChainedStruct WGPU_STRUCTURE_ATTRIBUTE;
+} __attribute__((swift_attr("@safe"))) SWIFT_ESCAPABLE WGPUChainedStruct WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUChainedStructOut {
     struct WGPUChainedStructOut * next;
     WGPUSType sType;
-} WGPUChainedStructOut WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPUChainedStructOut WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUAdapterProperties {
     WGPUChainedStructOut * nextInChain;
@@ -843,8 +846,12 @@ typedef struct WGPUColor {
 
 typedef struct WGPUCommandBufferDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
-} WGPUCommandBufferDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+    WGPU_NULLABLE WTF::String label;
+} __attribute__((swift_attr("@safe"))) SWIFT_ESCAPABLE WGPUCommandBufferDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+
+static inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetCommandBufferDescriptorNextChainedStruct(const WGPUCommandBufferDescriptor * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
+    return descriptor->nextInChain;
+}
 
 typedef struct WGPUCommandEncoderDescriptor {
     WGPUChainedStruct const * nextInChain;
@@ -868,7 +875,7 @@ typedef struct WGPUComputePassTimestampWrites {
     WGPUQuerySet querySet;
     uint32_t beginningOfPassWriteIndex;
     uint32_t endOfPassWriteIndex;
-} WGPUComputePassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPUComputePassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUConstantEntry {
     WGPUChainedStruct const * nextInChain;
@@ -1007,13 +1014,13 @@ typedef struct WGPURenderPassDepthStencilAttachment {
 typedef struct WGPURenderPassDescriptorMaxDrawCount {
     WGPUChainedStruct chain;
     uint64_t maxDrawCount;
-} WGPURenderPassDescriptorMaxDrawCount WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPURenderPassDescriptorMaxDrawCount WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURenderPassTimestampWrites {
     WGPUQuerySet querySet;
     uint32_t beginningOfPassWriteIndex;
     uint32_t endOfPassWriteIndex;
-} WGPURenderPassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
+} SWIFT_ESCAPABLE WGPURenderPassTimestampWrites WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPURequestAdapterOptions {
     WGPUChainedStruct const * nextInChain;
@@ -1157,6 +1164,10 @@ typedef struct WGPUTextureDataLayout {
     uint32_t rowsPerImage;
 } SWIFT_ESCAPABLE WGPUTextureDataLayout WGPU_STRUCTURE_ATTRIBUTE;
 
+inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetTextureDataLayoutNextInChain(const WGPUTextureDataLayout * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
+    return descriptor->nextInChain;
+}
+
 typedef struct WGPUTextureViewDescriptor {
     WGPUChainedStruct const * nextInChain;
     WGPU_NULLABLE char const * label;
@@ -1214,9 +1225,17 @@ inline std::span<const WGPUCompilationMessage> messagesSpan(const WGPUCompilatio
 
 typedef struct WGPUComputePassDescriptor {
     WGPUChainedStruct const * nextInChain;
-    WGPU_NULLABLE char const * label;
+    WGPU_NULLABLE WTF::String label;
     WGPU_NULLABLE WGPUComputePassTimestampWrites const * timestampWrites;
-} SWIFT_ESCAPABLE WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+} __attribute__((swift_attr("@safe"))) SWIFT_ESCAPABLE WGPUComputePassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+
+static inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetComputePassDescriptorNextChainedStruct(const WGPUComputePassDescriptor * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
+    return descriptor->nextInChain;
+}
+
+static inline WGPU_NULLABLE WGPUComputePassTimestampWrites const * _Nullable __counted_by(1) wgpuGetComputePassDescriptorTimestampWrites(const WGPUComputePassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
+    return descriptor->timestampWrites;
+}
 
 typedef struct WGPUDepthStencilState {
     WGPUChainedStruct const * nextInChain;
@@ -1238,6 +1257,10 @@ typedef struct WGPUImageCopyBuffer {
     WGPUBuffer buffer;
 } SWIFT_ESCAPABLE WGPUImageCopyBuffer WGPU_STRUCTURE_ATTRIBUTE;
 
+inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetImageCopyBufferNextInChain(const WGPUImageCopyBuffer * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
+    return descriptor->nextInChain;
+}
+
 typedef struct WGPUImageCopyTexture {
     WGPUChainedStruct const * nextInChain;
     WGPUTexture texture;
@@ -1245,6 +1268,10 @@ typedef struct WGPUImageCopyTexture {
     WGPUOrigin3D origin;
     WGPUTextureAspect aspect;
 } SWIFT_ESCAPABLE WGPUImageCopyTexture WGPU_STRUCTURE_ATTRIBUTE;
+
+inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetImageCopyTextureNextInChain(const WGPUImageCopyTexture * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
+    return descriptor->nextInChain;
+}
 
 typedef struct WGPUProgrammableStageDescriptor {
     WGPUChainedStruct const * nextInChain;
@@ -1355,7 +1382,24 @@ typedef struct WGPURenderPassDescriptor {
     WGPU_NULLABLE WGPURenderPassTimestampWrites const * timestampWrites;
 
     auto colorAttachmentsSpan() const { return unsafeMakeSpan(colorAttachments, colorAttachmentCount); }
-} SWIFT_ESCAPABLE WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+} __attribute__((swift_attr("@safe"))) SWIFT_ESCAPABLE WGPURenderPassDescriptor WGPU_STRUCTURE_ATTRIBUTE;
+
+inline struct WGPUChainedStruct const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorNextChainedStruct(const WGPURenderPassDescriptor * __counted_by(1) __attribute__((lifetimebound)) __attribute__((noescape)) descriptor) {
+    return descriptor->nextInChain;
+}
+
+inline WGPURenderPassTimestampWrites const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorTimestampWrites(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
+    return descriptor->timestampWrites;
+}
+
+inline WGPURenderPassColorAttachment const * __counted_by(count) wgpuGetRenderPassDescriptorColorAttachments(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor, size_t count) {
+    ((void)count);
+    return descriptor->colorAttachments;
+}
+
+inline WGPURenderPassDepthStencilAttachment const * _Nullable __counted_by(1) wgpuGetRenderPassDescriptorDepthSencilAttachment(const WGPURenderPassDescriptor * __attribute__((lifetimebound)) __counted_by(1) __attribute__((noescape)) descriptor) {
+    return descriptor->depthStencilAttachment;
+}
 
 typedef struct WGPUVertexState {
     WGPUChainedStruct const * nextInChain;
@@ -1906,5 +1950,7 @@ WGPU_EXPORT std::span<uint8_t> wgpuBufferGetBufferContents(WGPUBuffer buffer) WG
 WGPU_EXPORT std::span<uint8_t> wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size) WGPU_FUNCTION_ATTRIBUTE;
 
 #endif
+
+#pragma clang diagnostic pop
 
 #endif // WEBGPU_H_


### PR DESCRIPTION
#### d475dd8824a5353998281da54c246aa89e4677bb
<pre>
[WebGPU] Reduce usages of unsafe in Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=296998">https://bugs.webkit.org/show_bug.cgi?id=296998</a>
<a href="https://rdar.apple.com/157660610">rdar://157660610</a>

Reviewed by Mike Wyrzykowski.

Add annotations to reduce usages of `unsafe`.

* Source/WebGPU/WebGPU/APIConversions.h:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandBuffer.mm:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(CommandEncoder_finish_thunk(_:descriptor:)):
(WebGPU.finish(_:)):
(WebGPU.errorValidatingCopyTextureToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingCopyTextureToBuffer(_:destination:copySize:)):
(WebGPU.errorValidatingImageCopyBuffer(_:)):
(WebGPU.errorValidatingCopyBufferToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingRenderPassDescriptor(_:)):
(WebGPU.errorValidatingTimestampWrites(_:)):
(WebGPU.errorValidatingComputePassDescriptor(_:)):
(WebGPU.beginRenderPass(_:)):
(WebGPU.copyTextureToBuffer(_:destination:copySize:)):
(WebGPU.copyBufferToTexture(_:destination:copySize:)):
(WebGPU.copyTextureToTexture(_:destination:copySize:)):
(WebGPU.beginComputePass(_:)):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/WebGPU.h:
(wgpuGetCommandBufferDescriptorNextChainedStruct):
(wgpuGetComputePassDescriptorNextChainedStruct):
(wgpuGetComputePassDescriptorTimestampWrites):
(wgpuGetRenderPassDescriptorNextChainedStruct):
(wgpuGetRenderPassDescriptorTimestampWrites):

Canonical link: <a href="https://commits.webkit.org/299114@main">https://commits.webkit.org/299114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9c5a1637db9087bdbc3ba643b0e305098c4ce64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69309 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b284b5b-41c4-429e-b59d-a50dd54a231d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45580 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89038 "Found 14 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43707 "Found 7 new test failures: imported/w3c/web-platform-tests/wasm/core/simd/simd_align.wast.js.html imported/w3c/web-platform-tests/wasm/serialization/module/window-serviceworker-failure.https.html js/dom/JSON-parse-complex.html storage/indexeddb/modern/index-rename-1-private.html webgl/2.0.0/conformance2/textures/image_data/tex-3d-rgb5_a1-rgba-unsigned_byte.html webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-rg32f-rg-float.html webgl/2.0.y/conformance/extensions/ext-disjoint-timer-query.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd6fad4b-1f54-4532-9044-e5a6e712b112) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9dffb3e9-2574-4697-8a78-a2632494c2db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67095 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109428 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126543 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115830 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97709 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44577 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97504 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49752 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144530 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43549 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37203 "Found 1 new JSC binary failure: testapi, Found 20050 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46894 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->