### PR TITLE
[Bindings] Optimize union IDL attribute setters by avoiding conversion to variant

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMConvertBase.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertBase.h
@@ -67,15 +67,22 @@ struct DefaultExceptionThrower {
 };
 
 template<typename IDL> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue);
+template<typename IDL, typename F> decltype(auto) convert(JSC::JSGlobalObject&, JSC::JSValue, F&&);
 template<typename IDL> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSObject&);
 template<typename IDL> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSDOMGlobalObject&);
-template<typename IDL, typename ExceptionThrower> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, ExceptionThrower&&);
-template<typename IDL, typename ExceptionThrower> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSObject&, ExceptionThrower&&);
-template<typename IDL, typename ExceptionThrower> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSDOMGlobalObject&, ExceptionThrower&&);
+template<typename IDL> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSDOMGlobalObject&, const String&);
+template<typename IDL, ExceptionThrowerFunctor ExceptionThrower> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, ExceptionThrower&&);
+template<typename IDL, ExceptionThrowerFunctor ExceptionThrower> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSObject&, ExceptionThrower&&);
+template<typename IDL, ExceptionThrowerFunctor ExceptionThrower> ConversionResult<IDL> convert(JSC::JSGlobalObject&, JSC::JSValue, JSDOMGlobalObject&, ExceptionThrower&&);
 
 template<typename IDL> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
 {
     return Converter<IDL>::convert(lexicalGlobalObject, value);
+}
+
+template<typename IDL, typename ResultFunctor> inline decltype(auto) convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ResultFunctor&& resultFunctor)
+{
+    return Converter<IDL>::convert(lexicalGlobalObject, value, std::forward<ResultFunctor>(resultFunctor));
 }
 
 template<typename IDL> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject)
@@ -88,17 +95,22 @@ template<typename IDL> inline ConversionResult<IDL> convert(JSC::JSGlobalObject&
     return Converter<IDL>::convert(lexicalGlobalObject, value, globalObject);
 }
 
-template<typename IDL, typename ExceptionThrower> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower)
+template<typename IDL> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, const String& sink)
+{
+    return Converter<IDL>::convert(lexicalGlobalObject, value, globalObject, sink);
+}
+
+template<typename IDL, ExceptionThrowerFunctor ExceptionThrower> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower)
 {
     return Converter<IDL>::convert(lexicalGlobalObject, value, std::forward<ExceptionThrower>(exceptionThrower));
 }
 
-template<typename IDL, typename ExceptionThrower> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject, ExceptionThrower&& exceptionThrower)
+template<typename IDL, ExceptionThrowerFunctor ExceptionThrower> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject, ExceptionThrower&& exceptionThrower)
 {
     return Converter<IDL>::convert(lexicalGlobalObject, value, thisObject, std::forward<ExceptionThrower>(exceptionThrower));
 }
 
-template<typename IDL, typename ExceptionThrower> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower)
+template<typename IDL, ExceptionThrowerFunctor ExceptionThrower> inline ConversionResult<IDL> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower)
 {
     return Converter<IDL>::convert(lexicalGlobalObject, value, globalObject, std::forward<ExceptionThrower>(exceptionThrower));
 }

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -33,6 +33,9 @@
         "AtomString": {
             "contextsAllowed": ["type"]
         },
+        "BypassDocumentFullyActiveCheck": {
+            "contextsAllowed": ["type"]
+        },
         "CEReactions": {
             "contextsAllowed": ["attribute", "operation"],
             "values": ["Needed", "NotNeeded"],
@@ -185,6 +188,11 @@
         },
         "EnabledBySetting": {
             "contextsAllowed": ["interface", "namespace", "dictionary", "enum", "attribute", "operation", "constant", "dictionary-member", "includes"],
+            "values": ["*"],
+            "supportsConjunction": true
+        },
+        "EnabledConditionallyReadWriteBySetting": {
+            "contextsAllowed": ["attribute"],
             "values": ["*"],
             "supportsConjunction": true
         },
@@ -415,12 +423,12 @@
         "NotEnumerable": {
             "contextsAllowed": ["attribute", "operation"]
         },
