### PR TITLE
WebGL aquarium displays black screen

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
@@ -208,7 +208,9 @@ void WebXROpaqueFramebuffer::endFrame()
         tracePoint(WebXRLayerEndFrameEnd);
     });
 
+    ScopedDisableScissorTest disableScissorTest { m_context };
     ScopedWebGLRestoreFramebuffer restoreFramebuffer { m_context };
+
     switch (m_displayLayout) {
     case PlatformXR::Layout::Shared:
         blitShared(*gl);


### PR DESCRIPTION
#### 079f8e7202eda0a9aadf5018bb059cfa1ce721e6
<pre>
WebGL aquarium displays black screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=297108">https://bugs.webkit.org/show_bug.cgi?id=297108</a>
<a href="https://rdar.apple.com/140930296">rdar://140930296</a>

Reviewed by Mike Wyrzykowski and Kimmo Kinnunen.

An active scissor rectangle affects the operation of glBlitFramebuffer.
The aquarium sample is leaving scissor enabled with a rect that
completely removes the rectangles used to blit the WebGL content into
the compositor textures.

Disabling scissor test around the blit operation restores the sample
to work in immersive VR mode.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::endFrame):

Canonical link: <a href="https://commits.webkit.org/298493@main">https://commits.webkit.org/298493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3424ee27d3b72cff56d6d0019ef51d289f9b7b06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26a64e24-f381-4b62-a92c-2dea2aeafc11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87658 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42358 "Too many flaky failures: compositing/transforms/transformed-replaced-with-shadow-children.html, fast/css/matches-specificity-10.html, fast/dom/SelectorAPI/caseID.html, fast/dom/normalize-doesnt-check-string-length.html, fast/forms/change-inputmode-crash.html, fast/forms/number/number-min-max-spinbutton-appearance-none-crash.html, fast/shadow-dom/shadow-style-text-mutation.html, imported/w3c/web-platform-tests/event-timing/event-click-counts.html, js/arrowfunction-call.html, js/cached-call-uninitialized-arguments.html, js/dom/call-link-info-recursion.html, js/dom/function-argument-evaluation-before-exception.html, js/dom/function-argument-evaluation.html, js/stringimpl-to-jsstring-on-large-strings-3.html, storage/indexeddb/cursor-cast.html, storage/indexeddb/key-sort-order-date.html, storage/indexeddb/modern/cursor-2.html, storage/indexeddb/modern/idbobjectstore-count-1.html, storage/indexeddb/mozilla/remove-objectstore.html, storage/indexeddb/mozilla/versionchange-abort-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, streams/readable-stream-tee-worker.html, webgl/2.0.y/conformance/glsl/implicit/subtract_int_vec4.vert.html, webgl/2.0.y/conformance/glsl/literals/float_literal.vert.html, webgl/2.0.y/conformance/state/gl-geterror.html, webgl/2.0.y/conformance/uniforms/uniform-samplers-test.html, webgl/2.0.y/conformance2/extensions/ovr_multiview2_draw_buffers.html, webgl/2.0.y/conformance2/misc/null-object-behaviour-2.html, webgl/2.0.y/conformance2/query/occlusion-query.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3b1e800-b369-4f6e-94be-c5bf7921ecc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68052 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21686 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65124 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124630 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96439 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47751 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41700 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->