### PR TITLE
Test changes to RichJavascriptAPI

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -550,13 +550,13 @@ ApplePayEnabled:
   condition: ENABLE(APPLE_PAY)
   defaultValue:
     WebKitLegacy:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
+      "ENABLE(APPLE_PAY_REMOTE_UI)": false
       default: false
     WebKit:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
+      "ENABLE(APPLE_PAY_REMOTE_UI)": false
       default: false
     WebCore:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
+      "ENABLE(APPLE_PAY_REMOTE_UI)": false
       default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -765,6 +765,7 @@ BackgroundFetchAPIEnabled:
     WebKit:
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 BackgroundWebContentRunningBoardThrottlingEnabled:
   type: bool
@@ -963,10 +964,11 @@ BroadcastChannelEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 BuiltInNotificationsEnabled:
   type: bool
@@ -1614,10 +1616,11 @@ CacheAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
       default: false
   disableInLockdownMode: true
+  richJavaScript: true
 
 CanvasColorSpaceEnabled:
   type: bool
@@ -1906,6 +1909,7 @@ ContactPickerAPIEnabled:
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 ContentChangeObserverEnabled:
   type: bool
@@ -1977,6 +1981,7 @@ CookieConsentAPIEnabled:
     WebKit:
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 CookieEnabled:
@@ -2002,10 +2007,11 @@ CookieStoreAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: defaultCookieStoreAPIEnabled()
+      default: false
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 CookieStoreAPIExtendedAttributesEnabled:
   type: bool
@@ -2035,6 +2041,7 @@ CookieStoreManagerEnabled:
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 CoreMathMLEnabled:
   type: bool
@@ -2402,11 +2409,11 @@ DeviceOrientationEventEnabled:
   condition: ENABLE(DEVICE_ORIENTATION)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -2423,6 +2430,7 @@ DeviceOrientationPermissionAPIEnabled:
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 DeviceWidth:
   type: uint32_t
@@ -2472,7 +2480,7 @@ DigitalCredentialsEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: WebKit::defaultDigitalCredentialsEnabled()
+      default: false
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
@@ -2875,10 +2883,10 @@ FileSystemEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA)" : true
+      "PLATFORM(COCOA)" : false
       default: false
     WebCore:
-      "PLATFORM(COCOA)" : true
+      "PLATFORM(COCOA)" : false
       default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
@@ -3141,7 +3149,7 @@ GamepadsEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
       default: false
   disableInLockdownMode: true
@@ -3170,11 +3178,11 @@ GeolocationAPIEnabled:
   humanReadableDescription: "Enable Geolocation API"
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -3622,13 +3630,14 @@ IndexedDBAPIEnabled:
   humanReadableDescription: "IndexedDB API"
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 InlineMediaPlaybackRequiresPlaysInlineAttribute:
   type: bool
@@ -4599,9 +4608,10 @@ ManagedMediaSourceEnabled:
     WebKit:
       default: WebKit::defaultManagedMediaSourceEnabled()
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
+  richJavaScript: true
 
 ManagedMediaSourceHighThreshold:
   type: double
@@ -4907,13 +4917,14 @@ MediaRecorderEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA)": true
-      "USE(GSTREAMER)": true
+      "PLATFORM(COCOA)": false
+      "USE(GSTREAMER)": false
       default: false
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
+  richJavaScript: true
 
 MediaRecorderEnabledWebM:
   type: bool
@@ -4956,13 +4967,14 @@ MediaSessionCoordinatorEnabled:
   condition: ENABLE(MEDIA_SESSION_COORDINATOR)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
       default: WebKit::defaultMediaSessionCoordinatorEnabled()
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
+  richJavaScript: true
 
 MediaSessionEnabled:
   type: bool
@@ -5429,12 +5441,13 @@ NotificationEventEnabled:
   condition: ENABLE(NOTIFICATION_EVENT)
   defaultValue:
     WebCore:
-      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
+      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": false
       default: false
     WebKit:
-      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
+      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": false
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 NotificationsEnabled:
   type: bool
@@ -5446,13 +5459,13 @@ NotificationsEnabled:
   defaultValue:
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": false
-      default: true
+      default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": false
-      default: true
+      default: false
     WebCore:
       "PLATFORM(IOS_FAMILY)": false
-      default: true
+      default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -5727,13 +5740,13 @@ PeerConnectionEnabled:
   condition: ENABLE(WEB_RTC)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      "USE(LIBWEBRTC)": WebKit::defaultPeerConnectionEnabledAvailable()