+        "OptimizedUnionSetterUsingOverloads": {
+            "contextsAllowed": ["attribute"]
+        },
         "OverrideIDLType": {
             "contextsAllowed": ["type"],
             "values": ["*"]
-        },
-        "BypassDocumentFullyActiveCheck": {
-            "contextsAllowed": ["type"]
         },
         "Plugin": {
             "contextsAllowed": ["interface"],
@@ -515,11 +523,6 @@
         "SetterCallWith": {
             "contextsAllowed": ["attribute"],
             "values": ["CurrentScriptExecutionContext", "CurrentGlobalObject", "ActiveWindow", "FirstWindow", "PropertyName"],
-            "supportsConjunction": true
-        },
-        "EnabledConditionallyReadWriteBySetting": {
-            "contextsAllowed": ["attribute"],
-            "values": ["*"],
             "supportsConjunction": true
         },
         "SkipCallbackInvokeCheck": {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -2243,6 +2243,10 @@ static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_annotatedTypeInUnionAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_annotatedTypeInUnionAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_annotatedTypeInSequenceAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_annotatedTypeInSequenceAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_unionAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_unionAttr);
+static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_optimizedSetterUnionAttr);
+static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_optimizedSetterUnionAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_implementationEnumAttr);
 static JSC_DECLARE_CUSTOM_SETTER(setJSTestObj_implementationEnumAttr);
 static JSC_DECLARE_CUSTOM_GETTER(jsTestObj_mediaDevices);
