### PR TITLE
WebKit doesn't resize SVG element in response to viewBox change (with height specified and width unspecified)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-001-expected.txt
@@ -13,5 +13,5 @@ PASS adding specified width, in presence of specified viewBox
 PASS modifiying specified viewBox, in presence of specified width
 PASS removing specified width, in presence of specified viewBox
 PASS adding specified height, in presence of specified viewBox
-FAIL modifiying specified viewBox, in presence of specified height assert_equals: checking width. expected 50 but got 80
+PASS modifiying specified viewBox, in presence of specified height
 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2019 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2015-2022 Google Inc. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
  *
@@ -38,6 +38,7 @@
 #include "NodeName.h"
 #include "RenderBoxInlines.h"
 #include "RenderObjectInlines.h"
+#include "RenderReplaced.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGViewportContainer.h"
 #include "RenderView.h"
@@ -269,6 +270,7 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
             if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(renderer())) {
                 ASSERT(svgRoot->viewportContainer());
                 svgRoot->checkedViewportContainer()->updateHasSVGTransformFlags();
+                svgRoot->setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
             } else if (CheckedPtr viewportContainer = dynamicDowncast<RenderSVGViewportContainer>(renderer()))
                 viewportContainer->updateHasSVGTransformFlags();
 
@@ -277,8 +279,11 @@ void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)
             return;
         }
 
-        if (CheckedPtr renderer = this->renderer())
+        if (CheckedPtr renderer = this->renderer()) {
             renderer->setNeedsTransformUpdate();
+            if (CheckedPtr svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(*renderer))
+                svgRoot->setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
+        }
 
         invalidateResourceImageBuffersIfNeeded();
         updateSVGRendererForElementChange();


### PR DESCRIPTION
#### 89c1b8e055c79c53c32f3ada9ef9471d08b75ca2
<pre>
WebKit doesn&apos;t resize SVG element in response to viewBox change (with height specified and width unspecified)
<a href="https://bugs.webkit.org/show_bug.cgi?id=198609">https://bugs.webkit.org/show_bug.cgi?id=198609</a>
<a href="https://rdar.apple.com/51486522">rdar://51486522</a>

Reviewed by Nikolas Zimmermann.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch ensures that we set &apos;setNeedsLayoutIfNeededAfterIntrinsicSizeChange&apos;
for viewBox via svgAttributeChanged in case of dynamically changing the viewBox
attribute of the &lt;svg&gt; root.

* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::svgAttributeChanged):
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-001-expected.txt: Progression for both LegacySVG and LBSE

Canonical link: <a href="https://commits.webkit.org/298321@main">https://commits.webkit.org/298321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87f3087f8f9ed498c9c45e21b731503482847e63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65767 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e204751-e1ae-451d-b036-0b48d94a9b42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87488 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9777c9c7-ccbe-40bf-a5c6-3527b0db77d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67885 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21487 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64906 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124438 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96073 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41279 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19123 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47520 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44832 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43243 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->