### PR TITLE
Renderer is being used after free during ViewTransition copyElementBaseProperties

### DIFF
--- a/LayoutTests/fast/css/viewtransition-copyelementbaseproperties-no-flushed-style-crash-expected.txt
+++ b/LayoutTests/fast/css/viewtransition-copyelementbaseproperties-no-flushed-style-crash-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: This test passes if WebKit does not crash.
+

--- a/LayoutTests/fast/css/viewtransition-copyelementbaseproperties-no-flushed-style-crash.html
+++ b/LayoutTests/fast/css/viewtransition-copyelementbaseproperties-no-flushed-style-crash.html
@@ -1,0 +1,23 @@
+<style>
+* {
+  content: url(#a);
+  transform: translateZ(0);
+}
+</style>
+<script>
+  testRunner?.waitUntilDone();
+  testRunner?.dumpAsText();
+  window.addEventListener("load", () => {
+    let img = document.createElement("img");
+    img.srcset = "something";
+    document.startViewTransition();
+    iframe.src = location.href;
+    if (self !== top) {
+      console.log("This test passes if WebKit does not crash.");
+      testRunner?.notifyDone();
+    }
+  }, { once: true });
+</script>
+<body>
+  <iframe id="iframe"></iframe>
+</body>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -981,6 +981,8 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStylesRead()
     if (!document)
         return { };
 
+    document->updateStyleIfNeededIgnoringPendingStylesheets();
+
     for (auto& [name, capturedElement] : m_namedElements.map()) {
         if (auto newStyleable = capturedElement->newElement.styleable()) {
             CheckedPtr renderer = dynamicDowncast<RenderBoxModelObject>(newStyleable->renderer());


### PR DESCRIPTION
#### 634fd6d049d122a6d264d308261f843eb892bab6
<pre>
Renderer is being used after free during ViewTransition copyElementBaseProperties
<a href="https://rdar.apple.com/150195159">rdar://150195159</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293303">https://bugs.webkit.org/show_bug.cgi?id=293303</a>

Reviewed by Matt Woodrow.

This fixes the bug by adding an extra style flush

* LayoutTests/fast/css/viewtransition-copyelementbaseproperties-no-flushed-style-crash-expected.txt: Added.
* LayoutTests/fast/css/viewtransition-copyelementbaseproperties-no-flushed-style-crash.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePseudoElementStylesRead):

Originally-landed-as: 289651.537@safari-7621-branch (41211dd06597). <a href="https://rdar.apple.com/157791050">rdar://157791050</a>
Canonical link: <a href="https://commits.webkit.org/298924@main">https://commits.webkit.org/298924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc618026ddd74132253473630e6802dc0754400

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69124 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/600ab81d-74a1-44de-8ed6-03e0803ac41e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88903 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6483bc1d-d4c5-456b-9576-e09752f5262b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69395 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97579 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97378 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42718 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20650 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18702 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43891 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43358 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->