### PR TITLE
[JSC] Unwrap JSTag exception when it is thrown

### DIFF
--- a/JSTests/wasm/stress/js-tag-throw-from-wasm.js
+++ b/JSTests/wasm/stress/js-tag-throw-from-wasm.js
@@ -1,0 +1,30 @@
+import { instantiate } from "../exception-wast-wrapper.js";
+import * as assert from "../assert.js";
+
+let tryTableWat = `
+(module
+  (type $e (func (param externref)))
+  (tag $jsTag (import "env" "jstag") (type $e))
+  (func (export "trigger") (param externref)
+    (local.get 0)
+    (throw $jsTag)
+  )
+)
+`;
+
+
+async function main() {
+    const tryTableInstance = await instantiate(tryTableWat, {
+        env: {
+            jstag: WebAssembly.JSTag
+        }
+    });
+    let ok = new Error(42);
+    for (let i = 0; i < testLoopCount; ++i) {
+        assert.throws(() => {
+            tryTableInstance.exports.trigger(ok);
+        }, Error, `42`);
+    }
+}
+
+await main();

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -660,6 +660,8 @@ public:
             if (JSWebAssemblyException* wasmException = jsDynamicCast<JSWebAssemblyException*>(thrownValue)) {
                 m_catchableFromWasm = true;
                 m_wasmTag = &wasmException->tag();
+                if (m_wasmTag == &Wasm::Tag::jsExceptionTag())
+                    m_exception->tryUnwrapValueForJSTag(m_vm);
             } else if (ErrorInstance* error = jsDynamicCast<ErrorInstance*>(thrownValue))
                 m_catchableFromWasm = error->isCatchableFromWasm();
             else

--- a/Source/JavaScriptCore/runtime/Exception.cpp
+++ b/Source/JavaScriptCore/runtime/Exception.cpp
@@ -91,6 +91,19 @@ void Exception::finishCreation(VM& vm, StackCaptureAction action)
 
 #if ENABLE(WEBASSEMBLY)
 
+void Exception::tryUnwrapValueForJSTag(VM& vm)
+{
+    if (!m_value)
+        return;
+
+    if (auto* exception = jsDynamicCast<JSWebAssemblyException*>(m_value.get())) {
+        if (&exception->tag() == &Wasm::Tag::jsExceptionTag()) {
+            m_value.set(vm, this, JSValue::decode(exception->payload().at(0)));
+            return;
+        }
+    }
+}
+
 void Exception::wrapValueForJSTag(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/Exception.h
+++ b/Source/JavaScriptCore/runtime/Exception.h
@@ -67,6 +67,7 @@ public:
     void setDidNotifyInspectorOfThrow() { m_didNotifyInspectorOfThrow = true; }
 
 #if ENABLE(WEBASSEMBLY)
+    void tryUnwrapValueForJSTag(VM&);
     void wrapValueForJSTag(JSGlobalObject*);
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -459,11 +459,7 @@ WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntStackEn
     JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(pl[callee->localSizeToAlloc() + tryDepth - 1].i32);
 #endif
     RELEASE_ASSERT(exception);
-    JSValue thrownValue = exception;
-    if (&exception->tag() == &Wasm::Tag::jsExceptionTag())
-        thrownValue = JSValue::decode(exception->payload().at(0));
-
-    throwException(globalObject, throwScope, thrownValue);
+    throwException(globalObject, throwScope, exception);
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);
@@ -481,10 +477,7 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnre
 
     auto* exception = jsSecureCast<JSWebAssemblyException*>(JSValue::decode(exnref));
     RELEASE_ASSERT(exception);
-    JSValue thrownValue = exception;
-    if (&exception->tag() == &Wasm::Tag::jsExceptionTag())
-        thrownValue = JSValue::decode(exception->payload().at(0));
-    throwException(globalObject, throwScope, thrownValue);
+    throwException(globalObject, throwScope, exception);
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1707,11 +1707,6 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRethrow, void*, (JSWebAssemblyIns
     JSGlobalObject* globalObject = instance->globalObject();
 
     JSValue thrownValue = JSValue::decode(encodedThrownValue);
-    if (auto* exception = jsDynamicCast<JSWebAssemblyException*>(thrownValue)) {
-        if (&exception->tag() == &Wasm::Tag::jsExceptionTag())
-            thrownValue = JSValue::decode(exception->payload().at(0));
-    }
-
     throwException(globalObject, throwScope, thrownValue);
 
     genericUnwind(vm, callFrame);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1072,13 +1072,7 @@ WASM_SLOW_PATH_DECL(rethrow)
     auto instruction = pc->as<WasmRethrow>();
     JSValue exceptionValue = READ(instruction.m_exception).jsValue();
 
-    JSValue thrownValue = exceptionValue;
-    if (auto* exception = jsDynamicCast<JSWebAssemblyException*>(exceptionValue)) {
-        if (&exception->tag() == &Wasm::Tag::jsExceptionTag())
-            thrownValue = JSValue::decode(exception->payload().at(0));
-    }
-
-    throwException(globalObject, throwScope, thrownValue);
+    throwException(globalObject, throwScope, exceptionValue);
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);
@@ -1101,11 +1095,7 @@ WASM_SLOW_PATH_DECL(throw_ref)
         WASM_THROW(Wasm::ExceptionType::NullExnReference);
 
     auto* exception = jsCast<JSWebAssemblyException*>(exceptionValue);
-    JSValue thrownValue = exceptionValue;
-    if (&exception->tag() == &Wasm::Tag::jsExceptionTag())
-        thrownValue = JSValue::decode(exception->payload().at(0));
-
-    throwException(globalObject, throwScope, thrownValue);
+    throwException(globalObject, throwScope, exception);
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);


### PR DESCRIPTION
#### dfc499351972e376c1e67746401aaf9d3649167a
<pre>
[JSC] Unwrap JSTag exception when it is thrown
<a href="https://bugs.webkit.org/show_bug.cgi?id=297127">https://bugs.webkit.org/show_bug.cgi?id=297127</a>
<a href="https://rdar.apple.com/157867135">rdar://157867135</a>

Reviewed by Keith Miller.

It is possible that wasm module can use JSTag and emit wasm throw
instruction. In this case, JSTag wasm exception can be thrown even
outside of JS.
When throwing a JSTag wasm exception, we should just unwrap it
regardless. And then re-wrap it again when we need to pass it to wasm
exception handler with JSTag. Otherwise, we should not expose JSTag wasm
exception. The spec requires that it is unwraped whenever it is crossing
JS &lt;-&gt; wasm boundary[1].

[1]: <a href="https://webassembly.github.io/exception-handling/js-api/#call-an-exported-function">https://webassembly.github.io/exception-handling/js-api/#call-an-exported-function</a>

* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::UnwindFunctor::UnwindFunctor):
* Source/JavaScriptCore/runtime/Exception.cpp:
(JSC::Exception::tryUnwrapValueForJSTag):
* Source/JavaScriptCore/runtime/Exception.h:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):

Canonical link: <a href="https://commits.webkit.org/298416@main">https://commits.webkit.org/298416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e44b28a9269a74c1f5b9adac995e4de74f7d089

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121549 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fae4280b-ebde-465c-9892-aed2d144ea9a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43727 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47963a90-222b-43a0-a83e-e90edcaee743) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68122 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/27730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21763 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65206 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/107658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/97963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124712 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114001 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31768 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99830 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41529 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18471 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47840 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/141922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/41780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/141922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45108 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->