### PR TITLE
WKRemoteObjectCoder methodSignaturesAreCompatible always returns true.

### DIFF
--- a/JSTests/stress/regexp-lookbehind.js
+++ b/JSTests/stress/regexp-lookbehind.js
@@ -235,3 +235,27 @@ testRegExp(/(?<!(AB*))c/, "A", null);
 
 // Test 101
 testRegExp(/(?<=Result = |<)(\w+(?:Error|Response))/, "<Result = LoadFinishedResponse>(", ["LoadFinishedResponse", "LoadFinishedResponse"]);
+testRegExp(/(?<=\k<a>(?<a>[abx]))d/, "abxxd", ["d", "x"]);
+testRegExp(/(?<=\k<a>(?<a>\w+))c/, "ababc", ["c", "ab"]);
+testRegExp(/(?<=\k<a>(?<a>\w+))c/, "ababbc", ["c", "b"]);
+testRegExp(/(?<=\k<a>(?<a>\w+))c/, "ababbc", ["c", "b"]);
+
+// Test 106
+testRegExp(/(?<!(A)|\1{0})B/, "AB", null);
+testRegExp(/(?<!(A)|\1{0})B/, "XB", null);
+testRegExp(/(?<=(A)|\1{0})B/, "AB", ["B", "A"]);
+testRegExp(/(?<=(A)|\1{0})B/, "XB", ["B", undefined]);
+testRegExp(/(?<!(A)C|\1)B/, "AB", null);
+
+// Test 111
+testRegExp(/(?<!(A)C|\1)B/, "XB", null);
+testRegExp(/(?<!(.)C|\1)B/, "XB", null);
+testRegExp(/(?<=(A)C|\1)B/, "AB", ["B", undefined]);
+testRegExp(/(?<=(A)C|\1)B/, "XB", ["B", undefined]);
+testRegExp(/(?<!(?<alpha>A)C|\k<alpha>)B/, "AB", null);
+
+// Test 116
+testRegExp(/(?<!(?<alpha>A)C|\k<alpha>)B/, "XB", null);
+testRegExp(/(?<!(?<alpha>.)C|\k<alpha>)B/, "XB", null);
+testRegExp(/(?<=(?<alpha>A)C|\k<alpha>)B/, "AB", ["B", undefined]);
+testRegExp(/(?<=(?<alpha>A)C|\k<alpha>)B/, "XB", ["B", undefined]);

--- a/LayoutTests/fast/multicol/null-enclosing-fragmented-flow-crash-expected.txt
+++ b/LayoutTests/fast/multicol/null-enclosing-fragmented-flow-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if there is no crash.

--- a/LayoutTests/fast/multicol/null-enclosing-fragmented-flow-crash.html
+++ b/LayoutTests/fast/multicol/null-enclosing-fragmented-flow-crash.html
@@ -1,0 +1,16 @@
+<style>
+  *:last-of-type { overflow-y: -webkit-paged-y; }
+  html { overflow-y: clip; }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<div>
+  <div style="-webkit-column-span: all; scale: 1">
+    <div style="position: absolute; ">
+      PASS if there is no crash.
+      <video poster="data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9wDGhYvCNVA1EIAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAAjklEQVR42u3QIQEAMAgAsHNNVspTgARY1BZh0ZWP3VcgSJAgQYIECRKEIEGCBAkSJEgQggQJEiRIkCBBCBIkSJAgQYIECUKQIEGCBAkSJAhBggQJEiRIkCAECRIkSJAgQYIEIUiQIEGCBAkShCBBggQJEiRIEIIECRIkSJAgQYIQJEiQIEGCBAlCkCBBdwaeugIthHvZ+AAAAABJRU5ErkJggg==" >
+    </div>
+  </div>
+</div>

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1561,14 +1561,6 @@ public:
                 m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
                 return;
             }
-
-            if (parenthesisMatchDirection() == Backward
-                && term.type == PatternTerm::Type::ParentheticalAssertion
-                && term.matchDirection() == Backward
-                && subpatternId >= term.parentheses.subpatternId) {
-                m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
-                return;
-            }
         }
 
         m_alternative->m_terms.append(PatternTerm(subpatternId, m_flags));
