### PR TITLE
When a module fetch fails, we should not attempt to refetch the same module

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt
@@ -2,6 +2,6 @@
 PASS Importing a specifier that previously failed due to an incorrect type attribute can succeed if the correct attribute is later given
 PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
 PASS Two modules of different type with the same specifier can load if the server changes its responses
-FAIL An import should always fail if the same specifier/type attribute pair failed previously assert_unreached: Should have rejected: import should always fail if the same specifier/type attribute pair failed previously Reached unreachable code
+PASS An import should always fail if the same specifier/type attribute pair failed previously
 PASS If an import previously succeeded for a given specifier/type attribute pair, future uses of that pair should yield the same result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt
@@ -2,6 +2,6 @@
 PASS Importing a specifier that previously failed due to an incorrect type attribute can succeed if the correct attribute is later given
 PASS Importing a specifier that previously succeeded with the correct type attribute should fail if the incorrect attribute is later given
 PASS Two modules of different type with the same specifier can load if the server changes its responses
-FAIL An import should always fail if the same specifier/type attribute pair failed previously assert_unreached: Should have rejected: import should always fail if the same specifier/type attribute pair failed previously Reached unreachable code
+PASS An import should always fail if the same specifier/type attribute pair failed previously
 PASS If an import previously succeeded for a given specifier/type attribute pair, future uses of that pair should yield the same result
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub-expected.txt
@@ -1,8 +1,5 @@
 Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/module/imports-a.js
 Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/module/imports-a.js?x
-Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/module/imports-a.js?x
-Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/module/imports-b.js
-Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/module/imports-b.js
 Blocked access to external URL http://www2.localhost:8800/html/semantics/scripting-1/the-script-element/module/imports-b.js
 
 PASS import() must reject when there is a wrong MIME type
@@ -21,5 +18,5 @@ PASS import() must reject when there is a cross-origin module (without CORS)
 PASS import() must reject with a different error object for each import when there is a cross-origin module (without CORS)
 PASS import() must reject when there is a cross-origin module dependency (without CORS)
 PASS import() must reject with a different error object for each import when there is a cross-origin module dependency (without CORS)
-FAIL import() fetch errors must be cached assert_unreached: Should have rejected: Second import() must be rejected, because the result of the first import() is cached in the module map Reached unreachable code
+PASS import() fetch errors must be cached
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub-expected.txt
@@ -1,9 +1,6 @@
 CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
-CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
-CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
-CONSOLE MESSAGE: Origin http://web-platform.test:8800 is not allowed by Access-Control-Allow-Origin. Status code: 200
 
 PASS import() must reject when there is a wrong MIME type
 PASS import() must reject with a different error object for each import when there is a wrong MIME type
@@ -21,5 +18,5 @@ PASS import() must reject when there is a cross-origin module (without CORS)
 PASS import() must reject with a different error object for each import when there is a cross-origin module (without CORS)
 PASS import() must reject when there is a cross-origin module dependency (without CORS)
 PASS import() must reject with a different error object for each import when there is a cross-origin module dependency (without CORS)