@@ -2647,7 +2651,7 @@ template<> void JSTestObjDOMConstructor::initializeProperties(VM& vm, JSDOMGloba
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 298> JSTestObjPrototypeTableValues {
+static const std::array<HashTableValue, 300> JSTestObjPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObjConstructor, 0 } },
     HashTableValue { "readOnlyLongAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyLongAttr, 0 } },
     HashTableValue { "readOnlyStringAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyStringAttr, 0 } },
@@ -2682,6 +2686,8 @@ static const std::array<HashTableValue, 298> JSTestObjPrototypeTableValues {
     HashTableValue { "nullableDictionaryAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_nullableDictionaryAttr, setJSTestObj_nullableDictionaryAttr } },
     HashTableValue { "annotatedTypeInUnionAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_annotatedTypeInUnionAttr, setJSTestObj_annotatedTypeInUnionAttr } },
     HashTableValue { "annotatedTypeInSequenceAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_annotatedTypeInSequenceAttr, setJSTestObj_annotatedTypeInSequenceAttr } },
+    HashTableValue { "unionAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_unionAttr, setJSTestObj_unionAttr } },
+    HashTableValue { "optimizedSetterUnionAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_optimizedSetterUnionAttr, setJSTestObj_optimizedSetterUnionAttr } },
     HashTableValue { "implementationEnumAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_implementationEnumAttr, setJSTestObj_implementationEnumAttr } },
     HashTableValue { "mediaDevices"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_mediaDevices, 0 } },
     HashTableValue { "XMLObjAttr"_s, JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_XMLObjAttr, setJSTestObj_XMLObjAttr } },
@@ -4427,6 +4433,78 @@ static inline bool setJSTestObj_annotatedTypeInSequenceAttrSetter(JSGlobalObject
 JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_annotatedTypeInSequenceAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
 {
     return IDLAttribute<JSTestObj>::set<setJSTestObj_annotatedTypeInSequenceAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_unionAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnion<IDLLong, IDLInterface<Node>>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.unionAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_unionAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_unionAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_unionAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto nativeValueConversionResult = convert<IDLUnion<IDLLong, IDLInterface<Node>>>(lexicalGlobalObject, value);
+    if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return false;
+    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+        return impl.setUnionAttr(nativeValueConversionResult.releaseReturnValue());
+    });
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_unionAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_unionAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
+}
+
+static inline JSValue jsTestObj_optimizedSetterUnionAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    RELEASE_AND_RETURN(throwScope, (toJS<IDLUnion<IDLLong, IDLInterface<Node>>>(lexicalGlobalObject, *thisObject.globalObject(), throwScope, impl.optimizedSetterUnionAttr())));
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsTestObj_optimizedSetterUnionAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::get<jsTestObj_optimizedSetterUnionAttrGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+}
+
+static inline bool setJSTestObj_optimizedSetterUnionAttrSetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject, JSValue value)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(&lexicalGlobalObject);
+    UNUSED_PARAM(vm);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = thisObject.wrapped();
+    auto valueFunctor = [&]<typename T>(T&& nativeValueConversionResult) -> bool {
+        if constexpr (std::same_as<T, ConversionResultException>) {
+            return false;
+        } else {
+            if (nativeValueConversionResult.hasException(throwScope)) [[unlikely]]
+                return false;
+            invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
+                return impl.setOptimizedSetterUnionAttr(nativeValueConversionResult.releaseReturnValue());
+            });
+            return true;
+        }
+    };
+    return convert<IDLUnion<IDLLong, IDLInterface<Node>>>(lexicalGlobalObject, value, valueFunctor);
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setJSTestObj_optimizedSetterUnionAttr, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    return IDLAttribute<JSTestObj>::set<setJSTestObj_optimizedSetterUnionAttrSetter>(*lexicalGlobalObject, thisValue, encodedValue, attributeName);
 }
 
 static inline JSValue jsTestObj_implementationEnumAttrGetter(JSGlobalObject& lexicalGlobalObject, JSTestObj& thisObject)

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -99,6 +99,8 @@ enum TestConfidence { "high", "kinda-low" };
     attribute TestDictionary? nullableDictionaryAttr;
     attribute (DOMString or [Clamp] long or undefined) annotatedTypeInUnionAttr;
     attribute sequence<[Clamp] long> annotatedTypeInSequenceAttr;
+    attribute (long or Node) unionAttr;
+    [OptimizedUnionSetterUsingOverloads] attribute (long or Node) optimizedSetterUnionAttr;
 
     attribute TestEnumTypeWithAlternateImplementationName implementationEnumAttr;
 

--- a/Source/WebCore/html/canvas/CanvasFillStrokeStyles.idl
+++ b/Source/WebCore/html/canvas/CanvasFillStrokeStyles.idl
@@ -42,8 +42,8 @@ typedef (HTMLImageElement
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasfillstrokestyles
 interface mixin CanvasFillStrokeStyles {
     // colors and styles (see also the CanvasPathDrawingStyles and CanvasTextDrawingStyles interfaces)
-    attribute (DOMString or CanvasGradient or CanvasPattern) strokeStyle; // (default black)
-    attribute (DOMString or CanvasGradient or CanvasPattern) fillStyle; // (default black)
+    [OptimizedUnionSetterUsingOverloads] attribute (DOMString or CanvasGradient or CanvasPattern) strokeStyle; // (default black)
+    [OptimizedUnionSetterUsingOverloads] attribute (DOMString or CanvasGradient or CanvasPattern) fillStyle; // (default black)
 
     CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1);
     CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2077,39 +2077,36 @@ CanvasRenderingContext2DBase::StyleVariant CanvasRenderingContext2DBase::strokeS
     return toStyleVariant(state().strokeStyle);
 }
 
-void CanvasRenderingContext2DBase::setStrokeStyle(CanvasRenderingContext2DBase::StyleVariant&& style)
+void CanvasRenderingContext2DBase::setStrokeStyle(String&& colorString)
 {
-    if (std::holds_alternative<String>(style)) {
-        auto colorString = std::get<String>(WTFMove(style));
-        if (colorString == state().unparsedStrokeColor)
-            return;
-
-        auto color = parseColor(colorString, canvasBase());
-        if (!color.isValid())
-            return;
-
-        setStrokeColorImpl(WTFMove(color), WTFMove(colorString));
+    if (colorString == state().unparsedStrokeColor)
         return;
-    }
 
-    if (std::holds_alternative<RefPtr<CanvasGradient>>(style)) {
-        Ref gradient = std::get<RefPtr<CanvasGradient>>(WTFMove(style)).releaseNonNull();
-        realizeSaves();
-        if (auto* c = effectiveDrawingContext())
-            c->setStrokeGradient(gradient->gradient());
-        auto& state = modifiableState();
-        state.strokeStyle = WTFMove(gradient);
-        state.unparsedStrokeColor = String();
+    auto color = parseColor(colorString, canvasBase());
+    if (!color.isValid())
         return;
-    }
 
-    Ref pattern = std::get<RefPtr<CanvasPattern>>(WTFMove(style)).releaseNonNull();
-    checkOrigin(pattern.ptr());
+    setStrokeColorImpl(WTFMove(color), WTFMove(colorString));
+}
+
+void CanvasRenderingContext2DBase::setStrokeStyle(RefPtr<CanvasGradient>&& gradient)
+{
+    realizeSaves();
+    if (auto* c = effectiveDrawingContext())
+        c->setStrokeGradient(gradient->gradient());
+    auto& state = modifiableState();
+    state.strokeStyle = gradient.releaseNonNull();
+    state.unparsedStrokeColor = String();
+}
+
+void CanvasRenderingContext2DBase::setStrokeStyle(RefPtr<CanvasPattern>&& pattern)
+{
+    checkOrigin(pattern.get());
     realizeSaves();
     if (auto* c = effectiveDrawingContext())
         c->setStrokePattern(pattern->pattern());
     auto& state = modifiableState();
-    state.strokeStyle = WTFMove(pattern);
+    state.strokeStyle = pattern.releaseNonNull();
     state.unparsedStrokeColor = String();
 }
 
@@ -2118,39 +2115,36 @@ CanvasRenderingContext2DBase::StyleVariant CanvasRenderingContext2DBase::fillSty
     return toStyleVariant(state().fillStyle);
 }
 