@@ -1594,14 +1586,6 @@ public:
                 ASSERT((term.type == PatternTerm::Type::ParenthesesSubpattern) || (term.type == PatternTerm::Type::ParentheticalAssertion));
 
                 if ((term.type == PatternTerm::Type::ParenthesesSubpattern) && term.capture() && (subpatternId == term.parentheses.subpatternId)) {
-                    m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
-                    return;
-                }
-
-                if (parenthesisMatchDirection() == Backward
-                    && term.type == PatternTerm::Type::ParentheticalAssertion
-                    && term.matchDirection() == Backward
-                    && subpatternId >= term.parentheses.subpatternId) {
                     m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
                     return;
                 }

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1326,8 +1326,8 @@ void IDBTransaction::putOrAddOnServer(IDBClient::TransactionOperation& operation
 
         // If the IDBValue doesn't have any data, then something went wrong writing the blobs to disk.
         // In that case, we cannot successfully store this record, so we callback with an error.
-        auto result = IDBResultData::error(protectedOperation->identifier(), IDBError { ExceptionCode::UnknownError, "Error preparing Blob/File data to be stored in object store"_s });
-        callOnMainThread([protectedThis = WTFMove(protectedThis), protectedOperation = WTFMove(protectedOperation), result = WTFMove(result)]() mutable {
+        callOnMainThread([protectedThis = WTFMove(protectedThis), protectedOperation = WTFMove(protectedOperation)]() mutable {
+            auto result = IDBResultData::error(protectedOperation->identifier(), IDBError { ExceptionCode::UnknownError, "Error preparing Blob/File data to be stored in object store"_s });
             protectedOperation->doComplete(result);
         });
     });

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2996,6 +2996,22 @@ bool Document::updateStyleIfNeeded()
     return true;
 }
 