-FAIL import() fetch errors must be cached assert_unreached: Should have rejected: Second import() must be rejected, because the result of the first import() is cached in the module map Reached unreachable code
+PASS import() fetch errors must be cached
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -183,6 +183,7 @@ namespace JSC {
     macro(handlePositiveProxySetTrapResult) \
     macro(handleProxyGetTrapResult) \
     macro(importModule) \
+    macro(moduleFetchFailureKind) \
     macro(copyDataProperties) \
     macro(cloneObject) \
     macro(meta) \

--- a/Source/JavaScriptCore/builtins/ModuleLoader.js
+++ b/Source/JavaScriptCore/builtins/ModuleLoader.js
@@ -166,20 +166,12 @@ function requestFetch(entry, parameters, fetcher)
     "use strict";
 
     if (entry.fetch) {
-        var currentAttempt = entry.fetch;
-        if (entry.state !== @ModuleFetch)
-            return currentAttempt;
-
-        return currentAttempt.catch((error) => {
-            // Even if the existing fetching request failed, this attempt may succeed.
-            // For example, previous attempt used invalid integrity="" value. But this
-            // request could have the correct integrity="" value. In that case, we should
-            // retry fetching for this request.
-            // https://html.spec.whatwg.org/#fetch-a-single-module-script
-            if (currentAttempt === entry.fetch)
-                entry.fetch = @undefined;
-            return this.requestFetch(entry, parameters, fetcher);
-        });
+        var promiseConstructor = @InternalPromise;
+        var newPromise = @createPromise(promiseConstructor, /* isInternalPromise */ true);
+        entry.fetch.then(
+            (result) => @fulfillPromiseWithFirstResolvingFunctionCallCheck(newPromise, result),
+            (error) => @rejectPromiseWithFirstResolvingFunctionCallCheck(newPromise, this.createTypeErrorCopy(error)));
+        return newPromise;
     }
 
     // Hook point.

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -61,6 +61,7 @@
 #include "WebCoreJSClientData.h"
 #include "runtime_root.h"
 #include <JavaScriptCore/AbstractModuleRecord.h>
+#include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Debugger.h>
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/ImportMap.h>
@@ -362,7 +363,7 @@ void ScriptController::setupModuleScriptHandlers(LoadableModuleScript& moduleScr
         auto scope = DECLARE_CATCH_SCOPE(vm);
         if (errorValue.isObject()) {
             auto* object = JSC::asObject(errorValue);
-            if (JSValue failureKindValue = object->getDirect(vm, builtinNames(vm).failureKindPrivateName())) {
+            if (JSValue failureKindValue = object->getDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName())) {
                 // This is host propagated error in the module loader pipeline.
                 switch (static_cast<ModuleFetchFailureKind>(failureKindValue.asInt32())) {
                 case ModuleFetchFailureKind::WasPropagatedError:

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -52,6 +52,7 @@
 #include "WorkerScriptLoader.h"
 #include "WorkletGlobalScope.h"
 #include <JavaScriptCore/AbstractModuleRecord.h>
+#include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Completion.h>
 #include <JavaScriptCore/ImportMap.h>
 #include <JavaScriptCore/JSInternalPromise.h>
@@ -134,7 +135,7 @@ JSC::Identifier ScriptModuleLoader::resolve(JSC::JSGlobalObject* jsGlobalObject,
     if (!result) {
         auto* error = JSC::createTypeError(jsGlobalObject, result.error());
         ASSERT(error);
-        error->putDirect(vm, builtinNames(vm).failureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(ModuleFetchFailureKind::WasResolveError)));
+        error->putDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(ModuleFetchFailureKind::WasResolveError)));
         JSC::throwException(jsGlobalObject, scope, error);
         return { };
     }
@@ -152,7 +153,7 @@ static void rejectToPropagateNetworkError(ScriptExecutionContext& context, Ref<D
             // https://bugs.webkit.org/show_bug.cgi?id=167553
             auto* error = JSC::createTypeError(&jsGlobalObject, message);
             ASSERT(error);
-            error->putDirect(vm, builtinNames(vm).failureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(failureKind)));
+            error->putDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(failureKind)));
             return error;
         });
     });
