### PR TITLE
Remove SiteIsolationOverlay

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -278,7 +278,6 @@ loader/cache/MemoryCache.cpp
 mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
 page/ContextMenuController.cpp
-page/DebugPageOverlays.cpp
 page/DeviceController.cpp
 page/DragController.cpp
 page/ElementTargetingController.cpp

--- a/Source/WebCore/page/DebugOverlayRegions.h
+++ b/Source/WebCore/page/DebugOverlayRegions.h
@@ -33,7 +33,6 @@ enum class DebugOverlayRegions : uint8_t {
     TouchActionRegion = 1 << 2,
     EditableElementRegion = 1 << 3,
     InteractionRegion = 1 << 4,
-    SiteIsolationRegion = 1 << 5,
 };
 
 }

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -45,9 +45,8 @@ public:
         WheelEventHandlers,
         NonFastScrollableRegion,
         InteractionRegion,
-        SiteIsolationRegion
     };
-    static constexpr unsigned NumberOfRegionTypes = static_cast<unsigned>(RegionType::SiteIsolationRegion) + 1;
+    static constexpr unsigned NumberOfRegionTypes = static_cast<unsigned>(RegionType::InteractionRegion) + 1;
 
     static void didLayout(LocalFrame&);
     static void didChangeEventHandlers(LocalFrame&);
@@ -98,7 +97,6 @@ inline void DebugPageOverlays::didLayout(LocalFrame& frame)
     sharedDebugOverlays->regionChanged(frame, RegionType::WheelEventHandlers);
     sharedDebugOverlays->regionChanged(frame, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->regionChanged(frame, RegionType::InteractionRegion);
-    sharedDebugOverlays->regionChanged(frame, RegionType::SiteIsolationRegion);
 }
 
 inline void DebugPageOverlays::didChangeEventHandlers(LocalFrame& frame)
@@ -108,7 +106,6 @@ inline void DebugPageOverlays::didChangeEventHandlers(LocalFrame& frame)
     sharedDebugOverlays->regionChanged(frame, RegionType::WheelEventHandlers);
     sharedDebugOverlays->regionChanged(frame, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->regionChanged(frame, RegionType::InteractionRegion);
-    sharedDebugOverlays->regionChanged(frame, RegionType::SiteIsolationRegion);
 }
 
 inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
@@ -119,7 +116,6 @@ inline void DebugPageOverlays::doAfterUpdateRendering(Page& page)
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::WheelEventHandlers);
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::NonFastScrollableRegion);
     sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::InteractionRegion);
