### PR TITLE
[Liquid Glass] indiatimes.com: opening the hamburger menu before scrolling causes the top scroll pocket to disappear

### DIFF
--- a/LayoutTests/fast/page-color-sampling/blend-modal-background-color-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/blend-modal-background-color-expected.txt
@@ -1,0 +1,5 @@
+PASS colors.top is "rgb(102, 102, 102)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/blend-modal-background-color.html
+++ b/LayoutTests/fast/page-color-sampling/blend-modal-background-color.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=100 ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+            margin: 0;
+        }
+
+        div.dimming {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.6);
+        }
+
+        .tall {
+            width: 100%;
+            height: 2000px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(100, 0, 0, 0);
+        await UIHelper.ensurePresentationUpdate();
+        colors = await UIHelper.fixedContainerEdgeColors();
+
+        shouldBeEqualToString("colors.top", "rgb(102, 102, 102)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<div class="dimming"></div>
+<div class="tall"></div>
+<header></header>
+</body>
+</html>

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -899,6 +899,8 @@ DOMAudioSessionType Page::audioSessionType() const
 
 void Page::setUserDidInteractWithPage(bool didInteract)
 {
+    m_userHasInteractedSinceLastPageLoad = didInteract;
+
     if (m_topDocumentSyncData->userDidInteractWithPage == didInteract)
         return;
 
@@ -1844,6 +1846,7 @@ void Page::didCommitLoad()
 #endif
 
     m_hasEverSetVisibilityAdjustment = false;
+    m_userHasInteractedSinceLastPageLoad = false;
 
     m_mainFrameURLFragment = { };
 
@@ -5370,7 +5373,7 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
         auto maximumOffset = frameView->maximumScrollOffset();
 
         bool canSampleTopEdge = settings().topContentInsetBackgroundCanChangeAfterScrolling()
-            || !frameView->wasEverScrolledExplicitlyByUser()
+            || (!frameView->wasEverScrolledExplicitlyByUser() && !m_userHasInteractedSinceLastPageLoad)
             || document->parsing();
 
         if (scrollOffset.y() < minimumOffset.y() || !canSampleTopEdge)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1742,6 +1742,7 @@ private:
     Color m_underPageBackgroundColorOverride;
     std::optional<Color> m_sampledPageTopColor;
     std::pair<UniqueRef<FixedContainerEdges>, WeakElementEdges> m_fixedContainerEdgesAndElements;
+    bool m_userHasInteractedSinceLastPageLoad { false };
 
     const bool m_httpsUpgradeEnabled { true };
     mutable Markable<MediaSessionGroupIdentifier> m_mediaSessionGroupIdentifier;


### PR DESCRIPTION
#### d146201b066c48c4254e948676a683a02bfa3402
<pre>
[Liquid Glass] indiatimes.com: opening the hamburger menu before scrolling causes the top scroll pocket to disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=297020">https://bugs.webkit.org/show_bug.cgi?id=297020</a>
<a href="https://rdar.apple.com/157665752">rdar://157665752</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

When opening the hamburger menu on indiatimes.com without having scrolled the page, a dimming layer
appears over the page, which the heuristic in `LocalFrameView::fixedContainerEdges` correctly
identifies. We then attempt to take the sampled color (black at ~50% opacity) and use it as the
fixed color extension and solid color hard pocket background.

The problem with this is that `UIScrollView` internally rejects any rejects any explicitly-set
capture color that has an alpha &lt; 1, instead treating the color as `nil`. This in turn breaks luma
tracking in the scroll pocket, resulting in an unexpected solid white top pocket in dark mode. To
mitigate this, we ensure that even in the modal &quot;dimming layer&quot; case, we always return an opaque
fixed color by blending the dimming layer&apos;s background color against the page background color (so
in this case, `rgba(0, 0, 0, 0.5)` against the white page background yields solid medium-gray).

It&apos;s also somewhat unexpected that the top scroll pocket background color changes as a result of the
user opening a menu — while our current policy prevents the pocket from changing after the user has
scrolled the page, it should probably extend to after the user has started interacting with the page
by clicking or tapping.

We fix both of these issues in this patch.

* LayoutTests/fast/page-color-sampling/blend-modal-background-color-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/blend-modal-background-color.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

See above.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setUserDidInteractWithPage):
(WebCore::Page::didCommitLoad):
(WebCore::Page::updateFixedContainerEdges):

In addition to user-triggered scrolling, make it so that any other interaction with the page (i.e.
anything that triggers a user gesture token) will also prevent the sampled color from changing. This
prevents us from picking up the color change at all, in this case.

* Source/WebCore/page/Page.h:

Add a new flag to keep track of whether the user has interacted with the page, since the last load
committed.

Canonical link: <a href="https://commits.webkit.org/298351@main">https://commits.webkit.org/298351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4add3701b18af3de0d1cf1a6a3b71ffc1811b035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65838 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4eee91d-e6c3-498b-af38-f846d4e958a0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7329925-a847-4147-bc2b-67281d92f87f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67950 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21560 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64982 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124511 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42179 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96348 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24460 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38138 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47604 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41583 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->