+bool Document::updateStyleIfNeededIgnoringPendingStylesheets()
+{
+    bool oldIgnore = m_ignorePendingStylesheets;
+    m_ignorePendingStylesheets = true;
+    // FIXME: This should just invalidate elements with missing styles.
+    if (m_hasNodesWithMissingStyle)
+        scheduleFullStyleRebuild();
+
+    updateRelevancyOfContentVisibilityElements();
+
+    bool result = updateStyleIfNeeded();
+
+    m_ignorePendingStylesheets = oldIgnore;
+    return result;
+}
+
 auto Document::updateLayoutIgnorePendingStylesheets(OptionSet<LayoutOptions> layoutOptions, const Element* context) -> UpdateLayoutResult
 {
     layoutOptions.add(LayoutOptions::IgnorePendingStylesheets);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -734,6 +734,7 @@ public:
     enum class ResolveStyleType : bool { Normal, Rebuild };
     WEBCORE_EXPORT void resolveStyle(ResolveStyleType = ResolveStyleType::Normal);
     WEBCORE_EXPORT bool updateStyleIfNeeded();
+    bool updateStyleIfNeededIgnoringPendingStylesheets();
     bool needsStyleRecalc() const;
     unsigned lastStyleUpdateSizeForTesting() const { return m_lastStyleUpdateSizeForTesting; }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2617,9 +2617,13 @@ void RenderBlock::setCachedEnclosingFragmentedFlowNeedsUpdate()
 
 RenderFragmentedFlow* RenderBlock::updateCachedEnclosingFragmentedFlow(RenderFragmentedFlow* fragmentedFlow) const
 {
-    RenderBlockRareData& rareData = const_cast<RenderBlock&>(*this).ensureBlockRareData();
-    rareData.m_enclosingFragmentedFlow = fragmentedFlow;
+    if (!fragmentedFlow) {
+        if (auto* rareData = const_cast<RenderBlock&>(*this).blockRareData())
+            rareData->m_enclosingFragmentedFlow = { };
+        return { };
+    }
 
+    const_cast<RenderBlock&>(*this).ensureBlockRareData().m_enclosingFragmentedFlow = fragmentedFlow;
     return fragmentedFlow;
 }
 

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -63,7 +63,7 @@ namespace WebKit {
 
 bool methodSignaturesAreCompatible(NSString *wire, NSString *local)
 {
-    if ([local isEqualToString:wire] ==  NSOrderedSame)
+    if ([local isEqualToString:wire])
         return true;
 
     if (local.length != wire.length)

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -258,7 +258,6 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
 
         if (!WebKit::methodSignaturesAreCompatible(wireBlockSignature.get(), expectedBlockSignature.get())) {
             NSLog(@"_invokeMethod: Failed to validate reply block signature: %@ != %@", wireBlockSignature.get(), expectedBlockSignature.get());
-            ASSERT_NOT_REACHED();
             return;
         }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h
@@ -54,22 +54,29 @@
 - (void)doNotCallCompletionHandler:(void (^)())completionHandler;
 - (void)sendRequest:(NSURLRequest *)request response:(NSURLResponse *)response challenge:(NSURLAuthenticationChallenge *)challenge error:(NSError *)error nsNull:(id)nsNull uuid:(id)uuid completionHandler:(void (^)(NSURLRequest *, NSURLResponse *, NSURLAuthenticationChallenge *, NSError *, id, id))completionHandler;
 - (void)callUIProcessMethodWithReplyBlock;
+- (void)callUIProcessMethodWithInvalidTypeSignature;
 - (void)sendError:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler;
 - (void)sendAwakener:(TestAwakener *)awakener completionHandler:(void (^)(TestAwakener *))completionHandler;
 - (void)getGroupIdentifier:(void(^)(NSString *))completionHandler;
 
 @end
 
-@protocol LocalObjectProtocol <NSObject>
-
-- (void)doSomethingWithCompletionHandler:(void (^)(void))completionHandler;
-
-@end
-
 @protocol StringReplyObjectProtocol
 
 - (void)methodWithInteger:(uint64_t)integer;
-- (void)methodWithCompletionHandler:(void (^)(id, NSString *))completionHandler;
+- (void)methodWithCompletionHandler:(void (^)(id, NSString *)) completionHandler;
+
+@end
+
+@protocol IntegerReplyObjectProtocol
+
+- (void)methodWithCompletionHandler:(void (^)(uint64_t, uint64_t, uint64_t, uint64_t)) completionHandler;
+
+@end
+
+@protocol LocalObjectProtocol <NSObject>
+
+- (void)doSomethingWithCompletionHandler:(void (^)(void))completionHandler;
 
 @end
 
@@ -92,5 +99,11 @@ static inline _WKRemoteObjectInterface *localObjectInterface()
 static inline _WKRemoteObjectInterface *stringReplyObjectInterface()
 {
     _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(StringReplyObjectProtocol)];
+    return interface;
+}
+
+static inline _WKRemoteObjectInterface *integerReplyObjectInterface()
+{
+    _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(IntegerReplyObjectProtocol)];
     return interface;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm
@@ -134,6 +134,13 @@
     [localObject doSomethingWithCompletionHandler:^{ }];
 }
 
+- (void)callUIProcessMethodWithInvalidTypeSignature
+{
+    // Note: The purposeful cast to the wrong protocol here allows us to trigger a remote invocation with a different type signature than expected.
+    id<IntegerReplyObjectProtocol> integerObject = [[_browserContextController _remoteObjectRegistry] remoteObjectProxyWithInterface:stringReplyObjectInterface()];
+    [integerObject methodWithCompletionHandler:^(uint64_t, uint64_t, uint64_t, uint64_t) { }];
+}
+
 - (void)getGroupIdentifier:(void(^)(NSString *))completionHandler
 {
     completionHandler([_browserContextController _groupIdentifier]);


### PR DESCRIPTION
#### 347666e0f9ddf01a592ac271490ba4e2e1d720e4
<pre>
WKRemoteObjectCoder methodSignaturesAreCompatible always returns true.
<a href="https://bugs.webkit.org/show_bug.cgi?id=290103">https://bugs.webkit.org/show_bug.cgi?id=290103</a>
<a href="https://rdar.apple.com/145728698">rdar://145728698</a>

Reviewed by Alex Christensen.

Remove the invalid comparison against NSOrderedSame, returning to a simple boolean check.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(WebKit::methodSignaturesAreCompatible):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h:
(stringReplyObjectInterface):
(integerReplyObjectInterface):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm:
(-[StringReplyObject methodWithCompletionHandler:]):
(TEST(RemoteObjectRegistry, CallReplyBlockWithInvalidTypeSignature)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm:
(-[RemoteObjectRegistryPlugIn callUIProcessMethodWithInvalidTypeSignature]):

Originally-landed-as: 289651.476@safari-7621-branch (1fff6c4e5b32). <a href="https://rdar.apple.com/157794213">rdar://157794213</a>
Canonical link: <a href="https://commits.webkit.org/298425@main">https://commits.webkit.org/298425@main</a>
</pre>
----------------------------------------------------------------------
#### 6866fd6e4b226edcc295ffff0e5803d715e387d6
<pre>
Crash under IDBTransaction::requestPutOrAdd()
<a href="https://bugs.webkit.org/show_bug.cgi?id=292340">https://bugs.webkit.org/show_bug.cgi?id=292340</a>
<a href="https://rdar.apple.com/149937426">rdar://149937426</a>

Reviewed by Sihui Liu and Per Arne Vollan.

The code was constructing the IDBResultData on the background thread and then
capturing it in the lambda with a WTFMove() before using it on the main thread.
This didn&apos;t look thread-safe. We could call `isolatedCopy()` but I have opted
to delay the construction of the IDBResultData until we&apos;re on the main thread.

* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::putOrAddOnServer):

Originally-landed-as: 289651.475@safari-7621-branch (05d9b16c830a). <a href="https://rdar.apple.com/157794363">rdar://157794363</a>
Canonical link: <a href="https://commits.webkit.org/298424@main">https://commits.webkit.org/298424@main</a>
</pre>
----------------------------------------------------------------------
#### 4b12cc4800e184666a4ea7dbc85e92de0f9a7912
<pre>
heap-use-after-free | WebCore::forEachRendererInPaintOrder inside ViewTransition::captureNewState.
<a href="https://bugs.webkit.org/show_bug.cgi?id=292314">https://bugs.webkit.org/show_bug.cgi?id=292314</a>
&lt;<a href="https://rdar.apple.com/149686168">rdar://149686168</a>&gt;

Reviewed by Alan Baradlay.

captureNewStyle flushes style before iterating RenderLayer z-order lists and
reading style properties.

This calls into the ComputedStyleExtractor, which can call
updateLayoutIgnorePendingStylesheets which can do new style work that wasn&apos;t
captured in the previous flush (pending stylesheets, and content-visibility
relevancy).

This extra style flush can mutate renderers and invalidate the z-order lists
that are currently being iterated.

Adds a new helper updateStyleIfNeededIgnorePendingStylesheets, and use it from
view-transitions, since we need the same level of flushing as inside the
iteration.

Also removes the updateLayout call from
Document::updateRelevancyOfContentVisibilityElements() since all existing
callers already flush layout directly after the call, except for the new
instance added in this patch (which doesn&apos;t want/need layout flushed).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateStyleIfNeededIgnoringPendingStylesheets):
(WebCore::Document::updateRelevancyOfContentVisibilityElements):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::forEachRendererInPaintOrder):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::updatePseudoElementRenderers):

