### PR TITLE
Re-enable the remaining JSON module tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -870,8 +870,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/cs
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset-bom.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/referrer-policies.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/relative-urls.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-2.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-no-referrer.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-origin-when-cross-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/referrer-origin.sub.html [ Skip ]
@@ -6393,7 +6391,6 @@ webkit.org/b/233267 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 # Flaky because of network ordering
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/charset.html [ Pass Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/cors-crossorigin-requests.html [ Pass Failure ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html [ Pass Failure ]
 
 # modulepreload is not supported
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
@@ -6532,7 +6529,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-pic
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/show-picker-cross-origin-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/proxy-modifier-click-to-associated-element.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/028.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-4.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-refresh-immediate.window.html [ Skip ]
 imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-while-navigating.window.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-2-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration.
-CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration.
 
-Harness Error (TIMEOUT), message = null
-
+PASS JSON module should be loaded as utf-8 even if it is encoded in windows-1250 and served with a windows-1250 charset response header, and this document's encoding is windows-1250
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt
@@ -1,3 +1,6 @@
+Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/data.json?pipe=header(Access-Control-Allow-Origin,*)
+Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/data.json
+Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/parse-error.json?pipe=header(Access-Control-Allow-Origin,*)
 json-module-crossorigin
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html
@@ -7,26 +7,33 @@
 </head>
 <body>
     <h1>json-module-crossorigin</h1>
-    <iframe id="import-WithCORS" src="crossorigin-import-with-cors.sub.html"></iframe>
-    <iframe id="import-NoCORS" src="crossorigin-import-without-cors.sub.html"></iframe>
-    <iframe id="import-parseerror-WithCors" src="crossorigin-import-parse-error-with-cors.sub.html"></iframe>
     <script>
 
         var tests = [
-                { "obj": async_test("Imported JSON module, cross-origin with CORS"), "id": "import-WithCORS", "expected": "imported JSON: 42" },
-                { "obj": async_test("Imported JSON module, cross-origin, missing CORS ACAO header"), "id": "import-NoCORS", "expected": "error" },
-                { "obj": async_test("Imported JSON module with parse error, cross-origin, with CORS"), "id": "import-parseerror-WithCors", "expected": "SyntaxError" },
+                { "obj": async_test("Imported JSON module, cross-origin with CORS"), "id": "import-WithCORS", "expected": "imported JSON: 42", "url": "crossorigin-import-with-cors.sub.html" },
+                { "obj": async_test("Imported JSON module, cross-origin, missing CORS ACAO header"), "id": "import-NoCORS", "expected": "error", "url": "crossorigin-import-without-cors.sub.html" },
+                { "obj": async_test("Imported JSON module with parse error, cross-origin, with CORS"), "id": "import-parseerror-WithCors", "expected": "SyntaxError", "url": "crossorigin-import-parse-error-with-cors.sub.html" },
             ];
 
-        window.addEventListener("load", function () {
-            tests.forEach(function (test) {
-                var target = document.getElementById(test.id);
+        async function loadTest(test) {
+            return new Promise((resolve) => {
+                const iframe = document.createElement('iframe');
+                iframe.id = test.id;
+                iframe.src = test.url;
+                iframe.onload = () => resolve(iframe);
+                document.body.appendChild(iframe);
+            });
+        }
+
+        (async function () {
+            for (const test of tests) {
+                const target = await loadTest(test);
                 test.obj.step(function () {
                     assert_equals(target.contentDocument._log, test.expected, "Unexpected _log value");
                 });
                 test.obj.done();
-            });
-        });
+            }
+        })();
 
     </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/parse-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/parse-error-expected.txt
@@ -1,6 +1,4 @@
-CONSOLE MESSAGE: TypeError: 'application/json' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: SyntaxError: JSON Parse error: Expected '}'
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT JSON modules: parse error Test timed out
+PASS JSON modules: parse error
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt
@@ -1,7 +1,7 @@
-CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration.
-CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration.
-CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration.
-CONSOLE MESSAGE: SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration.
+Blocked access to external URL http://www1.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/referrer-checker.py?name=remoteNoReferrerPolicy
+Blocked access to external URL http://www1.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/referrer-checker.py?name=remoteReferrerPolicyOrigin
+Blocked access to external URL http://www1.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/referrer-checker.py?name=remoteReferrerPolicyNoReferrer
+Blocked access to external URL http://www1.localhost:8800/html/semantics/scripting-1/the-script-element/json-module/referrer-checker.py?name=remoteNoReferrerPolicyUnsafeUrl
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt
@@ -1,0 +1,10 @@
+CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
+CONSOLE MESSAGE: SyntaxError: JSON Parse error: Expected '}'
+json-module-crossorigin
+
+
+
+PASS Imported JSON module, cross-origin with CORS
+PASS Imported JSON module, cross-origin, missing CORS ACAO header
+FAIL Imported JSON module with parse error, cross-origin, with CORS assert_equals: Unexpected _log value expected "SyntaxError" but got "0-0"
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Importing a same-origin top-level script with the default referrer policy.
+PASS Importing a remote-origin top-level script with the default referrer policy.
+PASS Importing a same-origin top-level script with the origin policy.
+PASS Importing a remote-origin top-level script with the origin policy.
+PASS Importing a same-origin top-level script with the no-referrer policy.
+PASS Importing a remote-origin top-level script with the no-referrer policy.
+PASS Importing a same-origin top-level script with the unsafe-url referrer policy.
+PASS Importing a remote-origin top-level script with the unsafe-url referrer policy.
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt
@@ -1,0 +1,10 @@
+CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
+CONSOLE MESSAGE: SyntaxError: JSON Parse error: Expected '}'
+json-module-crossorigin
+
+
+
+PASS Imported JSON module, cross-origin with CORS
+PASS Imported JSON module, cross-origin, missing CORS ACAO header
+FAIL Imported JSON module with parse error, cross-origin, with CORS assert_equals: Unexpected _log value expected "SyntaxError" but got "0-0"
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Importing a same-origin top-level script with the default referrer policy.
+PASS Importing a remote-origin top-level script with the default referrer policy.
+PASS Importing a same-origin top-level script with the origin policy.
+PASS Importing a remote-origin top-level script with the origin policy.
+PASS Importing a same-origin top-level script with the no-referrer policy.
+PASS Importing a remote-origin top-level script with the no-referrer policy.
+PASS Importing a same-origin top-level script with the unsafe-url referrer policy.
+PASS Importing a remote-origin top-level script with the unsafe-url referrer policy.
+


### PR DESCRIPTION
#### 64d9f346744e38d5893b65a53b1e444fe7ee251e
<pre>
Re-enable the remaining JSON module tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=297054">https://bugs.webkit.org/show_bug.cgi?id=297054</a>

Reviewed by Anne van Kesteren.

Re-enable and rebaseline the remaining web platform tests for JSON module.
Also merge <a href="https://github.com/web-platform-tests/wpt/pull/54195.">https://github.com/web-platform-tests/wpt/pull/54195.</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/charset-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/parse-error-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/cors-crossorigin-requests-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/referrer-policies.sub-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/298382@main">https://commits.webkit.org/298382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4ecdff1d1203955164e04bf3c6c909e5c547a12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121437 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65929 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/21800ec5-6f74-4652-a0c3-b602b6d493c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87632 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc11936c-1d8e-4d8c-b9e3-936bf41add55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68027 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21666 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65098 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96417 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96204 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38218 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18449 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42169 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41674 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->