### PR TITLE
[GTK][WPE][OpenXR] Expose a way to query the immersive session status

### DIFF
--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -240,6 +240,9 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void startXRSession(WebKit::WebPageProxy&, const PlatformXR::Device::FeatureList&, std::optional<WebCore::XRCanvasConfiguration>&&, CompletionHandler<void(RetainPtr<id>, PlatformViewController *)>&& completionHandler) { completionHandler(nil, nil); }
     virtual void endXRSession(WebKit::WebPageProxy&, WebKit::PlatformXRSessionEndReason) { }
+#elif USE(OPENXR)
+    virtual void didStartXRSession(WebKit::WebPageProxy&) { }
+    virtual void didEndXRSession(WebKit::WebPageProxy&) { }
 #endif
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -374,6 +374,18 @@ private:
         webkit_permission_state_query_unref(query);
     }
 
+#if ENABLE(WEBXR) && USE(OPENXR)
+    void didStartXRSession(WebPageProxy&) final
+    {
+        webkitWebViewSetIsImmersiveModeEnabled(m_webView, true);
+    }
+
+    void didEndXRSession(WebPageProxy&) final
+    {
+        webkitWebViewSetIsImmersiveModeEnabled(m_webView, false);
+    }
+#endif
+
     WebKitWebView* m_webView;
 #if ENABLE(POINTER_LOCK)
     GWeakPtr<WebKitPointerLockPermissionRequest> m_pointerLockPermissionRequest { nullptr };

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -920,8 +920,11 @@ webkit_web_view_get_theme_color                      (WebKitWebView             
                                                       GdkRGBA                   *rgba);
 #endif
 
+WEBKIT_API gboolean
+webkit_web_view_is_immersive_mode_enabled            (WebKitWebView             *web_view);
+
 WEBKIT_API void
-webkit_web_view_end_immersive_session                (WebKitWebView             *web_view);
+webkit_web_view_leave_immersive_mode                 (WebKitWebView             *web_view);
 
 #if USE(GI_FINISH_FUNC_ANNOTATION)
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -132,3 +132,7 @@ guint createContextMenuSignal(WebKitWebViewClass*);
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 WebKit::RendererBufferDescription webkitWebViewGetRendererBufferDescription(WebKitWebView*);
 #endif
+
+#if ENABLE(WEBXR) && USE(OPENXR)
+void webkitWebViewSetIsImmersiveModeEnabled(WebKitWebView*, bool);
+#endif

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -27,6 +27,7 @@
 #include "OpenXRLayer.h"
 #include "OpenXRUtils.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #if USE(LIBEPOXY)
 #define __GBM__ 1
 #include <epoxy/egl.h>
@@ -208,6 +209,7 @@ void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoord
                 .renderState = renderState,
                 .renderThread = Thread::create("OpenXR render thread"_s, [this, renderState] { renderLoop(renderState); }),
             };
+            page.uiClient().didStartXRSession(page);
         },
         [&](Active&) {
             RELEASE_LOG_ERROR(XR, "OpenXRCoordinator: an existing immersive session is active");
@@ -252,6 +254,8 @@ void OpenXRCoordinator::endSessionIfExists(std::optional<WebCore::PageIdentifier
             }
 
             m_state = Idle { };
+            if (RefPtr page = WebProcessProxy::webPage(active.pageIdentifier))
+                page->uiClient().didEndXRSession(*page);
         });
 }
 

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -238,8 +238,10 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
     }
 
     if (keyval == WPE_KEY_Escape) {
-        webkit_web_view_end_immersive_session(webView);
-        return FALSE;
+        if (webkit_web_view_is_immersive_mode_enabled(webView)) {
+            webkit_web_view_leave_immersive_mode(webView);
+            return TRUE;
+        }
     }
 
     return FALSE;


### PR DESCRIPTION
#### d4e9102d6bb9aeac9df1844b949306945884d9ec
<pre>
[GTK][WPE][OpenXR] Expose a way to query the immersive session status
<a href="https://bugs.webkit.org/show_bug.cgi?id=297048">https://bugs.webkit.org/show_bug.cgi?id=297048</a>

Reviewed by Carlos Garcia Campos and Adrian Perez de Castro.

A new property &quot;is-immersive-mode-enabled&quot; is added to WebKitWebView,
allowing clients to query its value and to subscribe to its notify
signal.

The property is synchronised with the OpenXR coordinator&apos;s entering and
exiting the session, where the WebPageProxy&apos;s UI client is used to
report back to the WebView.

This renames webkit_web_view_end_immersive_session into
webkit_web_view_leave_immersive_mode for better consistency.

* Source/WebKit/UIProcess/API/APIUIClient.h: two new methods to report
  entering and exiting the XR session.
(API::UIClient::didStartXRSession):
(API::UIClient::didEndXRSession):
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp: implementing the
  UI client methods in terms of updating the immersive mode enabled
property.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp: add the new
  property, rename method leaving the mode.
(webkitWebViewGetProperty):
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in: rename method
  leaving the mode.
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h: adding method
  setting the immersive mode enabled property.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp: report when we
  enter and leave the XR session.
(WebKit::OpenXRCoordinator::startSession):
(WebKit::OpenXRCoordinator::endSessionIfExists):
* Tools/MiniBrowser/wpe/main.cpp: query whether we&apos;re in immersive mode
  before attempting to leave.

Canonical link: <a href="https://commits.webkit.org/298568@main">https://commits.webkit.org/298568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22b31dc6a3341898a24079a52134c7ea89877e5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88062 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22138 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65646 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125128 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96816 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24572 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42703 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48292 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->