### PR TITLE
Release assert in Vector::at via DisplayList::Recorder::didUpdateSingleState

### DIFF
--- a/JSTests/stress/json-const-raw-json-should-be-const.js
+++ b/JSTests/stress/json-const-raw-json-should-be-const.js
@@ -1,0 +1,6 @@
+const object = JSON.rawJSON('"a"');
+for (const name in object) {
+    object[name] = 0x1234;
+}
+JSON.stringify(object);
+

--- a/JSTests/stress/string-replace-speculate-string.js
+++ b/JSTests/stress/string-replace-speculate-string.js
@@ -1,0 +1,15 @@
+//@ runDefault("--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true", "--useConcurrentJIT=0", "--watchdog=500", "--watchdog-exception-ok")
+
+for (;;) {
+    (() => {
+        function f() {
+            return undefined;
+        }
+        try { f(); } catch (e) {}
+        const name = f.name;
+        try { name.isWellFormed(); } catch (e) {}
+        name.__proto__.replace(name, name);
+        for (let i = 0; i < 100; i++) {
+        }
+    })()
+}

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6166,6 +6166,7 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyF
 [ Debug ] ipc/send-invalid-message.html [ Skip ]
 webkit.org/b/272000 [ Debug ] ipc/send-filter.html [ Crash ]
 webkit.org/b/272000 [ Debug ] ipc/send-gradient.html [ Crash ]
