### PR TITLE
Implement resizable SABs for Wasm memories

### DIFF
--- a/JSTests/wasm/js-api/memory-toFixedLengthBuffer.js
+++ b/JSTests/wasm/js-api/memory-toFixedLengthBuffer.js
@@ -1,0 +1,95 @@
+//@ requireOptions("--useWasmMemoryToBufferAPIs=true")
+
+import { eq as assertEq, throws as assertThrows } from "../assert.js";
+const KB = 1024;
+const pageSize = 64*KB;
+
+function assertTrue(expr) {
+    assertEq(expr, true);
+}
+
+function assertFalse(expr) {
+    assertEq(expr, false);
+}
+
+function assertIsolatedFixedLengthBufferOfPageSize(pageCount, buffer) {
+    assertTrue(buffer instanceof ArrayBuffer);
+    assertFalse(buffer.resizable);
+    assertEq(buffer.byteLength, pageCount * pageSize);
+    assertEq(buffer.maxByteLength, pageCount * pageSize);
+}
+
+function assertDetachedBuffer(buffer) {
+    assertTrue(buffer instanceof ArrayBuffer);
+    assertTrue(buffer.detached);
+    assertEq(buffer.byteLength, 0);
+    assertEq(buffer.maxByteLength, 0);
+}
+
+function assertSharedFixedLengthBufferOfPageSize(pageCount, buffer) {
+    assertTrue(buffer instanceof SharedArrayBuffer);
+    assertEq(buffer.byteLength, pageCount * pageSize);
+    assertEq(buffer.maxByteLength, pageCount * pageSize);
+}
+
+{
+    let memory = new WebAssembly.Memory({initial: 1, maximum: 5});
+    let buffer = memory.toFixedLengthBuffer();
+    assertEq(buffer, memory.buffer);
+    assertIsolatedFixedLengthBufferOfPageSize(1, buffer);
+
+    // Growing the memory should detach this buffer
+    memory.grow(1);
+    assertDetachedBuffer(buffer);
+
+    // The buffer returned now should reflect the grown memory
+    let buffer2 = memory.toFixedLengthBuffer();
+    assertEq(buffer2, memory.buffer);
+    assertIsolatedFixedLengthBufferOfPageSize(2, buffer2);
+
+    // If we first get .buffer, .toFixedLengthBuffer() we get later is the same
+    memory.grow(1);
+    assertDetachedBuffer(buffer2);
+    let buffer3 = memory.buffer;
+    assertEq(memory.toFixedLengthBuffer(), buffer3);
+    assertIsolatedFixedLengthBufferOfPageSize(3, buffer3);
+
+    // If we get a resizable buffer, the old fixed one is detached
+    let buffer4 = memory.toResizableBuffer();
+    assertEq(buffer4, memory.buffer);
+    assertDetachedBuffer(buffer3);
+}
+
+// Now the same but with a shared memory
+
+{
+    let memory = new WebAssembly.Memory({initial: 1, maximum: 5, shared: true});
+    let buffer = memory.toFixedLengthBuffer();
+    assertEq(buffer, memory.buffer);
+    assertSharedFixedLengthBufferOfPageSize(1, buffer);
+
+    // Growing the memory does not detach the old buffer but it's no longer the memory's buffer and should reflect the old length
+    memory.grow(1);
+    assertTrue(memory.buffer !== buffer);
+    assertSharedFixedLengthBufferOfPageSize(1, buffer);
+
+    // The buffer returned now should reflect the grown memory
+    let buffer2 = memory.toFixedLengthBuffer();
+    assertEq(buffer2, memory.buffer);
+    assertSharedFixedLengthBufferOfPageSize(2, buffer2);
+
+    // If we first get .buffer, .toFixedLengthBuffer() we get later is the same buffer
+    memory.grow(1);
+    let buffer3 = memory.buffer;
+    assertEq(memory.toFixedLengthBuffer(), buffer3);
+    assertSharedFixedLengthBufferOfPageSize(3, buffer3);
+    assertSharedFixedLengthBufferOfPageSize(2, buffer2);
+
+    // If we get a resizable buffer, the old fixed one should stop tracking memory size
+    let buffer4 = memory.toResizableBuffer();
+    assertEq(buffer4, memory.buffer);
+    assertTrue(buffer3 !== memory.buffer);
+    memory.grow(1);
+    assertEq(buffer4, memory.buffer);
+    assertSharedFixedLengthBufferOfPageSize(3, buffer3);
+}

