### PR TITLE
Inline module script should not dispatch load event

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html
@@ -57,36 +57,42 @@
 
         <script type="module" nonce="noncynonce" id="allow1">
             import("./resources/import-scriptnonce-allowed1.js");
+            modules.delete('allow1');
         </script>
         <script type="module" nonce="noncynonce noncynonce" id="block1">
             import("./resources/import-scriptnonce-blocked1.js");
         </script>
         <script type="module" nonce="noncynonce" id="allow2">
             import("./resources/import-scriptnonce-allowed2.js");
+            modules.delete('allow2');
         </script>
         <script type="module" id="block2">
             import("./resources/import-scriptnonce-blocked2.js");
         </script>
         <script type="module" nonce="noncy+/=nonce" id="allow3">
             import("./resources/import-scriptnonce-allowed3.js");
+            modules.delete('allow3');
         </script>
         <script type="module" nonce="noncynonceno?" id="block3">
             import("./resources/import-scriptnonce-blocked3.js");
         </script>
         <script nonce="noncynonce" id="allow4">
             import("./resources/import-scriptnonce-allowed4.js");
+            modules.delete('allow4');
         </script>
         <script nonce="noncynonce noncynonce" id="block4">
             import("./resources/import-scriptnonce-blocked4.js");
         </script>
         <script nonce="noncynonce" id="allow5">
             import("./resources/import-scriptnonce-allowed5.js");
+            modules.delete('allow5');
         </script>
         <script id="block5">
             import("./resources/import-scriptnonce-blocked5.js");
         </script>
         <script nonce="noncy+/=nonce" id="allow6">
             import("./resources/import-scriptnonce-allowed6.js");
+            modules.delete('allow6');
         </script>
         <script nonce="noncynonceno?" id="block6">
             import("./resources/import-scriptnonce-blocked6.js");

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/import-scriptnonce-blocked1.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/import-scriptnonce-blocked1.js
@@ -1,1 +1,1 @@
-error(1);
+error('1a');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/load-error-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/load-error-events-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL inline, 200, parser-inserted assert_unreached: Load event should not be fired. Reached unreachable code
+PASS inline, 200, parser-inserted
 PASS inline, 404, parser-inserted
 PASS src, 200, parser-inserted
 PASS src, 404, parser-inserted
 PASS src, 200, not parser-inserted
 PASS src, 404, not parser-inserted
-FAIL inline, 200, not parser-inserted assert_unreached: Load event should not be fired. Reached unreachable code
+PASS inline, 200, not parser-inserted
 PASS inline, 404, not parser-inserted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/load-error-events-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/load-error-events-inline-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL src, 200, parser-inserted, defer, no async assert_unreached: Load event should not be fired. Reached unreachable code
-FAIL src, 200, parser-inserted, no defer, async assert_unreached: Load event should not be fired. Reached unreachable code
-FAIL src, 200, not parser-inserted, no defer, no async, no non-blocking assert_unreached: Load event should not be fired. Reached unreachable code
-FAIL src, 200, not parser-inserted, no defer, async assert_unreached: Load event should not be fired. Reached unreachable code
+PASS src, 200, parser-inserted, defer, no async
+PASS src, 200, parser-inserted, no defer, async
+PASS src, 200, not parser-inserted, no defer, no async, no non-blocking
+PASS src, 200, not parser-inserted, no defer, async
 PASS src, 404, parser-inserted, defer, no async
 PASS src, 404, parser-inserted, no defer, async
 PASS src, 404, not parser-inserted, no defer, no async, no non-blocking

