### PR TITLE
[cleanup] Remove Atom editor from Editor list as it is no longer supported

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py
@@ -29,14 +29,6 @@ from webkitcorepy.decorators import hybridmethod
 
 class Editor(object):
     @classmethod
-    def atom(cls):
-        return cls(
-            name='Atom',
-            path='/Applications/Atom.app/Contents/Resources/app/atom.sh',
-            wait=['-w'],
-        )
-
-    @classmethod
     def sublime(cls):
         path = shutil.which('subl') or '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl'
         return cls(
@@ -129,7 +121,6 @@ class Editor(object):
         for program in [
             Editor.sublime(),
             Editor.textmate(),
-            Editor.atom(),
             Editor.bbedit(),
             Editor.vscode(),
             Editor.xcode(),


### PR DESCRIPTION
#### 5b7ddfd2496552fddaa96531456b8ca5329acb4c
<pre>
[cleanup] Remove Atom editor from Editor list as it is no longer supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=297004#">https://bugs.webkit.org/show_bug.cgi?id=297004#</a>
<a href="https://rdar.apple.com/problem/157671913">rdar://problem/157671913</a>

Reviewed by Jonathan Bedard.

The Atom editor was sunset by GitHub more than 2 and a half years ago.

<a href="https://github.blog/news-insights/product-news/sunsetting-atom/">https://github.blog/news-insights/product-news/sunsetting-atom/</a>

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/editor.py:
(Editor):
(Editor.programs):
(Editor.atom): Deleted.

Canonical link: <a href="https://commits.webkit.org/298297@main">https://commits.webkit.org/298297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e85bb54df1d633da7f5306e0460bc52e0174f6b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65691 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11cf0c47-8022-42bd-bfea-7ddd4499ee5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87420 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7135d78c-294e-4875-bcbc-f361c352a396) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/117990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67816 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/114416 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/27392 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21407 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64814 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31418 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/114475 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41209 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19049 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41890 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41434 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44751 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43170 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->