### PR TITLE
[JSC] Ensure Sink+Escape+Materialize ArrayButterfly allocations are not Escaped kind

### DIFF
--- a/JSTests/stress/array-allocation-sink-escape-materialize-15.js
+++ b/JSTests/stress/array-allocation-sink-escape-materialize-15.js
@@ -1,0 +1,24 @@
+
+function test(arg_array) {
+    let new_array = (() => {
+        let res = new Array(8);
+        res.length
+        return res;
+    })();
+    let o1 = {};
+    new_array[0] = o1;
+
+    let f;
+    if (arg_array[1]) {
+        new_array[0] = new_array.length;
+        f = new_array;
+    } else {
+        f = 42;
+    }
+
+    var obj = { 'f': f };
+}
+
+for (let j = 0; j < 1e5; j++) {
+    test([1.1, 2.2]);
+}

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1013,7 +1013,7 @@ private:
             //      Allocation starts as sinkable but later escapes; it must be materialized at a specific point
             //      while preserving dependency ordering.
             //
-            // Cases:
+            // Cases: GetButterfly-State/Array-State
             //  (1)     S\S S\SEM: Fine. Let it sink. (e.g. [2])
             //  (2) S\E SEM\E E/E: Fine. But not profitable to sink GetButterfly.
             //  (3)       SEM\SEM: Fine iff they materialize at the same site due to PutByVal/GetByVal. (e.g. [1])
@@ -1561,7 +1561,10 @@ escapeChildren:
 
             for (const auto& pair : toAdd) {
                 m_sinkCandidates.add(pair.first);
-                escapees.add(pair.first, *pair.second);
+                Allocation allocation = *pair.second;
+                if (allocation.isEscapedAllocation())
+                    allocation = Allocation(allocation.identifier(), Allocation::Kind::ArrayButterfly);
+                escapees.add(pair.first, WTFMove(allocation));
             }
         };
 
@@ -1644,12 +1647,12 @@ escapeChildren:
         if (m_sinkCandidates.isEmpty())
             return hasUnescapedReads;
 
-        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Candidates: ", listDump(m_sinkCandidates));
-
         // Create the materialization nodes.
         forEachEscapee([&] (UncheckedKeyHashMap<Node*, Allocation>& escapees, Node* where) {
             placeMaterializations(WTFMove(escapees), where);
         });
+
+        dataLogLnIf(Options::verboseObjectAllocationSinking(), "Candidates: ", listDump(m_sinkCandidates));
 
         return hasUnescapedReads || !m_sinkCandidates.isEmpty();
     }


### PR DESCRIPTION
#### 92c8b7a59ef55148faa8e921b55f494ca2495825
<pre>
[JSC] Ensure Sink+Escape+Materialize ArrayButterfly allocations are not Escaped kind
<a href="https://bugs.webkit.org/show_bug.cgi?id=297097">https://bugs.webkit.org/show_bug.cgi?id=297097</a>
<a href="https://rdar.apple.com/157701415">rdar://157701415</a>

Reviewed by NOBODY (OOPS!).

When we Sink+Escape+Materialize an array, we also need to do
the same for its corresponding GetButterfly (ArrayButterfly allocation).
This is because GetButterfly cannot refer to a phantom array node - it
requires a materialized array. Therefore, when we Sink+Escape+Materialize
an ArrayButterfly allocation, we must ensure its allocation kind is
ArrayButterfly, not Escaped, so that createMaterialization() can properly
handle it.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92c8b7a59ef55148faa8e921b55f494ca2495825

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71379 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f14c17a-7fd5-4517-925b-51effd448b46) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/44aa8dde-b73f-40ad-b468-a157de651b7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71081 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7817a5d5-828a-4a40-bcb6-43e8262d099e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25076 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69196 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128554 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117825 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99222 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/118732 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99001 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22470 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46090 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/51790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146525 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45555 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37671 "Found 1 new JSC binary failure: testapi, Found 18624 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->