+webkit.org/b/272000 [ Debug ] ipc/invalid-feConvolveMatrix-crash.html [ Crash ]
 
 # mac-only IPC test
 ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6167,6 +6167,7 @@ imported/w3c/web-platform-tests/css/motion/offset-path-url-011.html [ ImageOnlyF
 webkit.org/b/272000 [ Debug ] ipc/send-filter.html [ Crash ]
 webkit.org/b/272000 [ Debug ] ipc/send-gradient.html [ Crash ]
 webkit.org/b/272000 [ Debug ] ipc/invalid-feConvolveMatrix-crash.html [ Crash ]
+webkit.org/b/272000 [ Debug ] ipc/restore-empty-stack-crash.html [ Crash ]
 
 # mac-only IPC test
 ipc/webpageproxy-correctionpanel-no-crash.html [ Skip ]

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
@@ -1,0 +1,127 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>
+    <script>
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
+
+        window.setTimeout(async () => {
+            if (!window.IPC)
+                return window.testRunner?.notifyDone();
+
+            const { CoreIPC } = await import('./coreipc.js');
+
+            const streamConnection = CoreIPC.newStreamConnection();
+
+            const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+                renderingBackendIdentifier: renderingBackendIdentifier,
+                connectionHandle: streamConnection
+            });
+            const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+            const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+            const contextIdentifier = Math.floor(Math.random() * 0x1000000);
+            remoteRenderingBackend.CreateImageBuffer({
+                logicalSize: {
+                    width: 32,
+                    height: 82
+                },
+                renderingMode: 1,
+                renderingPurpose: 0,
+                resolutionScale: 10,
+                colorSpace: {
+                    serializableColorSpace: {
+                        alias: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: 'WebCore::ColorSpace',
+                                    variant: 1
+                                }
+                            }
+                        }
+                    }
+                },
+                pixelFormat: 1,
+                identifier: imageBufferIdentifier,
+                contextIdentifier: contextIdentifier
+            });
+            const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+
+            try {
+                remoteImageBuffer.FilteredNativeImage({
+                    filter: {
+                        subclasses: {
+                            variantType: 'WebCore::CSSFilter',
+                            variant: {
+                                functions: [{
+                                    subclasses: {
+                                        variantType: 'WebCore::FEConvolveMatrix',
+                                        variant: {
+                                            kernelSize: {
+                                                width: 29,
+                                                height: 57
+                                            },
+                                            divisor: 103,
+                                            bias: 343597699707,
+                                            targetOffset: {
+                                                x: 1067253780,
+                                                y: 91
+                                            },
+                                            edgeMode: 0,
+                                            kernelUnitLength: {
+                                                x: 112,
+                                                y: 41
+                                            },
+                                            preserveAlpha: true,
+                                            kernel: [],
+                                            operatingColorSpace: {
+                                                serializableColorSpace: {
+                                                    alias: {
+                                                        m_cgColorSpace: {
+                                                            alias: {
+                                                                variantType: 'WebCore::ColorSpace',
+                                                                variant: 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }],
+                                filterRenderingModes: 1,
+                                filterScale: {
+                                    width: 68,
+                                    height: 3
+                                },
+                                filterRegion: {
+                                    location: {
+                                        x: 39,
+                                        y: 112
+                                    },
+                                    size: {
+                                        width: 32,
+                                        height: 110
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            } catch(err) {
+                if(!(err instanceof TypeError)) {
+                    console.log("Test failed: expected TypeError, got " + err);
+                }
+            }
+
+            streamConnection.connection.invalidate();
+
+            // Allow some time for the GPUP to receive the FilteredNativeImage message, otherwise we can finish
+            // the test before we detect a possible GPUP crash.
+            setTimeout(()=>{
+                window.testRunner?.notifyDone();
+            }, 500);
+        }, 20);
+    </script>
+    <p>This test passes if WebKit does not crash.</p>
+</body>

--- a/LayoutTests/ipc/restore-empty-stack-crash-expected.txt
+++ b/LayoutTests/ipc/restore-empty-stack-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if Webkit does not crash

--- a/LayoutTests/ipc/restore-empty-stack-crash.html
+++ b/LayoutTests/ipc/restore-empty-stack-crash.html
@@ -1,0 +1,25 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    if (window.IPC) {
+        import('./coreipc.js').then(({
+            CoreIPC
+        }) => {
+            o10=CoreIPC.newStreamConnection();
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0,{renderingBackendIdentifier:393219,connectionHandle:o10});
+            o12=o10.newInterface("RemoteRenderingBackend", 393219);
+            o12.CreateImageBuffer({logicalSize:{width:32,height:18},renderingMode:3,renderingPurpose:1,resolutionScale:489626271805,colorSpace:{serializableColorSpace:{alias:{m_cgColorSpace:{alias:{variantType:'WebCore::ColorSpace',variant:5}}}}},pixelFormat:1,identifier:393225,contextIdentifier:393226});
+            o31=o10.newInterface("RemoteDisplayListRecorder", 393226);
+            o31.Restore({});
+            o31.Restore({});
+        });
+    }
+
+    function callDone() {
+        window.testRunner?.notifyDone();
+    }
+</script>
+<body onload="setTimeout(callDone, 200)">
+    <p>This test passes if Webkit does not crash</p>
+</body>

--- a/LayoutTests/ipc/videoEncode-expected.txt
+++ b/LayoutTests/ipc/videoEncode-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/videoEncode.html
+++ b/LayoutTests/ipc/videoEncode.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+if (window.IPC) {
+    import('./coreipc.js').then(({
+        CoreIPC
+    }) => {
+        const id = 393216;
+        const width = 8000;
+        const height = 6000;
+
+        CoreIPC.GPU.LibWebRTCCodecsProxy.CreateEncoder(0, {
+            id, codecType:0, codecString:'avc1.64001f', parameters:[], useLowLatency:true, useAnnexB:false, scalabilityMode:1
+        });
+        CoreIPC.GPU.LibWebRTCCodecsProxy.InitializeEncoder(0, {
+            id, width, height, startBitrate:62, maxBitrate:91, minBitrate:5, maxFramerate:720916
+        });
+        CoreIPC.GPU.LibWebRTCCodecsProxy.EncodeFrame(0, {
+            id, buffer:{ time: { timeValue:43, timeScale:79, timeFlags:145 }, mirrored:false, rotation:0, buffer:{ alias: { variantType:'WebCore::IntSize', variant : { width, height } } } }, timeStamp:61, duration:{}, shouldEncodeAsKeyFrame:true
+        });
+        CoreIPC.GPU.LibWebRTCCodecsProxy.ReleaseEncoder(0, {
+            id
+        });
+    });
+}
+
+setTimeout(() => window.testRunner?.notifyDone(), 500);
+</script>
+This test passes if it does not crash.
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1756,16 +1756,15 @@ private:
             }
 
             if (node->child2()->shouldSpeculateString()) {
-                m_insertionSet.insertNode(
-                    m_indexInBlock, SpecNone, Check, node->origin,
-                    Edge(node->child2().node(), StringUse));
                 fixEdge<StringUse>(node->child2());
-            } else if (op == StringReplace || op == StringReplaceAll) {
+                break;
+            }
+
+            if (op == StringReplace || op == StringReplaceAll) {
                 if (node->child2()->shouldSpeculateRegExpObject() && m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node))
                     addStringReplacePrimordialChecks(node->child2().node());
                 else 
-                    m_insertionSet.insertNode(
-                        m_indexInBlock, SpecNone, ForceOSRExit, node->origin);
+                    m_insertionSet.insertNode(m_indexInBlock, SpecNone, ForceOSRExit, node->origin);
             }
 
             if (node->child1()->shouldSpeculateString()

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13455,22 +13455,41 @@ void SpeculativeJIT::compileStringReplace(Node* node)
         return;
     }
 
-    // If we fixed up the edge of child2, we inserted a Check(@child2, String).
-    OperandSpeculationMode child2SpeculationMode = AutomaticOperandSpeculation;
-    if (node->child2().useKind() == StringUse)
-        child2SpeculationMode = ManualOperandSpeculation;
+    switch (node->child2().useKind()) {
+    case StringUse: {
+        JSValueOperand string(this, node->child1());
+        SpeculateCellOperand search(this, node->child2());
+        JSValueOperand replace(this, node->child3());
+        JSValueRegs stringRegs = string.jsValueRegs();
+        GPRReg searchGPR = search.gpr();
+        JSValueRegs replaceRegs = replace.jsValueRegs();
 
-    JSValueOperand string(this, node->child1());
-    JSValueOperand search(this, node->child2(), child2SpeculationMode);
-    JSValueOperand replace(this, node->child3());
-    JSValueRegs stringRegs = string.jsValueRegs();
-    JSValueRegs searchRegs = search.jsValueRegs();
-    JSValueRegs replaceRegs = replace.jsValueRegs();
+        speculateString(node->child2(), searchGPR);
 
-    flushRegisters();
-    GPRFlushedCallResult result(this);
-    callOperation(node->op() == StringReplaceAll ? operationStringProtoFuncReplaceAllGeneric : operationStringProtoFuncReplaceGeneric, result.gpr(), LinkableConstant::globalObject(*this, node), stringRegs, searchRegs, replaceRegs);
-    cellResult(result.gpr(), node);
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        callOperation(node->op() == StringReplaceAll ? operationStringProtoFuncReplaceAllGeneric : operationStringProtoFuncReplaceGeneric, result.gpr(), LinkableConstant::globalObject(*this, node), stringRegs, CellValue(searchGPR), replaceRegs);
+        cellResult(result.gpr(), node);
+        break;
+    }
+    case UntypedUse: {
+        JSValueOperand string(this, node->child1());
+        JSValueOperand search(this, node->child2());
+        JSValueOperand replace(this, node->child3());
+        JSValueRegs stringRegs = string.jsValueRegs();
+        JSValueRegs searchRegs = search.jsValueRegs();
+        JSValueRegs replaceRegs = replace.jsValueRegs();
+
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        callOperation(node->op() == StringReplaceAll ? operationStringProtoFuncReplaceAllGeneric : operationStringProtoFuncReplaceGeneric, result.gpr(), LinkableConstant::globalObject(*this, node), stringRegs, searchRegs, replaceRegs);
+        cellResult(result.gpr(), node);
+        break;
+    }
+    default:
+        DFG_CRASH(m_graph, node, "Bad UseKind");
+        break;
+    }
 }
 
 void SpeculativeJIT::compileStringReplaceString(Node* node)

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -514,6 +514,8 @@ inline PropertyOffset Structure::add(VM& vm, PropertyName propertyName, unsigned
     checkConsistency();
     if (attributes & PropertyAttribute::DontEnum || propertyName.isSymbol())
         setIsQuickPropertyAccessAllowedForEnumeration(false);
+    if (attributes & PropertyAttribute::ReadOnly)
+        setContainsReadOnlyProperties();
     if (attributes & PropertyAttribute::DontEnum)
         setHasNonEnumerableProperties(true);
     if (attributes & PropertyAttribute::DontDelete) {
@@ -670,6 +672,8 @@ ALWAYS_INLINE auto Structure::addOrReplacePropertyWithoutTransition(VM& vm, Prop
     checkConsistency();
     if (newAttributes & PropertyAttribute::DontEnum || propertyName.isSymbol())
         setIsQuickPropertyAccessAllowedForEnumeration(false);
+    if (newAttributes & PropertyAttribute::ReadOnly)
+        setContainsReadOnlyProperties();
     if (newAttributes & PropertyAttribute::DontEnum)
         setHasNonEnumerableProperties(true);
     if (newAttributes & PropertyAttribute::DontDelete) {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -76,6 +76,11 @@ void RecorderImpl::save(GraphicsContextState::Purpose purpose)
 
 void RecorderImpl::restore(GraphicsContextState::Purpose purpose)
 {
+    if (stateStack().size() <= 1) {
+        LOG_ERROR("ERROR void RecorderImpl::restore() stack is empty");
+        return;
+    }
+
     if (!updateStateForRestore(purpose))
         return;
     m_items.append(Restore());

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -119,6 +119,9 @@ private:
         webrtc::LocalEncoder webrtcEncoder { nullptr };
         std::unique_ptr<SharedVideoFrameReader> frameReader;
         Deque<CompletionHandler<void(bool)>> encodingCallbacks;
+        WebCore::VideoCodecType codecType { WebCore::VideoCodecType::H264 };
+        bool useLowLatency { false };
+        bool isInvalid { false };
     };
     Encoder* findEncoder(VideoEncoderIdentifier) WTF_REQUIRES_CAPABILITY(workQueue());
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4110,14 +4110,14 @@ header: <WebCore/FEComponentTransfer.h>
 };
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEConvolveMatrix {
-    WebCore::IntSize kernelSize();
-    float divisor();
+    [Validator='!kernelSize->isEmpty()'] WebCore::IntSize kernelSize();
+    [Validator='*divisor != 0'] float divisor();
     float bias();
-    WebCore::IntPoint targetOffset();
+    [Validator='WebCore::IntRect({ }, *kernelSize).contains(*targetOffset)'] WebCore::IntPoint targetOffset();
     WebCore::EdgeModeType edgeMode();
-    WebCore::FloatPoint kernelUnitLength();
+    [Validator='kernelUnitLength->x() > 0 && kernelUnitLength->y() > 0'] WebCore::FloatPoint kernelUnitLength();
     bool preserveAlpha();
-    Vector<float> kernel();
+    [Validator='kernelSize->area() == kernel->size()'] Vector<float> kernel();
 
     WebCore::DestinationColorSpace operatingColorSpace();
 };

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -331,6 +331,7 @@ public:
         completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials are not supported."_s }));
     }
     virtual void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&& completionHandler) { completionHandler(true); }
+    virtual void dismissAnyOpenPicker() { }
 
     virtual void didChangeContentSize(const WebCore::IntSize&) = 0;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8678,6 +8678,9 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
             return;
         }
 
+        if (RefPtr pageClient = this->pageClient())
+            pageClient->dismissAnyOpenPicker();
+
         newPage->setOpenedByDOM();
 
         if (openerAppInitiatedState)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -218,6 +218,8 @@ private:
     void dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&&) override;
 #endif
 
+    void dismissAnyOpenPicker() override;
+
     void disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier) override;
     void handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel, bool nodeIsPluginElement) override;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -41,6 +41,7 @@
 #import "NativeWebKeyboardEvent.h"
 #import "NavigationState.h"
 #import "PDFPluginIdentifier.h"
+#import "PickerDismissalReason.h"
 #import "PlatformXRSystem.h"
 #import "RemoteLayerTreeNode.h"
 #import "RunningBoardServicesSPI.h"
@@ -770,6 +771,11 @@ void PageClientImpl::dismissDigitalCredentialsPicker(CompletionHandler<void(bool
     [contentView() _dismissDigitalCredentialsPicker:WTFMove(completionHandler)];
 }
 #endif
+
+void PageClientImpl::dismissAnyOpenPicker()
+{
+    [contentView() dismissPickersIfNeededWithReason:WebKit::PickerDismissalReason::ViewRemoved];
+}
 
 void PageClientImpl::showInspectorHighlight(const WebCore::InspectorOverlay::Highlight& highlight)
 {


### PR DESCRIPTION
#### 666b647c850902c8bfae1f748756cfb8c539c607
<pre>
Release assert in Vector::at via DisplayList::Recorder::didUpdateSingleState
<a href="https://bugs.webkit.org/show_bug.cgi?id=293971">https://bugs.webkit.org/show_bug.cgi?id=293971</a>

Reviewed by Said Abou-Hallawa.

Restore should not clear the last state stack entry if the state stack entry is zero or one.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/restore-empty-stack-crash-expected.txt: Added.
* LayoutTests/ipc/restore-empty-stack-crash.html: Added.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::restore):

Originally-landed-as: 292955.13@webkit-2025.4-embargoed (0f1f962ca278). <a href="https://rdar.apple.com/157789154">rdar://157789154</a>
Canonical link: <a href="https://commits.webkit.org/298466@main">https://commits.webkit.org/298466@main</a>
</pre>
----------------------------------------------------------------------
#### 632a293bf775414759bae05c34f380f2e624a2f6
<pre>
File picker dialog can create confusion about which page got the file
<a href="https://bugs.webkit.org/show_bug.cgi?id=294374">https://bugs.webkit.org/show_bug.cgi?id=294374</a>
<a href="https://rdar.apple.com/134570800">rdar://134570800</a>

Reviewed by Chris Dumez.

Whenever a window is created via window.open while a file picker dialog is up,
the window that was opened will be shown after the dialog is fulfilled/dismissed.

This can create confusion about which page got the file because the page shown
wasn&apos;t the page that got the file. This patch fixes that by closing any open file
pickers whenever a new window is created.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::dismissAnyOpenPickers):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::dismissAnyOpenPicker):

Originally-landed-as: 289651.572@safari-7621-branch (bcdb1e3948f7). <a href="https://rdar.apple.com/157789714">rdar://157789714</a>
Canonical link: <a href="https://commits.webkit.org/298465@main">https://commits.webkit.org/298465@main</a>
</pre>
----------------------------------------------------------------------
#### b5ecfaf8e75a6bec4d9db9cd9b479643cb39b46d
<pre>
<a href="https://rdar.apple.com/152426694">rdar://152426694</a> ([CoreIPC] VTEncoderXPCService crash in PreEncoderAve::InitBlkScanOrdrMapping_h264)

Reviewed by Eric Carlson and Jean-Yves Avenard.

H264 can only process up to 139264 macroblocks, which puts a hard limit on frame size.
VTB has limits as well which are below this.
We are adding a check that width should be equal or below 8680 and height equal or below 4320.
From testing, we do not need to add a similar check in LibWebRTCCodecsProxy::encodeFrame.
We do not add HEVC checks since we are protected by width and height being uint16_t values.

* LayoutTests/ipc/videoEncode-expected.txt: Added.
* LayoutTests/ipc/videoEncode.html: Added.
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createEncoder):
(WebKit::validateEncoderInitializationData):
(WebKit::LibWebRTCCodecsProxy::initializeEncoder):
(WebKit::LibWebRTCCodecsProxy::encodeFrame):

Originally-landed-as: 289651.557@safari-7621-branch (958622210a02). <a href="https://rdar.apple.com/157790143">rdar://157790143</a>
Canonical link: <a href="https://commits.webkit.org/298464@main">https://commits.webkit.org/298464@main</a>
</pre>
----------------------------------------------------------------------
#### 58218eebdaf5770a7c89bd3e09007a3c260b38f1
<pre>
DFG ASSERTION FAILED: Edge verification error: Node was expected to have type String but has type Cell
<a href="https://bugs.webkit.org/show_bug.cgi?id=293730">https://bugs.webkit.org/show_bug.cgi?id=293730</a>
<a href="https://rdar.apple.com/152217438">rdar://152217438</a>

Reviewed by Yijia Huang.

We should correctly do speculateString when edge says StringUse
regardless. It is possible that leading Check:String can be removed.

* JSTests/stress/string-replace-speculate-string.js: Added.
(catch):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Originally-landed-as: 289651.555@safari-7621-branch (b3f27c30ba5e). <a href="https://rdar.apple.com/157790307">rdar://157790307</a>
Canonical link: <a href="https://commits.webkit.org/298463@main">https://commits.webkit.org/298463@main</a>
</pre>
----------------------------------------------------------------------
#### 8857f57673cdf461f55124d8c8c65e0916c96b84
<pre>
addPropertyWithoutTransition doesn&apos;t call setContainsReadOnlyProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=293970">https://bugs.webkit.org/show_bug.cgi?id=293970</a>
<a href="https://rdar.apple.com/152417321">rdar://152417321</a>

Reviewed by Keith Miller and Mark Lam.

When a JSRawJSONObject is initialized, its property `rawJSON` should be read-only. However,
the object does not update its structure to indicate it has a read-only property. This hits
an assertion failure when we try to use the object in certain scenarios. We should make the
Structure correctly register read-only properties when they are added.

* JSTests/stress/json-const-raw-json-should-be-const.js: Added.
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::add):
(JSC::Structure::addOrReplacePropertyWithoutTransition):

Originally-landed-as: 289651.553@safari-7621-branch (62d3336558aa). <a href="https://rdar.apple.com/157790460">rdar://157790460</a>
Canonical link: <a href="https://commits.webkit.org/298462@main">https://commits.webkit.org/298462@main</a>
</pre>
----------------------------------------------------------------------
#### 94b0d0f626a15a3b8acba7e48c75cc67ddd4b81c
<pre>
Validate the decoded FEConvolveMatrix
<a href="https://bugs.webkit.org/show_bug.cgi?id=293707">https://bugs.webkit.org/show_bug.cgi?id=293707</a>
<a href="https://rdar.apple.com/149463698">rdar://149463698</a>

Reviewed by Simon Fraser.

Adopt the validations of SVGFEConvolveMatrixElement::createFilterEffect() to the
decoded FEConvolveMatrix to ensure the filter effect rectangle is within the
dimension of FilterImage. These validators should be enforced.

1. x of kernelSize &gt; 0
2. 0 &lt;= targetX &lt; x of kernelSize
3. divisor != 0
4. kernelUnitLength cannot be negative or zero
5. kernelSize is the dimension of the flattened kernel

* LayoutTests/TestExpectations:
* LayoutTests/ipc/invalid-feConvolveMatrix-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-feConvolveMatrix-crash.html: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Originally-landed-as: 289651.546@safari-7621-branch (3620d2286f59). <a href="https://rdar.apple.com/157790633">rdar://157790633</a>
Canonical link: <a href="https://commits.webkit.org/298461@main">https://commits.webkit.org/298461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/605514001087bece7efbb1f361290d9eb358cf41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66057 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87760 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61b87882-8ebc-4dae-b234-08a072c2aef0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68153 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21786 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65237 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107676 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124734 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114030 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96525 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41546 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38313 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47867 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41801 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45130 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43517 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->