### PR TITLE
Navigation API causing webpage crashes on Brightspace quiz

### DIFF
--- a/LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe-expected.txt
+++ b/LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe.html
+++ b/LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe.html
@@ -1,0 +1,34 @@
+PASS if no crash
+
+<script src='/js-test-resources/ui-helper.js'></script>
+
+<iframe id="iframe" srcdoc="<form method='post'><input type='submit' value='Submit'></form>"></iframe>
+
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+
+let clickCount = 0;
+
+iframe.onload = async () => {
+    let doc = iframe.contentDocument, button = doc.querySelector("input[type='submit']");
+
+    button.addEventListener('click', e => {
+        if (++clickCount === 10)
+            testRunner?.notifyDone();
+    });
+
+    let fr = iframe.getBoundingClientRect(), br = button.getBoundingClientRect();
+    let x = Math.round(fr.left + br.left + br.width / 2), y = Math.round(fr.top + br.top + br.height / 2);
+
+    for (let i = 0; i < 10; ++i) {
+        if (testRunner.isIOSFamily && window.eventSender)
+            await UIHelper.activateAt(x, y);
+        else {
+            await eventSender?.asyncMouseMoveTo(x, y);
+            await eventSender?.asyncMouseDown();
+            await eventSender?.asyncMouseUp();
+        }
+    }
+};
+</script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3563,6 +3563,7 @@ void FrameLoader::loadPostRequest(FrameLoadRequest&& request, const String& refe
     action.setLockBackForwardList(request.lockBackForwardList());
     action.setShouldReplaceDocumentIfJavaScriptURL(request.shouldReplaceDocumentIfJavaScriptURL());
     action.setNewFrameOpenerPolicy(request.newFrameOpenerPolicy());
+    action.setNavigationAPIType(determineNavigationType(loadType, request.navigationHistoryBehavior()));
 
     if (!frameName.isEmpty()) {
         // The search for a target frame is done earlier in the case of form submission.

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -160,8 +160,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
 
                 m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
 
-                if (navigationType) // Unset in the case of forms/POST requests.
-                    m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));
+                m_activation = NavigationActivation::create(*navigationType, *currentEntry(), WTFMove(previousEntry));
 
                 return;
             }


### PR DESCRIPTION
#### 0b66d56fa5dc4649dbe651b6215b6874e9e57aa3
<pre>
Navigation API causing webpage crashes on Brightspace quiz
<a href="https://bugs.webkit.org/show_bug.cgi?id=287808">https://bugs.webkit.org/show_bug.cgi?id=287808</a>
<a href="https://rdar.apple.com/145088211">rdar://145088211</a>

Reviewed by Charlie Wolfe.

The brightspace site has buttons that submit a form. The form is
submitted via a POST request. And this happens inside an iframe.

When we press the first button, since the form is submitted via
a POST request, it&apos;s loaded using FrameLoader::loadPostRequest().
This function erroneously does not set the Navigation API
navigation type (should be a Push navigation). As a result, when
we get to Navigation::initializeForNewWindow(), the code path we
go down is:

1. Frame is not a MainFrame
2. Should process previous navigation entries since there was
   a previous window
3. Navigation type is not Push or Traverse

In this code path, we end up not finding the current history entry
in the list of entries, and thus, we don&apos;t set m_currentEntryIndex.

Now we press the second button and we go down the same exact code path.
In Step 3, we dereference the previous window&apos;s m_currentEntryIndex,
which is of course not set, and so we crash.

The issue is that the navigation should have had a navigation type.
So we set this in FrameLoader::loadPostRequest() the same way we do in
FrameLoader::loadURL().

Now the first button press goes down the path:

1. Frame is not a MainFrame
2. Should process previous navigation entries since there was
   a previous window
3. Navigation type is a Push

And then m_currentEntryIndex gets set.

Then, when the second button is pressed, m_currentEntryIndex can be
safely dereferenced.

The crash from the site can be minimized to this:

&quot;&quot;&quot;
&lt;iframe srcdoc=&quot;&lt;form method=&apos;post&apos;&gt;&lt;input type=&apos;submit&apos; value=&apos;Submit&apos;&gt;&lt;/form&gt;&quot;&gt;&lt;/iframe&gt;
&quot;&quot;&quot;

Load this HTML in Safari, press the submit button twice, and it&apos;ll crash.

This patch converts this manual test case into a new layout test that passes
if it doesn&apos;t crash.

* LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe-expected.txt: Added.
* LayoutTests/http/tests/navigation-api/form-submission-post-request-iframe.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadPostRequest):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):

The spec does not say that a POST request or form submission
should not have a navigation type.

Canonical link: <a href="https://commits.webkit.org/298480@main">https://commits.webkit.org/298480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf0a9443256768a7760ec2dbe994751941eabc74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66106 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d5070a55-31c8-4406-89c7-ab8ed7c83b99) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87803 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42443 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f9762406-ac2b-48e6-b446-f7116d866e07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28666 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68201 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65317 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124788 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96346 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38359 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47949 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41852 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43567 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->