### PR TITLE
Web Extensions: Update an existing bookmark's properties using the Bookmarks API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -151,6 +151,17 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
  @param completionHandler A block that must be called upon completion.
  */
 - (void)_webExtensionController:(WKWebExtensionController * _Nonnull)controller removeBookmarkWithIdentifier:(NSString *)bookmarkIdentifier removeFolderWithChildren:(BOOL)removeFolderWithChildren forExtensionContext:(WKWebExtensionContext * _Nonnull)context completionHandler:(void (^)(NSError * _Nullable))completionHandler;
+
+/*!
+ @abstract Called to update properties of an existing bookmark node.
+ @param controller The WKWebExtensionController instance.
+ @param bookmarkId The identifier of the bookmark node to update.
+ @param title The new title for the bookmark node, or nil if not changing.
+ @param url The new URL for the bookmark (for bookmark types), or nil if not changing.
+ @param context The context in which the web extension is running.
+ @param completionHandler A block to call with the updated bookmark node or an error.
+ */
+- (void)_webExtensionController:(WKWebExtensionController *)controller updateBookmarkWithIdentifier:(NSString *)bookmarkId title:(nullable NSString *)title url:(nullable NSString *)url forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler;
 @end
 
 WK_HEADER_AUDIT_END(nullability, sendability)

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -73,6 +73,7 @@
 @property (nonatomic, copy) void (^createBookmarkWithParentIdentifier)(NSString *parentId, NSNumber *index, NSString *url, NSString *title, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
 @property (nonatomic, copy) void (^bookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *));
 @property (nonatomic, copy) void (^removeBookmarkWithIdentifier)(NSString *bookmarkId, BOOL removeFolderWithChildren, void (^completionHandler)(NSError *));
+@property (nonatomic, copy) void (^updateBookmarkWithIdentifier)(NSString *bookmarkId, NSString *title, NSString *url, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -195,6 +195,14 @@
         completionHandler(nil);
 }
 
+- (void)_webExtensionController:(WKWebExtensionController *)controller updateBookmarkWithIdentifier:(NSString *)bookmarkId title:(NSString *)title url:(NSString *)url forExtensionContext:(WKWebExtensionContext *)context completionHandler:(void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *))completionHandler
+{
+    if (_updateBookmarkWithIdentifier)
+        _updateBookmarkWithIdentifier(bookmarkId, title, url, completionHandler);
+    else if (completionHandler)
+        completionHandler(nil, nil);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### f95890f1d4b40d75372b9ebcc1db8535258af393
<pre>
Web Extensions: Update an existing bookmark&apos;s properties using the Bookmarks API
<a href="https://rdar.apple.com/152505906">rdar://152505906</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297057">https://bugs.webkit.org/show_bug.cgi?id=297057</a>

Reviewed by Brian Weinstein.

Adds bookmarks.update() to the WebProcess and UIProcess. Includes tests with error checking

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIBookmarksCocoa.mm:
(WebKit::WebExtensionContext::bookmarksUpdate):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
(WebKit::WebExtensionAPIBookmarks::update):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIBookmarks.mm:
(findBookmarkInMockTree):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureCreateBookmarkDelegate):
(TestWebKitAPI::WKWebExtensionAPIBookmarks::configureUpdateBookmarksDelegate):
(TestWebKitAPI::TEST_F(WKWebExtensionAPIBookmarks, BookmarksAPIUpdate)):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:updateBookmarkWithIdentifier:title:url:forExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/298520@main">https://commits.webkit.org/298520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db128962af002aca5cd37067349e5473f0710038

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87934 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65483 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124962 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41744 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19603 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38584 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48122 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->