### PR TITLE
Minor correction to CSS Typed OM IDL

### DIFF
--- a/Source/WebCore/css/typedom/CSSUnparsedValue.idl
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.idl
@@ -36,5 +36,5 @@ typedef (USVString or CSSOMVariableReferenceValue) CSSUnparsedSegment;
     iterable<CSSUnparsedSegment>;
     readonly attribute unsigned long length;
     getter CSSUnparsedSegment? (unsigned long index);
-    setter CSSUnparsedSegment (unsigned long index, CSSUnparsedSegment val);
+    setter undefined (unsigned long index, CSSUnparsedSegment val);
 };

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.idl
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.idl
@@ -32,7 +32,7 @@
     iterable<CSSTransformComponent>;
     readonly attribute unsigned long length;
     getter CSSTransformComponent (unsigned long index);
-    setter CSSTransformComponent (unsigned long index, CSSTransformComponent val);
+    setter undefined (unsigned long index, CSSTransformComponent val);
 
     readonly attribute boolean is2D;
     DOMMatrix toMatrix();


### PR DESCRIPTION
#### d0c0e52795c0c50803b6860a0759acd5cc9e13f2
<pre>
Minor correction to CSS Typed OM IDL
<a href="https://bugs.webkit.org/show_bug.cgi?id=297111">https://bugs.webkit.org/show_bug.cgi?id=297111</a>

Reviewed by Sam Weinig.

Setters don&apos;t return anything. Specification change:

<a href="https://github.com/w3c/css-houdini-drafts/pull/1143">https://github.com/w3c/css-houdini-drafts/pull/1143</a>
Canonical link: <a href="https://commits.webkit.org/298388@main">https://commits.webkit.org/298388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3782435f249bdc6f7390d293ec1e7f47def79799

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65969 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/13c93c7a-65ad-4559-ade7-cd9123fe829f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c7cb924-bb4a-4f36-99e6-af978b662bbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68066 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21704 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65137 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124644 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96454 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96240 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19328 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38241 "Hash 3782435f for PR 49111 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47766 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->