### PR TITLE
Block connections to port 0

### DIFF
--- a/LayoutTests/http/tests/security/block-connection-to-zero-port.https-expected.txt
+++ b/LayoutTests/http/tests/security/block-connection-to-zero-port.https-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Not allowed to use restricted network port 0: https://does-not-exist.com:0/
+This attempts to measure performance based on the zero port.

--- a/LayoutTests/http/tests/security/block-connection-to-zero-port.https.html
+++ b/LayoutTests/http/tests/security/block-connection-to-zero-port.https.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    fetch("https://does-not-exist.com:0/").catch((e) => {
+        const t1 = performance.now();
+        testRunner.notifyDone(); 
+    });
+</script>
+<p>This attempts to measure performance based on the zero port.</p>
+</body>
+</html>

--- a/LayoutTests/platform/gtk-wk2/security/block-test-expected.txt
+++ b/LayoutTests/platform/gtk-wk2/security/block-test-expected.txt
@@ -1,0 +1,91 @@
+CONSOLE MESSAGE: Not allowed to use restricted network port 1: http://255.255.255.255:1/test.jpg
+block-test.html - didFinishLoading
+CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://255.255.255.255:7/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 9: http://255.255.255.255:9/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 11: http://255.255.255.255:11/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 13: http://255.255.255.255:13/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 15: http://255.255.255.255:15/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 17: http://255.255.255.255:17/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 19: http://255.255.255.255:19/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 20: http://255.255.255.255:20/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 21: http://255.255.255.255:21/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://255.255.255.255:22/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 23: http://255.255.255.255:23/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 25: http://255.255.255.255:25/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 37: http://255.255.255.255:37/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 42: http://255.255.255.255:42/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 43: http://255.255.255.255:43/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 53: http://255.255.255.255:53/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 77: http://255.255.255.255:77/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 79: http://255.255.255.255:79/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 87: http://255.255.255.255:87/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 95: http://255.255.255.255:95/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 101: http://255.255.255.255:101/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 102: http://255.255.255.255:102/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 103: http://255.255.255.255:103/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 104: http://255.255.255.255:104/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 109: http://255.255.255.255:109/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 110: http://255.255.255.255:110/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 111: http://255.255.255.255:111/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 113: http://255.255.255.255:113/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 115: http://255.255.255.255:115/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 117: http://255.255.255.255:117/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 119: http://255.255.255.255:119/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 123: http://255.255.255.255:123/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 135: http://255.255.255.255:135/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 139: http://255.255.255.255:139/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 143: http://255.255.255.255:143/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 179: http://255.255.255.255:179/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 389: http://255.255.255.255:389/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 465: http://255.255.255.255:465/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 512: http://255.255.255.255:512/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 513: http://255.255.255.255:513/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 514: http://255.255.255.255:514/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 515: http://255.255.255.255:515/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 526: http://255.255.255.255:526/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 530: http://255.255.255.255:530/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 531: http://255.255.255.255:531/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 532: http://255.255.255.255:532/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 540: http://255.255.255.255:540/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 548: http://255.255.255.255:548/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 556: http://255.255.255.255:556/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 563: http://255.255.255.255:563/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 587: http://255.255.255.255:587/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 601: http://255.255.255.255:601/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 636: http://255.255.255.255:636/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 993: http://255.255.255.255:993/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 995: http://255.255.255.255:995/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 2049: http://255.255.255.255:2049/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 3659: http://255.255.255.255:3659/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 4045: http://255.255.255.255:4045/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 4190: http://255.255.255.255:4190/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6000: http://255.255.255.255:6000/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6665: http://255.255.255.255:6665/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6666: http://255.255.255.255:6666/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6667: http://255.255.255.255:6667/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6668: http://255.255.255.255:6668/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6669: http://255.255.255.255:6669/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6679: http://255.255.255.255:6679/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6697: http://255.255.255.255:6697/test.jpg
+http://255.255.255.255:65535/test.jpg - willSendRequest <NSURLRequest URL http://255.255.255.255:65535/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+http://255.255.255.255:65535/test.jpg - didFailLoadingWithError: <NSError domain g-io-error-quark, code 38, failing URL "http://255.255.255.255:65535/test.jpg">
+CONSOLE MESSAGE: Not allowed to use restricted network port 0: http://255.255.255.255:0/test.jpg
+http://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL http://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+http://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain g-io-error-quark, code 38, failing URL "http://255.255.255.255/test.jpg">
+http://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL http://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+http://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain g-io-error-quark, code 38, failing URL "http://255.255.255.255/test.jpg">
+ftp://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL ftp://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+CONSOLE MESSAGE: FTP URLs are disabled
+CONSOLE MESSAGE: Cannot load image ftp://255.255.255.255/test.jpg due to access control checks.
+ftp://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain WebKitInternal, code 0, failing URL "ftp://255.255.255.255/test.jpg">
+ftp://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL ftp://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+CONSOLE MESSAGE: FTP URLs are disabled
+CONSOLE MESSAGE: Cannot load image ftp://255.255.255.255/test.jpg due to access control checks.
+ftp://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain WebKitInternal, code 0, failing URL "ftp://255.255.255.255/test.jpg">
+ftp://255.255.255.255:22/test.jpg - willSendRequest <NSURLRequest URL ftp://255.255.255.255:22/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+CONSOLE MESSAGE: FTP URLs are disabled
+CONSOLE MESSAGE: Cannot load image ftp://255.255.255.255:22/test.jpg due to access control checks.
+ftp://255.255.255.255:22/test.jpg - didFailLoadingWithError: <NSError domain WebKitInternal, code 0, failing URL "ftp://255.255.255.255:22/test.jpg">
+This test attempts to change the src of an IMG tag to all blocked ports to confirm that WebKit returns the correct error for them - blocked instead of cannot find. It also tries the FTP ports for exemptions. Due to the nature of this test, the results can only be processed automatically via DumpRenderTree
+
+