-void CanvasRenderingContext2DBase::setFillStyle(CanvasRenderingContext2DBase::StyleVariant&& style)
+void CanvasRenderingContext2DBase::setFillStyle(String&& colorString)
 {
-    if (std::holds_alternative<String>(style)) {
-        auto colorString = std::get<String>(WTFMove(style));
-        if (colorString == state().unparsedFillColor)
-            return;
-
-        auto color = parseColor(colorString, canvasBase());
-        if (!color.isValid())
-            return;
-
-        setFillColorImpl(WTFMove(color), WTFMove(colorString));
+    if (colorString == state().unparsedFillColor)
         return;
-    }
 
-    if (std::holds_alternative<RefPtr<CanvasGradient>>(style)) {
-        Ref gradient = std::get<RefPtr<CanvasGradient>>(WTFMove(style)).releaseNonNull();
-        realizeSaves();
-        if (auto* c = effectiveDrawingContext())
-            c->setFillGradient(gradient->gradient());
-        auto& state = modifiableState();
-        state.fillStyle = WTFMove(gradient);
-        state.unparsedFillColor = String();
+    auto color = parseColor(colorString, canvasBase());
+    if (!color.isValid())
         return;
-    }
 
-    Ref pattern = std::get<RefPtr<CanvasPattern>>(WTFMove(style)).releaseNonNull();
-    checkOrigin(pattern.ptr());
+    setFillColorImpl(WTFMove(color), WTFMove(colorString));
+}
+
+void CanvasRenderingContext2DBase::setFillStyle(RefPtr<CanvasGradient>&& gradient)
+{
+    realizeSaves();
+    if (auto* c = effectiveDrawingContext())
+        c->setFillGradient(gradient->gradient());
+    auto& state = modifiableState();
+    state.fillStyle = gradient.releaseNonNull();
+    state.unparsedFillColor = String();
+}
+
+void CanvasRenderingContext2DBase::setFillStyle(RefPtr<CanvasPattern>&& pattern)
+{
+    checkOrigin(pattern.get());
     realizeSaves();
     if (auto* c = effectiveDrawingContext())
         c->setFillPattern(pattern->pattern());
     auto& state = modifiableState();
-    state.fillStyle = WTFMove(pattern);
+    state.fillStyle = pattern.releaseNonNull();
     state.unparsedFillColor = String();
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -214,9 +214,13 @@ public:
 
     using StyleVariant = Variant<String, RefPtr<CanvasGradient>, RefPtr<CanvasPattern>>;
     StyleVariant strokeStyle() const;
-    void setStrokeStyle(StyleVariant&&);
+    void setStrokeStyle(String&&);
+    void setStrokeStyle(RefPtr<CanvasGradient>&&);
+    void setStrokeStyle(RefPtr<CanvasPattern>&&);
     StyleVariant fillStyle() const;
-    void setFillStyle(StyleVariant&&);
+    void setFillStyle(String&&);
+    void setFillStyle(RefPtr<CanvasGradient>&&);
+    void setFillStyle(RefPtr<CanvasPattern>&&);
 
     ExceptionOr<Ref<CanvasGradient>> createLinearGradient(float x0, float y0, float x1, float y1);
     ExceptionOr<Ref<CanvasGradient>> createRadialGradient(float x0, float y0, float r0, float x1, float y1, float r1);


### PR DESCRIPTION
#### 16afa35bbfd9183c87f5d94dae94c49034e1ce4e
<pre>
[Bindings] Optimize union IDL attribute setters by avoiding conversion to variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=297124">https://bugs.webkit.org/show_bug.cgi?id=297124</a>

Reviewed by Chris Dumez.

Adds ability for implementations of union IDL attributes to optimize setting
by exposing function overloads for each member of the union. Implementations
that will not benefit from this can continue to expose a single setter function
that takes the Variant value.

For now, this functionality must also be opted into by using the an extended
attribute `OptimizedUnionSetterUsingOverloads`. This is needed due to existing
overloads of attribute setters that have different behaviors depending on
whether a Variant is the parameter or not. For example, HTMLScriptElement
has two overloads for setText:

    WEBCORE_EXPORT void setText(String&amp;&amp;);
    ExceptionOr&lt;void&gt; setText(Variant&lt;RefPtr&lt;TrustedScript&gt;, String&gt;&amp;&amp;);

but only the one taking a Variant passes the string through `trustedTypeCompliantString`.

To begin with, only the `strokeStyle` and `fillStyle` attributes on
the `CanvasFillStrokeStyles` mixin have the extended attribute added.

This is implemented by adding a new kind of JS-&gt;Implementation convert
function that takes a &quot;return value functor&quot; and adopting it in JSDOMConvertUnion.
In this new type of convert, instead of returning the converted value, the
converted value is passed to a provided &quot;return value functor&quot;, and the
function instead returns result of calling that functor. This allows us
to pass in a generic lambda as the &quot;return value functor&quot; allowing for
distinct behaviors for each call. In the case of the union, instead of
converting all the way to the variant result, the &quot;return value functor&quot;
is called with the concrete result types.

The original `convert` function can be maintained by calling the new one
with a lambda that just converts to and returns the variant.

* Source/WebCore/bindings/js/JSDOMConvertBase.h:
(WebCore::convert):
    - Adds a new overload for the &quot;return value functor&quot; version.
    - Adds missing overload taking a string.
    - Utilize the `ExceptionThrowerFunctor` concept to disambiguate
      between different functors.

* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
    - Adopt new &quot;return value functor&quot; style convert function, and
      use it to implement the old version.

* Source/WebCore/bindings/scripts/IDLAttributes.json:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
    - Special case non-nullable unions attribute setters to call
      the new &quot;return value functor&quot; style convert function. This
      can be expanded to nullable unions in the future, but requires
      re-thinking the representation.

* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
* Source/WebCore/bindings/scripts/test/TestObj.idl:
    - Add new tests and results for when the extended attribute is set.

* Source/WebCore/html/canvas/CanvasFillStrokeStyles.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
    - Adopt optimized setting for CanvasRenderingContext2D&apos;s `strokeStyle` and
      `fillStyle` attributes.

Canonical link: <a href="https://commits.webkit.org/301035@main">https://commits.webkit.org/301035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c0af6d4f9f19766d7ef3f98b69c7869542c28c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124471 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94689 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62803 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111323 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75266 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/no-web-process-leak (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29484 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74801 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133979 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102956 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48299 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51223 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57010 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->