### PR TITLE
Incorrect memory allocation in vp9_create_compressor and source_var_based_partition_search_method functions

### DIFF
--- a/JSTests/wasm/stress/lower-stack-args-huge-frame.js
+++ b/JSTests/wasm/stress/lower-stack-args-huge-frame.js
@@ -1,0 +1,60 @@
+//@ requireOptions("--coalesceSpillSlots=0")
+
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+globalThis.wasmTestLoopCount ??= 10000;
+
+const verbose = false;
+// Create a large enough frame so that stack slots are not directly addressable from %sp or %fp.
+const num_copies = 2048;
+
+const type = 'f64';
+
+let wat = `(module\n`;
+
+for (let i = 0; i < num_copies; i++)
+    wat += `  (global $g${i} (mut ${type}) (${type}.const ${i+1000}))\n`;
+for (let i = 0; i < num_copies; i++)
+    wat += `  (global $h${i} (mut ${type}) (${type}.const ${i}))\n`;
+
+wat += `  (func (export "test") (param $arg i32)(result ${type})\n`;
+for (let i = 0; i < num_copies; i++) {
+    wat += `    (local $a${i} ${type})\n`;
+    wat += `    (local $b${i} ${type})\n`;
+}
+
+for (let i = 0; i < num_copies; i++)
+    wat += `    (local.set $a${i} (global.get $g${i}))\n`;
+for (let i = 0; i < num_copies; i++)
+    wat += `    (local.set $b${i} (global.get $h${i}))\n`;
+
+// Induce 'Move (spillA), (spillB), scratchReg' stack coalescable Air instructions using local.set/local.get inside an if block.
+wat += `    (if (i32.ne (local.get $arg)(i32.const 0))\n`;
+wat += `      (then\n`;
+
+for (let i = 0; i < num_copies; i++)
+    wat += `        (local.set $a${i} (local.get $b${i}))\n`
+
+wat += `      )\n`
+wat += `    )\n`
+
+for (let i = 0; i < num_copies; i++)
+    wat += `    (${type}.add (local.get $a${i})(local.get $b${i}))\n`;
+
+for (let i = 0; i < num_copies - 1; i++)
+    wat += `    (${type}.add)\n`;
+
+wat += `  )\n)\n`;
+
+if (verbose)
+    print(wat);
+
+async function run() {
+    const instance = await instantiate(wat);
+    const {test} = instance.exports;
+    for (let i = 0; i < wasmTestLoopCount; ++i)
+        assert.eq(test(1), num_copies * (num_copies - 1));
+}
+
+assert.asyncTest(run());

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -66,6 +66,67 @@ void lowerStackArgs(Code& code)
 
         for (unsigned instIndex = 0; instIndex < block->size(); ++instIndex) {
             Inst& inst = block->at(instIndex);
+            bool extendedOffsetAddrRegInUse = false;
+
+            auto stackAddr = [&] (unsigned insertionIndex, Arg arg, Width width, Value::OffsetType offsetFromFP) -> Arg {
+                int32_t offsetFromSP = offsetFromFP + code.frameSize();
+
+                if (inst.admitsExtendedOffsetAddr(arg)) {
+                    // Stackmaps and patchpoints expect addr inputs relative to SP or FP only. We might as well
+                    // not even bother generating an addr with valid form for these opcodes since extended offset
+                    // addr is always valid.
+                    return Arg::extendedOffsetAddr(offsetFromFP);
+                }
+
+                Arg result = Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP);
+                if (result.isValidForm(Move, width))
+                    return result;
+
+                result = Arg::addr(Air::Tmp(MacroAssembler::stackPointerRegister), offsetFromSP);
+                if (result.isValidForm(Move, width))
+                    return result;
+
+                if (inst.kind.opcode == Patch)
+                    return Arg::extendedOffsetAddr(offsetFromFP);
+
+#if CPU(ARM64) || CPU(RISCV64)
+                RELEASE_ASSERT(!extendedOffsetAddrRegInUse);
+                Air::Tmp tmp = Air::Tmp(extendedOffsetAddrRegister());
+                extendedOffsetAddrRegInUse = true;
+
+                Arg largeOffset = Arg::isValidImmForm(offsetFromSP) ? Arg::imm(offsetFromSP) : Arg::bigImm(offsetFromSP);
+                insertionSet.insert(insertionIndex, Move, inst.origin, largeOffset, tmp);
+                insertionSet.insert(insertionIndex, Add64, inst.origin, Air::Tmp(MacroAssembler::stackPointerRegister), tmp);
+                result = Arg::addr(tmp, 0);
+                return result;
+#elif CPU(ARM)
+                // We solve this in AirAllocateRegistersAndStackAndGenerateCode.cpp.
+                UNUSED_PARAM(insertionIndex);
+                return result;
+#elif CPU(X86_64)
+                UNUSED_PARAM(insertionIndex);
+                // Can't happen on x86: immediates are always big enough for frame size.
+                RELEASE_ASSERT_NOT_REACHED();
+#else
+#error Unhandled architecture.
+#endif
+            };
+
+            auto isMove = [] (Inst& inst) -> std::optional<Width> {
+                switch (inst.kind.opcode) {
+                case Move:
+                    return pointerWidth();
+                case Move32:
+                case MoveFloat:
+                    return Width32;
+                case MoveDouble:
+                    return Width64;
+                case MoveVector:
+                    return Width128;
+                default:
+                    return std::nullopt;
+                }
+            };
 
             if (isARM64() && (inst.kind.opcode == Lea32 || inst.kind.opcode == Lea64)) {
                 // On ARM64, Lea is just an add. We can't handle this below because
@@ -106,50 +167,28 @@ void lowerStackArgs(Code& code)
                 continue;
             }
 
