### PR TITLE
Module loader should differentiate importing of a specifier with a distinct type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Importing a specifier that previously failed due to an incorrect type attribute can succeed if the correct attribute is later given
-FAIL Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given assert_unreached: Should have rejected: Dynamic import should fail with the type attribute missing even if the same specifier previously succeeded Reached unreachable code
-FAIL Two modules of different type with the same specifier can load if the server changes its responses assert_equals: expected (string) "hello" but got (object) object "[object Object]"
+PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
+PASS Two modules of different type with the same specifier can load if the server changes its responses
 FAIL An import should always fail if the same specifier/type attribute pair failed previously assert_unreached: Should have rejected: import should always fail if the same specifier/type attribute pair failed previously Reached unreachable code
 PASS If an import previously succeeded for a given specifier/type attribute pair, future uses of that pair should yield the same result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Importing a specifier that previously failed due to an incorrect type attribute can succeed if the correct attribute is later given
-FAIL Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given assert_unreached: Should have rejected: Dynamic import should fail with the type attribute missing even if the same specifier previously succeeded Reached unreachable code
-FAIL Two modules of different type with the same specifier can load if the server changes its responses assert_equals: expected (string) "hello" but got (object) object "[object Object]"
+PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
+PASS Two modules of different type with the same specifier can load if the server changes its responses
 FAIL An import should always fail if the same specifier/type attribute pair failed previously assert_unreached: Should have rejected: import should always fail if the same specifier/type attribute pair failed previously Reached unreachable code
 PASS If an import previously succeeded for a given specifier/type attribute pair, future uses of that pair should yield the same result
 


### PR DESCRIPTION
#### 05f40afb16d1dd7c0061f63a970f7a451cfbfadb
<pre>
Module loader should differentiate importing of a specifier with a distinct type
<a href="https://bugs.webkit.org/show_bug.cgi?id=297104">https://bugs.webkit.org/show_bug.cgi?id=297104</a>

Reviewed by Yusuke Suzuki.

This PR makes the module loader differentiate each module import using the specifier and the type instead of just the specifier.

To do this, this PR updates ensureRegistered in ModuleLoader.js to take the module type in addition to the module specifier / key and
maintains a nested Map for each type per given specifier. dependencyKeysIfEvaluated is also updated to look for the js-wasm module.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt:
* Source/JavaScriptCore/builtins/ModuleLoader.js:
(linkTimeConstant.newRegistryEntry):
(visibility.PrivateRecursive.ensureRegistered):
(visibility.PrivateRecursive.async loadModule):
(visibility.PrivateRecursive.linkAndEvaluateModule):
(visibility.PrivateRecursive.async loadAndEvaluateModule):
(visibility.PrivateRecursive.async requestImportModule):
(visibility.PrivateRecursive.dependencyKeysIfEvaluated):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::finishCreation):
(JSC::stringFromScriptFetchParametersType):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/298395@main">https://commits.webkit.org/298395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad607c1fe31321f94ef0cb42380814fc0f8d61a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65956 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37c53d64-d490-445c-8c84-848e9b0db9a1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87665 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d41ddbd9-9316-4d2d-be7f-5412dd2a2dce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68059 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65126 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107591 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124633 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113920 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96446 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96233 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41459 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38233 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42201 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47754 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41703 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->