### PR TITLE
Implement Font::applyTransforms with HarfBuzz

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -577,7 +577,7 @@ RefPtr<Font> Font::createHalfWidthFont() const
     return platformCreateHalfWidthFont();
 }
 
-#if !USE(CORE_TEXT)
+#if !USE(CORE_TEXT) && !USE(HARFBUZZ)
 GlyphBufferAdvance Font::applyTransforms(GlyphBuffer&, unsigned, unsigned, bool, bool, const AtomString&, StringView, TextDirection) const
 {
     return makeGlyphBufferAdvance();

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -657,7 +657,7 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=150791: @font-face features should also cause this to be complex.
 
-#if !USE(FONT_VARIANT_VIA_FEATURES) && !USE(FREETYPE)
+#if !USE(FONT_VARIANT_VIA_FEATURES) && !USE(FREETYPE) && !USE(HARFBUZZ)
     if (run.length() > 1 && (enableKerning() || requiresShaping()))
         return CodePath::Complex;
 #endif

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -241,4 +241,75 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         forEachHBRun<RTL>(characters, WTFMove(shapeFunction));
 }
 
+GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer,
+    unsigned beginningGlyphIndex,
+    unsigned beginningStringIndex,
+    bool enableKerning,
+    bool /* requiresShaping */,
+    const AtomString& locale,
+    StringView text,
+    TextDirection textDirection) const
+{
+    auto numOfGlyphs = glyphBuffer.size() - beginningGlyphIndex;
+    glyphBuffer.shrink(beginningGlyphIndex);
+
+    auto substring = text.substring(beginningStringIndex, numOfGlyphs);
+    constexpr unsigned bufferSize = 256;
+    auto characters = substring.upconvertedCharacters<bufferSize>();
+
+    auto* hbFont = platformData().hbFont();
+    RELEASE_ASSERT(hbFont);
+
+    const auto& features = platformData().features();
+    // Kerning is not handled as font features, so only in case it's explicitly disabled
+    // we need to create a new vector to include kern feature.
+    const hb_feature_t* featuresData = features.isEmpty() ? nullptr : features.span().data();
+    unsigned featuresSize = features.size();
+    Vector<hb_feature_t> featuresWithKerning;
+    if (!enableKerning) {
+        featuresWithKerning.reserveInitialCapacity(featuresSize + 1);
+        static hb_feature_t kernFeature { HB_TAG('k', 'e', 'r', 'n'), 0, 0, static_cast<unsigned>(-1) };
+        featuresWithKerning.append(kernFeature);
+        featuresWithKerning.appendVector(features);
+        featuresData = featuresWithKerning.span().data();
+        featuresSize = featuresWithKerning.size();
+    }
+
+    static thread_local HbUniquePtr<hb_buffer_t> buffer(hb_buffer_create());
+
+    // The computed "locale" equals the "lang" attribute. The latter must be a valid BCP 47 language tag,
+    // according to <https://html.spec.whatwg.org/multipage/dom.html#attr-lang>.
+    // This is exactly what hb_language_from_string() expects, so we can pass directly.
+    ASSERT(locale.is8Bit());
+    auto language = hb_language_from_string(reinterpret_cast<const char*>(locale.span8().data()), -1);
+
+    auto shapeFunction = [&](const HBRun& run) {
+        hb_buffer_set_language(buffer.get(), language);
+        hb_buffer_set_script(buffer.get(), hb_icu_script_to_script(run.script));
+        hb_buffer_set_direction(buffer.get(), textDirection == TextDirection::RTL ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
+        hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters.get()), characters.span().size(), run.startIndex, run.endIndex - run.startIndex);
+        hb_shape(hbFont, buffer.get(), featuresData, featuresSize);
+
+        unsigned glyphCount = hb_buffer_get_length(buffer.get());
+        auto infos = hb_buffer_get_glyph_infos(buffer.get(), nullptr);
+        auto positions = hb_buffer_get_glyph_positions(buffer.get(), nullptr);
+        for (unsigned i = 0; i < glyphCount; ++i) {
+            Glyph glyph = infos[i].codepoint;
+            GlyphBufferAdvance advance = { harfBuzzPositionToFloat(positions[i].x_advance), harfBuzzPositionToFloat(positions[i].y_advance) };
+            GlyphBufferStringOffset offsetsInString = beginningStringIndex + infos[i].cluster;
+            FloatPoint origin = { harfBuzzPositionToFloat(positions[i].x_offset), harfBuzzPositionToFloat(positions[i].y_offset) };
+            glyphBuffer.add(glyph, *this, advance, offsetsInString, origin);
+        }
+
+        hb_buffer_reset(buffer.get());
+    };
+    if (textDirection == TextDirection::RTL) {
+        forEachHBRun<RTL>(characters, WTFMove(shapeFunction));
+        glyphBuffer.reverse(beginningGlyphIndex, glyphBuffer.size() - beginningGlyphIndex);
+    } else
+        forEachHBRun<LTR>(characters, WTFMove(shapeFunction));
+
+    return makeGlyphBufferAdvance();
+}
+
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -143,8 +143,6 @@ static void seatDevicesChangedCallback(GdkSeat* seat, GdkDevice*, WebProcessPool
 
 void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
-    m_alwaysUsesComplexTextCodePath = true;
-
     if (const char* forceComplexText = getenv("WEBKIT_FORCE_COMPLEX_TEXT"))
         m_alwaysUsesComplexTextCodePath = !strcmp(forceComplexText, "1");
 


### PR DESCRIPTION
#### b65a8f6bb5cb3101ec17dd975b2b35077b409a73
<pre>
Implement Font::applyTransforms with HarfBuzz
<a href="https://bugs.webkit.org/show_bug.cgi?id=297088">https://bugs.webkit.org/show_bug.cgi?id=297088</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/Font.cpp:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::codePath const):
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
(WebCore::Font::applyTransforms const):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b65a8f6bb5cb3101ec17dd975b2b35077b409a73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117222 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43599 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87615 "Failure limit exceed. At least found 401 new test failures: css1/font_properties/font.html css1/font_properties/font_variant.html css1/pseudo/firstline.html css1/pseudo/multiple_pseudo_elements.html css2.1/t051201-c23-first-line-00-b.html css2.1/t051202-c26-psudo-nest-00-c.html css2.1/t0905-c5525-fltwidth-00-c-g.html css2.1/t1505-c524-font-var-00-b.html css2.1/t1508-c527-font-00-b.html css2.1/t1508-c527-font-04-b.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42339 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21656 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65086 "Hash b65a8f6b for PR 49092 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124592 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31655 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96405 "Found 357 new test failures: css1/font_properties/font.html css1/font_properties/font_variant.html css1/pseudo/firstline.html css1/pseudo/multiple_pseudo_elements.html css2.1/t051201-c23-first-line-00-b.html css2.1/t051202-c26-psudo-nest-00-c.html css2.1/t0905-c5525-fltwidth-00-c-g.html css2.1/t1505-c524-font-var-00-b.html css2.1/t1508-c527-font-00-b.html css2.1/t1508-c527-font-04-b.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96190 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19280 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38210 "Hash b65a8f6b for PR 49092 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47708 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41665 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->