--- a/JSTests/wasm/js-api/memory-toResizableBuffer.js
+++ b/JSTests/wasm/js-api/memory-toResizableBuffer.js
@@ -1,0 +1,115 @@
+//@ requireOptions("--useWasmMemoryToBufferAPIs=true")
+
+import { eq as assertEq, throws as assertThrows } from "../assert.js";
+const KB = 1024;
+const pageSize = 64*KB;
+
+function assertTrue(expr) {
+    assertEq(expr, true);
+}
+
+function assertFalse(expr) {
+    assertEq(expr, false);
+}
+
+function assertIsolatedResizableBufferOfPageSize(pageCount, buffer, maxPageCount) {
+    assertTrue(buffer instanceof ArrayBuffer);
+    assertTrue(buffer.resizable);
+    assertEq(buffer.byteLength, pageCount * pageSize);
+    assertEq(buffer.maxByteLength, maxPageCount * pageSize);
+}
+
+function assertDetachedBuffer(buffer) {
+    assertTrue(buffer instanceof ArrayBuffer);
+    assertTrue(buffer.detached);
+    assertEq(buffer.byteLength, 0);
+    assertEq(buffer.maxByteLength, 0);
+}
+
+function assertSharedGrowableBufferOfPageSize(pageCount, buffer, maxPageCount) {
+    assertTrue(buffer instanceof SharedArrayBuffer);
+    assertTrue(buffer.growable);
+    assertEq(buffer.byteLength, pageCount * pageSize);
+    assertEq(buffer.maxByteLength, maxPageCount * pageSize);
+}
+
+{
+    let memory = new WebAssembly.Memory({initial: 1, maximum: 5});
+    let buffer = memory.toResizableBuffer();
+    assertIsolatedResizableBufferOfPageSize(1, buffer, 5);
+    assertEq(buffer, memory.buffer);
+
+    // Growing the memory, the buffer should stay associated and properly refreshed
+    memory.grow(1);
+    assertEq(buffer, memory.buffer);
+    assertIsolatedResizableBufferOfPageSize(2, buffer, 5);
+
+    // Growing the memory via the buffer .resize API
+    buffer.resize(3 * pageSize);
+    assertEq(buffer, memory.buffer);
+    assertIsolatedResizableBufferOfPageSize(3, buffer, 5);
+
+    // Growing the memory via the buffer .resize API - no growth
+    buffer.resize(3 * pageSize);
+    assertEq(buffer, memory.buffer);
+    assertIsolatedResizableBufferOfPageSize(3, buffer, 5);
+
+    // Growing the memory via the buffer .resize API - illegal args: shrinking
+    assertThrows(() => buffer.resize(2 * pageSize), RangeError, "");
+
+    // Growing the memory via the buffer .resize API - illegal args: size not a page multiple
+    assertThrows(() => buffer.resize(4 * pageSize + 1), RangeError, "");
+
+    // Asking for a fixed length buffer should detach the old resizable one
+    let buffer2 = memory.toFixedLengthBuffer();
+    assertEq(buffer2, memory.buffer);
+    assertDetachedBuffer(buffer);
+    assertTrue(memory.buffer !== buffer);
+}
+
+// Now a similar sequence for a shared memory
+
+{
+    let memory = new WebAssembly.Memory({initial: 1, maximum: 5, shared: true});
+    let buffer = memory.toResizableBuffer();
+    assertSharedGrowableBufferOfPageSize(1, buffer, 5);
+    assertEq(buffer, memory.buffer);
+
+    // Growing the memory, the buffer should stay associated and properly refreshed
+    memory.grow(1);
+    assertEq(buffer, memory.buffer);
+    assertSharedGrowableBufferOfPageSize(2, buffer, 5);
+
+    // Growing the memory via the buffer .grow API
+    buffer.grow(3 * pageSize);
+    assertEq(buffer, memory.buffer);
+    assertSharedGrowableBufferOfPageSize(3, buffer, 5);
+
+    // Growing the memory via the buffer .grow API - no growth
+    buffer.grow(3 * pageSize);
+    assertEq(buffer, memory.buffer);
+    assertSharedGrowableBufferOfPageSize(3, buffer, 5);
+
+    // Growing the memory via the buffer .grow API - illegal args: shrinking
+    assertThrows(() => buffer.grow(2 * pageSize), RangeError, "");
+
+    // Growing the memory via the buffer .grow API - illegal args: size not a page multiple
+    assertThrows(() => buffer.grow(4 * pageSize + 1), RangeError, "");
+
+    // Asking for a fixed length buffer should disassociate the current one
+    let buffer2 = memory.toFixedLengthBuffer();
+    assertTrue(memory.buffer !== buffer);
+    assertTrue(memory.buffer === buffer2);
+    // The old buffer is not the associated buffer anymore but should track memory length
+    memory.grow(1);
+    assertEq(memory.buffer.byteLength, 4 * pageSize);
+    assertSharedGrowableBufferOfPageSize(4, buffer, 5);
+}
+
+// Non-shared memory with no user-specified maximum
+
+{
+    let memory = new WebAssembly.Memory({ initial: 0 });
+    let buffer = memory.toResizableBuffer();
+    assertEq(buffer.maxByteLength, pageSize * 65536);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any-expected.txt
@@ -46,15 +46,15 @@ PASS Memory interface: existence and properties of interface prototype object
 PASS Memory interface: existence and properties of interface prototype object's "constructor" property
 PASS Memory interface: existence and properties of interface prototype object's @@unscopables property
 PASS Memory interface: operation grow(unsigned long)
-FAIL Memory interface: operation toFixedLengthBuffer() assert_own_property: interface prototype object missing non-static operation expected property "toFixedLengthBuffer" missing
-FAIL Memory interface: operation toResizableBuffer() assert_own_property: interface prototype object missing non-static operation expected property "toResizableBuffer" missing
+PASS Memory interface: operation toFixedLengthBuffer()
+PASS Memory interface: operation toResizableBuffer()
 PASS Memory interface: attribute buffer
 PASS Memory must be primary interface of [object WebAssembly.Memory]
 PASS Stringification of [object WebAssembly.Memory]
 PASS Memory interface: [object WebAssembly.Memory] must inherit property "grow(unsigned long)" with the proper type
 PASS Memory interface: calling grow(unsigned long) on [object WebAssembly.Memory] with too few arguments must throw TypeError
-FAIL Memory interface: [object WebAssembly.Memory] must inherit property "toFixedLengthBuffer()" with the proper type assert_inherits: property "toFixedLengthBuffer" not found in prototype chain
-FAIL Memory interface: [object WebAssembly.Memory] must inherit property "toResizableBuffer()" with the proper type assert_inherits: property "toResizableBuffer" not found in prototype chain
+PASS Memory interface: [object WebAssembly.Memory] must inherit property "toFixedLengthBuffer()" with the proper type
+PASS Memory interface: [object WebAssembly.Memory] must inherit property "toResizableBuffer()" with the proper type
 PASS Memory interface: [object WebAssembly.Memory] must inherit property "buffer" with the proper type
 PASS Table interface: existence and properties of interface object
 PASS Table interface object length

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker-expected.txt
@@ -46,15 +46,15 @@ PASS Memory interface: existence and properties of interface prototype object
 PASS Memory interface: existence and properties of interface prototype object's "constructor" property
 PASS Memory interface: existence and properties of interface prototype object's @@unscopables property
 PASS Memory interface: operation grow(unsigned long)
-FAIL Memory interface: operation toFixedLengthBuffer() assert_own_property: interface prototype object missing non-static operation expected property "toFixedLengthBuffer" missing
-FAIL Memory interface: operation toResizableBuffer() assert_own_property: interface prototype object missing non-static operation expected property "toResizableBuffer" missing
+PASS Memory interface: operation toFixedLengthBuffer()
+PASS Memory interface: operation toResizableBuffer()
 PASS Memory interface: attribute buffer
 PASS Memory must be primary interface of [object WebAssembly.Memory]
 PASS Stringification of [object WebAssembly.Memory]
 PASS Memory interface: [object WebAssembly.Memory] must inherit property "grow(unsigned long)" with the proper type
 PASS Memory interface: calling grow(unsigned long) on [object WebAssembly.Memory] with too few arguments must throw TypeError
-FAIL Memory interface: [object WebAssembly.Memory] must inherit property "toFixedLengthBuffer()" with the proper type assert_inherits: property "toFixedLengthBuffer" not found in prototype chain
-FAIL Memory interface: [object WebAssembly.Memory] must inherit property "toResizableBuffer()" with the proper type assert_inherits: property "toResizableBuffer" not found in prototype chain
+PASS Memory interface: [object WebAssembly.Memory] must inherit property "toFixedLengthBuffer()" with the proper type
+PASS Memory interface: [object WebAssembly.Memory] must inherit property "toResizableBuffer()" with the proper type
 PASS Memory interface: [object WebAssembly.Memory] must inherit property "buffer" with the proper type
 PASS Table interface: existence and properties of interface object
 PASS Table interface object length

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any.worker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL toFixedLengthBuffer caching behavior memory.toFixedLengthBuffer is not a function. (In 'memory.toFixedLengthBuffer()', 'memory.toFixedLengthBuffer' is undefined)
+PASS toFixedLengthBuffer caching behavior
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL toFixedLengthBuffer caching behavior memory.toFixedLengthBuffer is not a function. (In 'memory.toFixedLengthBuffer()', 'memory.toFixedLengthBuffer' is undefined)
+PASS toFixedLengthBuffer caching behavior
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer-shared.any.worker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL API surface assert_equals: expected "object" but got "undefined"
-FAIL toFixedLengthBuffer caching behavior memory.toFixedLengthBuffer is not a function. (In 'memory.toFixedLengthBuffer()', 'memory.toFixedLengthBuffer' is undefined)
+PASS API surface
+PASS toFixedLengthBuffer caching behavior
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL API surface assert_equals: expected "object" but got "undefined"
-FAIL toFixedLengthBuffer caching behavior memory.toFixedLengthBuffer is not a function. (In 'memory.toFixedLengthBuffer()', 'memory.toFixedLengthBuffer' is undefined)
+PASS API surface
+PASS toFixedLengthBuffer caching behavior
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-fixed-length-buffer.any.worker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL toResizableBuffer caching behavior memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL toResizableBuffer max size memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL Resizing a Memory's resizable buffer memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
+PASS toResizableBuffer caching behavior
+PASS toResizableBuffer max size
+PASS Resizing a Memory's resizable buffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL toResizableBuffer caching behavior memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL toResizableBuffer max size memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL Resizing a Memory's resizable buffer memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
+PASS toResizableBuffer caching behavior
+PASS toResizableBuffer max size
+PASS Resizing a Memory's resizable buffer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer-shared.any.worker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL API surface assert_equals: expected "object" but got "undefined"
-FAIL toResizableBuffer caching behavior memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL toResizableBuffer max size memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL Resizing a Memory's resizable buffer memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL Resizable buffers from Memory cannot be detached by JS memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
+PASS API surface
+PASS toResizableBuffer caching behavior
+PASS toResizableBuffer max size
+PASS Resizing a Memory's resizable buffer
+PASS Resizable buffers from Memory cannot be detached by JS
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL API surface assert_equals: expected "object" but got "undefined"
-FAIL toResizableBuffer caching behavior memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL toResizableBuffer max size memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL Resizing a Memory's resizable buffer memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
-FAIL Resizable buffers from Memory cannot be detached by JS memory.toResizableBuffer is not a function. (In 'memory.toResizableBuffer()', 'memory.toResizableBuffer' is undefined)
+PASS API surface
+PASS toResizableBuffer caching behavior
+PASS toResizableBuffer max size
+PASS Resizing a Memory's resizable buffer
+PASS Resizable buffers from Memory cannot be detached by JS
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/memory/to-resizable-buffer.any.worker.html
@@ -1,1 +1,2 @@
+<!-- webkit-test-runner [ jscOptions=--useWasmMemoryToBufferAPIs=true ] -->
 <!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -647,6 +647,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, true, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useWasmJSStringBuiltins, false, Normal, "Enable the implementation of the JS String Builtins proposal."_s) \