-      "USE(GSTREAMER_WEBRTC)": true
+      "USE(LIBWEBRTC)": false
+      "USE(GSTREAMER_WEBRTC)": false
       default: false
     WebCore:
-      default: true
+      default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -5778,11 +5791,12 @@ PermissionsAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)" : true
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)" : false
       default: false
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 PhotoPickerPrefersOriginalImageFormat:
   type: bool
@@ -6062,6 +6076,7 @@ PushAPIEnabled:
       default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 ReadableByteStreamAPIEnabled:
   type: bool
@@ -6458,7 +6473,7 @@ ScreenOrientationAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: WebKit::defaultShouldEnableScreenOrientationAPI()
+      default: false
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
@@ -6784,13 +6799,14 @@ ServiceWorkerNavigationPreloadEnabled:
   humanReadableDescription: "Enable Service Worker Navigation Preload API"
   defaultValue:
     WebCore:
-      default: true
+      default: false
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
   disableInLockdownMode: true
+  richJavaScript: true
 
 ServiceWorkersEnabled:
   type: bool
@@ -6803,11 +6819,12 @@ ServiceWorkersEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
   disableInLockdownMode: true
+  richJavaScript: true
 
 ServiceWorkersUserGestureEnabled:
   type: bool
@@ -6897,8 +6914,9 @@ SharedWorkerEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 ShouldAllowUserInstalledFonts:
   type: bool
@@ -7330,7 +7348,7 @@ SpeechRecognitionEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "HAVE(SPEECHRECOGNIZER) && ENABLE(MEDIA_STREAM)": true
+      "HAVE(SPEECHRECOGNIZER) && ENABLE(MEDIA_STREAM)": false
       default: false
     WebCore:
       default: false
@@ -7345,11 +7363,11 @@ SpeechSynthesisAPIEnabled:
   humanReadableDescription: "SpeechSynthesis API"
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -8669,9 +8687,9 @@ WebAudioEnabled:
   condition: ENABLE(WEB_AUDIO)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
@@ -8704,10 +8722,11 @@ WebAuthenticationEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 WebCodecsAV1Enabled:
   type: bool
@@ -8772,12 +8791,12 @@ WebCodecsVideoEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "USE(LIBWEBRTC) && PLATFORM(COCOA)": WebKit::defaultPeerConnectionEnabledAvailable()
-      "USE(GSTREAMER)": true
+      "USE(LIBWEBRTC) && PLATFORM(COCOA)": false
+      "USE(GSTREAMER)": false
       default: false
     WebCore:
-      "PLATFORM(COCOA)": true
-      "USE(GSTREAMER)": true
+      "PLATFORM(COCOA)": false
+      "USE(GSTREAMER)": false
       default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
@@ -8863,9 +8882,9 @@ WebGLEnabled:
   humanReadableDescription: "Enable WebGL"
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
       default: false
   disableInLockdownMode: true
@@ -8894,13 +8913,13 @@ WebGPUEnabled:
   humanReadableDescription: "Enable WebGPU"
   defaultValue:
     WebKitLegacy:
-      "ENABLE(WEBGPU_BY_DEFAULT)": true
+      "ENABLE(WEBGPU_BY_DEFAULT)": false
       default: false
     WebKit:
-      "ENABLE(WEBGPU_BY_DEFAULT)": true
+      "ENABLE(WEBGPU_BY_DEFAULT)": false
       default: false
     WebCore:
-      "ENABLE(WEBGPU_BY_DEFAULT)": true
+      "ENABLE(WEBGPU_BY_DEFAULT)": false
       default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
@@ -8949,9 +8968,9 @@ WebLocksAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -9260,7 +9279,7 @@ WebShareEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)": true
+      "PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)": false
       default: false
     WebCore:
       default: false
@@ -9289,15 +9308,15 @@ WebSocketEnabled:
   defaultValue:
     WebKitLegacy:
       "PLATFORM(WATCHOS)": false
-      default: true
+      default: false
     WebKit:
       "PLATFORM(WATCHOS)": false
-      default: true
+      default: false
     WebCore:
       "PLATFORM(WATCHOS)": false
-      default: true
+      default: false
   sharedPreferenceForWebProcess: true
-
+  richJavaScript: true
 
 WebTransportEnabled:
   type: bool
@@ -9314,6 +9333,7 @@ WebTransportEnabled:
       default: false
   sharedPreferenceForWebProcess: true
   disableInLockdownMode: true
+  richJavaScript: true
 
 WebXRAugmentedRealityModuleEnabled:
   type: bool
@@ -9340,13 +9360,14 @@ WebXREnabled:
   condition: ENABLE(WEBXR)
   defaultValue:
     WebKitLegacy:
