### PR TITLE
[Navigation API] Rejected errors are wrapped in UnknownError instead of preserving original error.

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
-CONSOLE MESSAGE: Unhandled Promise Rejection: UnknownError: Uncaught Error:
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 
 Harness Error (FAIL), message = Unhandled rejection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for <a download> intercepted by passing a rejected promise to intercept() assert_equals: error objects must match: error object for transition.finished rejected did not match the one for navigateerror expected object "Error: boo" but got object "UnknownError: Uncaught Error: boo"
+PASS event and promise ordering for <a download> intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_no-currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for <a download> intercepted by passing a rejected promise to intercept() assert_equals: error objects must match: error object for transition.finished rejected did not match the one for navigateerror expected object "Error: boo" but got object "UnknownError: Uncaught Error: boo"
+PASS event and promise ordering for <a download> intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for same-document navigation.navigate() intercepted by passing a rejected promise to intercept() assert_equals: error objects must match: error object for transition.finished rejected did not match the one for navigateerror expected object "Error: boo" but got object "UnknownError: Uncaught Error: boo"
+PASS event and promise ordering for same-document navigation.navigate() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_no-currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for same-document navigation.navigate() intercepted by passing a rejected promise to intercept() assert_equals: error objects must match: error object for transition.finished rejected did not match the one for navigateerror expected object "Error: boo" but got object "UnknownError: Uncaught Error: boo"
+PASS event and promise ordering for same-document navigation.navigate() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for navigation.reload() intercepted by intercept() assert_equals: error objects must match: error object for transition.finished rejected did not match the one for navigateerror expected object "Error: boo" but got object "UnknownError: Uncaught Error: boo"
+PASS event and promise ordering for navigation.reload() intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_no-currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for navigation.reload() intercepted by intercept() assert_equals: error objects must match: error object for transition.finished rejected did not match the one for navigateerror expected object "Error: boo" but got object "UnknownError: Uncaught Error: boo"
+PASS event and promise ordering for navigation.reload() intercepted by intercept()
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1080,8 +1080,6 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
                         errorMessage = makeString("Uncaught "_s, errorInformation.errorTypeString, ": "_s, errorInformation.message);
                     }
                 }
-                auto exception = Exception(ExceptionCode::UnknownError, errorMessage);
-                auto domException = createDOMException(*protectedThis->protectedScriptExecutionContext()->globalObject(), exception.isolatedCopy());
 
                 protectedThis->dispatchEvent(ErrorEvent::create(eventNames().navigateerrorEvent, errorMessage, errorInformation.sourceURL, errorInformation.line, errorInformation.column, { protectedThis->protectedScriptExecutionContext()->globalObject()->vm(), result }));
 
@@ -1089,7 +1087,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
                     Ref { apiMethodTracker->finishedPromise }->reject<IDLAny>(result, RejectAsHandled::Yes);
 
                 if (RefPtr transition = std::exchange(protectedThis->m_transition, nullptr))
-                    transition->rejectPromise(exception, domException);
+                    transition->rejectPromise(result);
             });
         });
 

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -50,6 +50,11 @@ void NavigationTransition::rejectPromise(Exception& exception, JSC::JSValue exce
     m_finished->reject(exception, RejectAsHandled::Yes, exceptionObject);
 }
 
+void NavigationTransition::rejectPromise(JSC::JSValue exceptionObject)
+{
+    m_finished->reject<IDLAny>(exceptionObject, RejectAsHandled::Yes);
+}
+
 DOMPromise* NavigationTransition::finished()
 {
     if (!m_finishedDOMPromise) {

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -46,6 +46,7 @@ public:
 
     void resolvePromise();
     void rejectPromise(Exception&, JSC::JSValue exceptionObject);
+    void rejectPromise(JSC::JSValue exceptionObject);
 
 private:
     explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry, Ref<DeferredPromise>&& finished);


### PR DESCRIPTION
#### fe410c871b16c36f3a9bd8cffa42cb1f6307de6b
<pre>
[Navigation API] Rejected errors are wrapped in UnknownError instead of preserving original error.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296974">https://bugs.webkit.org/show_bug.cgi?id=296974</a>
<a href="https://rdar.apple.com/157320005">rdar://157320005</a>

Reviewed by Tim Nguyen.

The Navigation API was incorrectly wrapping all rejected errors from navigate event handlers in `UnknownError` exceptions,
which masked the original error types and messages. This change preserves the original error objects when rejecting navigation
promises.

Remove unnecessary wrapping of errors in `UnknownError` exceptions in `Navigation::innerDispatchNavigateEvent`.

* LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_no-currententrychange-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/NavigationTransition.cpp:
(WebCore::NavigationTransition::rejectPromise):
* Source/WebCore/page/NavigationTransition.h:

Canonical link: <a href="https://commits.webkit.org/298399@main">https://commits.webkit.org/298399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d3a838a67e18b74d9f48a1d74245fd4c75078ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65991 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9545995-0b55-40ed-b2ea-109cbb63d390) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43678 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87692 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d66a3c45-a742-4aaf-926e-2d2f9bde6bf6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68084 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65155 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124667 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31729 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96257 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24485 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41489 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38257 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47788 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41734 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->