### PR TITLE
[JSC] Location in JSToken is duplicate information

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -118,7 +118,7 @@ Protocol::ErrorStringOr<std::tuple<Protocol::Runtime::SyntaxErrorType, String /*
 
     if (error.syntaxErrorType() != ParserError::SyntaxErrorNone) {
         message = error.message();
-        range = buildErrorRangeObject(error.token().m_location);
+        range = buildErrorRangeObject(error.token().location());
     }
 
     return { { *result, message, WTFMove(range) } };

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -131,8 +131,8 @@ public:
     ALWAYS_INLINE StringView getToken(const JSToken& token)
     {
         SourceProvider* sourceProvider = m_source->provider();
-        ASSERT_WITH_MESSAGE(token.m_location.startOffset <= token.m_location.endOffset, "Calling this function with the baked token.");
-        return sourceProvider->getRange(token.m_location.startOffset, token.m_location.endOffset);
+        ASSERT_WITH_MESSAGE(token.m_startPosition.offset <= token.m_endPosition.offset, "Calling this function with the baked token.");
+        return sourceProvider->getRange(token.m_startPosition.offset, token.m_endPosition.offset);
     }
 
     size_t codeLength() { return m_codeEnd - m_codeStart; }
@@ -207,7 +207,7 @@ private:
     template <unsigned length>
     ALWAYS_INLINE bool consume(const char (&input)[length]);
 
-    void fillTokenInfo(JSToken*, JSTokenType, int lineNumber, int endOffset, int lineStartOffset, JSTextPosition endPosition);
+    void fillTokenInfo(JSToken*, JSTokenType, JSTextPosition endPosition);
 
     static constexpr size_t initialReadBufferCapacity = 32;
 
@@ -356,7 +356,6 @@ template <typename T>
 ALWAYS_INLINE JSTokenType Lexer<T>::lexExpectIdentifier(JSToken* tokenRecord, OptionSet<LexerFlags> lexerFlags, bool strictMode)
 {
     JSTokenData* tokenData = &tokenRecord->m_data;
-    JSTokenLocation* tokenLocation = &tokenRecord->m_location;
     ASSERT(lexerFlags.contains(LexerFlags::IgnoreReservedWords));
     const T* start = m_code;
     const T* ptr = start;
@@ -396,11 +395,6 @@ ALWAYS_INLINE JSTokenType Lexer<T>::lexExpectIdentifier(JSToken* tokenRecord, Op
     else
         tokenData->ident = makeLCharIdentifier({ start, ptr });
 
-    tokenLocation->line = m_lineNumber;
-    tokenLocation->lineStartOffset = currentLineStartOffset();
-    tokenLocation->startOffset = offsetFromSourcePtr(start);
-    tokenLocation->endOffset = currentOffset();
-    ASSERT(tokenLocation->startOffset >= tokenLocation->lineStartOffset);
     tokenRecord->m_startPosition = startPosition;
     tokenRecord->m_endPosition = currentPosition();
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1530,9 +1530,9 @@ private:
 
     ALWAYS_INLINE void next(OptionSet<LexerFlags> lexerFlags = { })
     {
-        int lastLine = m_token.m_location.line;
-        int lastTokenEnd = m_token.m_location.endOffset;
-        int lastTokenLineStart = m_token.m_location.lineStartOffset;
+        int lastLine = m_token.m_startPosition.line;
+        int lastTokenEnd = m_token.m_endPosition.offset;
+        int lastTokenLineStart = m_token.m_startPosition.lineStartOffset;
         m_lastTokenEndPosition = JSTextPosition(lastLine, lastTokenEnd, lastTokenLineStart);
         m_lexer->setLastLineNumber(lastLine);
         m_token.m_type = m_lexer->lex(&m_token, lexerFlags, strictMode());
@@ -1540,9 +1540,9 @@ private:
 
     ALWAYS_INLINE void nextWithoutClearingLineTerminator(OptionSet<LexerFlags> lexerFlags = { })
     {
-        int lastLine = m_token.m_location.line;
-        int lastTokenEnd = m_token.m_location.endOffset;
-        int lastTokenLineStart = m_token.m_location.lineStartOffset;
+        int lastLine = m_token.m_startPosition.line;
+        int lastTokenEnd = m_token.m_endPosition.offset;
+        int lastTokenLineStart = m_token.m_startPosition.lineStartOffset;
         m_lastTokenEndPosition = JSTextPosition(lastLine, lastTokenEnd, lastTokenLineStart);
         m_lexer->setLastLineNumber(lastLine);
         m_token.m_type = m_lexer->lexWithoutClearingLineTerminator(&m_token, lexerFlags, strictMode());
@@ -1550,9 +1550,9 @@ private:
 
     ALWAYS_INLINE void nextExpectIdentifier(OptionSet<LexerFlags> lexerFlags = { })
     {
-        int lastLine = m_token.m_location.line;
-        int lastTokenEnd = m_token.m_location.endOffset;
-        int lastTokenLineStart = m_token.m_location.lineStartOffset;
+        int lastLine = m_token.m_startPosition.line;
+        int lastTokenEnd = m_token.m_endPosition.offset;
+        int lastTokenLineStart = m_token.m_startPosition.lineStartOffset;
         m_lastTokenEndPosition = JSTextPosition(lastLine, lastTokenEnd, lastTokenLineStart);
         m_lexer->setLastLineNumber(lastLine);
         m_token.m_type = m_lexer->lexExpectIdentifier(&m_token, lexerFlags, strictMode());
@@ -1616,7 +1616,7 @@ private:
     
     ALWAYS_INLINE unsigned tokenStart()
     {
-        return m_token.m_location.startOffset;
+        return m_token.m_startPosition.offset;
     }
     
     ALWAYS_INLINE const JSTextPosition& tokenStartPosition()
@@ -1626,7 +1626,7 @@ private:
 
     ALWAYS_INLINE int tokenLine()
     {
-        return m_token.m_location.line;
+        return m_token.m_startPosition.line;
     }
     
     ALWAYS_INLINE int tokenColumn()
@@ -1641,12 +1641,12 @@ private:
     
     ALWAYS_INLINE unsigned tokenLineStart()
     {
-        return m_token.m_location.lineStartOffset;
+        return m_token.m_startPosition.lineStartOffset;
     }
     
-    ALWAYS_INLINE const JSTokenLocation& tokenLocation()
+    ALWAYS_INLINE JSTokenLocation tokenLocation()
     {
-        return m_token.m_location;
+        return m_token.location();
     }
 
     void setErrorMessage(const String& message)
@@ -2001,8 +2001,8 @@ private:
     ALWAYS_INLINE LexerState internalSaveLexerState()
     {
         LexerState result;
-        result.startOffset = m_token.m_location.startOffset;
-        result.oldLineStartOffset = m_token.m_location.lineStartOffset;
+        result.startOffset = m_token.m_startPosition.offset;
+        result.oldLineStartOffset = m_token.m_startPosition.lineStartOffset;
         result.oldLastLineNumber = m_lexer->lastLineNumber();
         result.oldLineNumber = m_lexer->lineNumber();
         result.hasLineTerminatorBeforeToken = m_lexer->hasLineTerminatorBeforeToken();

--- a/Source/JavaScriptCore/parser/ParserTokens.h
+++ b/Source/JavaScriptCore/parser/ParserTokens.h
@@ -275,9 +275,18 @@ struct JSTokenLocation {
 struct JSToken {
     JSTokenType m_type { ERRORTOK };
     JSTokenData m_data { { nullptr, nullptr, false } };
-    JSTokenLocation m_location;
     JSTextPosition m_startPosition;
     JSTextPosition m_endPosition;
+
+    JSTokenLocation location() const
+    {
+        JSTokenLocation result;
+        result.line = m_startPosition.line;
+        result.lineStartOffset = m_startPosition.lineStartOffset;
+        result.startOffset = m_startPosition.offset;
+        result.endOffset = m_endPosition.offset;
+        return result;
+    }
 
     void dump(WTF::PrintStream&) const;
 };

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -67,10 +67,10 @@ public:
         JSToken token;
         token.m_type = isBodyArrowExpression ? static_cast<JSTokenType>(tokenType) : CLOSEBRACE;
         token.m_data.offset = lastTokenStartOffset;
-        token.m_location.startOffset = lastTokenStartOffset;
-        token.m_location.endOffset = lastTokenEndOffset;
-        token.m_location.line = lastTokenLine;
-        token.m_location.lineStartOffset = lastTokenLineStartOffset;
+        token.m_startPosition.offset = lastTokenStartOffset;
+        token.m_startPosition.line = lastTokenLine;
+        token.m_startPosition.lineStartOffset = lastTokenLineStartOffset;
+        token.m_endPosition.offset = lastTokenEndOffset;
         // token.m_location.sourceOffset is initialized once by the client. So,
         // we do not need to set it here.
         return token;


### PR DESCRIPTION
#### a374eeb3f95f422b9ad97ae6197569f79700f0df
<pre>
[JSC] Location in JSToken is duplicate information
<a href="https://bugs.webkit.org/show_bug.cgi?id=297107">https://bugs.webkit.org/show_bug.cgi?id=297107</a>
<a href="https://rdar.apple.com/157820631">rdar://157820631</a>

Reviewed by Yijia Huang.

JSLocation stored in JSToken is completely duplicate information. This
can be constructed by using m_startPosition and m_endPosition.
Originally only JSLocation exists, but we added m_startPosition and
m_endPosition later. As a result, we are storing duplicate information.
This patch removes it.

* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
(Inspector::InspectorRuntimeAgent::parse):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::fillTokenInfo):
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator):
(JSC::Lexer&lt;T&gt;::scanRegExp):
(JSC::Lexer&lt;T&gt;::scanTemplateString):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer::getToken):
(JSC::Lexer&lt;T&gt;::lexExpectIdentifier):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::Parser):
(JSC::Parser&lt;LexerType&gt;::parseGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseAsyncGeneratorFunctionSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclarationList):
(JSC::Parser&lt;LexerType&gt;::createBindingPattern):
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):
(JSC::Parser&lt;LexerType&gt;::parseTryStatement):
(JSC::Parser&lt;LexerType&gt;::parseStatement):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parseArrayLiteral):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser::tokenStart):
(JSC::Parser::tokenLine):
(JSC::Parser::tokenLineStart):
(JSC::Parser::tokenLocation):
(JSC::Parser::internalSaveLexerState):
* Source/JavaScriptCore/parser/ParserTokens.h:
(JSC::JSToken::location const):
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
(JSC::SourceProviderCacheItem::endFunctionToken const):

Canonical link: <a href="https://commits.webkit.org/298443@main">https://commits.webkit.org/298443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd881ab7ddda19051ee46b89acc7ac06e96f6f3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66005 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a860f58-99dd-4c5b-a269-abc19d1f7a58) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43693 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87709 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3f4a623-7f9d-4117-9d5b-9aa1d642311d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68101 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65173 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107632 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124682 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113967 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96486 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96272 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41500 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38270 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42247 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47806 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41750 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->