@@ -166,7 +167,7 @@ static void rejectWithFetchError(ScriptExecutionContext& context, Ref<DeferredPr
             JSC::VM& vm = jsGlobalObject.vm();
             JSC::JSObject* error = JSC::jsCast<JSC::JSObject*>(createDOMException(&jsGlobalObject, ec, message));
             ASSERT(error);
-            error->putDirect(vm, builtinNames(vm).failureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(ModuleFetchFailureKind::WasFetchError)));
+            error->putDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName(), JSC::jsNumber(enumToUnderlyingType(ModuleFetchFailureKind::WasFetchError)));
             return error;
         });
     });

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -605,7 +605,6 @@ namespace WebCore {
     macro(encode) \
     macro(encoding) \
     macro(errorSteps) \
-    macro(failureKind) \
     macro(fatal) \
     macro(fetch) \
     macro(fetchRequest) \

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -49,6 +49,7 @@
 #include "WorkerRunLoop.h"
 #include "WorkerScriptFetcher.h"
 #include <JavaScriptCore/AbstractModuleRecord.h>
+#include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Completion.h>
 #include <JavaScriptCore/DeferTermination.h>
 #include <JavaScriptCore/DeferredWorkTimer.h>
@@ -350,7 +351,7 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
             auto scope = DECLARE_CATCH_SCOPE(vm);
             if (errorValue.isObject()) {
                 auto* object = JSC::asObject(errorValue);
-                if (JSValue failureKindValue = object->getDirect(vm, builtinNames(vm).failureKindPrivateName())) {
+                if (JSValue failureKindValue = object->getDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName())) {
                     // This is host propagated error in the module loader pipeline.
                     switch (static_cast<ModuleFetchFailureKind>(failureKindValue.asInt32())) {
                     case ModuleFetchFailureKind::WasPropagatedError:
@@ -547,7 +548,7 @@ void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL
             JSValue errorValue = callFrame->argument(0);
             if (errorValue.isObject()) {
                 auto* object = JSC::asObject(errorValue);
-                if (JSValue failureKindValue = object->getDirect(vm, builtinNames(vm).failureKindPrivateName())) {
+                if (JSValue failureKindValue = object->getDirect(vm, vm.propertyNames->builtinNames().moduleFetchFailureKindPrivateName())) {
                     auto catchScope = DECLARE_CATCH_SCOPE(vm);
                     String message = retrieveErrorMessageWithoutName(*globalObject, vm, object, catchScope);
                     switch (static_cast<ModuleFetchFailureKind>(failureKindValue.asInt32())) {


### PR DESCRIPTION
#### 537527cbaebdb1b76496bae4a97e94bc81aa59d9
<pre>
When a module fetch fails, we should not attempt to refetch the same module
<a href="https://bugs.webkit.org/show_bug.cgi?id=297120">https://bugs.webkit.org/show_bug.cgi?id=297120</a>

Reviewed by Yusuke Suzuki.

This PR updates JSC&apos;s module loader so that once the fetching of a (specifier, type) pair was attempted,
JSC doesn&apos;t try to fetch the same pair again in the future. The new behavior is more spec compliant and
matches that of Firefox and Chrome. Note that we still create a new Error object for every import per spec.

Also move WebCore&apos;s failureKind to JSC so that we could copy the value over when cloning the error object.
This portion of the PR is written by Shu-yu Guo.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/dynamic-imports-fetch-error.sub-expected.txt:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/ModuleLoader.js:
(visibility.PrivateRecursive.requestFetch):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::setupModuleScriptHandlers):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::resolve):
(WebCore::rejectToPropagateNetworkError):
(WebCore::rejectWithFetchError):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::loadModuleSynchronously):
(WebCore::WorkerOrWorkletScriptController::loadAndEvaluateModule):

Canonical link: <a href="https://commits.webkit.org/298544@main">https://commits.webkit.org/298544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2469e08a09f2dc4984ba3802f37e6e63383aecb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121858 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66334 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4053032e-c6ba-43a2-ba53-f57784094de9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87976 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d307d34-45e9-4fe0-ad4b-2cb9d22d53fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68378 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/27989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22030 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65530 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/107920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125010 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114339 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96731 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96517 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38620 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18517 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48176 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/142669 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42054 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36883 "Found 7354 new JSC stress test failures: airjs-tests.yaml/stress-test.js.lockdown, basic-tests.yaml/stress-test.js.lockdown, cdjs-tests.yaml/main.js.lockdown, cdjs-tests.yaml/motion_test.js.lockdown, cdjs-tests.yaml/red_black_tree_test.js.lockdown, cdjs-tests.yaml/reduce_collision_set_test.js.lockdown, microbenchmarks/Float32Array-matrix-mult.js.lockdown, microbenchmarks/Int16Array-bubble-sort-with-byteLength.js.lockdown, microbenchmarks/Int16Array-bubble-sort.js.lockdown, microbenchmarks/Int16Array-load-int-mul.js.lockdown ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45388 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->