### PR TITLE
[Safer CPP] Address issues in ExternalTexture

### DIFF
--- a/Source/WebGPU/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -1,2 +1,1 @@
 BindGroup.mm
-ExternalTexture.mm

--- a/Source/WebGPU/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,2 +1,1 @@
 BindGroup.mm
-ExternalTexture.mm

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -41,7 +41,7 @@ Ref<ExternalTexture> Device::createExternalTexture(const WGPUExternalTextureDesc
     if (!isValid())
         return ExternalTexture::createInvalid(*this);
 
-    return ExternalTexture::create(descriptor.pixelBuffer, descriptor.colorSpace, *this);
+    return ExternalTexture::create(RetainPtr { descriptor.pixelBuffer }.get(), descriptor.colorSpace, *this);
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ExternalTexture);
@@ -107,10 +107,10 @@ bool ExternalTexture::isDestroyed() const
 void ExternalTexture::update(CVPixelBufferRef pixelBuffer)
 {
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    if (IOSurfaceRef ioSurface = CVPixelBufferGetIOSurface(pixelBuffer)) {
+    if (RetainPtr ioSurface = CVPixelBufferGetIOSurface(pixelBuffer)) {
         if (auto optionalWebProcessID = protectedDevice()->webProcessID()) {
             if (auto webProcessID = optionalWebProcessID->sendRight())
-                IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
+                IOSurfaceSetOwnershipIdentity(ioSurface.get(), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
         }
     }
 #endif


### PR DESCRIPTION
#### c810a1676bdd207654ac0db38b19126d07d4ed59
<pre>
[Safer CPP] Address issues in ExternalTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=297022">https://bugs.webkit.org/show_bug.cgi?id=297022</a>
<a href="https://rdar.apple.com/157701524">rdar://157701524</a>

Reviewed by Mike Wyrzykowski.

Address SaferCPP issues in ExternalTexture.

* Source/WebGPU/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebGPU/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::Device::createExternalTexture):
(WebGPU::ExternalTexture::update):

Canonical link: <a href="https://commits.webkit.org/298362@main">https://commits.webkit.org/298362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c674bfe220623475aa3d43c6674d4c6ec0b4332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65754 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0fba210e-8b17-4580-bbce-b53417c8747d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87476 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b2901a1-ece7-47bf-b819-dfd87128cfed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67873 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27446 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64889 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124423 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19111 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38071 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47503 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->