+    v(Bool, useWasmMemoryToBufferAPIs, false, Normal, "Enable the toFixedLengthBuffer() and toResizableBuffer() Wasm Memory.prototype functions."_s) \
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -288,7 +288,8 @@ Expected<PageCount, GrowFailReason> Memory::growShared(VM& vm, PageCount delta)
         RELEASE_ASSERT(m_shared);
         RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
         RELEASE_ASSERT(desiredSize > size());
-        result = m_shared->grow(locker.value(), vm, desiredSize);
+        constexpr bool sizeMustBePageMultiple = true;
+        result = m_shared->grow(locker.value(), vm, desiredSize, sizeMustBePageMultiple);
     }
     if (!result)
         return makeUnexpected(result.error());

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -35,7 +35,7 @@
 #include <wtf/CagedPtr.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -51,7 +51,7 @@ class LLIntOffsetsExtractor;
 
 namespace Wasm {
 
-class Memory final : public RefCounted<Memory> {
+class Memory final : public RefCountedAndCanMakeWeakPtr<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Memory, JS_EXPORT_PRIVATE);
     friend LLIntOffsetsExtractor;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -65,10 +65,91 @@ JSWebAssemblyMemory::JSWebAssemblyMemory(VM& vm, Structure* structure)
 {
 }
 
+void JSWebAssemblyMemory::associateArrayBuffer(JSGlobalObject* globalObject, bool shouldBeFixedLength)
+{
+    ASSERT(!m_buffer);
+    ASSERT(!m_bufferWrapper);
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (m_memory->sharingMode() == MemorySharingMode::Shared && m_memory->shared())
+        m_buffer = ArrayBuffer::createShared(*m_memory->shared(), shouldBeFixedLength);
+    else {
+        Ref<BufferMemoryHandle> protectedHandle = m_memory->handle();
+        void* data = m_memory->basePointer();
+        size_t size = m_memory->size();
+        ASSERT(data);
+        if (shouldBeFixedLength) {
+            auto destructor = createSharedTask<void(void*)>([protectedHandle = WTFMove(protectedHandle)] (void*) { });
+            m_buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(data), size }, WTFMove(destructor));
+        } else {
+            // The determination of maxByteLength of a resizable non-shared array buffer may change in
+            // https://webassembly.github.io/threads/js-api/index.html#create-a-resizable-memory-buffer
+            // Currently we are implementing the behavior expected by WPT tests,
+            // so that maxByteLength is 2^32 if the memory has no user-defined max size.
+#if USE(LARGE_TYPED_ARRAYS)
+            // If sizeof(size_t) == 8 we use the proper spec value because it's representable.
+            constexpr size_t defaultMaxByteLengthIfMemoryHasNoMax = 65536ULL * 65536ULL;
+#else
+            // If sizeof(size_t) == 4, we say it's 2^16-1 pages which is not right but at least it still builds for ARMv7.
+            constexpr size_t defaultMaxByteLengthIfMemoryHasNoMax = static_cast<size_t>(65535) * 65536;
+#endif
+            PageCount memoryMax = m_memory->maximum();
+            size_t maxByteLength = memoryMax.isValid() ? memoryMax.bytes() : defaultMaxByteLengthIfMemoryHasNoMax;
+            ArrayBufferContents contents(data, size, maxByteLength, WTFMove(protectedHandle));
+            m_buffer = ArrayBuffer::create(WTFMove(contents));
+        }
+        if (m_memory->sharingMode() == MemorySharingMode::Shared)
+            m_buffer->makeShared();
+    }
+    m_buffer->makeWasmMemory();
+    if (m_buffer->isResizableNonShared())
+        m_buffer->setAssociatedWasmMemory(m_memory.ptr());
+
+    auto* arrayBuffer = JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(m_buffer->sharingMode()), m_buffer.get());
+    if (m_memory->sharingMode() == MemorySharingMode::Shared) {
+        objectConstructorFreeze(globalObject, arrayBuffer);
+        RETURN_IF_EXCEPTION(throwScope, void());
+    }
+
+    m_bufferWrapper.set(vm, this, arrayBuffer);
+    RELEASE_ASSERT(m_bufferWrapper);
+}
+
+void JSWebAssemblyMemory::disassociateArrayBuffer(VM& vm)
+{
+    ASSERT(m_buffer);
+    if (!m_buffer->isShared())
+        m_buffer->detach(vm);
+    m_buffer->setAssociatedWasmMemory(nullptr);
+    m_buffer = nullptr;
+    m_bufferWrapper.clear();
+}
+
+// https://webassembly.github.io/threads/js-api/index.html#dom-memory-buffer
 JSArrayBuffer* JSWebAssemblyMemory::buffer(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (Options::useWasmMemoryToBufferAPIs()) {
+        if (auto* wrapper = m_bufferWrapper.get()) {
+            // If SharedArrayBuffer's underlying memory is grown by another thread, we must refresh.
+            if (wrapper->impl()->byteLength() != memory().size())
+                disassociateArrayBuffer(vm);
+        }
+
+        if (!m_buffer) {
+            associateArrayBuffer(globalObject, true);
+            RETURN_IF_EXCEPTION(throwScope, { });
+        }
+
+        RELEASE_ASSERT(m_bufferWrapper);
+        return m_bufferWrapper.get();
+    }
+
+    // Historical behavior prior to the resizable SAB change follows
+    // Remove when the feature is permanent
 
     auto* wrapper = m_bufferWrapper.get();
     if (wrapper) {
@@ -101,13 +182,54 @@ JSArrayBuffer* JSWebAssemblyMemory::buffer(JSGlobalObject* globalObject)
     m_bufferWrapper.set(vm, this, arrayBuffer);
     RELEASE_ASSERT(m_bufferWrapper);
     return m_bufferWrapper.get();
+
+}
+
+// https://webassembly.github.io/threads/js-api/index.html#dom-memory-tofixedlengthbuffer
+JSArrayBuffer* JSWebAssemblyMemory::toFixedLengthBuffer(JSGlobalObject* globalObject)
+{
+    ASSERT(Options::useWasmMemoryToBufferAPIs());
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (!m_buffer) {
+        associateArrayBuffer(globalObject, true);
+        RETURN_IF_EXCEPTION(throwScope, { });
+    } else if (!m_buffer->isFixedLength()) {
+        disassociateArrayBuffer(vm);
+        associateArrayBuffer(globalObject, true);
+        RETURN_IF_EXCEPTION(throwScope, { });
+    }
+
+    RELEASE_ASSERT(m_bufferWrapper);
+    return m_bufferWrapper.get();
+}
+
+// https://webassembly.github.io/threads/js-api/index.html#dom-memory-toresizablebuffer
+JSArrayBuffer* JSWebAssemblyMemory::toResizableBuffer(JSGlobalObject* globalObject)
+{
+    ASSERT(Options::useWasmMemoryToBufferAPIs());
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    if (!m_buffer) {
+        associateArrayBuffer(globalObject, false);
+        RETURN_IF_EXCEPTION(throwScope, { });
+    } else if (m_buffer->isFixedLength()) {
+        disassociateArrayBuffer(vm);
+        associateArrayBuffer(globalObject, false);
+        RETURN_IF_EXCEPTION(throwScope, { });
+    }
+
+    RELEASE_ASSERT(m_bufferWrapper);
+    return m_bufferWrapper.get();
 }
 
 PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, uint32_t delta)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    auto grown = memory().grow(vm, PageCount(delta));
