### PR TITLE
[WPE] WPE Platform: Add API test for WPEDisplay screen handling

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp
@@ -27,6 +27,7 @@
 
 #include "WPEDisplayMock.h"
 #include "WPEMockPlatformTest.h"
+#include "WPEScreenMock.h"
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
@@ -137,6 +138,58 @@ static void testDisplayExplicitSync(WPEMockPlatformTest* test, gconstpointer)
     g_assert_true(wpe_display_use_explicit_sync(test->display()));
 }
 
+static void testDisplayScreens(WPEMockPlatformTest* test, gconstpointer)
+{
+    // Mock display has one screen by default.
+    g_assert_cmpuint(wpe_display_get_n_screens(test->display()), ==, 1);
+    auto* mainScreen = wpe_display_get_screen(test->display(), 0);
+    g_assert_true(WPE_IS_SCREEN(mainScreen));
+    test->assertObjectIsDeletedWhenTestFinishes(mainScreen);
+    g_assert_cmpuint(wpe_screen_get_id(mainScreen), ==, 1);
+    g_assert_cmpint(wpe_screen_get_x(mainScreen), ==, 0);
+    g_assert_cmpint(wpe_screen_get_y(mainScreen), ==, 0);
+    g_assert_cmpint(wpe_screen_get_width(mainScreen), ==, 800);
+    g_assert_cmpint(wpe_screen_get_height(mainScreen), ==, 600);
+    g_assert_cmpfloat(wpe_screen_get_scale(mainScreen), ==, 1.);
+    g_assert_cmpint(wpe_screen_get_refresh_rate(mainScreen), ==, 60000);
+
+    g_assert_null(wpe_display_get_screen(test->display(), 1));
+
+    gboolean screenAdded = FALSE;
+    auto screenAddedID = g_signal_connect(test->display(), "screen-added", G_CALLBACK(+[](WPEDisplay*, WPEScreen* screen, gboolean* screenAdded) {
+        *screenAdded = TRUE;
+        g_assert_cmpuint(wpe_screen_get_id(screen), ==, 2);
+    }), &screenAdded);
+    wpeDisplayMockAddSecondaryScreen(WPE_DISPLAY_MOCK(test->display()));
+    g_assert_true(screenAdded);
+    g_assert_cmpuint(wpe_display_get_n_screens(test->display()), ==, 2);
+    auto* secondaryScreen = wpe_display_get_screen(test->display(), 1);
+    g_assert_true(WPE_IS_SCREEN(secondaryScreen));
+    test->assertObjectIsDeletedWhenTestFinishes(secondaryScreen);
+    g_assert_cmpuint(wpe_screen_get_id(secondaryScreen), ==, 2);
+    g_assert_cmpint(wpe_screen_get_x(secondaryScreen), ==, 0);
+    g_assert_cmpint(wpe_screen_get_y(secondaryScreen), ==, 0);
+    g_assert_cmpint(wpe_screen_get_width(secondaryScreen), ==, 1024);
+    g_assert_cmpint(wpe_screen_get_height(secondaryScreen), ==, 768);
+    g_assert_cmpfloat(wpe_screen_get_scale(secondaryScreen), ==, 2.);
+    g_assert_cmpint(wpe_screen_get_refresh_rate(secondaryScreen), ==, 120000);
+
+    g_assert_null(wpe_display_get_screen(test->display(), 2));
+
+    gboolean screenRemoved = FALSE;
+    auto screenRemovedID = g_signal_connect(test->display(), "screen-removed", G_CALLBACK(+[](WPEDisplay*, WPEScreen* screen, gboolean* screenRemoved) {
+        *screenRemoved = TRUE;
+        g_assert_cmpuint(wpe_screen_get_id(screen), ==, 2);
+        g_assert_true(wpeScreenMockIsInvalid(WPE_SCREEN_MOCK(screen)));
+    }), &screenRemoved);
+    wpeDisplayMockRemoveSecondaryScreen(WPE_DISPLAY_MOCK(test->display()));
+    g_assert_true(screenRemoved);
+    g_assert_cmpuint(wpe_display_get_n_screens(test->display()), ==, 1);
+
+    g_signal_handler_disconnect(test->display(), screenAddedID);
+    g_signal_handler_disconnect(test->display(), screenRemovedID);
+}
+
 class WPEMockAvailableInputDevicesTest : public WPEMockPlatformTest {
 public:
     WPE_PLATFORM_TEST_FIXTURE(WPEMockAvailableInputDevicesTest);
@@ -222,6 +275,7 @@ void beforeAll()
     WPEMockPlatformTest::add("Display", "drm-nodes", testDisplayDRMNodes);
     WPEMockPlatformTest::add("Display", "dmabuf-formats", testDisplayDMABufFormats);
     WPEMockPlatformTest::add("Display", "explicit-sync", testDisplayExplicitSync);
+    WPEMockPlatformTest::add("Display", "screens", testDisplayScreens);
     WPEMockAvailableInputDevicesTest::add("Display", "available-input-devices", testDisplayAvailableInputDevices);
 }
 

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(WPEPlatformMock_SOURCES
     ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
     ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEViewMock.cpp
+    ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEScreenMock.cpp
 )
 
 set(WPEPlatformMock_PRIVATE_INCLUDE_DIRECTORIES

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEScreenMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEScreenMock.cpp
@@ -23,26 +23,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WPEScreenMock.h"
 
-#include <gio/gio.h>
-#include <glib-object.h>
-#include <wpe/wpe-platform.h>
+struct _WPEScreenMock {
+    WPEScreen parent;
 
-G_BEGIN_DECLS
+    gboolean isInvalid;
+};
+G_DEFINE_FINAL_TYPE(WPEScreenMock, wpe_screen_mock, WPE_TYPE_SCREEN)
 
-#define WPE_TYPE_DISPLAY_MOCK (wpe_display_mock_get_type())
-G_DECLARE_FINAL_TYPE(WPEDisplayMock, wpe_display_mock, WPE, DISPLAY_MOCK, WPEDisplay)
+static void wpeScreenMockInvalidate(WPEScreen* screen)
+{
+    auto* screenMock = WPE_SCREEN_MOCK(screen);
+    screenMock->isInvalid = TRUE;
 
-void wpeDisplayMockRegister(GIOModule*);
-WPEDisplay* wpeDisplayMockNew();
-void wpeDisplayMockUseFakeDRMNodes(WPEDisplayMock*, gboolean);
-void wpeDisplayMockUseFakeDMABufFormats(WPEDisplayMock*, gboolean);
-void wpeDisplayMockSetUseExplicitSync(WPEDisplayMock*, gboolean);
-void wpeDisplayMockSetInitialInputDevices(WPEDisplayMock*, WPEAvailableInputDevices);
-void wpeDisplayMockAddInputDevice(WPEDisplayMock*, WPEAvailableInputDevices);
-void wpeDisplayMockRemoveInputDevice(WPEDisplayMock*, WPEAvailableInputDevices);
-void wpeDisplayMockAddSecondaryScreen(WPEDisplayMock*);
-void wpeDisplayMockRemoveSecondaryScreen(WPEDisplayMock*);
+    WPE_SCREEN_CLASS(wpe_screen_mock_parent_class)->invalidate(screen);
+}
 
-G_END_DECLS
+static void wpe_screen_mock_class_init(WPEScreenMockClass* screenMockClass)
+{
+    WPEScreenClass* screenClass = WPE_SCREEN_CLASS(screenMockClass);
+    screenClass->invalidate = wpeScreenMockInvalidate;
+}
+
+static void wpe_screen_mock_init(WPEScreenMock*)
+{
+}
+
+gboolean wpeScreenMockIsInvalid(WPEScreenMock* screenMock)
+{
+    return screenMock->isInvalid;
+}

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEScreenMock.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEScreenMock.h
@@ -25,24 +25,14 @@
 
 #pragma once
 
-#include <gio/gio.h>
 #include <glib-object.h>
 #include <wpe/wpe-platform.h>
 
 G_BEGIN_DECLS
 
-#define WPE_TYPE_DISPLAY_MOCK (wpe_display_mock_get_type())
-G_DECLARE_FINAL_TYPE(WPEDisplayMock, wpe_display_mock, WPE, DISPLAY_MOCK, WPEDisplay)
+#define WPE_TYPE_SCREEN_MOCK (wpe_screen_mock_get_type())
+G_DECLARE_FINAL_TYPE(WPEScreenMock, wpe_screen_mock, WPE, SCREEN_MOCK, WPEScreen)
 
-void wpeDisplayMockRegister(GIOModule*);
-WPEDisplay* wpeDisplayMockNew();
-void wpeDisplayMockUseFakeDRMNodes(WPEDisplayMock*, gboolean);
-void wpeDisplayMockUseFakeDMABufFormats(WPEDisplayMock*, gboolean);
-void wpeDisplayMockSetUseExplicitSync(WPEDisplayMock*, gboolean);
-void wpeDisplayMockSetInitialInputDevices(WPEDisplayMock*, WPEAvailableInputDevices);
-void wpeDisplayMockAddInputDevice(WPEDisplayMock*, WPEAvailableInputDevices);
-void wpeDisplayMockRemoveInputDevice(WPEDisplayMock*, WPEAvailableInputDevices);
-void wpeDisplayMockAddSecondaryScreen(WPEDisplayMock*);
-void wpeDisplayMockRemoveSecondaryScreen(WPEDisplayMock*);
+gboolean wpeScreenMockIsInvalid(WPEScreenMock*);
 
 G_END_DECLS


### PR DESCRIPTION
#### 8c50841bd980c40c40c893df936fae3a9e777c4f
<pre>
[WPE] WPE Platform: Add API test for WPEDisplay screen handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=297047">https://bugs.webkit.org/show_bug.cgi?id=297047</a>

Reviewed by Alejandro G. Castro.

Canonical link: <a href="https://commits.webkit.org/298328@main">https://commits.webkit.org/298328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae97fb15b37073def48a96afab2c3449489545b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87519 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67916 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124480 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96106 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41316 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38111 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18423 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->