+            // Moves between stack spills may require using the extendedOffsetReg for both the src and dst addresses.
+            // In that case, split the move into separate load and store instructions so that the extendedOffsetReg can
+            // be used for each address, one at a time.
+            std::optional<Width> moveWidth = isMove(inst);
+            if (isARM64() && moveWidth && inst.args.size() == 3 && inst.args[0].isStack()) {
+                Arg& src = inst.args[0];
+                src = stackAddr(instIndex, src, *moveWidth, src.offset() + src.stackSlot()->offsetFromFP());
+                if (extendedOffsetAddrRegInUse) {
+                    Arg scratch = inst.args[2];
+                    ASSERT(scratch.isReg());
+                    // Insert Mov src, scratchReg
+                    insertionSet.insert(instIndex, inst.kind.opcode, inst.origin, src, scratch);
+                    extendedOffsetAddrRegInUse = false; // Used by the inserted instruction; no longer needed.
+                    // Modify inst to be 'Move scratch, dest'.
+                    src = scratch;
+                    inst.args.resize(2);
+                }
+                // Fall through to handle remainder of the original or modified inst, including potential ZDef handling.
+            }
+
             inst.forEachArg(
                 [&] (Arg& arg, Arg::Role role, Bank, Width width) {
-                    auto stackAddr = [&] (unsigned instIndex, Value::OffsetType offsetFromFP) -> Arg {
-                        int32_t offsetFromSP = offsetFromFP + code.frameSize();
-
-                        if (inst.admitsExtendedOffsetAddr(arg)) {
-                            // Stackmaps and patchpoints expect addr inputs relative to SP or FP only. We might as well
-                            // not even bother generating an addr with valid form for these opcodes since extended offset
-                            // addr is always valid.
-                            return Arg::extendedOffsetAddr(offsetFromFP);
-                        }
-
-                        Arg result = Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), offsetFromFP);
-                        if (result.isValidForm(Move, width))
-                            return result;
-
-                        result = Arg::addr(Air::Tmp(MacroAssembler::stackPointerRegister), offsetFromSP);
-                        if (result.isValidForm(Move, width))
-                            return result;
-
-                        if (inst.kind.opcode == Patch)
-                            return Arg::extendedOffsetAddr(offsetFromFP);
-
-#if CPU(ARM64) || CPU(RISCV64)
-                        Air::Tmp tmp = Air::Tmp(extendedOffsetAddrRegister());
-
-                        Arg largeOffset = Arg::isValidImmForm(offsetFromSP) ? Arg::imm(offsetFromSP) : Arg::bigImm(offsetFromSP);
-                        insertionSet.insert(instIndex, Move, inst.origin, largeOffset, tmp);
-                        insertionSet.insert(instIndex, Add64, inst.origin, Air::Tmp(MacroAssembler::stackPointerRegister), tmp);
-                        result = Arg::addr(tmp, 0);
-                        return result;
-#elif CPU(ARM)
-                        // We solve this in AirAllocateRegistersAndStackAndGenerateCode.cpp.
-                        UNUSED_PARAM(instIndex);
-                        return result;
-#elif CPU(X86_64)
-                        UNUSED_PARAM(instIndex);
-                        // Can't happen on x86: immediates are always big enough for frame size.
-                        RELEASE_ASSERT_NOT_REACHED();
-#else
-#error Unhandled architecture.
-#endif
-                    };
-                    
                     switch (arg.kind()) {
                     case Arg::Stack: {
                         StackSlot* slot = arg.stackSlot();
@@ -179,13 +218,14 @@ void lowerStackArgs(Code& code)
                             RELEASE_ASSERT(isValidForm(storeOpcode, operandKind, Arg::Stack));
                             insertionSet.insert(
                                 instIndex + 1, storeOpcode, inst.origin, operand,
-                                stackAddr(instIndex + 1, arg.offset() + 4 + slot->offsetFromFP()));
+                                stackAddr(instIndex + 1, arg, width, arg.offset() + 4 + slot->offsetFromFP()));
+                            extendedOffsetAddrRegInUse = false;
                         }
