### PR TITLE
ASAN_TRAP | WebCore::RenderFragmentedFlow::removeRenderBoxFragmentInfo; WebCore::RenderFragmentedFlow::removeFlowChildInfo; WebCore::RenderElement::removeFromRenderFragmentedFlowIncludingDescendants

### DIFF
--- a/JSTests/stress/variable-initialization-error-check.js
+++ b/JSTests/stress/variable-initialization-error-check.js
@@ -1,0 +1,13 @@
+//@ runDefault("--validateOptions=true", "--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true", "--useConcurrentJIT=0")
+class C0{
+    constructor(a2, a3){
+        const v4 = this.constructor
+        try { new v4() } catch(e){}
+        const v6 = []
+        const v7 = `
+            var __proto__ = v6;
+        `
+        eval(v7)
+    }
+}
+new C0(C0,C0)

--- a/LayoutTests/editing/deleting/delete-multiple-styling-elements-expected.txt
+++ b/LayoutTests/editing/deleting/delete-multiple-styling-elements-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/editing/deleting/delete-multiple-styling-elements.html
+++ b/LayoutTests/editing/deleting/delete-multiple-styling-elements.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener("load", () => {
+    window.testRunner?.dumpAsText();
+    window.getSelection().selectAllChildren(container);
+    document.execCommand("clearText");
+    document.body.innerHTML = "PASS if no crash.";
+  });
+</script>
+<style>
+  div {
+    text-combine-upright: all;
+    writing-mode: vertical-rl;
+  }
+</style>
+<div contenteditable="true">
+  <span id="container">
+    <link></link>
+    <link></link>
+  </span>
+</div>

--- a/LayoutTests/fast/grid/layout-positioned-grid-items-001-crash-expected.txt
+++ b/LayoutTests/fast/grid/layout-positioned-grid-items-001-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/grid/layout-positioned-grid-items-001-crash.html
+++ b/LayoutTests/fast/grid/layout-positioned-grid-items-001-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+body { white-space: pre-wrap; -webkit-user-modify: read-write; }
+#container { display: inline-grid; transform: rotate(90deg); }
+#container font, #container span { position: fixed; grid-area: customIdent; }
+</style>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+onload = () => {
+  document.execCommand("selectAll",false,null);
+  document.execCommand("hiliteColor",false,"#32E6E7F1");
+  document.execCommand("foreColor",false,"rgba(14,189,106,209)");
+  document.body.innerHTML = "PASS if no crash.";
+  window.testRunner?.notifyDone();
+}
+</script>
+<body><div id="container">&#xA;A</body>

--- a/LayoutTests/fast/grid/layout-positioned-grid-items-002-crash-expected.txt
+++ b/LayoutTests/fast/grid/layout-positioned-grid-items-002-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/grid/layout-positioned-grid-items-002-crash.html
+++ b/LayoutTests/fast/grid/layout-positioned-grid-items-002-crash.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+#container2 {
+    display: inline-grid;
+    -webkit-perspective: 1px;
+}
+#child1 {
+    grid-column: b / a;
+    position: absolute;
+}
+#child2 {
+    display: inline-grid;
+    position: absolute;
+}
+</style>
+<object>
+  <div id="container">
+    <div id="container2">
+      <span id="child1"></span>
+      <link id="child2">A</link>
+    </div>
+  </div>
+</object>
+<script>
+  onload = () => {
+    testRunner?.dumpAsText();
+    testRunner?.waitUntilDone();
+    container.appendChild(child1);
+    requestAnimationFrame(() => {
+      document.body.innerHTML = "PASS if no crash.";
+      testRunner?.notifyDone();
+    });
+}
+</script>

--- a/LayoutTests/fast/grid/layout-positioned-grid-items-003-crash-expected.txt
+++ b/LayoutTests/fast/grid/layout-positioned-grid-items-003-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/grid/layout-positioned-grid-items-003-crash.html
+++ b/LayoutTests/fast/grid/layout-positioned-grid-items-003-crash.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+#container, #child1, #child2 { position: fixed; }
+#container { translate: 1px; }
+#container { display: grid; top: 1em; }
+#child1 { top: 1em; }
+#child2 { grid-area: 1 / c }
+</style>
+<iframe src="data:text/html,foo"></iframe>
+<div id="container">A<span id="child1"></span><span id="child2"></span></div>
+<script>
+  onload = () => {
+    testRunner?.dumpAsText();
+    testRunner?.waitUntilDone();
+    child1.prepend(child2);
+    requestAnimationFrame(() => {
+      document.body.innerHTML = "PASS if no crash.";
+      testRunner?.notifyDone();
+    });
+  }
+</script>
+</body>

--- a/LayoutTests/fast/multicol/video-not-removed-from-fragmented-flow-crash-expected.txt
+++ b/LayoutTests/fast/multicol/video-not-removed-from-fragmented-flow-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/multicol/video-not-removed-from-fragmented-flow-crash.html
+++ b/LayoutTests/fast/multicol/video-not-removed-from-fragmented-flow-crash.html
@@ -1,0 +1,23 @@
+<style>
+html, div { column-width: 1px; }
+video { display: block; }
+</style>
+<body><video id=video></video><div id=columnBox><li></body>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  let sheets = document.styleSheets[0];
+  sheets.insertRule(".abc { }");
+
+  document.body.offsetHeight;
+
+  video.popover = "auto";
+  document.body.offsetHeight;
+
+  sheets.cssRules[0].selectorText = "abc";
+  document.execCommand('fontSize');
+
+  video.remove();
+  columnBox.style.columnWidth = "auto";
+</script>
+This test passes if it does not crash.

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2062,7 +2062,7 @@ bool JSGlobalObject::canDeclareGlobalFunction(const Identifier& ident)
 
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);
     bool hasProperty = getOwnPropertySlot(this, this, ident, slot);
-    scope.assertNoExceptionExceptTermination();
+    RETURN_IF_EXCEPTION(scope, { });
     if (!hasProperty) [[likely]]
         return isStructureExtensible();
 
@@ -2083,7 +2083,7 @@ void JSGlobalObject::createGlobalFunctionBinding(const Identifier& ident)
 
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);
     bool hasProperty = getOwnPropertySlot(this, this, ident, slot);
-    scope.assertNoExceptionExceptTermination();
+    RETURN_IF_EXCEPTION(scope, void());
     if (hasProperty) [[unlikely]] {
         if (slot.attributes() & PropertyAttribute::DontDelete) {
             ASSERT(!(slot.attributes() & PropertyAttribute::ReadOnly));

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -562,7 +562,7 @@ inline void JSGlobalObject::createGlobalVarBinding(const Identifier& ident)
 
     PropertySlot slot(this, PropertySlot::InternalMethodType::GetOwnProperty);
     bool hasProperty = getOwnPropertySlot(this, this, ident, slot);
-    scope.assertNoExceptionExceptTermination();
+    RETURN_IF_EXCEPTION(scope, void());
     if (hasProperty) [[unlikely]]
         return;
 

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp
@@ -77,8 +77,8 @@ void JSModuleNamespaceObject::finishCreation(JSGlobalObject* globalObject, Abstr
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-setprototypeof-v
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-isextensible
     // http://www.ecma-international.org/ecma-262/6.0/#sec-module-namespace-exotic-objects-preventextensions
+    scope.release();
     methodTable()->preventExtensions(this, globalObject);
-    scope.assertNoExceptionExceptTermination();
 }
 
 void JSModuleNamespaceObject::destroy(JSCell* cell)

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2567,8 +2567,6 @@ JSValue JSObject::ordinaryToPrimitive(JSGlobalObject* globalObject, PreferredPri
             return value;
     }
 
-    scope.assertNoExceptionExceptTermination();
-
     return throwTypeError(globalObject, scope, "No default value"_s);
 }
 
@@ -2801,9 +2799,9 @@ void JSObject::getOwnNonIndexPropertyNames(JSGlobalObject* globalObject, Propert
     methodTable()->getOwnSpecialPropertyNames(this, globalObject, propertyNames, mode);
     RETURN_IF_EXCEPTION(scope, void());
 
+    scope.release();
     getNonReifiedStaticPropertyNames(vm, propertyNames, mode);
     structure()->getPropertyNamesFromStructure(vm, propertyNames, mode);
-    scope.assertNoExceptionExceptTermination();
 }
 
 double JSObject::toNumber(JSGlobalObject* globalObject) const

--- a/Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.cpp
+++ b/Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.cpp
@@ -82,8 +82,8 @@ JSArray* JSTemplateObjectDescriptor::createTemplateObject(JSGlobalObject* global
 
     templateObject->putDirect(vm, vm.propertyNames->raw, rawObject, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete);
 
+    scope.release();
     objectConstructorFreeze(globalObject, templateObject);
-    scope.assertNoExceptionExceptTermination();
 
     return templateObject;
 }

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
@@ -107,8 +107,10 @@ bool objectPrototypeHasOwnProperty(JSGlobalObject* globalObject, JSObject* thisO
     Structure* structure = thisObject->structure();
     HasOwnPropertyCache& hasOwnPropertyCache = vm.ensureHasOwnPropertyCache();
     if (std::optional<bool> result = hasOwnPropertyCache.get(structure, propertyName)) {
+#if ASSERT_ENABLED
         ASSERT(*result == thisObject->hasOwnProperty(globalObject, propertyName) || vm.hasPendingTerminationException());
-        scope.assertNoExceptionExceptTermination();
+        RETURN_IF_EXCEPTION(scope, false);
+#endif
         return *result;
     }
 

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -121,7 +121,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
         for (auto& entry : lexicalDeclarations) {
             if (hasGlobalLexicalDeclarations) {
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, entry.key.get());
-                throwScope.assertNoExceptionExceptTermination();
+                RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (hasProperty) {
                     if (entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext()) [[unlikely]] {
                         // We only allow "const" duplicate declarations under this setting.
@@ -159,7 +159,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                 if (entry.value.isSloppyModeHoistedFunction())
                     continue;
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, entry.key.get());
-                throwScope.assertNoExceptionExceptTermination();
+                RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (hasProperty)
                     return createErrorForDuplicateGlobalVariableDeclaration(globalObject, entry.key.get());
             }
@@ -169,12 +169,12 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
             UnlinkedFunctionExecutable* unlinkedFunctionExecutable = unlinkedCodeBlock->functionDecl(i);
             ASSERT(!unlinkedFunctionExecutable->name().isEmpty());
             bool canDeclare = globalObject->canDeclareGlobalFunction(unlinkedFunctionExecutable->name());
-            throwScope.assertNoExceptionExceptTermination();
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             if (!canDeclare) {
                 if (requiresCanDeclareGlobalFunctionQuirk()) {
                     VM::DeletePropertyModeScope scope(vm, VM::DeletePropertyMode::IgnoreConfigurable);
                     JSCell::deleteProperty(globalObject, globalObject, unlinkedFunctionExecutable->name());
-                    throwScope.assertNoExceptionExceptTermination();
+                    RETURN_IF_EXCEPTION(throwScope, nullptr);
                     continue;
                 }
                 return createErrorForInvalidGlobalFunctionDeclaration(globalObject, unlinkedFunctionExecutable->name());
@@ -188,7 +188,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                 ASSERT(entry.value.isVar());
                 const Identifier& ident = Identifier::fromUid(vm, entry.key.get());
                 bool canDeclare = globalObject->canDeclareGlobalVar(ident);
-                throwScope.assertNoExceptionExceptTermination();
+                RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (!canDeclare)
                     return createErrorForInvalidGlobalVarDeclaration(globalObject, ident);
             }
@@ -209,18 +209,18 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
 
             if (hasGlobalLexicalDeclarations) {
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, ident);
-                throwScope.assertNoExceptionExceptTermination();
+                RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (hasProperty)
                     continue;
             }
 
             bool canDeclare = globalObject->canDeclareGlobalVar(ident);
-            throwScope.assertNoExceptionExceptTermination();
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             if (!canDeclare)
                 continue;
 
             globalObject->createGlobalVarBinding<BindingCreationContext::Global>(ident);
-            throwScope.assertNoExceptionExceptTermination();
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
         }
     }
 
