### PR TITLE
Web Inspector: Elements: Media details sidebar does not scroll

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js
@@ -120,10 +120,10 @@ WI.MediaDetailsSidebarPanel = class MediaDetailsSidebarPanel extends WI.DOMDetai
     {
         super.initialLayout();
 
-        this.element.appendChild(this.#ui.generalSection.element);
-        this.element.appendChild(this.#ui.videoSection.element);
-        this.element.appendChild(this.#ui.audioSection.element);
-        this.element.appendChild(this.#ui.spatialSection.element);
+        this.contentView.element.appendChild(this.#ui.generalSection.element);
+        this.contentView.element.appendChild(this.#ui.videoSection.element);
+        this.contentView.element.appendChild(this.#ui.audioSection.element);
+        this.contentView.element.appendChild(this.#ui.spatialSection.element);
     }
 
     // Private


### PR DESCRIPTION
#### 37ab62ab3bc2d23cd3429725647c51bc91ab1733
<pre>
Web Inspector: Elements: Media details sidebar does not scroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=297064">https://bugs.webkit.org/show_bug.cgi?id=297064</a>
<a href="https://rdar.apple.com/157768497">rdar://157768497</a>

Reviewed by Devin Rousso.

The sections of the Media details sidebar were attached to the sidebar panel
instead of its content view, like all other sidebars.

* Source/WebInspectorUI/UserInterface/Views/MediaDetailsSidebarPanel.js:
(WI.MediaDetailsSidebarPanel.prototype.initialLayout):

Canonical link: <a href="https://commits.webkit.org/298396@main">https://commits.webkit.org/298396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af864994aafb6f1a7f4dacbf1b5fe5f8f1a44866

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25458 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121364 "Hash af864994 for PR 49068 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65870 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1322d52d-ff49-47be-986e-3bba0fa8e656) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43529 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/121364 "Hash af864994 for PR 49068 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f602faf6-6f2b-40da-afd7-ecda033cfb4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103466 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/121364 "Hash af864994 for PR 49068 does not build (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21588 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65018 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97795 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124543 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96369 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96154 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24459 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38165 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18459 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47641 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43343 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->