### PR TITLE
[JSC] BBQJIT::addI31GetS needs to truncate the result to 32-bits

### DIFF
--- a/JSTests/wasm/gc/i31-array-index.js
+++ b/JSTests/wasm/gc/i31-array-index.js
@@ -1,0 +1,58 @@
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+const wat = `
+(module
+  (type $a (array (mut i32)))
+
+  (func (export "testSignedConst")
+    (result i32)
+
+    (array.new $a (i32.const 101)(i32.const 2))
+    (i31.get_s (ref.i31 (i32.const 1)))
+    (array.get $a)
+  )
+
+  (func (export "testUnsignedConst")
+    (result i32)
+
+    (array.new $a (i32.const 202)(i32.const 2))
+    (i31.get_u (ref.i31 (i32.const 1)))
+    (array.get $a)
+  )
+
+  (func (export "testSigned")
+    (result i32)
+
+    (array.new $a (i32.const 303)(i32.const 2))
+    (i31.get_s (call $getI31Ref (i32.const 1)))
+    (array.get $a)
+  )
+
+  (func (export "testUnsigned")
+    (result i32)
+
+    (array.new $a (i32.const 404)(i32.const 2))
+    (i31.get_u (call $getI31Ref (i32.const 1)))
+    (array.get $a)
+  )
+
+  (func $getI31Ref
+    (param $v i32)
+    (result i31ref)
+
+    (ref.i31 (local.get $v))
+  )
+)`;
+
+let instance = instantiate(wat);
+
+globalThis.testLoopCount ??= 10000;
+
+for (let i = 0; i < testLoopCount; i++) {
+  assert.eq(instance.exports.testSignedConst(), 101);
+  assert.eq(instance.exports.testUnsignedConst(), 202);
+  assert.eq(instance.exports.testSigned(), 303);
+  assert.eq(instance.exports.testUnsigned(), 404);
+
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1542,7 +1542,7 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addI31GetS(ExpressionType value, Expres
 
     LOG_INSTRUCTION("I31GetS", value, RESULT(result));
 
-    m_jit.move(initialValue.asGPR(), resultLocation.asGPR());
+    m_jit.zeroExtend32ToWord(initialValue.asGPR(), resultLocation.asGPR());
 
     return { };
 }


### PR DESCRIPTION
#### fa2f6d3ac3780e73c4c2a3c77fee045727776ac0
<pre>
[JSC] BBQJIT::addI31GetS needs to truncate the result to 32-bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=293518">https://bugs.webkit.org/show_bug.cgi?id=293518</a>
<a href="https://rdar.apple.com/151951424">rdar://151951424</a>

Reviewed by Yusuke Suzuki and Keith Miller.

The tag bits of i31ref need to be removed when evaluating i31.get_u.

Originally-landed-as: 289651.535@safari-7621-branch (b7fa9f7b95c9). <a href="https://rdar.apple.com/157791339">rdar://157791339</a>
Canonical link: <a href="https://commits.webkit.org/298527@main">https://commits.webkit.org/298527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/957368b65ea022ca77d1bba786f4b6c09fbb3041

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66065 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c02297c7-78bd-4390-8fca-793cc2a77b19) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87756 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42421 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07ba737f-a3eb-4bf8-91e1-966882ca57a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68149 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21794 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65246 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107683 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124742 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114043 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96528 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99866 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96314 "Found 1 new API test failure: /TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19413 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38320 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18504 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47876 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41809 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43525 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->