### PR TITLE
ANGLE: Recompute vertex capacity on transform feedback resume.

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.h
@@ -114,6 +114,7 @@ class TransformFeedback final : public RefCountObject<TransformFeedbackID>, publ
 
   private:
     void bindProgram(const Context *context, Program *program);
+    void recomputeVertexCapacity(const Context *context);
 
     TransformFeedbackState mState;
     rx::TransformFeedbackImpl *mImplementation;


### PR DESCRIPTION
#### 0764a86f016d860ea1fa8b0de631168c56c93691
<pre>
ANGLE: Recompute vertex capacity on transform feedback resume.
<a href="https://rdar.apple.com/156053084">rdar://156053084</a>

Reviewed by Jonathan Bedard.

Recompute the vertex capacity upon a transform feedback resume operation
in case an operation changed the underlying buffer between pause and
resume operations.

* Source/ThirdParty/ANGLE/src/libANGLE/TransformFeedback.cpp:
(gl::TransformFeedback::resume):

Originally-landed-as: 289651.608@safari-7621-branch (0c5e0151c010). <a href="https://rdar.apple.com/157787311">rdar://157787311</a>
Canonical link: <a href="https://commits.webkit.org/298533@main">https://commits.webkit.org/298533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2bae76c43669644cb0e5ca56410b90c88649251

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66035 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cee6aa39-2716-4957-9563-2abfc97ff4d5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87727 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42401 "Found 2 new test failures: js/dom/call-link-info-recursion.html storage/indexeddb/mozilla/key-requirements-put-no-key.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d3bd862-2441-4111-a442-3f6f94b049f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103640 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68119 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124711 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96504 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96290 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41524 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19385 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38293 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18508 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42279 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41779 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45107 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->