-    sharedDebugOverlays->updateRegionIfNecessary(page, RegionType::SiteIsolationRegion);
 }
 
 inline bool DebugPageOverlays::shouldPaintOverlayIntoLayerForRegionType(Page& page, RegionType regionType)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4146,7 +4146,7 @@ void RenderLayerBacking::paintContents(const GraphicsLayer* graphicsLayer, Graph
         paintIntoLayer(graphicsLayer, context, dirtyRect, behavior);
 
         auto visibleDebugOverlayRegions = OptionSet<DebugOverlayRegions>::fromRaw(renderer().settings().visibleDebugOverlayRegions());
-        if (visibleDebugOverlayRegions.containsAny({ DebugOverlayRegions::TouchActionRegion, DebugOverlayRegions::EditableElementRegion, DebugOverlayRegions::WheelEventHandlerRegion, DebugOverlayRegions::InteractionRegion, DebugOverlayRegions::SiteIsolationRegion }))
+        if (visibleDebugOverlayRegions.containsAny({ DebugOverlayRegions::TouchActionRegion, DebugOverlayRegions::EditableElementRegion, DebugOverlayRegions::WheelEventHandlerRegion, DebugOverlayRegions::InteractionRegion }))
             paintDebugOverlays(graphicsLayer, context);
 
     } else if (graphicsLayer == layerForHorizontalScrollbar()) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -38,7 +38,7 @@ typedef NS_OPTIONS(NSUInteger, _WKDebugOverlayRegions) {
     _WKTouchActionRegion = 1 << 2,
     _WKEditableElementRegion = 1 << 3,
     _WKInteractionRegion WK_API_AVAILABLE(macos(13.0), ios(16.0)) = 1 << 4,
-    _WKSiteIsolationRegion WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0)) = 1 << 5,
+    _WKSiteIsolationRegion WK_API_DEPRECATED_WITH_REPLACEMENT("ShowFrameProcessBordersEnabled", macos(15.0, WK_MAC_TBA), ios(18.0, WK_IOS_TBA), visionos(2.0, WK_XROS_TBA)) = 1 << 5,
 } WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
 typedef NS_OPTIONS(NSUInteger, _WKJavaScriptRuntimeFlags) {

--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -66,7 +66,6 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL usesGameControllerFramework;
 @property (nonatomic, readonly) BOOL networkCacheSpeculativeRevalidationDisabled;
 @property (nonatomic, readonly) BOOL advancedPrivacyProtectionsEnabled;
-@property (nonatomic, readonly) BOOL siteIsolationOverlayEnabled;
 @property (nonatomic, readonly) BOOL allowsContentJavascript;
 @property (nonatomic, readonly) BOOL allowUniversalAccessFromFileURLs;
 @property (nonatomic, readonly) BOOL siteSpecificQuirksModeEnabled;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -73,8 +73,6 @@ static NSString * const AdvancedPrivacyProtectionsPreferenceKey = @"AdvancedPriv
 static NSString * const AllowsContentJavascriptPreferenceKey = @"AllowsContentJavascript";
 static NSString * const AllowUniversalAccessFromFileURLsPreferenceKey = @"AllowUniversalAccessFromFileURLs";
 
-static NSString * const SiteIsolationOverlayPreferenceKey = @"SiteIsolationOverlayEnabled";
-
 // This default name intentionally overlaps with the key that WebKit2 checks when creating a view.
 static NSString * const UseRemoteLayerTreeDrawingAreaPreferenceKey = @"WebKit2UseRemoteLayerTreeDrawingArea";
 
@@ -87,7 +85,6 @@ typedef NS_ENUM(NSInteger, DebugOverylayMenuItemTag) {
     InteractionRegionOverlayTag,
     ExperimentalFeatureTag,
     InternalDebugFeatureTag,
-    SiteIsolationRegionOverlayTag,
 };
 
 typedef NS_ENUM(NSInteger, AttachmentElementEnabledMenuItemTag) {
@@ -225,7 +222,6 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItemToMenu(debugOverlaysMenu, @"Wheel Event Handler Region", @selector(toggleDebugOverlay:), NO, WheelEventHandlerRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Interaction Region", @selector(toggleDebugOverlay:), NO, InteractionRegionOverlayTag);
     addItemToMenu(debugOverlaysMenu, @"Resource Usage", @selector(toggleShowResourceUsageOverlay:), NO, 0);
-    addItemToMenu(debugOverlaysMenu, @"Site Isolation", @selector(toggleSiteIsolationOverlay:), NO, SiteIsolationRegionOverlayTag);
 
     NSMenu *experimentalFeaturesMenu = addSubmenu(@"Experimental Features");
     for (_WKExperimentalFeature *feature in WKPreferences._experimentalFeatures) {
@@ -432,8 +428,6 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         [menuItem setState:[self perWindowWebProcessesDisabled] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleDebugOverlay:))
         [menuItem setState:[self debugOverlayVisible:menuItem] ? NSControlStateValueOn : NSControlStateValueOff];
-    else if (action == @selector(toggleSiteIsolationOverlay:))
-        [menuItem setState:[self siteIsolationOverlayVisible:menuItem] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(changeCustomUserAgent:)) {
 
         NSString *savedUAIdentifier = [[NSUserDefaults standardUserDefaults] stringForKey:CustomUserAgentPreferenceKey];
@@ -802,9 +796,6 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 
     case InteractionRegionOverlayTag:
         return InteractionRegionOverlayVisiblePreferenceKey;
-
-    case SiteIsolationRegionOverlayTag:
-        return SiteIsolationOverlayPreferenceKey;
     }
     return nil;
 }
@@ -867,21 +858,6 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         return [[NSUserDefaults standardUserDefaults] boolForKey:preferenceKey];
 
     return NO;
-}
-
-- (void)toggleSiteIsolationOverlay:(id)sender
-{
-    [self _toggleBooleanDefault:SiteIsolationOverlayPreferenceKey];
-}
-
-- (BOOL)siteIsolationOverlayEnabled
-{
-    return [[NSUserDefaults standardUserDefaults] boolForKey:SiteIsolationOverlayPreferenceKey];
-}
-
-- (BOOL)siteIsolationOverlayVisible:(NSMenuItem *)menuItem
-{
-    return [self siteIsolationOverlayEnabled];
 }
 
 - (NSString *)customUserAgent

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -585,8 +585,6 @@ static BOOL areEssentiallyEqual(double a, double b)
         visibleOverlayRegions |= _WKWheelEventHandlerRegion;
     if (settings.interactionRegionOverlayVisible)
         visibleOverlayRegions |= _WKInteractionRegion;
-    if (settings.siteIsolationOverlayEnabled)
-        visibleOverlayRegions |= _WKSiteIsolationRegion;
     
     preferences._visibleDebugOverlayRegions = visibleOverlayRegions;
 


### PR DESCRIPTION
#### 6c83992cd184cbe81c2a38372aa918f60b7a78ef
<pre>
Remove SiteIsolationOverlay
<a href="https://bugs.webkit.org/show_bug.cgi?id=297086">https://bugs.webkit.org/show_bug.cgi?id=297086</a>
<a href="https://rdar.apple.com/157796265">rdar://157796265</a>

Reviewed by Charlie Wolfe.

It only ever worked in the main frame process, wasn&apos;t terribly useful,
and has since been superseded by &quot;Show frame process borders&quot; which works
in all processes and gives a consistent visual indicator of site isolation.

* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::SiteIsolationOverlay::drawRect):

Canonical link: <a href="https://commits.webkit.org/298415@main">https://commits.webkit.org/298415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/286642883ac6763fb4f89d95de78061536f20966

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121544 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b60c12dd-f50d-4269-903a-4e3d92bbe035) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43722 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ba8d09a-7de2-41e2-98f3-dc46cee98352) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68114 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21758 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65201 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21872 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124708 "Failed to checkout and rebase branch from PR 49091") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31767 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/124708 "Failed to checkout and rebase branch from PR 49091") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99825 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/124708 "Failed to checkout and rebase branch from PR 49091") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41518 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18470 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47835 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/41776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45103 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->