@@ -228,7 +228,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
         UnlinkedFunctionExecutable* unlinkedFunctionExecutable = unlinkedCodeBlock->functionDecl(i);
         ASSERT(!unlinkedFunctionExecutable->name().isEmpty());
         globalObject->createGlobalFunctionBinding<BindingCreationContext::Global>(unlinkedFunctionExecutable->name());
-        throwScope.assertNoExceptionExceptTermination();
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         if (vm.typeProfiler() || vm.controlFlowProfiler()) {
             vm.functionHasExecutedCache()->insertUnexecutedRange(sourceID(), 
                 unlinkedFunctionExecutable->unlinkedFunctionStart(),
@@ -241,7 +241,7 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
             continue;
         ASSERT(entry.value.isVar());
         globalObject->createGlobalVarBinding<BindingCreationContext::Global>(Identifier::fromUid(vm, entry.key.get()));
-        throwScope.assertNoExceptionExceptTermination();
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
     }
 
     {

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -607,18 +607,22 @@ void DeleteSelectionCommand::makeStylingElementsDirectChildrenOfEditableRootToPr
     if (!range)
         return;
     auto nodes = intersectingNodes(*range).begin();
+    Vector<Ref<HTMLElement>> stylingElements;
     while (nodes) {
         Ref node = *nodes;
         auto shouldMove = is<HTMLLinkElement>(node) || is<HTMLStyleElement>(node);
-        if (!shouldMove)
-            nodes.advance();
-        else {
+        if (shouldMove) {
             nodes.advanceSkippingChildren();
-            if (RefPtr rootEditableElement = node->rootEditableElement()) {
-                removeNode(node.get());
-                appendNode(node.get(), *rootEditableElement);
-            }
-        }
+            stylingElements.append(downcast<HTMLElement>(WTFMove(node)));
+        } else
+            nodes.advance();
+    }
+    for (auto& stylingElement : stylingElements) {
+        RefPtr rootEditableElement = stylingElement->rootEditableElement();
+        if (!rootEditableElement)
+            continue;
+        removeNode(stylingElement.get());
+        appendNode(stylingElement.get(), *rootEditableElement);
     }
 }
 

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
@@ -65,7 +65,7 @@ private:
 
     // Message handlers
     void invokeMethod(const RemoteObjectInvocation&);
-    void callReplyBlock(uint64_t replyID, const UserData& blockInvocation);
+    void callReplyBlock(IPC::Connection& connection, uint64_t replyID, const UserData& blockInvocation);
     void releaseUnusedReplyBlock(uint64_t replyID);
 
     WeakObjCPtr<_WKRemoteObjectRegistry> m_remoteObjectRegistry;

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -1009,6 +1009,9 @@ static RetainPtr<NSInvocation> decodeInvocation(WKRemoteObjectDecoder *decoder)
         if (!invocation)
             [NSException raise:NSInvalidUnarchiveOperationException format:@"Reply block for selector \"%s\" is not defined in the local interface", sel_getName(decoder->_replyToSelector)];
     } else {
+        if (decoder->_replyToSelector)
+            [NSException raise:NSInvalidUnarchiveOperationException format:@"%@: Expected reply block but received isReplyBlock false", decoder];
+
         RetainPtr<NSString> selectorString = [decoder decodeObjectOfClass:[NSString class] forKey:selectorKey];
         if (!selectorString)
             [NSException raise:NSInvalidUnarchiveOperationException format:@"Invocation had no selector"];

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -261,6 +261,9 @@
 		53FCDE6B229EFFB900598ECF /* IsoHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FCDE6A229EFFB900598ECF /* IsoHeap.cpp */; };
 		5597F8361D9596C80066BC21 /* SynchronizedFixedQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5597F8341D9596C80066BC21 /* SynchronizedFixedQueue.cpp */; };
 		55F9D2E52205031800A9AB38 /* AdditionalSupportedImageTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55F9D2E42205031800A9AB38 /* AdditionalSupportedImageTypes.mm */; };
+		56EEE4782D8D6B85003D4FB1 /* coreipc.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = 56EEE4772D8D6B85003D4FB1 /* coreipc.js */; };
+		56EEE4832D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 56EEE4822D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html */; };
+		56EEE48F2D8DB402003D4FB1 /* coreipc-helpers.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = 56EEE48E2D8DB402003D4FB1 /* coreipc-helpers.js */; };
 		57152B5E21CC2045000C37CA /* ApduTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57152B5D21CC2045000C37CA /* ApduTest.cpp */; };
 		57152B7821DD4E8D000C37CA /* U2fCommandConstructorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57D1D75E21DCB7A80093E86A /* U2fCommandConstructorTest.cpp */; };
 		572B403421769A88000AD43E /* CtapRequestTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 572B403321769A88000AD43E /* CtapRequestTest.cpp */; };
@@ -1886,6 +1889,8 @@
 				A17C47342C98E5C20023F3C7 /* CookieMessage.html in Copy Resources */,
 				A17C47352C98E5C20023F3C7 /* copy-html.html in Copy Resources */,
 				A17C47362C98E5C20023F3C7 /* copy-url.html in Copy Resources */,
+				56EEE48F2D8DB402003D4FB1 /* coreipc-helpers.js in Copy Resources */,
+				56EEE4782D8D6B85003D4FB1 /* coreipc.js in Copy Resources */,
 				A17C466E2C98E4D20023F3C7 /* CrossPartitionFileSchemeAccess.html in Copy Resources */,
 				A17C47372C98E5C20023F3C7 /* csp-document-uri-report.html in Copy Resources */,
 				A17C47382C98E5C20023F3C7 /* CSSViewportUnits.html in Copy Resources */,
@@ -2180,6 +2185,7 @@
 				A17C46E22C98E54B0023F3C7 /* push-state.html in Copy Resources */,
 				A17C46E32C98E54B0023F3C7 /* qr-code.png in Copy Resources */,
 				A17C46E42C98E54B0023F3C7 /* red.html in Copy Resources */,
+				56EEE4832D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html in Copy Resources */,
 				A17C46E52C98E54B0023F3C7 /* remove-node-on-drop.html in Copy Resources */,
 				A17C47EF2C98E5C20023F3C7 /* rendered-image-excluding-overflow.html in Copy Resources */,
 				A17C47F02C98E5C20023F3C7 /* resourceLoadStatisticsMissingUniqueIndex.db in Copy Resources */,
@@ -3021,6 +3027,9 @@
 		55A817FD218101DF0004A39A /* 400x400-green.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "400x400-green.png"; sourceTree = "<group>"; };
 		55A817FE218101DF0004A39A /* 100x100-red.tga */ = {isa = PBXFileReference; lastKnownFileType = file; path = "100x100-red.tga"; sourceTree = "<group>"; };
 		55F9D2E42205031800A9AB38 /* AdditionalSupportedImageTypes.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = AdditionalSupportedImageTypes.mm; sourceTree = "<group>"; };
+		56EEE4772D8D6B85003D4FB1 /* coreipc.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = coreipc.js; sourceTree = "<group>"; };
+		56EEE4822D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "RemoteObjectRegistry-BadReplyBlock.html"; sourceTree = "<group>"; };
+		56EEE48E2D8DB402003D4FB1 /* coreipc-helpers.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "coreipc-helpers.js"; sourceTree = "<group>"; };
 		5703BB8C2463F87200475FB2 /* web-authentication-make-credential-la-no-attestation.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-la-no-attestation.html"; sourceTree = "<group>"; };
 		570D26F323C3CA5500D5CF67 /* web-authentication-make-credential-hid-pin-get-key-agreement-error.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-hid-pin-get-key-agreement-error.html"; sourceTree = "<group>"; };
 		570D26F523C3D32700D5CF67 /* web-authentication-make-credential-hid-pin.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-make-credential-hid-pin.html"; sourceTree = "<group>"; };
@@ -5659,6 +5668,8 @@
 				5C2936941D5BFD1900DEAB1E /* CookieMessage.html */,
 				9B1056421F9047CC00D5583F /* copy-html.html */,
 				9B62630B1F8C2510007EE29B /* copy-url.html */,
+				56EEE48E2D8DB402003D4FB1 /* coreipc-helpers.js */,
+				56EEE4772D8D6B85003D4FB1 /* coreipc.js */,
 				4995A6EF25E876A300E5F0A9 /* csp-document-uri-report.html */,
 				952F7166270BD99700D00DCC /* CSSViewportUnits.html */,
 				952F7166270BD99700D00DCD /* CSSViewportUnits.svg */,
@@ -5850,6 +5861,7 @@
 				46FD40302A6B3E3500A1B210 /* postMessage-various-types.html */,
 				F41AB9941EF4692C0083FA08 /* prevent-operation.html */,
 				F41AB99A1EF4692C0083FA08 /* prevent-start.html */,
