### PR TITLE
[WebGPU] Fix the webGpuSwift build

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -85,7 +85,7 @@ WK_NO_STATIC_INITIALIZERS_Production_NO_ = $(WK_ERROR_WHEN_LINKING_WITH_STATIC_I
 // Work around rdar://139232237 by hiding all exported symbols from the "Cxx" module.
 UNEXPORT_SWIFT_CXX_LDFLAGS = -Wl,-unexported_symbol,_$s*3Cxx* -Wl,-unexported_symbol,_$s*defaultArg*;
 
-OTHER_LDFLAGS = $(inherited) $(UNEXPORT_SWIFT_CXX_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS);
+OTHER_LDFLAGS = $(inherited) $(UNEXPORT_SWIFT_CXX_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS) -Wl,-unexported_symbol,*s_heapSpec;
 
 SWIFT_OBJC_INTERFACE_HEADER_NAME = WebGPUSwift-Generated.h;
 SWIFT_VERSION = 6.0;

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -835,7 +835,9 @@ extension WebGPU.CommandEncoder {
         let mtlDescriptor = MTLRenderPassDescriptor()
         var counterSampleBuffer: MTLCounterSampleBuffer? = nil
         if let wgpuTimestampWrites = unsafe descriptor.timestampWrites {
-            counterSampleBuffer = unsafe WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBuffer()
+            let wgpuQuerySet = unsafe wgpuTimestampWrites.pointee.querySet
+            let querySet = unsafe WebGPU.fromAPI(wgpuQuerySet)
+            counterSampleBuffer = unsafe querySet.counterSampleBufferWithOffset().pointee.first
         }
 
         if (m_device.ptr().enableEncoderTimestamps() || counterSampleBuffer != nil) {
@@ -2065,7 +2067,7 @@ extension WebGPU.CommandEncoder {
         computePassDescriptor.dispatchType = MTLDispatchType.serial
         var counterSampleBuffer: MTLCounterSampleBuffer? = nil
         if let wgpuTimestampWrites = unsafe descriptor.timestampWrites {
-            counterSampleBuffer = unsafe WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBuffer()
+            counterSampleBuffer = unsafe WebGPU.fromAPI(wgpuTimestampWrites.pointee.querySet).counterSampleBufferWithOffset().pointee.first
         }
 
         if m_device.ptr().enableEncoderTimestamps() || counterSampleBuffer != nil {

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -80,13 +80,13 @@ public:
     uint32_t count() const { return m_count; }
     WGPUQueryType type() const { return m_type; }
     id<MTLBuffer> visibilityBuffer() const { return m_visibilityBuffer; }
-    const CounterSampleBuffer& counterSampleBufferWithOffset() const;
+    const CounterSampleBuffer& counterSampleBufferWithOffset() const SWIFT_RETURNS_INDEPENDENT_VALUE;
     [[noreturn]] id<MTLCounterSampleBuffer> counterSampleBuffer() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     void setCommandEncoder(CommandEncoder&) const;
     bool isDestroyed() const;
     static void destroyQuerySet(const QuerySet&);
-    static std::pair<id<MTLCounterSampleBuffer>, uint32_t> counterSampleBufferWithOffset(size_t, const Device&);
+    static CounterSampleBuffer counterSampleBufferWithOffsetForDevice(size_t, const Device&);
     static void createContainersIfNeeded();
 
 private:

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -56,7 +56,7 @@ Ref<QuerySet> Device::createQuerySet(const WGPUQuerySetDescriptor& descriptor)
     switch (type) {
     case WGPUQueryType_Timestamp: {
 #if !PLATFORM(WATCHOS)
-        std::pair<id<MTLCounterSampleBuffer>, uint32_t> querySetWithOffset = QuerySet::counterSampleBufferWithOffset(count, *this);
+        std::pair<id<MTLCounterSampleBuffer>, uint32_t> querySetWithOffset = QuerySet::counterSampleBufferWithOffsetForDevice(count, *this);
         if (!querySetWithOffset.first)
             return QuerySet::createInvalid(*this);
 
@@ -174,7 +174,7 @@ void QuerySet::destroyQuerySet(const QuerySet& querySet)
     }
 }
 
-QuerySet::CounterSampleBuffer QuerySet::counterSampleBufferWithOffset(size_t sampleCount, const Device& device)
+QuerySet::CounterSampleBuffer QuerySet::counterSampleBufferWithOffsetForDevice(size_t sampleCount, const Device& device)
 {
     Locker locker { querySetLock };
     uint32_t sampleCountInBytes = static_cast<uint32_t>(sampleCount * sizeof(uint64_t));


### PR DESCRIPTION
#### 6207d8e92a613b5434a6edcc79b79d7fd01fdee3
<pre>
[WebGPU] Fix the webGpuSwift build
<a href="https://bugs.webkit.org/show_bug.cgi?id=297049">https://bugs.webkit.org/show_bug.cgi?id=297049</a>
<a href="https://rdar.apple.com/157741213">rdar://157741213</a>

Reviewed by Mike Wyrzykowski.

There were 2 issues:
- A recent change to QuerySet::counterSampleBuffer made it [[noreturn]], so the
  Swift code needed to be updated to use the new function.
- Some symbols that should not be exported (s_heapSpec from CommandBuffer, RenderPassEncoder
  and ComputePassEncoder) were causing build errors, so they needed to be unexported

* Source/WebGPU/Configurations/WebGPU.xcconfig:
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
(WebGPU.beginComputePass(_:)):
* Source/WebGPU/WebGPU/QuerySet.h:
* Source/WebGPU/WebGPU/QuerySet.mm:
(WebGPU::Device::createQuerySet):
(WebGPU::QuerySet::counterSampleBufferWithOffsetForDevice):
(WebGPU::QuerySet::counterSampleBufferWithOffset): Deleted.

Canonical link: <a href="https://commits.webkit.org/298391@main">https://commits.webkit.org/298391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb4c48ef3605b9dd6930f0e55247703c2b11a51d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65811 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d77abcaa-d0ab-40ca-a92b-b042a01a35c2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87525 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57aa8b4e-0e43-4992-b2fd-a4c9f65c1b88) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67922 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27511 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/64957 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124485 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96325 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96112 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41321 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38116 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47572 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41556 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->