### PR TITLE
cookieStore.set() should not append / to path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieListItem_attributes.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieListItem_attributes.https.window-expected.txt
@@ -5,7 +5,7 @@ PASS CookieListItem - cookieStore.set with expires set to a timestamp 10 years i
 PASS CookieListItem - cookieStore.set with expires set to a Date 10 years in the future
 PASS CookieListItem - cookieStore.set with domain set to the current hostname
 PASS CookieListItem - cookieStore.set with path set to the current directory
-FAIL CookieListItem - cookieStore.set does not add / to path if it does not end with / assert_equals: expected "/cookiestore" but got "/cookiestore/"
+PASS CookieListItem - cookieStore.set does not add / to path if it does not end with /
 PASS CookieListItem - cookieStore.set with sameSite set to strict
 PASS CookieListItem - cookieStore.set with sameSite set to lax
 PASS CookieListItem - cookieStore.set with sameSite set to none

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any-expected.txt
@@ -8,8 +8,8 @@ PASS cookieStore.delete with domain set to a subdomain of the current hostname
 PASS cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
 PASS cookieStore.delete with path set to the current directory
 PASS cookieStore.delete with path set to subdirectory of the current directory
-FAIL cookieStore.delete does not append / at the end of path assert_equals: expected null but got object "[object Object]"
-FAIL cookieStore.delete can delete a cookie set by document.cookie if document is defined assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete does not append / at the end of path
+PASS cookieStore.delete can delete a cookie set by document.cookie if document is defined
 PASS cookieStore.delete with path that does not start with /
 PASS cookieStore.delete with get result
 FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
@@ -8,7 +8,7 @@ PASS cookieStore.delete with domain set to a subdomain of the current hostname
 PASS cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
 PASS cookieStore.delete with path set to the current directory
 PASS cookieStore.delete with path set to subdirectory of the current directory
-FAIL cookieStore.delete does not append / at the end of path assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete does not append / at the end of path
 PASS cookieStore.delete can delete a cookie set by document.cookie if document is defined
 PASS cookieStore.delete with path that does not start with /
 PASS cookieStore.delete with get result

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any-expected.txt
@@ -44,8 +44,8 @@ PASS cookieStore.set default domain is null and differs from current hostname
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /
-FAIL cookieStore.set does not add / to path that does not end with / assert_equals: expected null but got object "[object Object]"
-FAIL cookieStore.set can modify a cookie set by document.cookie if document is defined assert_equals: expected 1 but got 2
+PASS cookieStore.set does not add / to path that does not end with /
+PASS cookieStore.set can modify a cookie set by document.cookie if document is defined
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -44,7 +44,7 @@ PASS cookieStore.set default domain is null and differs from current hostname
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /
-FAIL cookieStore.set does not add / to path that does not end with / assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.set does not add / to path that does not end with /
 PASS cookieStore.set can modify a cookie set by document.cookie if document is defined
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -478,9 +478,6 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
             return;
         }
 
-        if (!cookie.path.endsWith('/'))
-            cookie.path = makeString(cookie.path, '/');
-
         // FIXME: <rdar://85515842> Obtain the encoded length without allocating and encoding.
         if (cookie.path.utf8().length() > maximumAttributeValueSize) {
             promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the path must not be greater than "_s, maximumAttributeValueSize, " bytes"_s) });


### PR DESCRIPTION
#### b33916a333693b549034319b057fa5e9b7b66b76
<pre>
cookieStore.set() should not append / to path
<a href="https://bugs.webkit.org/show_bug.cgi?id=297053">https://bugs.webkit.org/show_bug.cgi?id=297053</a>
<a href="https://rdar.apple.com/142339417">rdar://142339417</a>

Reviewed by Rupin Mittal.

The specification was updated with
<a href="https://github.com/whatwg/cookiestore/commit/abae748ecf1f94069772b80955dbf73d752221aa">https://github.com/whatwg/cookiestore/commit/abae748ecf1f94069772b80955dbf73d752221aa</a>
and Chromium was as well. So should we.

Canonical link: <a href="https://commits.webkit.org/298397@main">https://commits.webkit.org/298397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b785f2398bb4374bbd8bed16aae56b6c273ceb70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65978 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67d0a0cc-324b-49f4-84d2-c259025f4fbf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96e15a8d-8069-416e-90fb-4e430589aa15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68075 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21712 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65146 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96463 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24484 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47775 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45051 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->