### PR TITLE
JSON modules should always be loaded as UTF-8

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any-expected.txt
@@ -1,5 +1,5 @@
 
 PASS UTF-8 BOM should be stripped when decoding JSON module script
-FAIL UTF-16BE BOM should result in parse error in JSON module script assert_unreached: Should have rejected: Expected parse error from UTF-16BE BOM Reached unreachable code
-FAIL UTF-16LE BOM should result in parse error in JSON module script assert_unreached: Should have rejected: Expected parse error from UTF-16LE BOM Reached unreachable code
+PASS UTF-16BE BOM should result in parse error in JSON module script
+PASS UTF-16LE BOM should result in parse error in JSON module script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.sharedworker-expected.txt
@@ -1,5 +1,5 @@
 
 PASS UTF-8 BOM should be stripped when decoding JSON module script
-FAIL UTF-16BE BOM should result in parse error in JSON module script assert_unreached: Should have rejected: Expected parse error from UTF-16BE BOM Reached unreachable code
-FAIL UTF-16LE BOM should result in parse error in JSON module script assert_unreached: Should have rejected: Expected parse error from UTF-16LE BOM Reached unreachable code
+PASS UTF-16BE BOM should result in parse error in JSON module script
+PASS UTF-16LE BOM should result in parse error in JSON module script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
 PASS UTF-8 BOM should be stripped when decoding JSON module script
-FAIL UTF-16BE BOM should result in parse error in JSON module script assert_unreached: Should have rejected: Expected parse error from UTF-16BE BOM Reached unreachable code
-FAIL UTF-16LE BOM should result in parse error in JSON module script assert_unreached: Should have rejected: Expected parse error from UTF-16LE BOM Reached unreachable code
+PASS UTF-16BE BOM should result in parse error in JSON module script
+PASS UTF-16LE BOM should result in parse error in JSON module script
 

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -90,6 +90,7 @@ public:
 
     TextPosition startPosition() const { return m_startPosition; }
     SourceProviderSourceType sourceType() const { return m_sourceType; }
+    bool isModuleType() const { return m_sourceType == SourceProviderSourceType::Module || m_sourceType == SourceProviderSourceType::JSON; }
 
     SourceID asID()
     {

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -48,7 +48,7 @@ public:
 
     JSC::CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind kind) override
     {
-        return m_cachedScript->codeBlockHashConcurrently(startOffset, endOffset, kind, sourceType() == JSC::SourceProviderSourceType::Module ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
+        return m_cachedScript->codeBlockHashConcurrently(startOffset, endOffset, kind, isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
     }
 
 private:
@@ -66,18 +66,14 @@ inline unsigned CachedScriptSourceProvider::hash() const
 {
     // Modules should always be decoded as UTF-8.
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
-    if (sourceType() == JSC::SourceProviderSourceType::Module)
-        return m_cachedScript->scriptHash(CachedScript::ShouldDecodeAsUTF8Only::Yes);
-    return m_cachedScript->scriptHash();
+    return m_cachedScript->scriptHash(isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
 }
 
 inline StringView CachedScriptSourceProvider::source() const
 {
     // Modules should always be decoded as UTF-8.
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
-    if (sourceType() == JSC::SourceProviderSourceType::Module)
-        return m_cachedScript->script(CachedScript::ShouldDecodeAsUTF8Only::Yes);
-    return m_cachedScript->script();
+    return m_cachedScript->script(isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -51,7 +51,7 @@ Ref<WorkerModuleScriptLoader> WorkerModuleScriptLoader::create(ModuleScriptLoade
 
 WorkerModuleScriptLoader::WorkerModuleScriptLoader(ModuleScriptLoaderClient& client, DeferredPromise& promise, WorkerScriptFetcher& scriptFetcher, RefPtr<JSC::ScriptFetchParameters>&& parameters)
     : ModuleScriptLoader(client, promise, scriptFetcher, WTFMove(parameters))
-    , m_scriptLoader(WorkerScriptLoader::create())
+    , m_scriptLoader(WorkerScriptLoader::create(WorkerScriptLoader::AlwaysUseUTF8::Yes))
 {
 }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -61,9 +61,10 @@ class WorkerScriptLoader final : public RefCounted<WorkerScriptLoader>, public T
     WTF_MAKE_TZONE_ALLOCATED(WorkerScriptLoader);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerScriptLoader);
 public:
-    static Ref<WorkerScriptLoader> create()
+    enum class AlwaysUseUTF8 : bool { No, Yes };
+    static Ref<WorkerScriptLoader> create(AlwaysUseUTF8 alwaysUseUTF8 = AlwaysUseUTF8::No)
     {
-        return adoptRef(*new WorkerScriptLoader);
+        return adoptRef(*new WorkerScriptLoader(alwaysUseUTF8));
     }
 
     enum class Source : uint8_t { ClassicWorkerScript, ClassicWorkerImport, ModuleScript };
@@ -131,7 +132,7 @@ private:
     friend class RefCounted<WorkerScriptLoader>;
     friend struct std::default_delete<WorkerScriptLoader>;
 
-    WorkerScriptLoader();
+    WorkerScriptLoader(AlwaysUseUTF8);
     ~WorkerScriptLoader();
 
     std::unique_ptr<ResourceRequest> createResourceRequest(const String& initiatorIdentifier);
@@ -151,6 +152,7 @@ private:
     String m_referrerPolicy;
     CrossOriginEmbedderPolicy m_crossOriginEmbedderPolicy;
     Markable<ResourceLoaderIdentifier> m_identifier;
+    bool m_alwaysUseUTF8 { false };
     bool m_failed { false };
     bool m_finishing { false };
     bool m_isRedirected { false };


### PR DESCRIPTION
#### b7c26c8005d0450876c72c0addbf6ea1e8ab7af2
<pre>
JSON modules should always be loaded as UTF-8
<a href="https://bugs.webkit.org/show_bug.cgi?id=297030">https://bugs.webkit.org/show_bug.cgi?id=297030</a>

Reviewed by Keith Miller.

Always load JSON modules as UTF-8 like other JS modules.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.worker-expected.txt:
* Source/JavaScriptCore/parser/SourceProvider.h:
(JSC::SourceProvider::isModuleType const):
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
(WebCore::CachedScriptSourceProvider::hash const):
(WebCore::CachedScriptSourceProvider::source const):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::WorkerModuleScriptLoader):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::WorkerScriptLoader):
(WebCore::WorkerScriptLoader::didReceiveData):
* Source/WebCore/workers/WorkerScriptLoader.h:

Canonical link: <a href="https://commits.webkit.org/298319@main">https://commits.webkit.org/298319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89a6fb5b3fd5a6be0c641daaad7de055fadd0964

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65765 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54a780c7-3ec6-461b-acb9-3a4d90c8fb45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87492 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c92eec47-0392-4db0-9270-d87c730ef612) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67889 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64903 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107412 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124436 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113680 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96284 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96070 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19124 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18418 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/41976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47517 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137885 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41509 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36840 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->