### PR TITLE
[Liquid Glass] [macOS] Add a way to extend the height of the scroll pocket

### DIFF
--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -316,6 +316,10 @@ struct WebPageCreationParameters {
 
     bool hasResizableWindows { false };
 
+#if PLATFORM(MAC)
+    double overflowHeightForTopScrollEdgeEffect { 0 };
+#endif
+
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
 
     std::optional<RemotePageParameters> remotePageParameters { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -237,6 +237,10 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool hasResizableWindows;
 
+#if PLATFORM(MAC)
+    double overflowHeightForTopScrollEdgeEffect;
+#endif
+
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension;
 
     std::optional<WebKit::RemotePageParameters> remotePageParameters;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -895,6 +895,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 @property (nonatomic, readonly) NSEdgeInsets _obscuredContentInsets WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @property (nonatomic, setter=_setUsesAutomaticContentInsetBackgroundFill:) BOOL _usesAutomaticContentInsetBackgroundFill WK_API_AVAILABLE(macos(WK_MAC_TBA));
 @property (nonatomic, copy, setter=_setOverrideTopScrollEdgeEffectColor:) NSColor *_overrideTopScrollEdgeEffectColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, setter=_setOverflowHeightForTopScrollEdgeEffect:) CGFloat _overflowHeightForTopScrollEdgeEffect WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
 @property (nonatomic, readonly) NSScrollPocket *_topScrollPocket WK_API_AVAILABLE(macos(26.0));

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1151,7 +1151,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (!_page->preferences().contentInsetBackgroundFillEnabled())
         return NO;
 
-    return _page->obscuredContentInsets().top() > 0;
+    return _page->obscuredContentInsets().top() > 0 || _page->overflowHeightForTopScrollEdgeEffect() > 0;
 }
 
 - (void)registerPocketContainer:(NSView *)container onEdge:(NSScrollPocketEdge)edge
@@ -1607,6 +1607,26 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         static_cast<CGFloat>(insets.bottom()),
         static_cast<CGFloat>(insets.right())
     );
+}
+
+- (CGFloat)_overflowHeightForTopScrollEdgeEffect
+{
+    return _page->overflowHeightForTopScrollEdgeEffect();
+}
+
+- (void)_setOverflowHeightForTopScrollEdgeEffect:(CGFloat)height
+{
+    if (_page->overflowHeightForTopScrollEdgeEffect() == height)
+        return;
+
+    _page->setOverflowHeightForTopScrollEdgeEffect(height);
+
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+    _impl->updateScrollPocket();
+#endif
+
+    if (RetainPtr attachedInspectorWebView = [self _horizontallyAttachedInspectorWebView])
+        [attachedInspectorWebView _setOverflowHeightForTopScrollEdgeEffect:height];
 }
 
 - (NSColor *)_overrideTopScrollEdgeEffectColor

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -229,6 +229,7 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
     RetainPtr attachedView = [self _horizontallyAttachedInspectedWebView];
     [_webView _setOverrideTopScrollEdgeEffectColor:[attachedView _topScrollPocket].captureColor];
     [_webView _setAlwaysPrefersSolidColorHardPocket:!!attachedView];
+    [_webView _setOverflowHeightForTopScrollEdgeEffect:[attachedView _overflowHeightForTopScrollEdgeEffect]];
     [_webView _updateHiddenScrollPocketEdges];
 #endif
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11884,6 +11884,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.footerBannerHeight = footerBannerHeight();
     if (m_viewWindowCoordinates)
         parameters.viewWindowCoordinates = *m_viewWindowCoordinates;
+    parameters.overflowHeightForTopScrollEdgeEffect = m_overflowHeightForTopScrollEdgeEffect;
 #endif
 
 #if ENABLE(META_VIEWPORT)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -965,7 +965,10 @@ public:
     void setAutomaticallyAdjustsContentInsets(bool);
     bool automaticallyAdjustsContentInsets() const { return m_automaticallyAdjustsContentInsets; }
     void updateContentInsetsIfAutomatic();