--- a/LayoutTests/platform/wpe/security/block-test-expected.txt
+++ b/LayoutTests/platform/wpe/security/block-test-expected.txt
@@ -1,0 +1,91 @@
+CONSOLE MESSAGE: Not allowed to use restricted network port 1: http://255.255.255.255:1/test.jpg
+block-test.html - didFinishLoading
+CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://255.255.255.255:7/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 9: http://255.255.255.255:9/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 11: http://255.255.255.255:11/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 13: http://255.255.255.255:13/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 15: http://255.255.255.255:15/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 17: http://255.255.255.255:17/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 19: http://255.255.255.255:19/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 20: http://255.255.255.255:20/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 21: http://255.255.255.255:21/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://255.255.255.255:22/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 23: http://255.255.255.255:23/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 25: http://255.255.255.255:25/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 37: http://255.255.255.255:37/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 42: http://255.255.255.255:42/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 43: http://255.255.255.255:43/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 53: http://255.255.255.255:53/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 77: http://255.255.255.255:77/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 79: http://255.255.255.255:79/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 87: http://255.255.255.255:87/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 95: http://255.255.255.255:95/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 101: http://255.255.255.255:101/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 102: http://255.255.255.255:102/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 103: http://255.255.255.255:103/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 104: http://255.255.255.255:104/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 109: http://255.255.255.255:109/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 110: http://255.255.255.255:110/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 111: http://255.255.255.255:111/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 113: http://255.255.255.255:113/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 115: http://255.255.255.255:115/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 117: http://255.255.255.255:117/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 119: http://255.255.255.255:119/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 123: http://255.255.255.255:123/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 135: http://255.255.255.255:135/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 139: http://255.255.255.255:139/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 143: http://255.255.255.255:143/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 179: http://255.255.255.255:179/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 389: http://255.255.255.255:389/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 465: http://255.255.255.255:465/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 512: http://255.255.255.255:512/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 513: http://255.255.255.255:513/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 514: http://255.255.255.255:514/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 515: http://255.255.255.255:515/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 526: http://255.255.255.255:526/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 530: http://255.255.255.255:530/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 531: http://255.255.255.255:531/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 532: http://255.255.255.255:532/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 540: http://255.255.255.255:540/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 548: http://255.255.255.255:548/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 556: http://255.255.255.255:556/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 563: http://255.255.255.255:563/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 587: http://255.255.255.255:587/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 601: http://255.255.255.255:601/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 636: http://255.255.255.255:636/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 993: http://255.255.255.255:993/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 995: http://255.255.255.255:995/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 2049: http://255.255.255.255:2049/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 3659: http://255.255.255.255:3659/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 4045: http://255.255.255.255:4045/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 4190: http://255.255.255.255:4190/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6000: http://255.255.255.255:6000/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6665: http://255.255.255.255:6665/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6666: http://255.255.255.255:6666/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6667: http://255.255.255.255:6667/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6668: http://255.255.255.255:6668/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6669: http://255.255.255.255:6669/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6679: http://255.255.255.255:6679/test.jpg
+CONSOLE MESSAGE: Not allowed to use restricted network port 6697: http://255.255.255.255:6697/test.jpg
+http://255.255.255.255:65535/test.jpg - willSendRequest <NSURLRequest URL http://255.255.255.255:65535/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+http://255.255.255.255:65535/test.jpg - didFailLoadingWithError: <NSError domain g-io-error-quark, code 38, failing URL "http://255.255.255.255:65535/test.jpg">
+CONSOLE MESSAGE: Not allowed to use restricted network port 0: http://255.255.255.255:0/test.jpg
+http://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL http://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+http://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain g-io-error-quark, code 38, failing URL "http://255.255.255.255/test.jpg">
+http://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL http://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+http://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain g-io-error-quark, code 38, failing URL "http://255.255.255.255/test.jpg">
+ftp://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL ftp://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+CONSOLE MESSAGE: FTP URLs are disabled
+CONSOLE MESSAGE: Cannot load image ftp://255.255.255.255/test.jpg due to access control checks.
+ftp://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain WebKitInternal, code 0, failing URL "ftp://255.255.255.255/test.jpg">
+ftp://255.255.255.255/test.jpg - willSendRequest <NSURLRequest URL ftp://255.255.255.255/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+CONSOLE MESSAGE: FTP URLs are disabled
+CONSOLE MESSAGE: Cannot load image ftp://255.255.255.255/test.jpg due to access control checks.
+ftp://255.255.255.255/test.jpg - didFailLoadingWithError: <NSError domain WebKitInternal, code 0, failing URL "ftp://255.255.255.255/test.jpg">
+ftp://255.255.255.255:22/test.jpg - willSendRequest <NSURLRequest URL ftp://255.255.255.255:22/test.jpg, main document URL block-test.html, http method GET> redirectResponse (null)
+CONSOLE MESSAGE: FTP URLs are disabled
+CONSOLE MESSAGE: Cannot load image ftp://255.255.255.255:22/test.jpg due to access control checks.
+ftp://255.255.255.255:22/test.jpg - didFailLoadingWithError: <NSError domain WebKitInternal, code 0, failing URL "ftp://255.255.255.255:22/test.jpg">
+This test attempts to change the src of an IMG tag to all blocked ports to confirm that WebKit returns the correct error for them - blocked instead of cannot find. It also tries the FTP ports for exemptions. Due to the nature of this test, the results can only be processed automatically via DumpRenderTree
+
+

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1003,72 +1003,73 @@ bool portAllowed(const URL& url)
     if (!port)
         return true;
 