-                        arg = stackAddr(instIndex, arg.offset() + slot->offsetFromFP());
+                        arg = stackAddr(instIndex, arg, width, arg.offset() + slot->offsetFromFP());
                         break;
                     }
                     case Arg::CallArg:
-                        arg = stackAddr(instIndex, arg.offset() - code.frameSize());
+                        arg = stackAddr(instIndex, arg, width, arg.offset() - code.frameSize());
                         break;
                     default:
                         break;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encodeframe.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encodeframe.c
@@ -5594,7 +5594,7 @@ static void source_var_based_partition_search_method(VP9_COMP *cpi) {
       if (cpi->source_diff_var) vpx_free(cpi->source_diff_var);
 
       CHECK_MEM_ERROR(&cm->error, cpi->source_diff_var,
-                      vpx_calloc(cm->MBs, sizeof(cpi->source_diff_var)));
+                      vpx_calloc(cm->MBs, sizeof(*cpi->source_diff_var)));
     }
 
     if (!cpi->frames_till_next_var_check)

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encoder.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encoder.c
@@ -2705,7 +2705,7 @@ VP9_COMP *vp9_create_compressor(const VP9EncoderConfig *oxcf,
 
   // Allocate memory to store variances for a frame.
   CHECK_MEM_ERROR(&cm->error, cpi->source_diff_var,
-                  vpx_calloc(cm->MBs, sizeof(cpi->source_diff_var)));
+                  vpx_calloc(cm->MBs, sizeof(*cpi->source_diff_var)));
   cpi->source_var_thresh = 0;
   cpi->frames_till_next_var_check = 0;
 #define BFP(BT, SDF, SDSF, SDAF, VF, SVF, SVAF, SDX4DF, SDSX4DF) \

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -226,7 +226,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
     if (!previewController)
         return nil;
     RefPtr page = previewController->page();
-    if (page)
+    if (!page)
         return nil;
 
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the


### PR DESCRIPTION
#### 38437b0094ee90f728bdf09f288b3c30e8223508
<pre>
Incorrect memory allocation in vp9_create_compressor and source_var_based_partition_search_method functions
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=295735">https://bugs.webkit.org/show_bug.cgi?id=295735</a>&gt;
&lt;<a href="https://rdar.apple.com/154433059">rdar://154433059</a>&gt;

Reviewed by Darin Adler.

* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encodeframe.c:
(source_var_based_partition_search_method):
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encoder.c:
(vp9_create_compressor):
- Change sizeof() operator to use `struct Diff` instead of `Diff*`.

Originally-landed-as: 289651.604@safari-7621-branch (876b8705fe85). <a href="https://rdar.apple.com/157787764">rdar://157787764</a>
Canonical link: <a href="https://commits.webkit.org/298450@main">https://commits.webkit.org/298450@main</a>
</pre>
----------------------------------------------------------------------
#### 0e53111ba87fbf442878b5af9931b40b3fff0b83
<pre>
Follow-up: Store WebKit::SystemPreviewController as WeakPtr&lt;&gt; in Objective-C instance variables
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=295568">https://bugs.webkit.org/show_bug.cgi?id=295568</a>&gt;
&lt;<a href="https://rdar.apple.com/155061059">rdar://155061059</a>&gt;