-      default: true
+      default: false
     WebKit:
-      default: true
+      default: false
     WebCore:
-      default: true
+      default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
+  richJavaScript: true
 
 WebXRGamepadsModuleEnabled:
   type: bool

--- a/Source/WebKit/UIProcess/API/APIFeature.h
+++ b/Source/WebKit/UIProcess/API/APIFeature.h
@@ -39,14 +39,6 @@ public:
     template <FeatureStatus Status, bool DefaultValue>
     static Ref<Feature> create(const WTF::String& name, const WTF::String& key, FeatureConstant<Status> status, FeatureCategory category, const WTF::String& details, std::bool_constant<DefaultValue> defaultValue, bool hidden)
     {
-#if ENABLE(FEATURE_DEFAULT_VALIDATION)
-        constexpr auto impliedDefaultValue = API::defaultValueForFeatureStatus(Status);
-        if constexpr (impliedDefaultValue && *impliedDefaultValue)
-            static_assert(defaultValue, "Feature's status implies it should be on by default");
-        else if constexpr (impliedDefaultValue && !*impliedDefaultValue)
-            static_assert(!defaultValue, "Feature's status implies it should be off by default");
-#endif
-
         return uncheckedCreate(name, key, status, category, details, defaultValue, hidden);
     }
 


### PR DESCRIPTION
#### c815e5160324706c0a1b49e60e78f93817436fb9
<pre>
Test changes to RichJavascriptAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=297068">https://bugs.webkit.org/show_bug.cgi?id=297068</a>

Reviewed by NOBODY (OOPS!).