+				56EEE4822D8D706F003D4FB1 /* RemoteObjectRegistry-BadReplyBlock.html */,
 				A12DDBFF1E8373C100CF6CAE /* rendered-image-excluding-overflow.html */,
 				498D030926376B2C009CBFAD /* resourceLoadStatisticsMissingUniqueIndex.db */,
 				F46849BF1EEF5EDC00B937FE /* rich-and-plain-text.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry-BadReplyBlock.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry-BadReplyBlock.html
@@ -1,0 +1,91 @@
+<html>
+<head>
+    <script src="coreipc-helpers.js"></script>
+    <script src="coreipc.js"></script>
+</head>
+<body>
+<script>
+    // Milliseconds between checks that we've received an initial replyID to use for our messages.
+    const replyIDCheckInterval = 500;
+
+    let firstReplyID;
+    let secondReplyID;
+
+    // Our replyID is passed from the sender. This could just begin at 1 if we are the first/only test
+    // to run, but other tests may have run before us and used these early IDs, so we need to intercept the
+    // first InvokeMethod and check what the initial replyID is that we should use.
+    let wiretap = new IPCWireTap('UI', 'Incoming');
+    wiretap.tapEvery(IPC.messages['RemoteObjectRegistry_InvokeMethod'].name, function(process, connectionID, messageName, typedResult, result){
+        if (firstReplyID === undefined) {
+            firstReplyID = parseInt(result.invocation.replyInfo.optionalValue.replyID);
+        } else if (secondReplyID === undefined) {
+            // This will just be the firstReplyID+1, but we use it as a gate to wait to fire off the replies to
+            // the UI process.
+            secondReplyID = parseInt(result.invocation.replyInfo.optionalValue.replyID);
+        }
+    });
+
+    window.webkit.messageHandlers.testHandler.postMessage("Expecting InvokeMethod...");
+
+    function sendReplyBlockMessages() {
+        if (secondReplyID === undefined) {
+            setTimeout(sendReplyBlockMessages, replyIDCheckInterval);
+            return;
+        }
+
+        // This is a reply, so the destination ID should be to the WebPage identifier in the UI process. Current
+        // generation has this as being generated immediately before the proxy identifier, so we can get away with
+        // -1 to retrieve it here.
+        //
+        // See: WebPageProxy::WebPageProxy initialization of m_identifier and m_webPageID.
+        const uiProcessWebPageID = IPC.webPageProxyID - 1n;
+
+        // The corresponding InvokeMethod message will have already been sent to us by the UI process. Here we'll
+        // reply with our own custom response, which tests that encoding the NSInvocation in the wrong way gets
+        // rejected by the other side.
+        CoreIPC.UI.RemoteObjectRegistry.CallReplyBlock(uiProcessWebPageID, {
+            replyID: firstReplyID,
+            blockInvocation: {
+                protectedObject:
+                new API_Dictionary([
+                    {
+                        key: "$objectStream",
+                        value: new API_Array([
+                            new NSNumber(0x1122334455667788n).encode(),
+                            new NSNumber(0x1122334455667788n).encode(),
+                        ]).encode()
+                    },
+                    {
+                        key: 'invocation',
+                        value: new NSInvocation("methodWithInteger:", "v@:Q", isReplyBlock=false).encode()
+                    }
+                ]).encode()
+            }
+        });
+
+        // We also perform a second InvokeMethod and reply to this one correctly, this ensures the CoreIPC sending
+        // is functioning correctly.
+        CoreIPC.UI.RemoteObjectRegistry.CallReplyBlock(uiProcessWebPageID, {
+            replyID: secondReplyID,
+            blockInvocation: {
+                protectedObject:
+                    new API_Dictionary([
+                    {
+                        key: "$objectStream",
+                        value: new API_Array([
+                            new NSString("hello").encode(),
+                            new NSString("world").encode(),
+                        ]).encode()
+                    },
+                    {
+                        key: 'invocation',
+                        value: new NSInvocation("methodWithCompletionHandler:", 'v@?@@"NSString"', isReplyBlock=true).encode()
+                    }
+                ]).encode()
+            }
+        });
+    }
+
+    setTimeout(sendReplyBlockMessages, replyIDCheckInterval);
+</script>
+</body>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h
@@ -66,6 +66,13 @@
 
 @end
 
+@protocol StringReplyObjectProtocol
+
+- (void)methodWithInteger:(uint64_t)integer;
+- (void)methodWithCompletionHandler:(void (^)(id, NSString *))completionHandler;
+
+@end
+
 static inline _WKRemoteObjectInterface *remoteObjectInterface()
 {
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(RemoteObjectProtocol)];
@@ -79,5 +86,11 @@ static inline _WKRemoteObjectInterface *localObjectInterface()
 {
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(LocalObjectProtocol)];
 
+    return interface;
+}
+
+static inline _WKRemoteObjectInterface *stringReplyObjectInterface()
+{
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(StringReplyObjectProtocol)];
     return interface;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm
@@ -31,10 +31,13 @@
 #import "Test.h"
 #import "TestAwakener.h"
 #import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <wtf/BlockPtr.h>
@@ -277,3 +280,46 @@ TEST(RemoteObjectRegistry, SerializeErrorWithCertificates)
     }];
     TestWebKitAPI::Util::run(&roundTripComplete);
 }
+
+#if ENABLE(IPC_TESTING_API)
+
+TEST(RemoteObjectRegistry, CallReplyBlockWithBadInvocation)
+{
+    NSString * const testPlugInClassName = @"RemoteObjectRegistryPlugIn";
+    auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
+
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration: configuration.get()]);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"RemoteObjectRegistry-BadReplyBlock" withExtension:@"html"]]];
+
+    [webView waitForMessage:@"Expecting InvokeMethod..."];
+
+    __block bool invalidCallReceived = false;
+
+    id stringReplyObjectProxy = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:stringReplyObjectInterface()];
+    [stringReplyObjectProxy methodWithCompletionHandler:^(id, NSString * reply) {
+        NSLog(@"Failed, should not have received: %@", reply);
+        invalidCallReceived = true;
+    }];
+
+    __block bool validCallReceived = false;
+
+    [stringReplyObjectProxy methodWithCompletionHandler:^(id, NSString * reply) {
+        NSLog(@"Success, received: %@", reply);
+        validCallReceived = true;
+    }];
+
+    TestWebKitAPI::Util::run(&validCallReceived);
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+    EXPECT_FALSE(invalidCallReceived);
+}
+
+#endif // ENABLE(IPC_TESTING_API)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/coreipc-helpers.js
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/coreipc-helpers.js
@@ -1,0 +1,137 @@
+class API_Boolean {
+    constructor(value) {
+        this.value = value;
+    }
+
+    encode() {
+        return {
+            optionalValue: {
+                subclasses: {
+                    variantType: "API::Boolean",
+                    variant: {
+                        value: this.value
+                    }
+                }
+            }
+        }
+    }
+}
+
+class API_String {
+    constructor(str) {
+        this.str = str;
+    }
+
+    encode() {
+        return {
+            optionalValue: {
+                subclasses: {
+                    variantType: "API::String",
+                    variant: {
+                        string: this.str
+                    }
+                }
+            }
+        }
+    }
+}
+
+class API_Array {
+    constructor(elements) {
+        this.elements = elements;
+    }
+
+    encode() {
+        return {
+            optionalValue: {
+                subclasses: {
+                    variantType: "API::Array",
+                    variant: {
+                        elements: this.elements
+                    }
+                }
+            }
+        }
+    }
+}
+
+class API_Dictionary {
+    constructor(values) {
+        this.values = values;
+    }
+
+    encode() {
+        return {
+            optionalValue: {
+                subclasses: {
+                    variantType: "API::Dictionary",
+                    variant: {
+                        map: this.values
+                    }
+                }
+            }
+        }
+    }
+}
+
+class API_UInt64 {
+    constructor(value) {
+        this.value = value;
+    }
+
+    encode() {
+        return {
+            optionalValue: {
+                subclasses: {
+                    variantType: "API::UInt64",
+                    variant: {
+                        value: this.value
+                    }
+                }
+            }
+        }
+    }
+}
+
+class NSString {
+    constructor(str) {
+        this.str = str;
+    }
+
+    encode() {
+        return new API_Dictionary([
+            { key: '$class', value: new API_String("NSString").encode() },
+            { key: '$string', value: new API_String(this.str).encode() }
+        ]).encode();
+    }
+}
+
+class NSNumber {
+    constructor(value) {
+        this.value = value;
+    }
+
+    encode() {
+        return new API_Dictionary([
+            { key: '$class', value: new API_String("NSNumber").encode() },
+            // see     frame #0: 0x0000000184f8fc04 Foundation`-[NSPlaceholderNumber initWithCoder:](self=0x00000001ea154ca0, _cmd=<unavailable>, decoder=0x00006000027c8040) at NSValue.m:2158:13 [opt]
+            { key: 'NS.intval', value: new API_UInt64(this.value).encode() }
+        ]).encode();
+    }
+}
+
+class NSInvocation {
+    constructor(selector, typeString, isReplyBlock=false) {
+        this.selector = selector;
+        this.typeString = typeString;
+        this.isReplyBlock = isReplyBlock;
+    }
+    encode() {
+        return new API_Dictionary([
+            { key: '$class', value: new API_String("NSInvocation").encode() },
+            { key: 'selector', value: new NSString(this.selector).encode() },
+            { key: 'typeString', value: new NSString(this.typeString).encode() },
+            { key: 'isReplyBlock', value: new API_Boolean(this.isReplyBlock).encode() }
+        ]).encode()
+    }
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/coreipc.js
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/coreipc.js
@@ -1,0 +1,1292 @@
+const MAX_UINT8 = Math.pow(2, 8)-1;
+const MIN_UINT = 0;
+const MAX_UINT16 = Math.pow(2, 16)-1;
+const MAX_UINT32 = Math.pow(2, 32)-1;
+const MAX_UINT64 = Math.pow(2, 64)-1;
+
+const MAX_INT8 = Math.pow(2, 8-1)-1;
+const MIN_INT8 = -Math.pow(2, 8-1)+1;
+const MAX_INT16 = Math.pow(2, 16-1)-1;
+const MIN_INT16 = -Math.pow(2, 16-1)+1;
+const MAX_INT32 = Math.pow(2, 32-1)-1;
+const MIN_INT32 = -Math.pow(2, 32-1)+1;
+const MAX_INT64 = Math.pow(2, 64-1)-1;
+const MIN_INT64 = -Math.pow(2, 64-1)+1;
+
+
+function deepCopy(object) {
+    return JSON.parse(JSON.stringify(object));
+}
+
+function splitClassAndFunction(name) {
+    const [clz, ...rest] = name.split("_");
+    return [clz, rest.join("_")];
+}
+
+class CoreIPCClass {
+    messages;
+    typeInfo;
+    UI;
+    GPU;
+    Networking;
+    messageByName = {};
+
+    default_timeout = 1;
+
+    constructor() {
+        // Take a copy of IPC dictionaries to avoid calling into IPC API frequently
+        this.messages = deepCopy(IPC.messages);
+        this.typeInfo = deepCopy(IPC.serializedTypeInfo);
+        this.enumInfo = deepCopy(IPC.serializedEnumInfo);
+        this.objectIdentifiers = deepCopy(IPC.objectIdentifiers);
+
+        this.initializeMessageByName();
+
+        // fix-ups
+        this.objectIdentifiers.push('WebKit::WebPageProxyIdentifier');
+        this.objectIdentifiers.push('WebCore::ProcessIdentifier');
+        this.objectIdentifiers.push('WebKit::RemoteCDMIdentifier');
+
+        this.UI = this.initializeMessages("UI");
+        this.GPU = this.initializeMessages("GPU");
+        this.Networking = this.initializeMessages("Networking");
+    }
+
+    initializeMessageByName() {
+        for(const [key, value] of Object.entries(this.messages)) {
+            let [className, functionName] = splitClassAndFunction(key);
+            value.className = className;
+            value.functionName = functionName;
+            this.messageByName[value.name] = value;
+        }
+    }
+
+    initializeMessages(process) {
+        const messages = {};
+        for(const [key, value] of Object.entries(this.messages)) {
+            let [className, functionName] = splitClassAndFunction(key);
+            if(!(className in messages)) {
+                messages[className] = {};
+            }
+            messages[className][functionName] = this.generateSendingFunction(process, value);
+        }
+        return messages;
+    }
+
+    generateSendingFunction(process, definition) {
+        const name = definition.name;
+        if(definition.replyArguments === null) {
+            if(definition.isSync) {
+                return (connectionIdentifier, messageArguments) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    IPC.sendSyncMessage(process, connectionIdentifier, name, this.default_timeout, serializedArguments);
+                }
+            } else {
+                return (connectionIdentifier, messageArguments) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    IPC.sendMessage(process, connectionIdentifier, name, serializedArguments);
+                }
+            }
+        } else {
+            const replyArguments = definition.replyArguments;
+            if(definition.isSync) {
+                return (connectionIdentifier, messageArguments, replyHandler) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    const reply = IPC.sendSyncMessage(process, connectionIdentifier, name, this.default_timeout, serializedArguments);
+                    if(reply && replyHandler) {
+                        const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
+                        replyHandler(parsedReply, reply.buffer, typedReply);
+                    }
+                }
+            } else {
+                return (connectionIdentifier, messageArguments, replyHandler) => {
+                    const connection = IPC.connectionForProcessTarget(process);
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    connection.sendWithAsyncReply(connectionIdentifier, name, serializedArguments, (reply)=> {
+                        if(replyHandler) {
+                            const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
+                            replyHandler(parsedReply, reply.buffer, typedReply);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    newStreamConnection() {
+        return new StreamConnection();
+    }
+}
+
+class StreamConnection {
+    #connectionPair;
+    handle;
+    connection;
+    constructor() {
+        this.#connectionPair = IPC.createStreamClientConnection(14, 0.1);
+        this.handle = this.#connectionPair[1];
+        this.connection = this.#connectionPair[0];
+        this.connection.open();
+    }
+
+    newInterface(interfaceName, connectionIdentifier) {
+        return new StreamConnectionInterface(interfaceName, connectionIdentifier, this.connection);
+    }
+}
+
+class StreamConnectionInterface {
+    #connectionIdentifier;
+    constructor(interfaceName, connectionIdentifier, connection) {
+        this.interfaceName = interfaceName;
+        this.connection = connection;
+        this.#connectionIdentifier = connectionIdentifier;
+        this.generatedFunctions = [];
+        this.initializeMessages();
+    }
+
+    getIdentifier() {
+        return this.#connectionIdentifier;
+    }
+
+    initializeMessages() {
+        for(const [key, value] of Object.entries(CoreIPC.messages)) {
+            let [className, functionName] = splitClassAndFunction(key);
+            if(className == this.interfaceName) {
+                this[functionName] = this.generateStreamSendingFunction(value);
+                this.generatedFunctions.push(functionName);
+            }
+        }
+    }
+
+    generateStreamSendingFunction(definition) {
+        const name = definition.name;
+        if(definition.replyArguments === null) {
+            if(definition.isSync) {
+                return (messageArguments) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    this.connection.sendSyncMessage(this.#connectionIdentifier, name, serializedArguments);
+                }
+            } else {
+                return (messageArguments) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    this.connection.sendMessage(this.#connectionIdentifier, name, serializedArguments);
+                }
+            }
+        } else {
+            const replyArguments = definition.replyArguments;
+            if(definition.isSync) {
+                return (messageArguments, replyHandler) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    const reply = this.connection.sendSyncMessage(this.#connectionIdentifier, name, serializedArguments);
+                    if(reply && replyHandler) {
+                        const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
+                        replyHandler(parsedReply, reply.buffer, typedReply);
+                    }
+                }
+            } else {
+                return (messageArguments, replyHandler) => {
+                    const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
+                    this.connection.sendWithAsyncReply(this.#connectionIdentifier, name, serializedArguments, (reply)=> {
+                        if(replyHandler) {
+                            const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
+                            replyHandler(parsedReply, reply.buffer, typedReply);
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+class SerializationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'SerializationError';
+    }
+}
+
+const aliases = {
+    'int': 'uint32_t',
+    'unsigned': 'uint32_t',
+    'char': 'uint8_t',
+    'size_t': 'uint64_t',
+    'pid_t': 'uint32_t',
+    'unsigned short': 'uint16_t',
+    'const bool': 'bool',
+    'const uint8_t': 'uint8_t',
+    'const char': 'uint8_t',
+    'unsigned long': 'uint64_t',
+    'long': 'uint64_t',
+    'unsigned char': 'uint8_t',
+    'CGFloat': 'double',
+    'long long': 'int64_t',
+    'unsigned long long': 'uint64_t',
+    'short': 'int16_t',
+    'const float': 'float',
+    'const int32_t': 'int32_t',
+    'const uint32_t': 'uint32_t',
+    'NSInteger': 'int64_t',
+    'NSUInteger': 'uint64_t',
+    'WebCore::ContextMenuAction': 'uint32_t',
+    'CGBitmapInfo': 'uint32_t',
+    'UInt32': 'uint32_t',
+    'CTFontDescriptorOptions': 'uint32_t',
+    'SystemMemoryPressureStatus': 'WTF::SystemMemoryPressureStatus',
+    // WebGL types
+    'GCGLenum': 'uint32_t',
+    'GCGLint': 'int32_t',
+    'GCGLErrorCodeSet': 'OptionSet<GCGLErrorCode>',
+    // these RetainPtr<T> should not be treated as optionnal because
+    // of the 'Ref wrapped by' in Source/WebKit/Shared/cf/CFTypes.serialization.in
+    // see generated code in WebKitBuild/Debug/DerivedSources/WebKit/WebKitPlatformGeneratedSerializers.mm
+    'RetainPtr<CFTypeRef>': 'WebKit::CoreIPCCFType',
+    'RetainPtr<CFDataRef>': 'WebKit::CoreIPCData',
+    'RetainPtr<CFStringRef>': 'String',
+    'RetainPtr<CFArrayRef>': 'WebKit::CoreIPCCFArray',
+    'RetainPtr<CFDictionaryRef>': 'WebKit::CoreIPCCFDictionary',
+    'RetainPtr<CFBooleanRef>': 'WebKit::CoreIPCBoolean',
+    'RetainPtr<CFNumberRef>': 'WebKit::CoreIPCNumber',
+    'RetainPtr<CFDateRef>': 'WebKit::CoreIPCDate',
+    'RetainPtr<CFURLRef>': 'WebKit::CoreIPCCFURL',
+    'RetainPtr<CFNullRef>': 'WebKit::CoreIPCNull',
+    'RetainPtr<SecAccessControlRef>': 'WebKit::CoreIPCSecAccessControl',
+    'RetainPtr<SecCertificateRef>': 'WebKit::CoreIPCSecCertificate',
+    'RetainPtr<SecKeychainItemRef>': 'WebKit::CoreIPCSecKeychainItem',
+    'RetainPtr<CVPixelBufferRef>': 'WebKit::CoreIPCCVPixelBufferRef',
+    'RetainPtr<SecTrustRef>': 'WebKit::CoreIPCSecTrust',
+    'RetainPtr<CFCharacterSetRef>': 'WebKit::CoreIPCCFCharacterSet',
+    'RetainPtr<CGColorRef>': 'WebCore::Color',
+    'RetainPtr<CGColorSpaceRef>': 'WebKit::CoreIPCCGColorSpace'
+}
+
+function resolveAlias(argumentType) {
+    if(argumentType in aliases) {
+        return resolveAlias(aliases[argumentType]);
+    }
+    return argumentType;
+}
+
+function isPrimtiveType(type) {
+    return ["double", "float", "bool","String","uint8_t", "int8_t","uint16_t", "int16_t","uint32_t", "int32_t","uint64_t", "int64_t",].includes(type);
+}
+
+function isEnum(type) {
+    return CoreIPC.enumInfo[type] != undefined;
+}
+
+function isIdentifier(type) {
+    return CoreIPC.objectIdentifiers.includes(type);
+}
+
+class ArgumentSerializer {
+    static enumSizeMap = {
+      1: 'uint8_t',
+      2: 'uint16_t',
+      4: 'uint32_t',
+      8: 'uint64_t'
+    };
+
+    static splitTemplateType(templateType) {
+        const result = [];
+        let current = '';
+        let depth = 0;
+        for(let index=0; index<templateType.length; index++) {
+            const currentCharacter = templateType.charAt(index);
+            if(currentCharacter == '>') {
+                depth -= 1;
+            }
+            if(currentCharacter == '<') {
+                depth += 1;
+            }
+            if(depth==0 && currentCharacter == ',') {
+                result.push(current.trim());
+                current = '';
+            } else {
+                current += currentCharacter;
+            }
+        }
+        if(depth != 0) {
+            throw new SerializationError(`unbalanced angle brackets when parsing '${ templateType }'`)
+        }
+        result.push(current.trim());
+        return result;
+    }
+
+    static parseTemplate(name) {
+        name = name.trim();
+        if(!name.endsWith(">")) {
+            throw new SerializationError(`Cannot parse template '${ name }'. Does not end with '>'`);
+        }
+        const start = name.indexOf("<");
+        if(start == -1) {
+            throw new SerializationError(`Couldn't find start of template '${ name }'`);
+        }
+        return [name.substring(0, start), name.substring(start + 1, name.length-1)];
+    }
+
+    static serializeOptional(innerType, argument) {
+        if(Object.hasOwn(argument, "optionalValue")) {
+            const argumentDefinition = {
+                type: innerType,
+                name: 'optionalValue'
+            };
+            try {
+                const serializedValue = ArgumentSerializer.serializeArgument(argumentDefinition, argument.optionalValue);
+                return [{value: 1, type: 'bool'}, serializedValue];
+            } catch (error) {
+                if(error instanceof SerializationError) {
+                    throw new SerializationError(`when serializing optional value of type '${ innerType }': ${ error.message }`);
+                } else {
+                    throw error;
+                }
+            }
+        } else {
+            return [{value: 0, type: 'bool'}];
+        }
+    }
+
+    static serializeMarkable(innerType, argument) {
+        if(Object.hasOwn(argument, "optionalValue")) {
+            const argumentDefinition = {
+                type: innerType,
+                name: 'optionalValue'
+            };
+            try {
+                const serializedValue = ArgumentSerializer.serializeArgument(argumentDefinition, argument.optionalValue);
+                return [{value: 0, type: 'bool'}, serializedValue];
+            } catch (error) {
+                if(error instanceof SerializationError) {
+                    throw new SerializationError(`when serializing optional value of type '${ innerType }': ${ error.message }`);
+                } else {
+                    throw error;
+                }
+            }
+        } else {
+            return [{value: 1, type: 'bool'}];
+        }
+    }
+
+    static serializeVector(innerType, argument) {
+        const splitType = ArgumentSerializer.splitTemplateType(innerType);
+        innerType = splitType[0];
+        if(Array.isArray(argument)) {
+            const result = [];
+            const argumentDefinition = {
+                type: innerType,
+            };
+            let count = 0;
+            for(const element of argument) {
+                argumentDefinition.name = `element#${ count }`;
+                count += 1;
+                result.push([ ArgumentSerializer.serializeArgument(argumentDefinition, element) ]);
+            }
+            return [{value: result, type: 'Vector'}];
+        }
+        throw new SerializationError('argument of vector-type is not an array');
+    }
+
+    static serializeArrayReferenceTuple(innerType, argument) {
+        const innerTypes = ArgumentSerializer.splitTemplateType(innerType);
+        if(Array.isArray(argument)) {
+            if(argument.length != innerTypes.length) {
+                throw new SerializationError(`expected ${ innerTypes.length } arguments but ${ argument.length } given`);
+            }
+            let allOfSameSize = argument.every((element) => argument[0].length == element.length);
+            if(!allOfSameSize) {
+                let sizes = argument.map(element => element.length);
+                throw new SerializationError(`ArrayReferenceTuple array elements must be have the same size: ${ sizes }`);
+            }
+            const result = [];
+            for(let i=0; i<innerTypes.length; i++) {
+                const argumentDefinition = {
+                    type: innerTypes[i],
+                }
+                for(let j=0; j<argument[i].length; j++) {
+                    argumentDefinition.name = `element#${ i }#${ j }`
+                    result.push(ArgumentSerializer.serializeArgument(argumentDefinition, argument[i][j]));
+                }
+            }
+            return [{value: argument[0].length, type: 'uint64_t'}, result]
+        }
+        throw new SerializationError('argument of ArrayReferenceTuple is not an array');
+    }
+
+    static serializeHashSet(innerType, argument) {
+        const splitType = ArgumentSerializer.splitTemplateType(innerType);
+        innerType = splitType[0];
+        if(Array.isArray(argument)) {
+            const result = [];
+            const argumentDefinition = {
+                type: innerType,
+            };
+            let count = 0;
+            for(const element of argument) {
+                argumentDefinition.name = `element#${ count }`;
+                count += 1;
+                result.push([ ArgumentSerializer.serializeArgument(argumentDefinition, element) ]);
+            }
+            return [{value: count, type: 'uint32_t'}, result];
+        }
+        throw new SerializationError('argument of HashSet type is not an array');
+    }
+
+    static serializeHashMap(innerType, argument) {
+        if(Array.isArray(argument)) {
+            const result = [];
+            let count = 0;
+            for(const element of argument) {
+                count += 1;
+                result.push([ ArgumentSerializer.serializeKeyValuePair(innerType, element) ]);
+            }
+            return [{value: count, type: 'uint32_t'}, result];
+        }
+        throw new SerializationError('argument of HashMap type is not an array');
+    }
+
+    static serializeStdArray(innerType, argument) {
+        const splitType = ArgumentSerializer.splitTemplateType(innerType);
+        if(splitType.length != 2) {
+            throw new SerializationError('std::pair does not have a fixed cardinality')
+        }
+        const size = Number(splitType[1]);
+        innerType = splitType[0];
+        if(Array.isArray(argument) || argument.length != size) {
+            const result = [];
+            const argumentDefinition = {
+                type: innerType,
+            };
+            let count = 0;
+            for(const element of argument) {
+                argumentDefinition.name = `element#${ count }`;
+                count += 1;
+                result.push([ ArgumentSerializer.serializeArgument(argumentDefinition, element) ]);
+            }
+            return result;
+        }
+        throw new SerializationError('argument of std::pair type is not an array');
+    }
+
+    static serializePair(innerType, argument) {
+        if(Array.isArray(argument) && argument.length == 2) {
+            const result = [];
+            const innerTypes = ArgumentSerializer.splitTemplateType(innerType);
+            let argumentDefinition = {
+                type: innerTypes[0],
+                name: 'element#0',
+            }
+            result.push([ ArgumentSerializer.serializeArgument(argumentDefinition, argument[0]) ]);
+            argumentDefinition.type = innerTypes[1];
+            argumentDefinition.name = 'element#1';
+            result.push([ ArgumentSerializer.serializeArgument(argumentDefinition, argument[1]) ]);
+            return result;
+        }
+        throw new SerializationError('argument of pair-type is not an array with two elements');
+    }
+
+    static serializeKeyValuePair(innerType, argument) {
+        const splitTemplateType = ArgumentSerializer.splitTemplateType(innerType);
+        if(argument['key'] === undefined)
+            throw new SerializationError('argument of key value type is missing the key attribute');
+        if(argument['value'] === undefined)
+            throw new SerializationError('argument of key value type is missing the key attribute');
+        const result = [];
+        let argumentDefinition = {type: splitTemplateType[0], name: "key"};
+        result.push(ArgumentSerializer.serializeArgument(argumentDefinition, argument['key']));
+        argumentDefinition = {type: splitTemplateType[1], name: "value"};
+        result.push(ArgumentSerializer.serializeArgument(argumentDefinition, argument['value']));
+        return result;
+    }
+
+    static serializeVariant(innerType, argument) {
+        const variantTypes = ArgumentSerializer.splitTemplateType(innerType);
+        if(!Object.hasOwn(argument, 'variantType')) {
+            throw new SerializationError('missing field \'variantType\' when serializing variant');
+        }
+        const variantType = argument.variantType;
+        const variantIndex = variantTypes.indexOf(variantType);
+        if(variantIndex == -1) {
+            throw new SerializationError(`type '${ variantType }' is not valid for variant (${ variantTypes })`);
+        }
+        if(!Object.hasOwn(argument, 'variant')) {
+            throw new SerializationError('missing field \'variant\' when serializing variant');
+        }
+        const argumentDefinition = {
+            name: 'variant',
+            type: variantType
+        };
+        return [{value: variantIndex, type: 'uint8_t'}, ArgumentSerializer.serializeArgument(argumentDefinition, argument.variant)];
+    }
+
+    static serializeTemplate(argumentDefinition, argument) {
+        const argumentType = argumentDefinition.type;
+        if(argumentType.includes("<")) {
+            const [ templateType, innerType ] = ArgumentSerializer.parseTemplate(argumentType);
+            switch (templateType) {
+                case 'RefPtr':
+                case 'std::unique_ptr':
+                case 'RetainPtr':
+                case 'std::optional':
+                case 'Optional':
+                    return ArgumentSerializer.serializeOptional(innerType, argument);
+                case 'Vector':
+                case 'std::vector':
+                case 'std::span':
+                case 'ArrayReference':
+                case 'Span':
+                    return ArgumentSerializer.serializeVector(innerType, argument);
+                case 'IPC::ArrayReferenceTuple':
+                    return ArgumentSerializer.serializeArrayReferenceTuple(innerType, argument);
+                case 'std::array':
+                    return ArgumentSerializer.serializeStdArray(innerType, argument);
+                case 'HashSet':
+                    return ArgumentSerializer.serializeHashSet(innerType, argument);
+                case 'std::variant':
+                    return ArgumentSerializer.serializeVariant(innerType, argument);
+                case 'std::pair':
+                    return ArgumentSerializer.serializePair(innerType, argument);
+                case 'OptionSet':
+                    return ArgumentSerializer.serializeOptionSet(innerType, argumentDefinition.name, argument);
+                case 'WTF::Markable':
+                case 'Markable':
+                    return ArgumentSerializer.serializeMarkable(innerType, argument);
+                case 'KeyValuePair':
+                    return ArgumentSerializer.serializeKeyValuePair(innerType, argument);
+                case 'HashMap':
+                case 'MemoryCompactRobinHoodHashMap':
+                    return ArgumentSerializer.serializeHashMap(innerType, argument);
+                case 'Ref':
+                case 'UniqueRef':
+                    return ArgumentSerializer.serializeArgument({type: innerType, name: argumentDefinition.name}, argument);
+                default:
+                    throw new SerializationError(`Don't know how to serialize template '${ templateType }'`);
+            }
+        }
+        return undefined;
+    }
+
+    static serializeIdentifier(argumentDefinition, argument) {
+        if(CoreIPC.objectIdentifiers.includes(argumentDefinition.type)) {
+            if(typeof argument != 'number' && typeof argument != 'bigint') {
+                throw new SerializationError(`Identifier of type ${ argumentDefinition.type } is not a number`);
+            }
+            if(argument < MIN_INT64 || argument > MAX_INT64) {
+                throw new SerializationError(`Identifier value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+            }
+            // magic object identifier for WebGL hotpatches
+            let type = argumentDefinition.type.endsWith("::uint32_t") ? "uint32_t" : "uint64_t";
+            return {value: argument, type: type};
+        }
+        return undefined;
+    }
+
+    static serializeOptionSet(innerType, name, argument) {
+        const argumentDefinition = {
+            type: innerType,
+            name: name
+        }
+        return this.serializeEnum(argumentDefinition, argument);
+    }
+
+    static serializeEnum(argumentDefinition, argument) {
+        const enumType = argumentDefinition.enum ? argumentDefinition.enum : argumentDefinition.type;
+        if(enumType in CoreIPC.enumInfo) {
+            const enumDefinition = CoreIPC.enumInfo[enumType];
+            const enumRepresentation = ArgumentSerializer.enumSizeMap[enumDefinition.size];
+            if(!enumRepresentation) {
+                throw new SerializationError(`Invalid enum size '${ enumDefinition.size }' when serializing ${ enumType } of member ${ argumentDefinition.name }`);
+            }
+            if(!enumDefinition.isOptionSet && !enumDefinition.validValues.includes(argument)) {
+                throw new SerializationError(`Invalid enum value ${ argument } when serializing ${ enumType } of member ${ argumentDefinition.name }`);
+            }
+            return {value: argument, type: enumRepresentation};
+        }
+        return undefined;
+    }
+
+    static serializeType(argumentDefinition, argument) {
+        if(argumentDefinition.type in CoreIPC.typeInfo) {
+            try {
+                return ArgumentSerializer.serializeArguments(CoreIPC.typeInfo[argumentDefinition.type], argument);
+            } catch(error) {
+                if(error instanceof SerializationError) {
+                    let message = `When serializing struct ${ argumentDefinition.name } of type ${ argumentDefinition.type }: ${ error.message }`;
+                    throw new SerializationError(message);
+                } else {
+                    throw error;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    static serializePrimitive(argumentDefinition, argument) {
+        switch(argumentDefinition.type) {
+            case 'uint8_t':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_UINT || argument > MAX_UINT8) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'int8_t':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_INT8 || argument > MAX_INT8) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'uint16_t':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_UINT || argument > MAX_UINT16) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'int16_t':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_INT16 || argument > MAX_INT16) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'uint32_t':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_UINT || argument > MAX_UINT32) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'int32_t':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_INT32 || argument > MAX_INT32) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'uint64_t':
+                if(typeof argument != "number" && typeof argument != "bigint") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number. it is ${ typeof(argument) }. ${ argument }`);
+                }
+                if(argument < MIN_UINT || argument > MAX_UINT64) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'int64_t':
+                if(typeof argument != "number" && typeof argument != "bigint") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                if(argument < MIN_INT64 || argument > MAX_INT64) {
+                    throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'float':
+            case 'double':
+                if(typeof argument != "number") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'String':
+                if(typeof argument != 'string') {
+                    throw new SerializationError(`Primitive value is not a string`);
+                }
+                return {value: argument, type: argumentDefinition.type};
+            case 'bool':
+                if(typeof argument != 'boolean') {
+                    throw new SerializationError(`Primitive value is not a bool`);
+                }
+                return {value: argument ? 1 : 0, type: argumentDefinition.type};
+            case 'IPC::ConnectionHandle':
+                if(argument instanceof StreamConnection) {
+                    return {value: argument.handle, type: 'ConnectionHandle'};
+                } else if(argument.open) {
+                    return {value: argument, type: 'ConnectionHandle'};
+                } else {
+                    throw new SerializationError(`ConnectionHandle is not a connection object`);
+                }
+            case 'IPC::StreamServerConnectionHandle':
+                if(argument instanceof StreamConnection) {
+                    return {value: argument.handle, type: 'StreamServerConnectionHandle'};
+                } else if(argument.open) {
+                    return {value: argument, type: 'StreamServerConnectionHandle'};
+                } else {
+                    throw new SerializationError(`ConnectionHandle is not a connection object`);
+                }
+            case 'std::nullptr_t':
+                if(argument === null) {
+                    return [];
+                } else throw new SerializationError(`std::nullptr_t is not null`);
+            case 'WebCore::SharedMemory::Handle':
+            case 'WebCore::SharedMemoryHandle':
+            case 'MachSendRight':
+                if(typeof argument != 'object') {
+                    throw new SerializationError('SharedMemory argument is not an object');
+                }
+                if(!argument.protection) {
+                    throw new SerializationError('SharedMemory argument is missing \'protection\' attribute');
+                }
+                if(argument.protection != 'ReadOnly' && argument.protection != 'ReadWrite') {
+                    throw new SerializationError("SharedMemory protection should be either 'ReadWrite' or 'ReadOnly'");
+                }
+                if(!argument.handle) {
+                    throw new SerializationError('SharedMemory argument is missing \'handle\' attribute');
+                }
+                if(!argument.handle.writeBytes) {
+                    throw new SerializationError('SharedMemory handle argument is not an Object created with IPC.createSharedMemory');
+                }
+                return {value: argument.handle, type: 'SharedMemory', protection: argument.protection};
+            case 'IPC::Semaphore':
+                if(typeof(argument) != 'object' || !argument.signal) {
+                    throw new SerializationError('IPC::Semaphore argument is not an Object created with IPC.createSemaphore');
+                }
+                return {value: argument, type: 'Semaphore'};
+        }
+        return undefined;
+    }
+
+    static serializeArgument(argumentDefinition, argument) {
+        let result;
+        argumentDefinition.type = resolveAlias(argumentDefinition.type);
+        if(argumentDefinition.optional === true) {
+            argumentDefinition.type = `Optional<${ argumentDefinition.type }>`;
+            argumentDefinition.optional = false;
+        }
+        if(result = ArgumentSerializer.serializeTemplate(argumentDefinition, argument))
+            return result;
+        if(result = ArgumentSerializer.serializeIdentifier(argumentDefinition, argument))
+            return result;
+        if(result = ArgumentSerializer.serializeEnum(argumentDefinition, argument))
+            return result;
+        if(result = ArgumentSerializer.serializePrimitive(argumentDefinition, argument))
+            return result;
+        if(result = ArgumentSerializer.serializeType(argumentDefinition, argument))
+            return result;
+        throw new Error(`Don't know how to serialize ${ argumentDefinition.name } of type ${ argumentDefinition.type }`);
+    }
+
+    static serializeArguments(methodArgumentsDefinition, methodArguments) {
+        const result = [];
+        for(const argument of methodArgumentsDefinition) {
+            const name = ArgumentSerializer.simplifyName(argument.name);
+            if(name in methodArguments) {
+                try {
+                    result.push(ArgumentSerializer.serializeArgument(argument, methodArguments[name]));
+                } catch (error) {
+                    if(error instanceof SerializationError) {
+                        throw new SerializationError(`When serializing argument/field '${ name }': ` + error.message);
+                    } else {
+                        throw error;
+                    }
+                }
+            } else {
+                throw new SerializationError(`argument/field '${ name }' is missing`);
+            }
+        }
+        return result;
+    }
+
+    static simplifyName(name) {
+        name = name.replaceAll("()", "");
+        let pos = -1;
+        while((pos = name.indexOf(".")) > -1) {
+            name = name.substring(0, pos) + name.charAt(pos+1).toUpperCase() + name.substring(pos+2, name.length);
+        }
+        return name
+    }
+
+}
+
+class ParserError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'ParserError';
+    }
+}
+
+const MESSAGE_HEADER_SIZE = 0x10;
+
+class ArgumentParser {
+    static align(position, granularity) {
+        if(position%granularity) {
+            position = position + granularity-(position%granularity);
+        }
+        return position;
+    }
+
+    static parseReply(reply, replyArguments) {
+        const buffer = new DataView(reply.buffer);
+        const [, typedResult, result] = ArgumentParser.parseArguments(buffer, MESSAGE_HEADER_SIZE, replyArguments);
+        return [result, typedResult]
+    }
+
+    static checkOutOfBounds(buffer, position, requestedSize) {
+        if(position + requestedSize > buffer.byteLength) {
+            throw new ParserError('out of bounds');
+        }
+    }
+
+    static parseIdentifier(buffer, position, argumentDefinition) {
+        if(CoreIPC.objectIdentifiers.includes(argumentDefinition.type)) {
+            // magic object identifier for WebGL hotpatches
+            if(argumentDefinition.type.endsWith("::uint32_t")) {
+                position = ArgumentParser.align(position, 4);
+                ArgumentParser.checkOutOfBounds(buffer, position, 4);
+                return [position + 8, {parsedValue: buffer.getUint32(position, true), parsedType: argumentDefinition.type}];
+            } else {
+                position = ArgumentParser.align(position, 8);
+                ArgumentParser.checkOutOfBounds(buffer, position, 8);
+                return [position + 8, {parsedValue: buffer.getBigUint64(position, true), parsedType: argumentDefinition.type}];
+            }
+        }
+        return undefined;
+    }
+
+    static parseType(buffer, position, argumentDefinition) {
+        if(argumentDefinition.type in CoreIPC.typeInfo) {
+            const [newPosition, value] = this.parseArguments(
+                buffer, position, CoreIPC.typeInfo[argumentDefinition.type]
+            );
+            return [newPosition, {parsedValue: value, parsedType: argumentDefinition.type}];
+        }
+        return undefined;
+    }
+
+    static parseVector(buffer, position, innerType) {
+        position = ArgumentParser.align(position, 8);
+        ArgumentParser.checkOutOfBounds(buffer, position, 8);
+        const elementCount = buffer.getBigUint64(position, true);
+        position += 8;
+        const values = [];
+        let element;
+        const argumentDefinition = {type: innerType};
+        for(let index = 0; index < elementCount; index++) {
+            argumentDefinition.name = `element#${ index }`;
+            try {
+                [position, element] = ArgumentParser.parseArgument(buffer, position, argumentDefinition);
+            } catch (error) {
+                throw new ParserError(`when parsing element #${ index } of array: ${ error.message }`);
+            }
+            values.push(element);
+        }
+        return [position, values];
+    }
+
+    static parsePair(buffer, position, innerType) {
+        const values = [];
+        const innerTypes = ArgumentSerializer.splitTemplateType(innerType);
+        let argumentDefinition = {type: innerTypes[0]};
+        argumentDefinition.name = "element#0";
+        let element;
+        [position, element] = ArgumentParser.parseArgument(buffer, position, argumentDefinition);
+        values.push(element);
+        argumentDefinition.name = "element#1";
+        argumentDefinition.type = innerTypes[1];
+        [position, element] = ArgumentParser.parseArgument(buffer, position, argumentDefinition);
+        values.push(element);
+        return [position, values];
+    }
+
+    static parseHashMap(buffer, position, innerType) {
+        position = ArgumentParser.align(position, 4);
+        ArgumentParser.checkOutOfBounds(buffer, position, 4);
+        const elementCount = buffer.getUint32(position, true);
+        position += 4;
+        const values = [];
+        let element;
+        for(let index = 0; index < elementCount; index++) {
+            try {
+                [position, element] = ArgumentParser.parsePair(buffer, position, innerType);
+            } catch (error) {
+                throw new ParserError(`when parsing element #${ index } of HashMap: ${ error.message }`);
+            }
+            values.push(element);
+        }
+        return [position, values];
+    }
+
+    static parseOptional(buffer, position, innerType) {
+        ArgumentParser.checkOutOfBounds(buffer, position, 1);
+        const has = !!buffer.getUint8(position);
+        position += 1;
+        if(has) {
+            const argumentDefinition = {name: 'optionalValue', type: innerType};
+            const [newPosition, optionalValue] = ArgumentParser.parseArgument(buffer, position, argumentDefinition)
+            return [newPosition, {optionalValue: optionalValue}];
+        } else {
+            return [position, {}]
+        }
+    }
+
+    static parseMarkable(buffer, position, innerType) {
+        ArgumentParser.checkOutOfBounds(buffer, position, 1);
+        const isEmpty = !!buffer.getUint8(position);
+        position += 1;
+        if(!isEmpty) {
+            const argumentDefinition = {name: 'optionalValue', type: innerType};
+            return ArgumentParser.parseArgument(buffer, position, argumentDefinition);
+        } else {
+            return [position, {}]
+        }
+    }
+
+    static parseVariant(buffer, position, innerType) {
+        ArgumentParser.checkOutOfBounds(buffer, position, 1);
+        const variantTypes = ArgumentSerializer.splitTemplateType(innerType);
+        const variantIndex = buffer.getUint8(position, true);
+        if(variantIndex > variantTypes.length - 1) {
+            throw new ParserError(`invalid variant index ${ variantIndex }`)
+        }
+        position += 1;
+        const variantType = variantTypes[variantIndex];
+        const argumentDefinition = {name: 'variant', type: variantType};
+        const [newPosition, value] = ArgumentParser.parseArgument(buffer, position, argumentDefinition);
+        return [newPosition, {variantType: variantType, variant: value}];
+    }
+
+    static parseTemplate(buffer, position, argumentDefinition) {
+        const argumentType = argumentDefinition.type;
+        if(argumentType.includes("<")) {
+            const [ templateType, innerType ] = ArgumentSerializer.parseTemplate(argumentType);
+            switch (templateType) {
+                case 'RefPtr':
+                case 'std::unique_ptr':
+                case 'RetainPtr':
+                case 'std::optional':
+                case 'Optional': {
+                    const [newPosition, value] = ArgumentParser.parseOptional(buffer, position, innerType);
+                    return [newPosition, {parsedType: argumentDefinition.type, parsedValue: value}]
+                }
+                case 'std::span':
+                case 'Vector': {
+                    const [newPosition, values] = ArgumentParser.parseVector(buffer, position, innerType);
+                    return [newPosition, {parsedType: argumentDefinition.type, value: values}];
+                }
+                // TODO: HashSet and std::array and KeyValuePair and HashMap
+                case 'std::variant': {
+                    const [newPosition, variant] = ArgumentParser.parseVariant(buffer, position, innerType);
+                    return [newPosition, {parsedType: argumentDefinition.type, parsedValue: variant}];
+                }
+                case 'std::pair': {
+                    let [newPosition, values] = ArgumentParser.parsePair(buffer, position, innerType);
+                    return [newPosition, {parsedType: argumentDefinition.type, parsedValue: values}];
+                }
+                case 'OptionSet': {
+                    let [newPosition, optionSet] = ArgumentParser.parseEnum(buffer, position, {type: innerType, name: argumentDefinition.name});
+                    return [newPosition, {parsedType: argumentDefinition.type, parsedValue: optionSet}];
+                }
+                case 'WTF::Markable':
+                case 'Markable': {
+                    const [newPosition, value] = ArgumentParser.parseMarkable(buffer, position, innerType);
+                    return [newPosition, {parsedType: argumentDefinition.type, parsedValue: value}]
+                }
+                case 'Ref':
+                case 'UniqueRef': {
+                    return ArgumentParser.parseArgument(buffer, position, {type: innerType, name: argumentDefinition.name});
+                }
+                case 'HashMap': {
+                    return ArgumentParser.parseHashMap(buffer, position, innerType);
+                }
+                default:
+                    throw new ParserError(`Don't know how to parse template type '${ templateType }'`)
+            }
+        }
+        return undefined;
+    }
+
+    static parseEnum(buffer, position, argumentDefinition) {
+        const argumentType = argumentDefinition.type;
+        if(argumentType in CoreIPC.enumInfo) {
+            const enumArgumentDefintion = {
+                type: ArgumentSerializer.enumSizeMap[CoreIPC.enumInfo[argumentType].size],
+                name: argumentDefinition.name
+            };
+            return ArgumentParser.parsePrimitive(buffer, position, enumArgumentDefintion);
+        }
+        return undefined;
+    }
+
+    static parsePrimitive(buffer, position, argumentDefinition) {
+        switch(argumentDefinition.type) {
+            case 'bool':
+                ArgumentParser.checkOutOfBounds(buffer, position, 1);
+                return [position + 1, {parsedValue: !!buffer.getUint8(position), parsedType: argumentDefinition.type}];
+            case 'uint8_t':
+                ArgumentParser.checkOutOfBounds(buffer, position, 1);
+                return [position + 1, {parsedValue: buffer.getUint8(position), parsedType: argumentDefinition.type}];
+            case 'int8_t':
+                ArgumentParser.checkOutOfBounds(buffer, position, 1);
+                return [position + 1, {parsedValue: buffer.getInt8(position), parsedType: argumentDefinition.type}];
+            case 'uint16_t':
+                position = ArgumentParser.align(position, 2);
+                ArgumentParser.checkOutOfBounds(buffer, position, 2);
+                return [position + 2, {parsedValue: buffer.getUint16(position, true), parsedType: argumentDefinition.type}];
+            case 'int16_t':
+                position = ArgumentParser.align(position, 2);
+                ArgumentParser.checkOutOfBounds(buffer, position, 2);
+                return [position + 2, {parsedValue: buffer.getInt16(position, true), parsedType: argumentDefinition.type}]
+            case 'uint32_t':
+                position = ArgumentParser.align(position, 4);
+                ArgumentParser.checkOutOfBounds(buffer, position, 4);
+                return [position + 4, {parsedValue: buffer.getUint32(position, true), parsedType: argumentDefinition.type}];
+            case 'int32_t':
+                position = ArgumentParser.align(position, 4);
+                ArgumentParser.checkOutOfBounds(buffer, position, 4);
+                return [position + 4, {parsedValue: buffer.getInt32(position, true), parsedType: argumentDefinition.type}];
+            case 'uint64_t':
+                position = ArgumentParser.align(position, 8);
+                ArgumentParser.checkOutOfBounds(buffer, position, 8);
+                return [position + 8, {parsedValue: buffer.getBigUint64(position, true), parsedType: argumentDefinition.type}];
+            case 'int64_t':
+                position = ArgumentParser.align(position, 8);
+                ArgumentParser.checkOutOfBounds(buffer, position, 8);
+                return [position + 8, {parsedValue: buffer.getBigInt64(position, true), parsedType: argumentDefinition.type}];
+            case 'float':
+                position = ArgumentParser.align(position, 4);
+                ArgumentParser.checkOutOfBounds(buffer, position, 4);
+                return [position + 4, {parsedValue: buffer.getFloat32(position), parsedType: argumentDefinition.type}];
+            case 'double':
+                position = ArgumentParser.align(position, 8);
+                ArgumentParser.checkOutOfBounds(buffer, position, 8);
+                return [position + 8, {parsedValue: buffer.getFloat64(position), parsedType: argumentDefinition.type}];
+            case 'String': {
+                position = ArgumentParser.align(position, 4);
+                ArgumentParser.checkOutOfBounds(buffer, position, 4);
+                const stringLength = buffer.getUint32(position, true);
+                position += 4;
+                if(stringLength == 0xffffffff) {
+                    // null string
+                    return [position, {parsedValue: null, parsedType: 'String'}];
+                }
+                const is8Bit = !!buffer.getUint8(position);
+                position += 1;
+                let result = '';
+                if(is8Bit) {
+                    ArgumentParser.checkOutOfBounds(buffer, position, stringLength);
+                    for(let i=0; i<stringLength; i++) {
+                        result += String.fromCharCode(buffer.getUint8(position));
+                        position += 1;
+                    }
+                } else {
+                    ArgumentParser.checkOutOfBounds(buffer, position, stringLength * 2);
+                    for(let i=0; i<stringLength; i++) {
+                        result += String.fromCharCode(buffer.getUint16(position));
+                        position += 2;
+                    }
+                }
+                return [position, {parsedValue: result, parsedType: 'String'}];
+            }
+            case 'std::nullptr_t':
+                return [position, {parsedValue: 'null', parsedType: 'std::nullptr_t'}];
+        }
+        return undefined;
+    }
+
+    static parseArgument(buffer, position, argumentDefinition) {
+        let result;
+        argumentDefinition.type = resolveAlias(argumentDefinition.type);
+        if(argumentDefinition.optional === true) {
+            argumentDefinition.type = `Optional<${ argumentDefinition.type }>`;
+            argumentDefinition.optional = false;
+        }
+        if(result = ArgumentParser.parseTemplate(buffer, position, argumentDefinition)) {
+            return result;
+        }
+        if(result = ArgumentParser.parseIdentifier(buffer, position, argumentDefinition)) {
+            return result;
+        }
+        if(result = ArgumentParser.parseEnum(buffer, position, argumentDefinition)) {
+            return result;
+        }
+        if(result = ArgumentParser.parsePrimitive(buffer, position, argumentDefinition)) {
+            return result;
+        }
+        if(result = ArgumentParser.parseType(buffer, position, argumentDefinition)) {
+            return result;
+        }
+        throw new ParserError(`Don't know how to parse type '${ argumentDefinition.type }'`);
+    }
+
+    static untypeResultOld(typedResult) {
+        let result;
+        if(Array.isArray(typedResult)) {
+            result = [];
+            for(const value of typedResult) {
+                if(typeof(value.value) == 'object') {
+                    result.push(ArgumentParser.untypeResult(value));
+                } else {
+                    result.push(value.value);
+                }
+            }
+        } else {
+            result = {};
+            for(const [key, value] of Object.entries(typedResult)) {
+                if(typeof(value.value) == 'object') {
+                    result[key] = ArgumentParser.untypeResult(value.value);
+                } else {
+                    result[key] = value.value;
+                }
+            }
+        }
+        return result;
+    }
+
+    static untypeResult(typedResult) {
+        if(typeof(typedResult)=='object') {
+            if('parsedType' in typedResult) {
+                if(isEnum(typedResult.parsedType) || isPrimtiveType(typedResult.parsedType) || isIdentifier(typedResult.parsedType)) {
+                    return typedResult.parsedValue;
+                }
+                return ArgumentParser.untypeResult(typedResult.parsedValue);
+            } else {
+                const result = {};
+                for(const [key, value] of Object.entries(typedResult)) {
+                    result[key] = ArgumentParser.untypeResult(value);
+                }
+                return result;
+            }
+        }
+        if(Array.isArray(typedResult)) {
+            const newArray = [];
+            for(const element of typedResult) {
+                newArray.push(ArgumentParser.untypeResult(element));
+            }
+            return newArray;
+        }
+        return typedResult;
+    }
+
+    static parseArguments(buffer, position, replyArguments) {
+        const typedResult = {}
+        for(const argument of replyArguments) {
+            try {
+                let parseResult;
+                [position, parseResult] = ArgumentParser.parseArgument(buffer, position, argument);
+                typedResult[ArgumentSerializer.simplifyName(argument.name)] = parseResult;
+            } catch (error) {
+                if(error instanceof ParserError) {
+                    throw new ParserError(`When parsing field '${ argument.name }' of type '${ argument.type }': ${ error.message }`);
+                } else {
+                    throw error;
+                }
+            }
+        }
+        return [position, typedResult, ArgumentParser.untypeResult(typedResult)];
+    }
+}
+
+class IPCWireTap {
+    #nextTaps
+    #allTaps
+    #everyTaps
+    #listenerFunction
+    #process
+
+    constructor(process, direction) {
+        if(!['UI','GPU','Networking'].includes(process)){
+            throw new Error(`WireTap: process has to be one of 'UI','GPU' or 'Networking' but is '${process}'`);
+        }
+        if(direction != "Outgoing" && direction != "Incoming") {
+            throw new Error(`WireTap: direction has to be one of 'Outgoing' or 'Incoming' but is '${direction}'`);
+        }
+        this.#process = process;
+        this.#allTaps = [];
+        this.#everyTaps = {};
+        this.#nextTaps = {};
+        this.#listenerFunction = this.createListener();
+        if(direction == "Outgoing") {
+            IPC.addOutgoingMessageListener(process, this.#listenerFunction);
+        } else {
+            IPC.addIncomingMessageListener(process, this.#listenerFunction);
+        }
+        // self reference to avoid gc issues
+        if(!window.refs) {
+            window.refs = [];
+        }
+        window.refs.push(this);
+    }
+
+    tapNext(message, tap) {
+        if(!(message in this.#nextTaps)) {
+            this.#nextTaps[message] = [];
+        }
+        this.#nextTaps[message].push(tap);
+    }
+
+    tapEvery(message, tap) {
+        if(!(message in this.#everyTaps)) {
+            this.#everyTaps[message] = [];
+        }
+        this.#everyTaps[message].push(tap);
+    }
+
+    tapAll(tap) {
+        this.#allTaps.push(tap);
+    }
+
+    parseMessage(messageName, buffer) {
+        const messageArguments = CoreIPC.messageByName[messageName].arguments;
+        if(!messageArguments) return [0, {}, {}];
+        try {
+            return ArgumentParser.parseArguments(buffer, MESSAGE_HEADER_SIZE, messageArguments);
+        } catch (error) {
+            if(window.$vm) {
+                $vm?.print("WireTap couldn't parse message: " + error.message);
+            } else {
+                console.log("WireTap couldn't parse message: " + error.message);
+            }
+        }
+    }
+
+    isFuzzMessage(buffer) {
+            if(buffer.byteLength >= 24) {
+                const slice = new Int32Array(buffer.slice(buffer.byteLength - 12));
+                if(slice[0] == 0x5a5a5546)
+                    return true;
+            }
+            return false;
+    }
+
+    createListener() {
+        return (tapArguments) => {
+            const messageName = tapArguments.name;
+            const connectionID = tapArguments.destinationID;
+            const buffer = tapArguments.buffer;
+            if(this.isFuzzMessage(buffer)) {
+                return;
+            }
+            let typedResult;
+            let result;
+            for(const tap of this.#allTaps) {
+                if(typedResult == undefined && buffer)
+                    [, typedResult, result] = this.parseMessage(messageName, new DataView(buffer));
+                tap(this.#process, connectionID, messageName, typedResult, result);
+            }
+            const everyTaps = this.#everyTaps[messageName];
+            if(everyTaps) {
+                for(const tap of everyTaps) {
+                    if(typedResult == undefined && buffer)
+                        [, typedResult, result] = this.parseMessage(messageName, new DataView(buffer));
+                    tap(this.#process, connectionID, messageName, typedResult, result);
+                }
+            }
+            const nextTaps = this.#nextTaps[messageName];
+            if(nextTaps) {
+                let tap;
+                while(tap = nextTaps.pop()) {
+                    if(typedResult == undefined && buffer)
+                        [, typedResult, result] = this.parseMessage(messageName, new DataView(buffer));
+                    tap(this.#process, connectionID, messageName, typedResult, result);
+                    break; // TODO: only do this while fuzzing
+                }
+            }
+        };
+    }
+}
+
+const CoreIPC = new CoreIPCClass();
+


### PR DESCRIPTION
#### eee20c1971ee579f81ba731bcc3aee847f680aa4
<pre>
ASAN_TRAP | WebCore::RenderFragmentedFlow::removeRenderBoxFragmentInfo; WebCore::RenderFragmentedFlow::removeFlowChildInfo; WebCore::RenderElement::removeFromRenderFragmentedFlowIncludingDescendants
<a href="https://bugs.webkit.org/show_bug.cgi?id=288447">https://bugs.webkit.org/show_bug.cgi?id=288447</a>

Reviewed by Alan Baradlay.

In the test case the video element is added to a fragmented flow, but is not properly removed
when it becomes out of flow due to the popover attribute. The logic in RenderElement::adjustFragmentedFlowStateOnContainingBlockChangeIfNeeded
will not work for this kind of element since the fragmened flow container information is not known anymore, the video having become a top-level element.

To properly remove renderers from their fragmented flow, detect this situation in RenderElement::styleWillChange, and use the fragmented flow access (through locateEnclosingFragmentedFlow())
before the containing block is changed.

* LayoutTests/fast/multicol/video-not-removed-from-fragmented-flow-crash-expected.txt: Added.
* LayoutTests/fast/multicol/video-not-removed-from-fragmented-flow-crash.html: Added.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):

Originally-landed-as: 292955.3@webkit-embargoed (19b66665ae74). <a href="https://rdar.apple.com/157795098">rdar://157795098</a>
Canonical link: <a href="https://commits.webkit.org/298381@main">https://commits.webkit.org/298381@main</a>
</pre>
----------------------------------------------------------------------
#### c1ec6110d0328f22d38353891c01b05be06f57b9
<pre>
RemoteObjectRegistry should decode an invocation with a ReplyBlock if expected.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290377">https://bugs.webkit.org/show_bug.cgi?id=290377</a>
<a href="https://rdar.apple.com/145728621">rdar://145728621</a>

Reviewed by Alex Christensen.

RemoteObjectRegistry had a logic issue when decoding a RemoteInvocation.

If a CallReplyBlock message was received, this would contain an encoded NSInvocation
representing the method to call and the arguments. It was possible to supply an
alternate selector, with differing arguments, and still have the original ReplyBlock
called with these, leading to a mismatch in argument types.

The RemoteObjectRegistry should ensure the NSInvocation is decoded based on the original
expected ReplyBlock, instead of accepting another selector from the wire.

Originally-landed-as: 289651.466@safari-7621-branch (4a186489a84d). <a href="https://rdar.apple.com/157795161">rdar://157795161</a>
Canonical link: <a href="https://commits.webkit.org/298380@main">https://commits.webkit.org/298380@main</a>
</pre>
----------------------------------------------------------------------
#### 83ab558246f2ebcaf4dc89f32e0668dfa85abc08
<pre>
[JSC] ASSERTION FAILED: Unexpected exception observed on thread Thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=291747">https://bugs.webkit.org/show_bug.cgi?id=291747</a>
<a href="https://rdar.apple.com/149546774">rdar://149546774</a>

Reviewed by Yijia Huang.

Many of operations (e.g. JSObject::put with stack overflow detection)
can throw random errors. Thus, let&apos;s use RETURN_IF_EXCEPTION more
instead of assertNoExceptionExceptTermination.

* JSTests/stress/variable-initialization-error-check.js: Added.
(C0):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeEval):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::canDeclareGlobalFunction):
(JSC::JSGlobalObject::createGlobalFunctionBinding):
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::createGlobalVarBinding):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp:
(JSC::JSModuleNamespaceObject::finishCreation):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::ordinaryToPrimitive const):
(JSC::JSObject::getOwnNonIndexPropertyNames):
* Source/JavaScriptCore/runtime/JSTemplateObjectDescriptor.cpp:
(JSC::JSTemplateObjectDescriptor::createTemplateObject):
* Source/JavaScriptCore/runtime/ObjectPrototype.cpp:
(JSC::objectPrototypeHasOwnProperty):
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):

Originally-landed-as: 289651.444@safari-7621-branch (b850d2257e8d). <a href="https://rdar.apple.com/157795300">rdar://157795300</a>
Canonical link: <a href="https://commits.webkit.org/298379@main">https://commits.webkit.org/298379@main</a>
</pre>
----------------------------------------------------------------------
#### 2ea747749a42d71c11e5ad6f36dde43f4de306b8
<pre>
stack-overflow | WebCore::Calculation::copy; WebCore::Calculation::copy; WebCore::Calculation::copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=289378">https://bugs.webkit.org/show_bug.cgi?id=289378</a>
<a href="https://rdar.apple.com/144403520">rdar://144403520</a>

Reviewed by Ryosuke Niwa.

The node loop in makeStylingElementsDirectChildrenOfEditableRootToPreventStyleLoss can change the DOM, so
split it up in two parts.

* LayoutTests/editing/deleting/delete-multiple-styling-elements-expected.txt: Added.
* LayoutTests/editing/deleting/delete-multiple-styling-elements.html: Added.
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::makeStylingElementsDirectChildrenOfEditableRootToPreventStyleLoss):

Originally-landed-as: 292955.4@webkit-embargoed (55ed8716be7f). <a href="https://rdar.apple.com/157795436">rdar://157795436</a>
Canonical link: <a href="https://commits.webkit.org/298378@main">https://commits.webkit.org/298378@main</a>
</pre>
----------------------------------------------------------------------
#### b49b65901c3681e159e81f4374fd25fdc11b3290
<pre>
Add non-regression tests for bugs 287481, 287482 and 287483.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287481">https://bugs.webkit.org/show_bug.cgi?id=287481</a>

Reviewed by Alan Baradlay.

This adds reduction of test cases for bugs reported by fuzzers:

- bug 287482 and bug 287483, fixed by <a href="https://commits.webkit.org/289863@main">https://commits.webkit.org/289863@main</a>
- bug 287481, fixed by <a href="https://commits.webkit.org/290546@main.">https://commits.webkit.org/290546@main.</a>

* LayoutTests/fast/grid/layout-positioned-grid-items-001-crash-expected.txt: Added.
* LayoutTests/fast/grid/layout-positioned-grid-items-001-crash.html: Added. Reduced from test case of bug 287481.
* LayoutTests/fast/grid/layout-positioned-grid-items-002-crash.html: Added. Reduced from test case of bug 287483.
* LayoutTests/fast/grid/layout-positioned-grid-items-003-crash.html: Added. Reduced from test case of bug 287482.

Originally-landed-as: 292955.2@webkit-embargoed (56e799de94f9). <a href="https://rdar.apple.com/157795614">rdar://157795614</a>
Canonical link: <a href="https://commits.webkit.org/298377@main">https://commits.webkit.org/298377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b282aa6bfea657971b47951d7615d7e57a2788e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65920 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87617 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/750855c3-0bde-4f92-9778-b191281b7c91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68013 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21657 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65087 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107567 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113875 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24476 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38211 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47709 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41666 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/44991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->