### PR TITLE
Web Extensions: Add the ability for extensions to delete bookmark nodes using

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -141,6 +141,16 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
  represents the created item.
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller createBookmarkWithParentIdentifier:(nullable NSString *)parentId index:(nullable NSNumber *)index url:(nullable NSString *)url title:(NSString * _Nonnull)title forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> * _Nullable, NSError * _Nullable))completionHandler;
+
+/*!
+ @abstract Called when a bookmark or bookmark folder is requested to be removed.
+ @param controller The web extension controller initiating the request.
+ @param bookmarkIdentifier The unique string identifier of the bookmark or folder to remove.
+ @param recursively If YES, the entire subtree should be removed (for removeTree). If NO, only a single bookmark or an empty folder should be removed (for remove).
+ @param context The context within which the web extension is running.
+ @param completionHandler A block that must be called upon completion.
+ */
+- (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller removeBookmarkWithIdentifier:(NSString *)bookmarkIdentifier removeFolderWithChildren:(BOOL)removeFolderWithChildren forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSError * _Nullable))completionHandler;
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm
@@ -162,7 +162,7 @@ void WebExtensionContext::bookmarksCreate(const std::optional<String>& parentId,
 
     [controllerDelegate _webExtensionController:controllerWrapper createBookmarkWithParentIdentifier:parentIdString index:indexNumber url:urlString title:titleString forExtensionContext:contextWrapper completionHandler:^(NSObject<_WKWebExtensionBookmark> *newBookmark, NSError *error) {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"error was reported"));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
         auto parametersOptional = createParametersFromProtocolObject(newBookmark, contextWrapper);
@@ -196,7 +196,7 @@ void WebExtensionContext::bookmarksGetTree(CompletionHandler<void(Expected<Vecto
 
     [controllerDelegate _webExtensionController:controllerWrapper bookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *bookmarkNodes, NSError *error) {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -231,7 +231,7 @@ void WebExtensionContext::bookmarksGetSubTree(const String& bookmarkId, Completi
 
     [controllerDelegate _webExtensionController:controllerWrapper bookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -278,7 +278,7 @@ void WebExtensionContext::bookmarksGet(const Vector<String>& bookmarkId, Complet
 
     [controllerDelegate _webExtensionController:controllerWrapper bookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -328,7 +328,7 @@ void WebExtensionContext::bookmarksGetChildren(const String& bookmarkId, Complet
 
     [controllerDelegate _webExtensionController:controllerWrapper bookmarksForExtensionContext:contextWrapper completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -384,7 +384,7 @@ void WebExtensionContext::bookmarksGetRecent(uint64_t count, CompletionHandler<v
     [controllerDelegate _webExtensionController:controllerWrapper bookmarksForExtensionContext:contextWrapper
         completionHandler:^(NSArray<id<_WKWebExtensionBookmark>> *allTopLevelNodes, NSError *error) {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nullString(), @"failed because it returned an error"));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -427,11 +427,62 @@ void WebExtensionContext::bookmarksMove(const String& bookmarkId, const std::opt
 }
 void WebExtensionContext::bookmarksRemove(const String& bookmarkId, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString *const apiName = @"bookmarks.remove()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:removeBookmarkWithIdentifier:removeFolderWithChildren:forExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    NSString *bookmarkIdString = bookmarkId.createNSString().get();
+    [controllerDelegate _webExtensionController:controllerWrapper removeBookmarkWithIdentifier:bookmarkIdString removeFolderWithChildren:NO forExtensionContext:contextWrapper completionHandler:^(NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
+            return;
+        }
+        completionHandler({ });
+    }];
 }
 void WebExtensionContext::bookmarksRemoveTree(const String& bookmarkId, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
+    static NSString *const apiName = @"bookmarks.removeTree()";
+    ASSERT(isLoaded());
+    if (!isLoaded())
+        return;
 
+    RefPtr controller = extensionController();
+    if (!controller)
+        return;
+
+    auto *controllerDelegate = controller->delegate();
+    auto *controllerWrapper = controller->wrapper();
+    WKWebExtensionContext *contextWrapper = wrapper();
+
+    if (![controllerDelegate respondsToSelector:@selector(_webExtensionController:removeBookmarkWithIdentifier:removeFolderWithChildren:forExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    NSString *bookmarkIdString = bookmarkId.createNSString().get();
+
+    [controllerDelegate _webExtensionController:controllerWrapper removeBookmarkWithIdentifier:bookmarkIdString removeFolderWithChildren:YES forExtensionContext:contextWrapper completionHandler:^(NSError *error) {
+        if (error) {
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
+            return;
+        }
+        completionHandler({ });
+    }];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
@@ -280,12 +280,32 @@ void WebExtensionAPIBookmarks::move(NSString *bookmarkIdentifier, NSDictionary *
 
 void WebExtensionAPIBookmarks::remove(NSString *bookmarkIdentifier, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    WebProcess::singleton().sendWithAsyncReply(
+        Messages::WebExtensionContext::BookmarksRemove(bookmarkIdentifier),
+        [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+            if (!result) {
+                callback->reportError(result.error().createNSString().get());
+                return;
+            }
+            callback->call({ });
+        },
+        extensionContext().identifier()
+    );
 }
 
 void WebExtensionAPIBookmarks::removeTree(NSString *bookmarkIdentifier, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    callback->reportError(@"unimplemented");
+    WebProcess::singleton().sendWithAsyncReply(
+        Messages::WebExtensionContext::BookmarksRemoveTree(bookmarkIdentifier),
+        [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<void, WebExtensionError>&& result) {
+            if (!result) {
+                callback->reportError(result.error().createNSString().get());
+                return;
+            }
+            callback->call({ });
+        },
+        extensionContext().identifier()
+    );
 }
 
 void WebExtensionAPIBookmarks::search(NSObject *query, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -72,6 +72,7 @@
 
 @property (nonatomic, copy) void (^createBookmarkWithParentIdentifier)(NSString *parentId, NSNumber *index, NSString *url, NSString *title, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
 @property (nonatomic, copy) void (^bookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *));
+@property (nonatomic, copy) void (^removeBookmarkWithIdentifier)(NSString *bookmarkId, BOOL removeFolderWithChildren, void (^completionHandler)(NSError *));
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -187,6 +187,14 @@
         completionHandler(@[], nil);
 }
 
+- (void)_webExtensionController:(WKWebExtensionController *)controller removeBookmarkWithIdentifier:(NSString *)bookmarkId removeFolderWithChildren:(BOOL)removeFolderWithChildren forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    if (_removeBookmarkWithIdentifier)
+        _removeBookmarkWithIdentifier(bookmarkId, removeFolderWithChildren, completionHandler);
+    else if (completionHandler)
+        completionHandler(nil);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 086f3606d1bf705580e3061d207bfee7a3f1c43b
<pre>
Web Extensions: Add the ability for extensions to delete bookmark nodes using
the Bookmarks API
<a href="https://rdar.apple.com/152506190">rdar://152506190</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296905">https://bugs.webkit.org/show_bug.cgi?id=296905</a>

Reviewed by Brian Weinstein.

Added UIProcess and WebProcess implementation more bookmarks.remove() and
bookmarks.removeTree(). Added tests for these functions as well

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::WebExtensionContext::bookmarksCreate):
(WebKit::WebExtensionContext::bookmarksGetTree):
(WebKit::WebExtensionContext::bookmarksGetSubTree):
(WebKit::WebExtensionContext::bookmarksGet):
(WebKit::WebExtensionContext::bookmarksGetChildren):
(WebKit::WebExtensionContext::bookmarksGetRecent):
(WebKit::WebExtensionContext::bookmarksRemove):
(WebKit::WebExtensionContext::bookmarksRemoveTree):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::WebExtensionAPIBookmarks::remove):
(WebKit::WebExtensionAPIBookmarks::removeTree):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(findBookmarkAndParentArrayInMockTree):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureCreateBookmarkDelegate):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureRemoveBookmarksDelegate):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIRemoveAndRemoveTree)):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:removeBookmarkWithIdentifier:removeFolderWithChildren:forExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/298453@main">https://commits.webkit.org/298453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3deab6c0aa1e4c43d0a5489e5d3a5ee93e4d74a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87745 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96518 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96304 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41539 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19401 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47862 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41798 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->