### PR TITLE
Strip TAB & SPACE from name & value passed to CookieStore methods

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any-expected.txt
@@ -16,4 +16,5 @@ FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejec
 FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS cookieStore.delete with maximum cookie name size
 PASS cookieStore.delete with a __Host- prefix should not have a domain
+PASS cookieStore.delete with whitespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any.js
@@ -220,3 +220,12 @@ promise_test(async testCase => {
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
 }, 'cookieStore.delete with a __Host- prefix should not have a domain');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  const cookie = await cookieStore.delete(' cookie-name \t');
+  assert_equals(cookie, undefined);
+}, 'cookieStore.delete with whitespace');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_delete_arguments.https.any.serviceworker-expected.txt
@@ -16,4 +16,5 @@ FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejec
 FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
 PASS cookieStore.delete with maximum cookie name size
 PASS cookieStore.delete with a __Host- prefix should not have a domain
+PASS cookieStore.delete with whitespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_getAll_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_getAll_arguments.https.any-expected.txt
@@ -10,4 +10,5 @@ PASS cookieStore.getAll with invalid url path in options
 PASS cookieStore.getAll with invalid url host in options
 PASS cookieStore.getAll with absolute url with fragment in options
 PASS cookieStore.getAll with absolute different url in options
+PASS cookieStore.getAll with whitespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_getAll_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_getAll_arguments.https.any.js
@@ -194,3 +194,14 @@ promise_test(async testCase => {
     assert_equals(cookies[0].value, 'cookie-value');
   }
 }, 'cookieStore.getAll with absolute different url in options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  const cookies = await cookieStore.getAll(' cookie-name \t');
+  assert_equals(cookies.length, 1);
+  assert_equals(cookies[0].name, 'cookie-name');
+  assert_equals(cookies[0].value, 'cookie-value');
+}, 'cookieStore.getAll with whitespace');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_getAll_arguments.https.any.serviceworker-expected.txt
@@ -10,4 +10,5 @@ PASS cookieStore.getAll with same-origin url path in options
 PASS cookieStore.getAll with invalid url host in options
 PASS cookieStore.getAll with absolute url with fragment in options
 PASS cookieStore.getAll with absolute different url in options
+PASS cookieStore.getAll with whitespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_get_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_get_arguments.https.any-expected.txt
@@ -10,4 +10,5 @@ PASS cookieStore.get with invalid url path in options
 PASS cookieStore.get with invalid url host in options
 PASS cookieStore.get with absolute url with fragment in options
 PASS cookieStore.get with absolute different url in options
+PASS cookieStore.get with whitespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_get_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_get_arguments.https.any.js
@@ -142,3 +142,13 @@ promise_test(async testCase => {
     assert_equals(cookie.value, 'cookie-value');
   }
 }, 'cookieStore.get with absolute different url in options');
+
+promise_test(async testCase => {
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+  const cookie = await cookieStore.get(' cookie-name \t');
+  assert_equals(cookie.name, 'cookie-name');
+  assert_equals(cookie.value, 'cookie-value');
+}, 'cookieStore.get with whitespace');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_get_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_get_arguments.https.any.serviceworker-expected.txt
@@ -10,4 +10,5 @@ PASS cookieStore.get with same-origin url path in options
 PASS cookieStore.get with invalid url host in options
 PASS cookieStore.get with absolute url with fragment in options
 PASS cookieStore.get with absolute different url in options
+PASS cookieStore.get with whitespace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any-expected.txt
@@ -51,6 +51,6 @@ PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long
 PASS cookieStore.set checks if the domain is too long
 PASS cookieStore.set with a __Host- prefix should not have a domain
-FAIL cookieStore.set with whitespace only name and value assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with whitespace at begining or end assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set with whitespace only name and value
+PASS cookieStore.set with whitespace at begining or end
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -51,6 +51,6 @@ PASS cookieStore.set with get result
 PASS cookieStore.set checks if the path is too long
 PASS cookieStore.set checks if the domain is too long
 PASS cookieStore.set with a __Host- prefix should not have a domain
-FAIL cookieStore.set with whitespace only name and value assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with whitespace at begining or end assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set with whitespace only name and value
+PASS cookieStore.set with whitespace at begining or end
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https.html
@@ -3,8 +3,6 @@
   <head>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/resources/testdriver.js"></script>
-    <script src="/resources/testdriver-vendor.js"></script>
   </head>
   <body>
     <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.tentative.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.tentative.sub.https.html
@@ -3,8 +3,6 @@
   <head>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/resources/testdriver.js"></script>
-    <script src="/resources/testdriver-vendor.js"></script>
   </head>
   <body>
     <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/resources/domain_parsing-child.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/resources/domain_parsing-child.sub.https.html
@@ -2,8 +2,6 @@
 <html>
 <head>
   <script src="/resources/testharness.js"></script>
-  <script src="/resources/testdriver.js"></script>
-  <script src="/resources/testdriver-vendor.js"></script>
 </head>
 <body>
   <script>

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -781,16 +781,16 @@ template<typename CharacterType, typename CodeUnitPredicate> inline Ref<StringIm
 
     unsigned start = 0;
     unsigned end = span.size() - 1;
-    
-    // skip white space from start
+
+    // skip matched characters from start
     while (start <= end && predicate(span[start]))
         ++start;
-    
-    // only white space
+
+    // only matched characters
     if (start > end) 
         return *empty();
 
-    // skip white space from end
+    // skip matched characters from end
     while (end && predicate(span[end]))
         --end;
 


### PR DESCRIPTION
#### 0b04262c9b8a699f5b21a185512f756e2b915a14
<pre>
Strip TAB &amp; SPACE from name &amp; value passed to CookieStore methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=297118">https://bugs.webkit.org/show_bug.cgi?id=297118</a>

Reviewed by Rupin Mittal.

The specification already covers set() and
<a href="https://github.com/whatwg/cookiestore/pull/281">https://github.com/whatwg/cookiestore/pull/281</a> will cover get(),
getAll(), and delete() for consistency.

subscribe() and unsubscribe() are not covered by this PR. They are not
shipping and have various outstanding specification issues.

This also removes an unused argument from
CookieStore::MainThreadBridge::set.

While using trim() I also discovered that the comments in
Source/WTF/wtf/text/StringImpl.cpp were out-of-date so this updates
those as well.

Canonical link: <a href="https://commits.webkit.org/298470@main">https://commits.webkit.org/298470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da64dee537b10137c46536e94a0425eb8ec8a73a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/65994 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a725977-8683-4f00-8c54-cae8afabba5d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87695 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8370e8b8-908b-4a29-aa98-a59eebcdf66e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103600 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68087 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65159 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107622 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124671 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113956 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96473 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96259 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41490 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19346 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38260 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18479 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42236 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47792 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139053 "Build was cancelled. Recent messages:Failed to print configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41738 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139053 "Build was cancelled. Recent messages:Failed to print configuration") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->