### PR TITLE
ANGLE: Simplify PoolAllocator further

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp
@@ -14,20 +14,20 @@
 namespace angle
 {
 
-class PoolAllocatorTest : public testing::TestWithParam<size_t>
+class PoolAllocatorTest : public testing::Test
 {
   protected:
-    static constexpr size_t kPoolAllocatorPageSize = 16 * 1024;
-    static size_t GetAlignment() { return GetParam(); }
+    static constexpr size_t kPoolAllocatorPageSize  = 32768;
+    static constexpr size_t kPoolAllocatorAlignment = sizeof(void *);
 };
 
 // Verify the public interface of PoolAllocator class
-TEST_P(PoolAllocatorTest, Interface)
+TEST_F(PoolAllocatorTest, Interface)
 {
     size_t numBytes               = 1024;
     constexpr uint32_t kTestValue = 0xbaadbeef;
     // Create a default pool allocator and allocate from it
-    PoolAllocator poolAllocator{GetAlignment()};
+    PoolAllocator poolAllocator;
     void *allocation = poolAllocator.allocate(numBytes);
     // Verify non-zero ptr returned
     EXPECT_NE(nullptr, allocation);
@@ -36,7 +36,7 @@ TEST_P(PoolAllocatorTest, Interface)
     *writePtr          = kTestValue;
     // Test other allocator creating a new allocation
     {
-        PoolAllocator poolAllocator2{GetAlignment()};
+        PoolAllocator poolAllocator2;
         allocation = poolAllocator2.allocate(numBytes);
         EXPECT_NE(nullptr, allocation);
         // Make an allocation that spans multiple pages
@@ -50,7 +50,7 @@ TEST_P(PoolAllocatorTest, Interface)
     {
         for (uint32_t i = 0; i < 1000; ++i)
         {
-            numBytes   = (rand() % kPoolAllocatorPageSize) + 1;
+            numBytes   = (rand() % kPoolAllocatorPageSize * 3) + 1;
             allocation = poolAllocator.allocate(numBytes);
             EXPECT_NE(nullptr, allocation);
             // Write data into full allocation. In debug case if we
@@ -62,18 +62,18 @@ TEST_P(PoolAllocatorTest, Interface)
 }
 
 // Tests that PoolAllocator returns pointers with expected alignment.
-TEST_P(PoolAllocatorTest, Alignment)
+TEST_F(PoolAllocatorTest, Alignment)
 {
-    PoolAllocator poolAllocator{GetAlignment()};
+    PoolAllocator poolAllocator;
     for (uint32_t j = 0; j < 10; ++j)
     {
         for (uint32_t i = 0; i < 100; ++i)
         {
-            // Vary the allocation size around 16k to hit some multi-page allocations.
-            const size_t numBytes = (rand() % kPoolAllocatorPageSize) + 1;
+            // Vary the allocation size to hit some large object allocations.
+            const size_t numBytes = (rand() % kPoolAllocatorPageSize * 3) + 1;
             void *allocation      = poolAllocator.allocate(numBytes);
             // Verify alignment of allocation matches expected default
-            EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(allocation) % GetAlignment())
+            EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(allocation) % kPoolAllocatorAlignment)
                 << "Iteration " << j << ", " << i << " allocating " << numBytes
                 << " got: " << allocation;
             memset(allocation, i, numBytes);
@@ -85,9 +85,9 @@ TEST_P(PoolAllocatorTest, Alignment)
 #if !defined(ANGLE_DISABLE_POOL_ALLOC)
 
 // Test that reset recycles memory.
-TEST_P(PoolAllocatorTest, ResetRecyclesMemory)
+TEST_F(PoolAllocatorTest, ResetRecyclesMemory)
 {
-    PoolAllocator poolAllocator{GetAlignment()};
+    PoolAllocator poolAllocator;
     void *allocation1 = poolAllocator.allocate(1);
     void *allocation2 = poolAllocator.allocate(2);
     memset(allocation1, 11, 1);
@@ -110,21 +110,16 @@ TEST_P(PoolAllocatorTest, ResetRecyclesMemory)
 
 #endif
 
-INSTANTIATE_TEST_SUITE_P(,
-                         PoolAllocatorTest,
-                         testing::Values(1, 2, 4, 8, 16, 32, 64, 128),
-                         testing::PrintToStringParamName());
-
-#if !defined(ANGLE_DISABLE_POOL_ALLOC) && defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
+#if defined(ANGLE_POOL_ALLOC_GUARD_BLOCKS)
 
 class PoolAllocatorGuardTest : public PoolAllocatorTest
 {};
 
 // Verify that alignment guard detects overflowing write.
-TEST_P(PoolAllocatorGuardTest, AlignmentGuardDetectsOverflowWrite)
+TEST_F(PoolAllocatorGuardTest, AlignmentGuardDetectsOverflowWrite)
 {
     auto testOverflowAlignment = []() {
-        PoolAllocator poolAllocator{GetAlignment()};
+        PoolAllocator poolAllocator;
         void *allocation = poolAllocator.allocate(15);
         memset(allocation, 11, 16);
     };
@@ -132,10 +127,10 @@ TEST_P(PoolAllocatorGuardTest, AlignmentGuardDetectsOverflowWrite)
 }
 
 // Verify that allocation guard detects overflowing write.
-TEST_P(PoolAllocatorGuardTest, AllocationGuardsDetectsOverflowWrite)
+TEST_F(PoolAllocatorGuardTest, AllocationGuardsDetectsOverflowWrite)
 {
     auto testOverflow = []() {
-        PoolAllocator poolAllocator{GetAlignment()};
+        PoolAllocator poolAllocator;
         void *allocation1 = poolAllocator.allocate(16);
         memset(allocation1, 11, 17);
     };
@@ -143,20 +138,15 @@ TEST_P(PoolAllocatorGuardTest, AllocationGuardsDetectsOverflowWrite)
 }
 
 // Verify that allocation guard detects underflowing write.
-TEST_P(PoolAllocatorGuardTest, AllocationGuardsDetectsUnderflowWrite)
+TEST_F(PoolAllocatorGuardTest, AllocationGuardsDetectsUnderflowWrite)
 {
     auto testUnderflow = []() {
-        PoolAllocator poolAllocator{GetAlignment()};
+        PoolAllocator poolAllocator;
         void *allocation1 = poolAllocator.allocate(16);
         memset(reinterpret_cast<uint8_t *>(allocation1) - 1, 11, 1);
     };
     ASSERT_DEATH(testUnderflow(), "");
 }
-
-INSTANTIATE_TEST_SUITE_P(,
-                         PoolAllocatorGuardTest,
-                         testing::Values(2, 4, 8, 16, 32, 64, 128),
-                         testing::PrintToStringParamName());
 
 #endif
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.h
@@ -38,7 +38,7 @@ class DedicatedCommandBlockAllocator
   private:
     // Using a pool allocator per CBH to avoid threading issues that occur w/ shared allocator
     // between multiple CBHs.
-    DedicatedCommandMemoryAllocator mAllocator{1};
+    DedicatedCommandMemoryAllocator mAllocator;
 };
 
 // Used in SecondaryCommandBuffer
@@ -56,8 +56,8 @@ class DedicatedCommandBlockPool final
     using CommandHeaderIDType                  = uint16_t;
     // Make sure the size of command header ID type is less than total command header size.
     static_assert(sizeof(CommandHeaderIDType) < kCommandHeaderSize, "Check size of CommandHeader");
-    // Pool Alloc uses 16kB pages w/ 16byte header = 16368bytes. To minimize waste
-    //  using a 16368/12 = 1364. Also better perf than 1024 due to fewer block allocations
+    // PoolAllocator uses 32768 byte pools. To minimize waste using a 32768/24 = 1365.
+    // Also better perf than 1024 due to fewer block allocations.
     static constexpr size_t kBlockSize = 1360;
     // Make sure block size is 8-byte aligned to avoid ASAN errors.
     static_assert((kBlockSize % 8) == 0, "Check kBlockSize alignment");


### PR DESCRIPTION
#### 51961a5a88419fefa2fb98de35fbd979e2c72bcc
<pre>
ANGLE: Simplify PoolAllocator further
<a href="https://bugs.webkit.org/show_bug.cgi?id=297041">https://bugs.webkit.org/show_bug.cgi?id=297041</a>
<a href="https://rdar.apple.com/157725945">rdar://157725945</a>

Reviewed by Dan Glastonbury.

- Remove distinct implementations of the member functions when
  ANGLE_DISABLE_POOL_ALLOC is defined
- Support guards with ANGLE_DISABLE_POOL_ALLOC.
- Hardcode alignment
- Store the segments in a std::vector instead linked list entries inside
  the pools
- Avoid having padding guard and after guard, just have padding guard
  if needed, otherwise after guard
- Increase pool size from 16k to 32k

* Source/ThirdParty/ANGLE/src/common/PoolAlloc.cpp:
(angle::PoolAllocator::Segment::Segment):
(angle::PoolAllocator::Segment::~Segment):
(angle::PoolAllocator::Segment::operator=):
(angle::PoolAllocator::Segment::Allocate):
(angle::PoolAllocator::Segment::data const):
(angle::PoolAllocator::~PoolAllocator):
(angle::PoolAllocator::addGuard):
(angle::PoolAllocator::reset):
(angle::PoolAllocator::allocateNewPoolSegment):
(angle::PoolAllocator::allocateSingleObject):
(angle::PoolAllocator::PoolAllocator): Deleted.
(angle::PoolAllocator::PageHeader::PageHeader): Deleted.
(angle::PoolAllocator::adjustAllocationExtent const): Deleted.
(angle::PoolAllocator::allocateNewPage): Deleted.
(angle::PoolAllocator::allocate): Deleted.
* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:
(angle::PoolAllocator::allocate):
(angle::PoolAllocator::adjustAllocationExtent const): Deleted.
(angle::PoolAllocator::addGuard): Deleted.
(angle::PoolAllocator::bump): Deleted.
* Source/ThirdParty/ANGLE/src/common/PoolAlloc_unittest.cpp:
(angle::TEST_F(PoolAllocatorTest, Interface)):
(angle::TEST_F(PoolAllocatorTest, Alignment)):
(angle::TEST_F(PoolAllocatorTest, ResetRecyclesMemory)):
(angle::TEST_F(PoolAllocatorGuardTest, AlignmentGuardDetectsOverflowWrite)):
(angle::TEST_F(PoolAllocatorGuardTest, AllocationGuardsDetectsOverflowWrite)):
(angle::TEST_F(PoolAllocatorGuardTest, AllocationGuardsDetectsUnderflowWrite)):
(angle::PoolAllocatorTest::GetAlignment): Deleted.
(angle::TEST_P): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/vulkan/AllocatorHelperPool.h:

Canonical link: <a href="https://commits.webkit.org/298409@main">https://commits.webkit.org/298409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79be5b67c1e518f7003623833e974ee025eb1579

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d01cae6c-586a-42a5-be99-5e065a21d023) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b49e8337-d7a1-49dd-8b70-305849082322) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68073 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65143 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124651 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96462 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38246 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42217 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41720 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45048 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43439 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->