Originally-landed-as: 289651.473@safari-7621-branch (927a0bf9a118). <a href="https://rdar.apple.com/157794459">rdar://157794459</a>
Canonical link: <a href="https://commits.webkit.org/298423@main">https://commits.webkit.org/298423@main</a>
</pre>
----------------------------------------------------------------------
#### ea77bc796c0687039628ea5fadabe4fe02a54c1d
<pre>
[JSC] [e72bdd394922cc4a] ASAN_ILL | Yarr::YarrPatternConstructor::quantifyAtom; Yarr::Parser::parseTokens; JSC::Yarr::parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=292305">https://bugs.webkit.org/show_bug.cgi?id=292305</a>
<a href="https://rdar.apple.com/149760394">rdar://149760394</a>

Reviewed by Daniel Liu.

We were inadvertently creating ForwardReference atoms when we should have been creating
BackReference atoms.  This is because we would create a ForwardReference when the referenced
subpatternId was equal to the value of a parenthesis&apos; subpatternId, but that is a valid
BackReference.  The code in question made a &gt;= comparison, but the greater than case was
already handled prior to the code that this change removes.

Added some new regression test cases.

* JSTests/stress/regexp-lookbehind.js:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomBackReference):
(JSC::Yarr::YarrPatternConstructor::atomNamedBackReference):

Originally-landed-as: 289651.472@safari-7621-branch (3665da825356). <a href="https://rdar.apple.com/157794638">rdar://157794638</a>
Canonical link: <a href="https://commits.webkit.org/298422@main">https://commits.webkit.org/298422@main</a>
</pre>
----------------------------------------------------------------------
#### c3e39daf3a050519b2650f61e02f9699f6c12f80
<pre>
ASAN_TRAP | WebCore::RenderFragmentedFlow::setFragmentRangeForBox; WebCore::RenderBlockFlow::layoutBlockChild; WebCore::RenderBlockFlow::layoutBlockChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=289389">https://bugs.webkit.org/show_bug.cgi?id=289389</a>

Reviewed by Alan Baradlay.

The method updateCachedEnclosingFragmentedFlow can be called with a null value for the fragmentedFlow
parameter while the render tree is not fully built yet, leading to possible assertion failures later.
To fix this, do not cache null values for the enclosing fragmented flow and instead make sure the enclosing
fragmented flow is set to null.

* LayoutTests/fast/multicol/null-enclosing-fragmented-flow-crash-expected.txt: Added.
* LayoutTests/fast/multicol/null-enclosing-fragmented-flow-crash.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::updateCachedEnclosingFragmentedFlow const):

Originally-landed-as: 292955.5@webkit-2025.4-embargoed (65ae446abd0b). <a href="https://rdar.apple.com/157794730">rdar://157794730</a>
Canonical link: <a href="https://commits.webkit.org/298421@main">https://commits.webkit.org/298421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e12f54d80902ee66dd1468a049646dde2234be9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66014 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/55d9d9ba-01fe-439a-9f46-92f07addfa76) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87717 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf898b48-9985-4821-a8df-1c04f1c627f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68109 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21744 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65182 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107640 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124691 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113977 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24496 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47816 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/139452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41759 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/139452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->