--- a/LayoutTests/js/dom/modules/module-inline-ignore-integrity.html
+++ b/LayoutTests/js/dom/modules/module-inline-ignore-integrity.html
@@ -13,7 +13,7 @@ promise_test(() => {
         script.type = 'module';
         script.textContent = `window.inlineModuleIsExecuted = true`;
         script.integrity = 'sha256-deadbeef';
-        script.onload = function () {
+        window.onload = function () {
             assert_equals(window.inlineModuleIsExecuted, true);
             resolve();
         };

--- a/LayoutTests/js/dom/modules/module-load-event.html
+++ b/LayoutTests/js/dom/modules/module-load-event.html
@@ -9,14 +9,14 @@ description('Test module execution order between tags.');
 // Module will be executed asynchronously.
 window.jsTestIsAsync = true;
 debug('Module is not executed yet.');
-function onLoad()
+onload = function ()
 {
     shouldBeTrue(`moduleExecuted`);
     finishJSTest();
 }
 </script>
 <script src="../../../resources/js-test-post.js"></script>
-<script type="module" onload="onLoad()">
+<script type="module">
 debug('Executing an inlined module.');
 window.moduleExecuted = true;
 </script>

--- a/LayoutTests/js/dom/modules/module-load-same-module-from-different-entry-point-dynamic.html
+++ b/LayoutTests/js/dom/modules/module-load-same-module-from-different-entry-point-dynamic.html
@@ -26,7 +26,7 @@ shouldBe(`window.moduleExecutedCount`, `1`);
 var element = document.createElement("script");
 element.type = "module";
 element.innerText = `import "./resources/module-load-same-module-from-different-entry-point.js"`;
-element.onload = onLoad;
+window.onload = onLoad;
 document.body.appendChild(element);
 </script>
 </body>

--- a/LayoutTests/js/dom/modules/module-load-same-module-from-different-entry-point.html
+++ b/LayoutTests/js/dom/modules/module-load-same-module-from-different-entry-point.html
@@ -23,15 +23,17 @@ function onLoad() {
 }
 </script>
 <script src="../../../resources/js-test-post.js"></script>
-<script type="module" onload="onLoad()">
+<script type="module">
 import "./resources/module-load-same-module-from-different-entry-point.js"
 debug('Executing the module.');
 window.firstModuleIsExecuted = true;
+onLoad();
 </script>
-<script type="module" onload="onLoad()">
+<script type="module">
 import "./resources/module-load-same-module-from-different-entry-point.js"
 debug('Executing the module.');
 window.secondModuleIsExecuted = true;
+onLoad();
 </script>
 </body>
 </html>

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -49,6 +49,7 @@ public:
     bool hasError() const final;
     std::optional<Error> takeError() final;
     bool wasCanceled() const final;
+    bool isInlineModule() const final { return false; }
 
     Document* document() { return m_weakDocument.get(); }
     CachedScript& cachedScript() { return *m_cachedScript; }

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -35,14 +35,15 @@
 
 namespace WebCore {
 
-Ref<LoadableModuleScript> LoadableModuleScript::create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+Ref<LoadableModuleScript> LoadableModuleScript::create(IsInline isInline, const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
 {
-    return adoptRef(*new LoadableModuleScript(nonce, integrity, policy, fetchPriority, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree));
+    return adoptRef(*new LoadableModuleScript(isInline, nonce, integrity, policy, fetchPriority, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree));
 }
 
-LoadableModuleScript::LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
+LoadableModuleScript::LoadableModuleScript(IsInline isInline, const AtomString& nonce, const AtomString& integrity, ReferrerPolicy policy, RequestPriority fetchPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree)
     : LoadableScript(nonce, policy, fetchPriority, crossOriginMode, charset, initiatorType, isInUserAgentShadowTree)
     , m_parameters(ModuleFetchParameters::create(JSC::ScriptFetchParameters::Type::JavaScript, integrity, /* isTopLevelModule */ true))
+    , m_isInline(isInline == IsInline::Yes)
 {
 }
 

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -38,12 +38,14 @@ class LoadableModuleScript final : public LoadableScript {
 public:
     virtual ~LoadableModuleScript();
 
-    static Ref<LoadableModuleScript> create(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    enum class IsInline : bool { No, Yes };
+    static Ref<LoadableModuleScript> create(IsInline, const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     bool isLoaded() const final;
     bool hasError() const final;
     std::optional<Error> takeError() final;
     bool wasCanceled() const final;
+    bool isInlineModule() const final { return m_isInline; }
 
     ScriptType scriptType() const final { return ScriptType::Module; }
 
@@ -59,13 +61,14 @@ public:
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 
 private:
-    LoadableModuleScript(const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
+    LoadableModuleScript(IsInline, const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
     const Ref<ModuleFetchParameters> m_parameters;
     RefPtr<UniquedStringImpl> m_moduleKey;
     std::optional<LoadableScript::Error> m_error;
     bool m_wasCanceled { false };
     bool m_isLoaded { false };
+    bool m_isInline { false };
 };
 
 }

--- a/Source/WebCore/dom/LoadableScript.h
+++ b/Source/WebCore/dom/LoadableScript.h
@@ -52,6 +52,7 @@ public:
     virtual bool hasError() const = 0;
     virtual std::optional<Error> takeError() = 0;
     virtual bool wasCanceled() const = 0;
+    virtual bool isInlineModule() const = 0;
 
     virtual void execute(ScriptElement&) = 0;
 


### PR DESCRIPTION
#### 44ffe10b7658c2146fca15d20ceebb8a6b06a437
<pre>
Inline module script should not dispatch load event
<a href="https://bugs.webkit.org/show_bug.cgi?id=297044">https://bugs.webkit.org/show_bug.cgi?id=297044</a>

Reviewed by Anne van Kesteren.

Don&apos;t dispatch load event after executing an inline module script per spec.

* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/import-scriptnonce.html: Fixed the test for new behavior.
* LayoutTests/http/tests/security/contentSecurityPolicy/1.1/resources/import-scriptnonce-blocked1.js: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/load-error-events-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/load-error-events-inline-expected.txt: Ditto.
* LayoutTests/js/dom/modules/module-inline-ignore-integrity.html: Fixed the test for new behavior.
* LayoutTests/js/dom/modules/module-load-event.html: Ditto.
* LayoutTests/js/dom/modules/module-load-same-module-from-different-entry-point-dynamic.html: Ditto.
* LayoutTests/js/dom/modules/module-load-same-module-from-different-entry-point.html: Ditto.
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::create):
(WebCore::LoadableModuleScript::LoadableModuleScript):
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/LoadableScript.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestModuleScript):
(WebCore::ScriptElement::executeScriptAndDispatchEvent):

Canonical link: <a href="https://commits.webkit.org/298334@main">https://commits.webkit.org/298334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87d69598bd013474944e2e4f884c861511566ccf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65804 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa3bab15-7b65-4aca-8d56-fb67cb6100c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87518 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96f48f16-6ec9-4448-9992-edb09962e5a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67915 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21526 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64951 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107456 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124479 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113729 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96105 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41315 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19161 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38110 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18426 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47566 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/137933 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41550 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36849 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->