-    // This blocked port list matches the port blocking that Mozilla implements.
-    // See http://www.mozilla.org/projects/netlib/PortBanning.html for more information.
+    // This blocked port list is defined by the Fetch spec, with the addition of port 0.
+    // See https://fetch.spec.whatwg.org/#port-blocking for more information.
     static const uint16_t blockedPortList[] = {
-        1,    // tcpmux
-        7,    // echo
-        9,    // discard
-        11,   // systat
-        13,   // daytime
-        15,   // netstat
-        17,   // qotd
-        19,   // chargen
-        20,   // FTP-data
-        21,   // FTP-control
-        22,   // SSH
-        23,   // telnet
-        25,   // SMTP
-        37,   // time
-        42,   // name
-        43,   // nicname
-        53,   // domain
-        69,   // TFTP
-        77,   // priv-rjs
-        79,   // finger
-        87,   // ttylink
-        95,   // supdup
-        101,  // hostriame
-        102,  // iso-tsap
-        103,  // gppitnp
-        104,  // acr-nema
-        109,  // POP2
-        110,  // POP3
-        111,  // sunrpc
-        113,  // auth
-        115,  // SFTP
-        117,  // uucp-path
-        119,  // nntp
-        123,  // NTP
-        135,  // loc-srv / epmap
-        137,  // NetBIOS
-        139,  // netbios
-        143,  // IMAP2
-        161,  // SNMP
-        179,  // BGP
-        389,  // LDAP
-        427,  // SLP (Also used by Apple Filing Protocol)
-        465,  // SMTP+SSL
-        512,  // print / exec
-        513,  // login
-        514,  // shell
-        515,  // printer
-        526,  // tempo
-        530,  // courier
-        531,  // Chat
-        532,  // netnews
-        540,  // UUCP
-        548,  // afpovertcp [Apple addition]
-        554,  // rtsp
-        556,  // remotefs
-        563,  // NNTP+SSL
-        587,  // ESMTP
-        601,  // syslog-conn
-        636,  // LDAP+SSL
-        989,  // ftps-data
-        990,  // ftps
-        993,  // IMAP+SSL
-        995,  // POP3+SSL
+        0, // reserved
+        1, // tcpmux
+        7, // echo
+        9, // discard
+        11, // systat
+        13, // daytime
+        15, // netstat
+        17, // qotd
+        19, // chargen
+        20, // FTP-data
+        21, // FTP-control
+        22, // SSH
+        23, // telnet
+        25, // SMTP
+        37, // time
+        42, // name
+        43, // nicname
+        53, // domain
+        69, // TFTP
+        77, // priv-rjs
+        79, // finger
+        87, // ttylink
+        95, // supdup
+        101, // hostriame
+        102, // iso-tsap
+        103, // gppitnp
+        104, // acr-nema
+        109, // POP2
+        110, // POP3
+        111, // sunrpc
+        113, // auth
+        115, // SFTP
+        117, // uucp-path
+        119, // nntp
+        123, // NTP
+        135, // loc-srv / epmap
+        137, // NetBIOS
+        139, // netbios
+        143, // IMAP2
+        161, // SNMP
+        179, // BGP
+        389, // LDAP
+        427, // SLP (Also used by Apple Filing Protocol)
+        465, // SMTP+SSL
+        512, // print / exec
+        513, // login
+        514, // shell
+        515, // printer
+        526, // tempo
+        530, // courier
+        531, // Chat
+        532, // netnews
+        540, // UUCP
+        548, // afpovertcp [Apple addition]
+        554, // rtsp
+        556, // remotefs
+        563, // NNTP+SSL
+        587, // ESMTP
+        601, // syslog-conn
+        636, // LDAP+SSL
+        989, // ftps-data
+        990, // ftps
+        993, // IMAP+SSL
+        995, // POP3+SSL
         1719, // H323 (RAS)
         1720, // H323 (Q931)
         1723, // H323 (H245)


### PR DESCRIPTION
#### c3811ccef9594d3af1c2dcd3764b75faabd42a14
<pre>
Block connections to port 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=292888">https://bugs.webkit.org/show_bug.cgi?id=292888</a>
<a href="https://rdar.apple.com/143927479">rdar://143927479</a>

Reviewed by Anne van Kesteren.

Requesting connections to port 0 can be leveraged in some interesting ways.
This change prevents creating connections with port 0.

* LayoutTests/http/tests/security/block-connection-to-zero-port.https-expected.txt: Added.
* LayoutTests/http/tests/security/block-connection-to-zero-port.https.html: Added.
* LayoutTests/platform/gtk-wk2/security/block-test-expected.txt: Added.
* LayoutTests/platform/wpe/security/block-test-expected.txt: Added.
* Source/WTF/wtf/URL.cpp:
(WTF::portAllowed):

Originally-landed-as: 289651.542@safari-7621-branch (e53b026d3ace). <a href="https://rdar.apple.com/157790661">rdar://157790661</a>
Canonical link: <a href="https://commits.webkit.org/298983@main">https://commits.webkit.org/298983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a93c4364edae92aeaffa744a6bedf80814fe0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123473 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/69361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6ac21f4-dc72-46e4-bbff-b24596b0e5d4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89067 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/69361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c473768f-5824-4f1d-8e12-0fbbe4ab038d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69574 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bcb8e00-9da8-4bbd-bdba-a7c0c0831e2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23354 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67146 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126594 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115881 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44271 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33270 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97733 "Found 1 new test failure: security/block-test.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97527 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20829 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18735 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49803 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144581 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43600 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->