### PR TITLE
Web Driver: add support for navigation events

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -951,6 +951,18 @@ void WebAutomationSession::didCreatePage(WebPageProxy& page)
 {
     m_bidiProcessor->browserAgent().didCreatePage(page);
 }
+
+void WebAutomationSession::navigationStartedForFrame(const WebFrameProxy& frame, const String& url, std::optional<WebCore::NavigationIdentifier> navigationID, double timestamp)
+{
+    String browsingContextHandle = handleForWebFrameProxy(frame);
+    String navigationIDString = nullString();
+    if (navigationID) {
+        uint64_t id = navigationID->toUInt64();
+        auto uuid = WTF::UUID(id, id);
+        navigationIDString = uuid.toString();
+    }
+    m_bidiProcessor->browsingContextDomainNotifier().navigationStarted(browsingContextHandle, navigationIDString, timestamp, url);
+}
 #endif
 
 void WebAutomationSession::willClosePage(const WebPageProxy& page)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/NavigationIdentifier.h>
 #include <WebCore/ShareableBitmap.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
@@ -165,6 +166,7 @@ public:
     void wheelEventsFlushedForPage(const WebPageProxy&);
 #if ENABLE(WEBDRIVER_BIDI)
     void didCreatePage(WebPageProxy&);
+    void navigationStartedForFrame(const WebFrameProxy&, const String& url, std::optional<WebCore::NavigationIdentifier>, double timestamp);
 #endif
     void willClosePage(const WebPageProxy&);
     void handleRunOpenPanel(const WebPageProxy&, const WebFrameProxy&, const API::OpenPanelParameters&, WebOpenPanelResultListenerProxy&);

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json
@@ -41,6 +41,18 @@
             "type": "string"
         },
         {
+            "id": "NavigationInfo",
+            "description": "Information about a navigation.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-NavigationInfo",
+            "type": "object",
+            "properties": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext" },
+                { "name": "navigation", "$ref": "BidiBrowsingContext.Navigation", "nullable": true },
+                { "name": "timestamp", "type": "number" },
+                { "name": "url", "type": "string" }
+            ]
+        },
+        {
             "id": "ReadinessState",
             "description": "Represents the stage of document loading at which a navigation command will return.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-browsingContext-ReadinessState",
@@ -153,6 +165,17 @@
         }
     ],
     "events": [
+        {
+            "name": "navigationStarted",
+            "description": "Event fired when navigation starts in a navigable.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationStarted",
+            "parameters": [
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext" },
+                { "name": "navigation", "$ref": "BidiBrowsingContext.Navigation", "nullable": true },
+                { "name": "timestamp", "type": "number", "description": "Time value in milliseconds representing the current date and time in UTC." },
+                { "name": "url", "type": "string" }
+            ]
+        },
         {
             "name": "userPromptClosed",
             "description": "Event fired when a user prompt is dismissed in a navigable.",

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6835,6 +6835,15 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
     frame->setUnreachableURL(unreachableURL);
     frame->didStartProvisionalLoad(WTFMove(url));
 
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_controlledByAutomation) {
+        if (RefPtr automationSession = process->processPool().automationSession()) {
+            automationSession->navigationStartedForFrame(*frame, url.string(),
+                navigationID, timestamp.secondsSinceEpoch().milliseconds());
+        }
+    }
+#endif
+
     pageLoadState->commitChanges();
     if (m_loaderClient)
         m_loaderClient->didStartProvisionalLoadForFrame(*this, *frame, navigation.get(), process->transformHandlesToObjects(userData.protectedObject().get()).get());


### PR DESCRIPTION
#### a9cb9e78eda3580235bbedcb8584a983046f7494
<pre>
WebDriver BiDi: support for navigation-related events in `browsingContext`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297278">https://bugs.webkit.org/show_bug.cgi?id=297278</a>
<a href="https://rdar.apple.com/137019783">rdar://137019783</a>

Reviewed by NOBODY (OOPS!).

Navigation events are now hooked into WebKit&apos;s existing page load lifecycle callbacks:
didCommitLoadForFrame() for committed navigation,
didFailProvisionalLoadForFrameShared() and didFailLoadForFrame() for failed events,
didCancelClientRedirectForFrame() for aborted navigation,
didSameDocumentNavigationForFrame() variants for fragment navigation.

The implementation extends the initial navigationStarted foundation. A new helper
convertNavigationIDToString() added.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::convertNavigationIDToString):
(WebKit::WebAutomationSession::navigationStartedForFrame):
(WebKit::WebAutomationSession::navigationCommittedForFrame):
(WebKit::WebAutomationSession::navigationFailedForFrame):
(WebKit::WebAutomationSession::navigationAbortedForFrame):
(WebKit::WebAutomationSession::fragmentNavigatedForFrame):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/protocol/BidiBrowsingContext.json:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCancelClientRedirectForFrame):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):
</pre>