+    auto grown = memory().grow(vm, PageCount(delta)); // calls growSuccessCallback() after growing
     if (!grown) {
         switch (grown.error()) {
         case GrowFailReason::InvalidDelta:
@@ -155,13 +277,26 @@ JSObject* JSWebAssemblyMemory::type(JSGlobalObject* globalObject)
 
 void JSWebAssemblyMemory::growSuccessCallback(VM& vm, PageCount oldPageCount, PageCount newPageCount)
 {
-    // We need to clear out the old array buffer because it might now be pointing to stale memory.
     if (m_buffer) {
-        if (m_memory->sharingMode() == MemorySharingMode::Default)
-            m_buffer->detach(vm);
-        m_buffer = nullptr;
-        m_bufferWrapper.clear();
+        if (Options::useWasmMemoryToBufferAPIs()) {
+            // https://webassembly.github.io/threads/js-api/index.html#refresh-the-memory-buffer
+            // Fixed length buffers are "refreshed" by discarding them, so an updated one is created lazily.
+            // Shared growable buffers are always fresh because growing is handled by their SharedArrayBufferContents.
+            // Non-shared resizable buffers need to be refreshed explicitly.
+            if (m_buffer->isFixedLength())
+                disassociateArrayBuffer(vm);
+            else if (!m_buffer->isShared())
+                m_buffer->refreshAfterWasmMemoryGrow(m_memory.ptr());
+        } else {
+            // historical behavior before the SAB feature:
+            // clear out the old array buffer because it might now be pointing to stale memory.
+            if (m_memory->sharingMode() == MemorySharingMode::Default)
+                m_buffer->detach(vm);
+            m_buffer = nullptr;
+            m_bufferWrapper.clear();
+        }
     }
+
     
     memory().checkLifetime();
     

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -60,6 +60,8 @@ public:
     JS_EXPORT_PRIVATE void adopt(Ref<Wasm::Memory>&&);
     Wasm::Memory& memory() { return m_memory.get(); }
     JSArrayBuffer* buffer(JSGlobalObject*);
+    JSArrayBuffer* toFixedLengthBuffer(JSGlobalObject*);
+    JSArrayBuffer* toResizableBuffer(JSGlobalObject*);
     PageCount grow(VM&, JSGlobalObject*, uint32_t delta);
     JS_EXPORT_PRIVATE void growSuccessCallback(VM&, PageCount oldPageCount, PageCount newPageCount);
 
@@ -75,6 +77,9 @@ public:
 private:
     JSWebAssemblyMemory(VM&, Structure*);
     void finishCreation(VM&);
+
+    void associateArrayBuffer(JSGlobalObject*, bool shouldBeFixedLength);
+    void disassociateArrayBuffer(VM&);
 
     Ref<Wasm::Memory> m_memory;
     WriteBarrier<JSArrayBuffer> m_bufferWrapper;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
@@ -39,6 +39,8 @@
 
 namespace JSC {
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyMemoryProtoFuncGrow);
+static JSC_DECLARE_HOST_FUNCTION(webAssemblyMemoryProtoFuncToFixedLengthBuffer);
+static JSC_DECLARE_HOST_FUNCTION(webAssemblyMemoryProtoFuncToResizableBuffer);
 static JSC_DECLARE_CUSTOM_GETTER(webAssemblyMemoryProtoGetterBuffer);
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyMemoryProtoFuncType);
 }
@@ -52,11 +54,12 @@ const ClassInfo WebAssemblyMemoryPrototype::s_info = { "WebAssembly.Memory"_s, &
 
 /* Source for WebAssemblyMemoryPrototype.lut.h
 @begin prototypeTableWebAssemblyMemory
- grow   webAssemblyMemoryProtoFuncGrow   Function 1
- buffer webAssemblyMemoryProtoGetterBuffer ReadOnly|CustomAccessor
- type   webAssemblyMemoryProtoFuncType   Function 0
+ grow   webAssemblyMemoryProtoFuncGrow      Function 1
+ buffer webAssemblyMemoryProtoGetterBuffer  ReadOnly|CustomAccessor
+ type   webAssemblyMemoryProtoFuncType      Function 0
 @end
 */
+// two more functions are added if Options::useWasmMemoryToBufferAPIs() is true; see finishCreation()
 
 ALWAYS_INLINE JSWebAssemblyMemory* getMemory(JSGlobalObject* globalObject, VM& vm, JSValue value)
 {
@@ -88,6 +91,26 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyMemoryProtoFuncGrow, (JSGlobalObject* global
     return JSValue::encode(jsNumber(result.pageCount()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(webAssemblyMemoryProtoFuncToFixedLengthBuffer, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSWebAssemblyMemory* memory = getMemory(globalObject, vm, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(throwScope, { });
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(memory->toFixedLengthBuffer(globalObject)));
+}
+
+JSC_DEFINE_HOST_FUNCTION(webAssemblyMemoryProtoFuncToResizableBuffer, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSWebAssemblyMemory* memory = getMemory(globalObject, vm, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(throwScope, { });
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(memory->toResizableBuffer(globalObject)));
+}
+
 JSC_DEFINE_CUSTOM_GETTER(webAssemblyMemoryProtoGetterBuffer, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -109,10 +132,10 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyMemoryProtoFuncType, (JSGlobalObject* global
 }
 
 
-WebAssemblyMemoryPrototype* WebAssemblyMemoryPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
+WebAssemblyMemoryPrototype* WebAssemblyMemoryPrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
 {
     auto* object = new (NotNull, allocateCell<WebAssemblyMemoryPrototype>(vm)) WebAssemblyMemoryPrototype(vm, structure);
-    object->finishCreation(vm);
+    object->finishCreation(vm, globalObject);
     return object;
 }
 
@@ -121,11 +144,16 @@ Structure* WebAssemblyMemoryPrototype::createStructure(VM& vm, JSGlobalObject* g
     return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
 }
 
-void WebAssemblyMemoryPrototype::finishCreation(VM& vm)
+void WebAssemblyMemoryPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    if (Options::useWasmMemoryToBufferAPIs()) {
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toFixedLengthBuffer"_s, webAssemblyMemoryProtoFuncToFixedLengthBuffer, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toResizableBuffer"_s, webAssemblyMemoryProtoFuncToResizableBuffer, static_cast<unsigned>(PropertyAttribute::None), 0, ImplementationVisibility::Public);
+    }
 }
 
 WebAssemblyMemoryPrototype::WebAssemblyMemoryPrototype(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.h
@@ -51,7 +51,7 @@ public:
 
 private:
     WebAssemblyMemoryPrototype(VM&, Structure*);
-    void finishCreation(VM&);
+    void finishCreation(VM&, JSGlobalObject*);
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### e65b5874938c034f2d03b029d67afb64dff45eca
<pre>
Implement resizable SABs for Wasm memories
<a href="https://bugs.webkit.org/show_bug.cgi?id=297071">https://bugs.webkit.org/show_bug.cgi?id=297071</a>
<a href="https://rdar.apple.com/147437929">rdar://147437929</a>

Reviewed by Yusuke Suzuki.

This patch adds the implementation of the .toFixedLengthBuffer()
and .toResizableBuffer() methods of WebAssembly.Memory.prototype
as specified by <a href="https://webassembly.github.io/threads/js-api/index.html#memories.">https://webassembly.github.io/threads/js-api/index.html#memories.</a>

Availability of this feature is controlled by the option `useWasmMemoryToBufferAPIs`.
It is set to false on landing, except for the tests specifically targeting this,
such as `imported/w3c/web-platform-tests/wasm/jsapi/idlharness.any`.

Notable changes:

  - ArrayBuffer is given the ability to point at the Wasm memory it represents.
    This is used when the buffer is resizable non-shared, so that growth requests
    initiated by the buffer are routed to the memory. (In the shared case that
    is not needed because growing is always done by SharedArrayBufferContents).

  - To support the above, Wasm::Memory is made CanMakeWeakPtr.

  - JSWebAssemblyMemory::growSuccessCallback sends a refresh notification to
    its associated buffer if it&apos;s resizable non-shared, to update its length.
    Again, this explicit update is needed because in that setup there is no
    SharedArrayBufferContents common to the buffer and the memory.

  - The ArrayBuffer::isFixedLength() function is added, not because it&apos;s strictly
    necessary, but to match the IsFixedLengthArrayBuffer abstract operations in the spec,
    making it harder to make a mistake.

The expectations of WPT jsapi/memory tests are updated to expect the tests to pass.

Canonical link: <a href="https://commits.webkit.org/298955@main">https://commits.webkit.org/298955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3147d0243b4cbcdee46a02eea73a25cbc2906c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69251 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d3e1df4-d7ca-41bd-a771-b03ba77fa1a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88996 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43665 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ad46a3c8-34df-401b-ad3b-f9254c1a5915) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69504 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67038 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109371 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126486 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115773 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97667 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24820 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40513 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49695 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144473 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43492 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37178 "Failed to checkout and rebase branch from PR 49086") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->