Run an EWS pass with features selected to be included in the RichJavascript SPI set to false, we should hopefully see failures but no crashes

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/APIFeature.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c815e5160324706c0a1b49e60e78f93817436fb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/34989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65889 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3f410b1-07c1-4b39-99ef-9ed6ce164bd4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43559 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87588 "Failure limit exceed. At least found 426 new test failures: crypto/subtle/rsa-indexeddb-non-exportable-private.html crypto/subtle/rsa-indexeddb-non-exportable.html crypto/subtle/rsa-indexeddb-private.html crypto/subtle/rsa-indexeddb.html crypto/workers/subtle/aes-indexeddb.html fast/dom/Geolocation/argument-types.html fast/dom/Geolocation/cached-position-iframe.html fast/dom/Geolocation/callback-exception.html fast/dom/Geolocation/callback-to-deleted-context.html fast/dom/Geolocation/callback-to-remote-context.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42326 "Found 60 new test failures: fast/animation/css-animation-resuming-when-visible-with-style-change2.html fast/canvas/webgl/largeBuffer.html fast/canvas/webgl/lose-context-on-timeout-async.html fast/canvas/webgl/lose-context-on-timeout.html fast/canvas/webgl/match-page-color-space-p3.html fast/canvas/webgl/match-page-color-space.html fast/canvas/webgl/multisample-resolve-consistency.html fast/canvas/webgl/no-info-log-for-simple-shaders.html fast/canvas/webgl/null-object-behaviour.html fast/canvas/webgl/null-uniform-location.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9cf47d2b-c221-4a14-a7c2-04dd3315ba8a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118241 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28421 "Found 60 new test failures: crypto/subtle/rsa-indexeddb.html crypto/workers/subtle/aes-indexeddb.html fast/canvas/canvas-drawImage-detached-leak.html fast/device-orientation/device-motion-request-permission-denied.html fast/device-orientation/device-motion-request-permission-granted.html fast/dom/Geolocation/argument-types.html fast/media/createImageBitmap-from-video-crash.html fast/mediastream/RTCIceCandidate.html fast/mediastream/RTCPeerConnection-add-removeTrack.html fast/mediastream/RTCPeerConnection-addIceCandidate.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103491 "Found 285 new API test failures: TestWebKitAPI.WKWebsiteDataStore.MigrateCacheStorageDataToGeneralStorageDirectory, TestWebKitAPI.IndexedDB.DeleteRecovery, TestWebKitAPI.WebAuthenticationPanel.MakeCredentialPinAuthBlockedError, TestWebKitAPI.ServiceWorkers.InterceptFirstLoadAfterRestoreFromDisk, TestWebKitAPI.WKWebsiteDataStore.RemoveDataStoreWithIdentifier, TestWebKitAPI.ServiceWorker.openWindowWithoutDelegate, TestWebKitAPI.WKWebExtensionAPIExtension.GetBackgroundPageForServiceWorker, TestWebKitAPI.WebAuthenticationPanel.CloseHidCancel, TestWebKitAPI.ServiceWorker.ServiceWorkerReadableStreamDownloadCancel, TestWebKitAPI.WKWebsiteDataStoreConfiguration.TotalQuotaRatioWithResourceLoadStatisticsEnabled ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/67984 "Found 19 new API test failures: /WPE/TestGeolocationManager:/webkit/WebKitGeolocationManager/current-position, /TestWebKit:WebKit.GeolocationTransitionToLowAccuracy, /WPE/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/databases, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-disallowed, /WPE/TestWebKitWebView:/webkit/WebKitWebView/enable-html5-database ... (failure)") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27583 "Found 60 new test failures: imported/w3c/web-platform-tests/IndexedDB/abort-in-initial-upgradeneeded.html imported/w3c/web-platform-tests/IndexedDB/back-forward-cache-open-connection.window.html imported/w3c/web-platform-tests/IndexedDB/back-forward-cache-open-transaction.window.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.worker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-values-bypass.any.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-values-bypass.any.serviceworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-values-bypass.any.sharedworker.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21614 "Found 60 new test failures: compositing/backface-visibility/backface-visibility-webgl.html compositing/clipping/border-radius-on-webgl.html compositing/visibility/visibility-simple-webgl-layer.html compositing/webgl/update-composited-canvas-layer.html compositing/webgl/webgl-background-color.html compositing/webgl/webgl-no-alpha.html compositing/webgl/webgl-reflection.html compositing/webgl/webgl-repaint.html crypto/subtle/rsa-indexeddb-non-exportable-private.html crypto/subtle/rsa-indexeddb-non-exportable.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65048 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107537 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98325 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Running apply-patch; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21728 "Found 60 new test failures: crypto/subtle/rsa-indexeddb-non-exportable-private.html crypto/subtle/rsa-indexeddb-non-exportable.html crypto/subtle/rsa-indexeddb-private.html crypto/subtle/rsa-indexeddb.html fast/dom/Geolocation/argument-types.html fast/dom/Geolocation/cached-position-iframe.html fast/dom/Geolocation/callback-exception.html fast/dom/Geolocation/callback-to-deleted-context.html fast/dom/Geolocation/callback-to-remote-context.html fast/dom/Geolocation/callback-to-remote-context2.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124562 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113835 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42239 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31617 "Found 60 new test failures: crypto/subtle/rsa-indexeddb-non-exportable-private.html crypto/subtle/rsa-indexeddb-non-exportable.html crypto/subtle/rsa-indexeddb-private.html crypto/subtle/rsa-indexeddb.html crypto/workers/subtle/aes-indexeddb.html fast/dom/Geolocation/argument-types.html fast/dom/Geolocation/cached-position-iframe.html fast/dom/Geolocation/callback-exception.html fast/dom/Geolocation/callback-to-deleted-context.html fast/dom/Geolocation/callback-to-remote-context.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96381 "Failure limit exceed. At least found 427 new test failures: crypto/subtle/rsa-indexeddb-non-exportable-private.html crypto/subtle/rsa-indexeddb-non-exportable.html crypto/subtle/rsa-indexeddb-private.html crypto/subtle/rsa-indexeddb.html crypto/workers/subtle/aes-indexeddb.html fast/dom/Geolocation/argument-types.html fast/dom/Geolocation/cached-position-iframe.html fast/dom/Geolocation/callback-exception.html fast/dom/Geolocation/callback-to-deleted-context.html fast/dom/Geolocation/callback-to-remote-context.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99681 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96186 "Found 19 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/geolocation-permission-requests, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/current-position, /TestWebKit:WebKit.GeolocationTransitionToLowAccuracy, /WebKitGTK/TestWebKitNetworkSession:/webkit/WebKitNetworkSession/proxy, /WebKitGTK/TestWebKitSettings:/webkit/WebKitSettings/config-file, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/query-permission-requests, /WebKitGTK/TestGeolocationManager:/webkit/WebKitGeolocationManager/watch-position, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/enable-html5-database, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/configuration ... (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41394 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19240 "Found 60 new test failures: accessibility/password-notifications-timing.html compositing/backing/overflow-gains-content.html compositing/geometry/composited-frame-contents.html crypto/subtle/rsa-indexeddb-non-exportable-private.html crypto/subtle/rsa-indexeddb-non-exportable.html crypto/subtle/rsa-indexeddb-private.html css3/color-filters/color-filter-text-stroke.html css3/viewport-percentage-lengths/vh-resize.html fast/dom/Geolocation/argument-types.html fast/dom/Geolocation/cached-position-iframe.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42118 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47671 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/138888 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41635 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/138888 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->