-#endif
+
+    double overflowHeightForTopScrollEdgeEffect() const { return m_overflowHeightForTopScrollEdgeEffect; }
+    void setOverflowHeightForTopScrollEdgeEffect(double);
+#endif // PLATFORM(MAC)
 
     // Corresponds to the web content's `<meta name="theme-color">` or application manifest's `"theme_color"`.
     WebCore::Color themeColor() const;
@@ -3543,6 +3546,7 @@ private:
 
 #if PLATFORM(MAC)
     bool m_acceptsFirstMouse { false };
+    double m_overflowHeightForTopScrollEdgeEffect { 0 };
 #endif
 
 #if USE(SYSTEM_PREVIEW)

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -435,6 +435,16 @@ void WebPageProxy::updateContentInsetsIfAutomatic()
     scheduleSetObscuredContentInsetsDispatch();
 }
 
+void WebPageProxy::setOverflowHeightForTopScrollEdgeEffect(double value)
+{
+    if (m_overflowHeightForTopScrollEdgeEffect == value)
+        return;
+
+    m_overflowHeightForTopScrollEdgeEffect = value;
+
+    protectedLegacyMainFrameProcess()->send(Messages::WebPage::SetOverflowHeightForTopScrollEdgeEffect(value), webPageIDInMainFrameProcess());
+}
+
 void WebPageProxy::setObscuredContentInsetsAsync(const FloatBoxExtent& obscuredContentInsets)
 {
     m_internals->pendingObscuredContentInsets = obscuredContentInsets;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7073,10 +7073,11 @@ void WebViewImpl::updateScrollPocket()
 
     RetainPtr view = m_view.get();
     CGFloat topContentInset = obscuredContentInsets().top();
+    CGFloat additionalHeight = m_page->overflowHeightForTopScrollEdgeEffect();
     bool needsTopView = m_page->preferences().contentInsetBackgroundFillEnabled()
         && view
         && !view->_reasonsToHideTopScrollPocket
-        && topContentInset > 0;
+        && (topContentInset > 0 || additionalHeight > 0);
 
     RetainPtr topScrollPocketSelector = NSStringFromSelector(@selector(_topScrollPocket));
     if (!needsTopView) {
@@ -7113,7 +7114,7 @@ void WebViewImpl::updateScrollPocket()
     if (RetainPtr attachedInspectorView = [view _horizontallyAttachedInspectorWebView])
         bounds = NSUnionRect(bounds, [attachedInspectorView convertRect:[attachedInspectorView bounds] toView:view.get()]);
 
-    auto topInsetFrame = NSMakeRect(NSMinX(bounds), NSMinY(bounds), NSWidth(bounds), std::min<CGFloat>(topContentInset, NSHeight(bounds)));
+    auto topInsetFrame = NSMakeRect(NSMinX(bounds), NSMinY(bounds) - additionalHeight, NSWidth(bounds), additionalHeight + std::min<CGFloat>(topContentInset, NSHeight(bounds)));
 
     if ([m_view _usesAutomaticContentInsetBackgroundFill]) {
         for (NSView *pocketContainer in m_viewsAboveScrollPocket.get())

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1402,9 +1402,15 @@ BoxSideSet WebPage::sidesRequiringFixedContainerEdges() const
     auto obscuredInsets = m_page->obscuredContentInsets();
 #endif
 
+#if PLATFORM(MAC)
+    auto additionalHeight = m_overflowHeightForTopScrollEdgeEffect;
+#else
+    auto additionalHeight = 0;
+#endif
+
     auto sides = m_page->fixedContainerEdges().fixedEdges();
 
-    if (obscuredInsets.top() > 0)
+    if ((additionalHeight + obscuredInsets.top()) > 0)
         sides.add(BoxSideFlag::Top);
 
     if (obscuredInsets.left() > 0)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -653,6 +653,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     , m_isWindowResizingEnabled(parameters.hasResizableWindows)
 #endif
+#if PLATFORM(MAC)
+    , m_overflowHeightForTopScrollEdgeEffect(parameters.overflowHeightForTopScrollEdgeEffect)
+#endif
 #if ENABLE(META_VIEWPORT)
     , m_forceAlwaysUserScalable(parameters.ignoresViewportScaleLimits)
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2047,6 +2047,10 @@ public:
 
     std::unique_ptr<FrameInfoData> takeMainFrameNavigationInitiator();
 
+#if PLATFORM(MAC)
+    void setOverflowHeightForTopScrollEdgeEffect(double value) { m_overflowHeightForTopScrollEdgeEffect = value; }
+#endif
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2872,6 +2876,10 @@ private:
 
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     bool m_isWindowResizingEnabled { false };
+#endif
+
+#if PLATFORM(MAC)
+    double m_overflowHeightForTopScrollEdgeEffect { 0 };
 #endif
 
     bool m_needsScrollGeometryUpdates { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -608,6 +608,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     DidBeginMagnificationGesture()
     DidEndMagnificationGesture()
+
+    SetOverflowHeightForTopScrollEdgeEffect(double value)
 #endif
 
     StartDeferringResizeEvents();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm
@@ -348,6 +348,35 @@ TEST(ObscuredContentInsets, AdjustedColorForTopContentInsetColor)
     EXPECT_TRUE(Util::compareColors([[webView _topScrollPocket] captureColor], blueColor.get()));
 }
 
+TEST(ObscuredContentInsets, OverflowHeightForTopScrollEdgeEffect)
+{
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+
+    [webView setFrame:NSMakeRect(0, 0, 600, 400)];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(50, 0, 0, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    auto checkScrollPocket = [webView] {
+        RetainPtr pocket = [webView _topScrollPocket];
+        auto color = WebCore::serializationForCSS(WebCore::colorFromCocoaColor([pocket captureColor]));
+        auto rect = [pocket convertRect:[pocket bounds] toView:nil];
+        EXPECT_EQ(rect, NSMakeRect(0, 350, 600, 50));
+        EXPECT_WK_STREQ(color, "rgb(255, 99, 71)"_s);
+    };
+
+    checkScrollPocket();
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+    [webView setFrame:NSMakeRect(0, 0, 600, 350)];
+    [webView _setOverflowHeightForTopScrollEdgeEffect:50];
+    [webView waitForNextPresentationUpdate];
+
+    checkScrollPocket();
+}
+
 #endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8ac8e902cceaddc21445b0837575fa16a494d5a1
<pre>
[Liquid Glass] [macOS] Add a way to extend the height of the scroll pocket
<a href="https://bugs.webkit.org/show_bug.cgi?id=297106">https://bugs.webkit.org/show_bug.cgi?id=297106</a>
<a href="https://rdar.apple.com/157815756">rdar://157815756</a>

Reviewed by Aditya Keerthi.

Add a new macOS-specific property, `-_setOverflowHeightForTopScrollEdgeEffect:`, to allow Safari to
extend the height of the web view&apos;s scroll pocket upwards by a specified amount. See below for more
details.

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:

Add `overflowHeightForTopScrollEdgeEffect` to WebPage creation parameters, so that newly created web
views will start with the correct height.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView scrollViewDrawsMagicPocket]):

Return true if either the top obscured content inset or the additional overflow height is nonzero.

(-[WKWebView _overflowHeightForTopScrollEdgeEffect]):
(-[WKWebView _setOverflowHeightForTopScrollEdgeEffect:]):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController didAttachOrDetach]):

Also propagate this SPI over to the attached inspector web view, so that docked inspector views will
also get the extra pocket height.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::setOverflowHeightForTopScrollEdgeEffect):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateScrollPocket):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::sidesRequiringFixedContainerEdges const):

Make sure we sample for the top fixed container, in the case where a nonzero overflow top pocket
height is set.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, OverflowHeightForTopScrollEdgeEffect)):

Add an API test to exercise this new property.

Canonical link: <a href="https://commits.webkit.org/298394@main">https://commits.webkit.org/298394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd9f37e46b86c3c1b3c418d75f423118f584809a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65950 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6cbdd3f-d8d5-4786-8116-d8d688bb1d28) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87654 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a06f145-3a48-487a-b491-6da8303b5069) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68048 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65121 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124627 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96436 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19312 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38230 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47747 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41697 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->