### PR TITLE
Improve paste performance in 'textarea'

### DIFF
--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -41,6 +41,7 @@
 #include "DataTransfer.h"
 #include "Document.h"
 #include "DocumentFragment.h"
+#include "Editing.h"
 #include "EditingBehavior.h"
 #include "EditingInlines.h"
 #include "ElementIteratorInlines.h"
@@ -1384,7 +1385,10 @@ void ReplaceSelectionCommand::doApply()
 
     if (insertedNodes.isEmpty())
         return;
-    removeUnrenderedTextNodesAtEnds(insertedNodes);
+
+    // removeUnrenderedTextNodesAtEnds can trigger layout, so for performance, only do it when the presence of richly-editable text requires us to.
+    if (isRichlyEditablePosition(insertionPos))
+        removeUnrenderedTextNodesAtEnds(insertedNodes);
 
     if (!handledStyleSpans)
         handleStyleSpans(insertedNodes);


### PR DESCRIPTION
#### ace50174bd3c4058fc0bd5ba64b11a1d26537fe0
<pre>
Improve paste performance in &apos;textarea&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=297100">https://bugs.webkit.org/show_bug.cgi?id=297100</a>
<a href="https://rdar.apple.com/157813510">rdar://157813510</a>

Reviewed by Ryosuke Niwa and Tyler Wilcock.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/6b84474a3a718e09d19280edfa6065564b249ea6">https://chromium.googlesource.com/chromium/src.git/+/6b84474a3a718e09d19280edfa6065564b249ea6</a>

This patch is to skip unnecessary layout by removeUnrenderedTextNodesAtEnds
by ensuring that it only happens when we are in richly editable field.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/298505@main">https://commits.webkit.org/298505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dee2bc02604ee513138c3dfc5b7119ec2997f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65987 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71e6b266-557c-4ce4-bf4d-0f20cb96096e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87689 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42374 "Too many flaky failures: fast/dom/Window/setTimeout-no-arguments.html, fast/dom/microtask-reverse.html, fast/dom/move-nodes-across-documents.html, fast/dom/option-properties.html, fast/events/device-orientation-crash.html, fast/events/popup-blocked-from-iframe-script.html, fast/forms/checkValidity-001.html, fast/forms/required-attribute-001.html, fast/viewport/viewport-66.html, js/ShadowRealm-iframe-sandboxed.html, js/arrowfunction-bind.html, js/dom/call-link-info-recursion.html, loader/image-loader-adoptNode-assert.html, loader/meta-refresh-disabled.html, webgl/2.0.0/conformance2/transform_feedback/two-unreferenced-varyings.html, webgl/2.0.y/conformance/uniforms/uniform-samplers-test.html, webgl/2.0.y/conformance2/extensions/oes-draw-buffers-indexed.html, webgl/2.0.y/conformance2/glsl3/array-initialize-with-same-name-array.html, webgl/2.0.y/conformance2/misc/object-deletion-behaviour-2.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/06bd71d1-aabe-40b7-a3ef-5d6420c12a7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68081 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65152 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124663 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96470 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24539 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38254 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42228 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47784 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->