### PR TITLE
CARenderServerRender* APIs are deprecated

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -276,13 +276,6 @@ typedef uint32_t CAHighFrameRateReason;
 
 WTF_EXTERN_C_BEGIN
 
-// FIXME: Declare these functions even when USE(APPLE_INTERNAL_SDK) is true once we can fix <rdar://problem/26584828> in a better way.
-#if !USE(APPLE_INTERNAL_SDK)
-void CARenderServerCaptureLayerWithTransform(mach_port_t, uint32_t clientId, uint64_t layerId, uint32_t slotId, int32_t ox, int32_t oy, const CATransform3D*);
-void CARenderServerRenderLayerWithTransform(mach_port_t server_port, uint32_t client_id, uint64_t layer_id, IOSurfaceRef, int32_t ox, int32_t oy, const CATransform3D*);
-void CARenderServerRenderDisplayLayerWithTransformAndTimeOffset(mach_port_t, CFStringRef display_name, uint32_t client_id, uint64_t layer_id, IOSurfaceRef, int32_t ox, int32_t oy, const CATransform3D*, CFTimeInterval);
-#endif // USE(APPLE_INTERNAL_SDK)
-
 typedef struct _CAMachPort *CAMachPortRef;
 CAMachPortRef CAMachPortCreate(mach_port_t);
 mach_port_t CAMachPortGetPort(CAMachPortRef);
@@ -306,6 +299,12 @@ void CARenderUpdateAddContext(CARenderUpdate*, CARenderContext*);
 void CARenderUpdateAddRect(CARenderUpdate*, const CGRect*);
 void CARenderUpdateFinish(CARenderUpdate*);
 bool CASupportsFeature(uint64_t);
+
+#if HAVE(CORE_ANIMATION_RENDER_SERVER)
+#ifdef __OBJC__
+bool CARenderServerSnapshot(mach_port_t, NSDictionary *);
+#endif
+#endif
 
 WTF_EXTERN_C_END
 
@@ -347,4 +346,18 @@ extern NSString * const kCAContextPortNumber;
 #if PLATFORM(IOS_FAMILY)
 extern NSString * const kCAContextSecure;
 extern NSString * const kCAContentsFormatRGBA10XR;
+#endif
+
+#if HAVE(CORE_ANIMATION_RENDER_SERVER)
+extern NSString * const kCASnapshotMode;
+extern NSString * const kCASnapshotModeLayer;
+extern NSString * const kCASnapshotDisplayName;
+#define kCARenderServerDefaultDisplay @"defaultDisplay"
+extern NSString * const kCASnapshotContextId;
+extern NSString * const kCASnapshotLayerId;
+extern NSString * const kCASnapshotDestination;
+extern NSString * const kCASnapshotOriginX;
+extern NSString * const kCASnapshotOriginY;
+extern NSString * const kCASnapshotTransform;
+extern NSString * const kCASnapshotTimeOffset;
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1601,10 +1601,17 @@ static void configureScrollViewWithOverlayRegionsIDs(RetainPtr<WKBaseScrollView>
     if (!surface)
         return nullptr;
 
-    // FIXME: rdar://157581000
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    CARenderServerRenderLayerWithTransform(MACH_PORT_NULL, self.layer.context.contextId, reinterpret_cast<uint64_t>(self.layer), surface->surface(), 0, 0, &transform);
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    CARenderServerSnapshot(MACH_PORT_NULL, @{
+        kCASnapshotMode: kCASnapshotModeLayer,
+        kCASnapshotDisplayName: kCARenderServerDefaultDisplay,
+        kCASnapshotContextId: @(self.layer.context.contextId),
+        kCASnapshotLayerId: @(reinterpret_cast<uint64_t>(self.layer)),
+        kCASnapshotDestination: (__bridge id)surface->surface(),
+        kCASnapshotOriginX: @(0),
+        kCASnapshotOriginY: @(0),
+        kCASnapshotTransform: @(transform),
+        kCASnapshotTimeOffset: @(0),
+    });
 
 #if HAVE(IOSURFACE_ACCELERATOR)
     WebCore::IOSurface::Format compressedFormat = WebCore::IOSurface::Format::YUV422;
@@ -4821,9 +4828,19 @@ static bool isLockdownModeWarningNeeded()
         CGFloat imageScaleInViewCoordinates = imageWidth / rectInViewCoordinates.size.width;
         CATransform3D transform = CATransform3DMakeScale(imageScaleInViewCoordinates, imageScaleInViewCoordinates, 1);
         transform = CATransform3DTranslate(transform, -rectInViewCoordinates.origin.x, -rectInViewCoordinates.origin.y, 0);
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        CARenderServerRenderDisplayLayerWithTransformAndTimeOffset(MACH_PORT_NULL, (CFStringRef)displayName, self.layer.context.contextId, reinterpret_cast<uint64_t>(self.layer), surface->surface(), 0, 0, &transform, 0);
-        ALLOW_DEPRECATED_DECLARATIONS_END
+
+        CARenderServerSnapshot(MACH_PORT_NULL, @{
+            kCASnapshotMode: kCASnapshotModeLayer,
+            kCASnapshotDisplayName: displayName,
+            kCASnapshotContextId: @(self.layer.context.contextId),
+            kCASnapshotLayerId: @(reinterpret_cast<uint64_t>(self.layer)),
+            kCASnapshotDestination: (__bridge id)surface->surface(),
+            kCASnapshotOriginX: @(0),
+            kCASnapshotOriginY: @(0),
+            kCASnapshotTransform: @(transform),
+            kCASnapshotTimeOffset: @(0),
+        });
+
         completionHandler(WebCore::IOSurface::sinkIntoImage(WTFMove(surface)).get());
         return;
     }


### PR DESCRIPTION
#### e5e28a5fb38ca98f27be4062d01f7a45e3c43cb6
<pre>
CARenderServerRender* APIs are deprecated
<a href="https://bugs.webkit.org/show_bug.cgi?id=297098">https://bugs.webkit.org/show_bug.cgi?id=297098</a>
<a href="https://rdar.apple.com/157581000">rdar://157581000</a>

Reviewed by Simon Fraser.

CARenderServerRender* APIs, used to composite layers onto a destination
surface, have been deprecated in recent SDKs.

In this patch, we migrate to CARenderServerSnapshot, which is the
preferred alternative.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
Removed (now unused) forward declarations, and introduce a few new
delcarations.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _takeViewSnapshot]):
(-[WKWebView _snapshotRectAfterScreenUpdates:rectInViewCoordinates:intoImageOfWidth:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/298375@main">https://commits.webkit.org/298375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f896cd16dbceb01b3a07cdcacbdd0375ff0584e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115346 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35040 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65928 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89a96e26-16ee-407b-b0e5-72e98278b661) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87631 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b4b8846-9e41-489b-b0e7-afcdbc5dd6e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68026 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21664 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65097 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124603 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96416 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96203 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24475 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19289 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42168 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47721 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41673 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->