Unreviewed typo fix.

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
- Fix missing &quot;!&quot; in early return check.

Originally-landed-as: 289651.599@safari-7621-branch (3fb8d5612db9). <a href="https://rdar.apple.com/157788225">rdar://157788225</a>
Canonical link: <a href="https://commits.webkit.org/298449@main">https://commits.webkit.org/298449@main</a>
</pre>
----------------------------------------------------------------------
#### 781ab9dc83d42bcb4ff5bd69296476c3339def13
<pre>
Store WebKit::SystemPreviewController as WeakPtr&lt;&gt; in Objective-C instance variables
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=295568">https://bugs.webkit.org/show_bug.cgi?id=295568</a>&gt;
&lt;<a href="https://rdar.apple.com/155061059">rdar://155061059</a>&gt;

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
- Deploy WeakPtr&lt;WebKit::SystemPreviewController&gt; instance variable to
  Objective-C classes, and use local RefPtr variables when accessing it.

Originally-landed-as: 289651.598@safari-7621-branch (aaa2155fec4f). <a href="https://rdar.apple.com/157788350">rdar://157788350</a>
Canonical link: <a href="https://commits.webkit.org/298448@main">https://commits.webkit.org/298448@main</a>
</pre>
----------------------------------------------------------------------
#### 4637324afb310494fa33a672e479289c9461c688
<pre>
CRASH: HRTFDatabaseLoader::createAndLoadAsynchronouslyIfNecessary() crashes in HRTFDatabaseLoader::ref()
<a href="https://bugs.webkit.org/show_bug.cgi?id=295382">https://bugs.webkit.org/show_bug.cgi?id=295382</a>
<a href="https://rdar.apple.com/153904348">rdar://153904348</a>

Reviewed by Andy Estes and Chris Dumez.

Don&apos;t store raw pointers as a cache; that&apos;s what ThreadSafeWeakPtr is for.

* Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp:
(WebCore::loaderMap):
(WebCore::HRTFDatabaseLoader::createAndLoadAsynchronouslyIfNecessary):
(): Deleted.

Originally-landed-as: 289651.596@safari-7621-branch (0de4de353f69). <a href="https://rdar.apple.com/157788821">rdar://157788821</a>
Canonical link: <a href="https://commits.webkit.org/298447@main">https://commits.webkit.org/298447@main</a>
</pre>
----------------------------------------------------------------------
#### 98e442e1a20e5cc987964efa446a24508d2db976
<pre>
[JSC] Fix lowerStackArgs handling of moves between spill slots and large frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=295317">https://bugs.webkit.org/show_bug.cgi?id=295317</a>
<a href="https://rdar.apple.com/154809096">rdar://154809096</a>

Reviewed by Yusuke Suzuki, Keith Miller, and Mark Lam.

On ARM64, when a stack slot&apos;s offset from %fp/%sp cannot be
encoded directly in an instruction, lowerStackArgs uses %lr
to materialize the address. Most instructions on ARM have only
one memory operand, however the Air instruction:

   Move (spillA), (spillB), scratchReg

has two stack operands and it&apos;s possible for neither to be
directly addressable. Since there is only one register available
to materialize, fix lowering of these stack slots by transforming
this instruction to:

   Move (spillA), scratchReg
   Move scratchReg, (spillB)

Then the spill slot addresses can be materialized using the single
register. Note that this is the same transformation that will eventually
be done by the MacroAssembler anyway and stack slot coalescing and
allocation has already occurred at this point.

Originally-landed-as: 289651.594@safari-7621-branch (254f4eefafe1). <a href="https://rdar.apple.com/157788802">rdar://157788802</a>
Canonical link: <a href="https://commits.webkit.org/298446@main">https://commits.webkit.org/298446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42a61dc6f782a7c84df85d9e96a75f717406161f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8c42e6a-cc5d-4051-806c-4d742f9f4f98) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87725 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cf8ee53-8b7b-4646-a6d0-81bdb7e22839) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68117 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65202 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107655 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124709 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/113997 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96502 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24507 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38291 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47836 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/141919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41777 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/141919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->