### PR TITLE
Fix issue with  preference changes in WKTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1276,6 +1276,11 @@ void TestController::ensureViewSupportsOptionsForTest(const TestInvocation& test
         if (!m_createdOtherPage && m_mainWebView->viewSupportsOptions(options) && !options.isAppBoundWebView())
             return;
 
+        // If we're creating a new view due to different preferences, terminate all existing WebContent processes
+        // to prevent stale processes from handling messages with incorrect preference states
+        if (!m_mainWebView->viewSupportsOptions(options))
+            terminateWebContentProcess();
+
         willDestroyWebView();
 
         WKPageSetPageUIClient(m_mainWebView->page(), nullptr);


### PR DESCRIPTION
#### 5c55aa6ea1a8aeed68fe73ef018a56cef0db5014
<pre>
Fix issue with  preference changes in WKTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=297009">https://bugs.webkit.org/show_bug.cgi?id=297009</a>
<a href="https://rdar.apple.com/157679789">rdar://157679789</a>

Reviewed by NOBODY (OOPS!).

Properly handle preference changes in WKTestRunner by terminating the
old WebContent process that contains stale preferences

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::ensureViewSupportsOptionsForTest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c55aa6ea1a8aeed68fe73ef018a56cef0db5014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121179 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65706 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f12ba6b0-b610-4eb1-acd6-9451e1f0108f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/116953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87438 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42239 "Too many flaky failures: fast/css/fontsize-unit-rems-crash.html, fast/css/list-item-pseudo-nocrash.html, fast/dom/SelectorAPI/elementRoot.html, fast/dom/Window/666869.html, fast/dom/normalize-doesnt-check-string-length.html, fast/forms/label/labels-remove-htmlFor-label.html, fast/forms/label/labels-remove-parent-label.html, fast/forms/range/range-set-value-repaint.html, fast/text/font-loading-font-display.html, http/tests/security/cannot-read-cssrules.html, imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html, js/arrowfunction-block-2.html, js/arrowfunction-call.html, js/arrowfunction-constructor.html, js/dom/array-sort-accessor-decreases-length.html, js/dom/call-link-info-recursion.html, performance-api/performance-mark-name.html, resize-observer/element-leak.html, storage/domstorage/storage-functions-not-overwritten.html, storage/indexeddb/cursor-cast.html, storage/indexeddb/cursor-continue-add-error-private.html, storage/indexeddb/modern/cursor-2.html, streams/readable-stream-default-controller-error.html, wasm/iframe-parent-postmessage.html, webgl/2.0.y/conformance/buffers/buffer-data-and-buffer-sub-data.html, webgl/2.0.y/conformance/misc/is-object.html, webgl/2.0.y/conformance2/rendering/canvas-resizing-with-pbo-bound.html, webgl/2.0.y/conformance2/textures/canvas/tex-2d-r8-red-unsigned_byte.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d6076e02-643b-4ccc-b9b3-05b13c6d70af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67834 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64832 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124367 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96234 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96019 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38037 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41908 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44768 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->