### PR TITLE
Move Style::CustomProperty off of WebCore::Length

### DIFF
--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -71,20 +71,11 @@ Ref<CSSValue> CustomProperty::propertyValue(CSSValuePool& pool, const RenderStyl
 {
     auto convertValue = [&](const Value& value) {
         return WTF::switchOn(value,
-            [&](const WebCore::Length& value) -> Ref<CSSValue> {
-                return CSSPrimitiveValue::create(value, style);
-            },
-            [&](const Numeric& value) -> Ref<CSSValue> {
-                return CSSPrimitiveValue::create(value.value, value.unitType);
-            },
-            [&](const RefPtr<StyleImage>& value) -> Ref<CSSValue> {
-                return value->computedStyleValue(style);
+            [&](const Transform& value) -> Ref<CSSValue> {
+                return ExtractorConverter::convertTransformOperation(style, value.operation);
             },
             [&](const auto& value) -> Ref<CSSValue> {
                 return createCSSValue(pool, style, value);
-            },
-            [&](const Transform& value) -> Ref<CSSValue> {
-                return ExtractorConverter::convertTransformOperation(style, value.operation);
             }
         );
     };
@@ -127,20 +118,6 @@ void CustomProperty::propertyValueSerialization(StringBuilder& builder, const CS
 {
     auto serializeValue = [&](StringBuilder& builder, const Value& value) {
         WTF::switchOn(value,
-            [&](const WebCore::Length& value) {
-                if (value.type() == LengthType::Calculated) {
-                    // FIXME: Implement serialization for CalculationValue directly.
-                    builder.append(CSSCalcValue::create(value.protectedCalculationValue(), style)->cssText(context));
-                    return;
-                }
-                builder.append(CSSPrimitiveValue::create(value, style)->cssText(context));
-            },
-            [&](const Numeric& value) {
-                builder.append(CSSPrimitiveValue::create(value.value, value.unitType)->cssText(context));
-            },
-            [&](const RefPtr<StyleImage>& value) {
-                builder.append(value->computedStyleValue(style)->cssText(context));
-            },
             [&](const Transform& value) {
                 ExtractorSerializer::serializeTransformOperation(style, builder, context, value.operation);
             },
@@ -187,20 +164,6 @@ void CustomProperty::propertyValueSerializationForTokenization(StringBuilder& bu
 
     auto serializeValue = [&](StringBuilder& builder, const Value& value) {
         WTF::switchOn(value,
-            [&](const WebCore::Length& value) {
-                if (value.type() == LengthType::Calculated) {
-                    // FIXME: Implement serialization for CalculationValue directly.
-                    builder.append(CSSCalcValue::create(value.protectedCalculationValue(), style)->cssText(context));
-                    return;
-                }
-                builder.append(CSSPrimitiveValue::create(value, style)->cssText(context));
-            },
-            [&](const Numeric& value) {
-                builder.append(CSSPrimitiveValue::create(value.value, value.unitType)->cssText(context));
-            },
-            [&](const RefPtr<StyleImage>& value) {
-                builder.append(value->computedStyleValue(style)->cssText(context));
-            },
             [&](const Transform& value) {
                 ExtractorSerializer::serializeTransformOperation(style, builder, context, value.operation);
             },

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -27,9 +27,9 @@
 #include "CSSValue.h"
 #include "CSSValueAggregates.h"
 #include "CSSVariableData.h"
-#include "Length.h"
 #include "StyleColor.h"
-#include "StyleImage.h"
+#include "StyleImageWrapper.h"
+#include "StylePrimitiveNumeric.h"
 #include "StyleURL.h"
 #include "TransformOperation.h"
 #include <wtf/RefCounted.h>
@@ -50,21 +50,20 @@ public:
     // https://drafts.csswg.org/css-variables-2/#guaranteed-invalid
     struct GuaranteedInvalid { };
 
-    struct Numeric {
-        double value;
-        CSSUnitType unitType;
-        bool operator==(const Numeric&) const = default;
-    };
-
     struct Transform {
         Ref<TransformOperation> operation;
         bool operator==(const Transform& other) const { return arePointingToEqualData(operation, other.operation); }
     };
 
     using Value = Variant<
-        WebCore::Length,
-        Numeric,
-        RefPtr<StyleImage>,
+        LengthPercentage<>,
+        Length<>,
+        Number<>,
+        Percentage<>,
+        Angle<>,
+        Time<>,
+        Resolution<>,
+        ImageWrapper,
         Color,
         URL,
         CustomIdentifier,


### PR DESCRIPTION
#### 0d9a7374d5782bd4e5f082b866d45a9d433a7761
<pre>
Move Style::CustomProperty off of WebCore::Length
<a href="https://bugs.webkit.org/show_bug.cgi?id=297008">https://bugs.webkit.org/show_bug.cgi?id=297008</a>

Reviewed by Darin Adler.

Updates `Style::CustomProperty` to use strong style types for all
currently supported values. This replaces the use of `WebCore::Length`
with `Style::LengthPercentage&lt;&gt;`, `CustomProperty::Numeric` with
standard `Style::{numeric}` types, and `RefPtr&lt;StyleImage&gt;` with
`Style::ImageWrapper`.

Also adds missing `requiresInterpolationForAccumulativeIteration`
needed for bare `LengthPercentage&lt;&gt;` blending.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/style/StyleCustomProperty.cpp:
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/style/StyleInterpolation.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:

Canonical link: <a href="https://commits.webkit.org/298410@main">https://commits.webkit.org/298410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7a00a3a5ab1f4e6653bf6e0a6b3da9480c9004c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115419 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87698 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96475 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96261 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24491 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19348 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38262 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41740 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->