### PR TITLE
ASAN_SEGV | WebCore::CanvasBase::setImageBuffer; WebCore::OffscreenCanvas::setImageBufferAndMarkDirty; WebCore::ImageBitmapRenderingContext::setBlank

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-no-script-context-crash-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-no-script-context-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/canvas/offscreen-no-script-context-crash.html
+++ b/LayoutTests/fast/canvas/offscreen-no-script-context-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script>
+const map = new Map([['Window', [new WeakRef(globalThis)]]]);
+function storeObject(key, o) {
+  let weak = new WeakRef(o);
+  let entriesForKey = map.get(key) ?? [];
+  entriesForKey.push(weak);
+  map.set(key, entriesForKey);
+}
+function getObject(key) {
+  let entriesForKey = map.get(key);
+  let nextEntry = entriesForKey.shift();
+  let theObject = nextEntry.deref();
+  entriesForKey.push(nextEntry);
+  return theObject;
+}
+
+(async () => {
+  testRunner?.dumpAsText();
+  testRunner?.waitUntilDone();
+  storeObject('Document', Document.parseHTMLUnsafe( trustedTypes.emptyHTML));
+  storeObject('HTMLCanvasElement', getObject('Document').createElementNS('http://www.w3.org/1999/xhtml', 'canvas'));
+  let offscreen = getObject('HTMLCanvasElement').transferControlToOffscreen();
+  await (()=>{ return frames.cookieStore.delete("bar") })();
+  offscreen.getContext('bitmaprenderer');
+  testRunner?.notifyDone();
+})();
+</script>
+PASS if no crash.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3224,3 +3224,5 @@ media/video-setSinkId-default.html [ Skip ]
 dom/xsl/lockdown-mode [ Skip ]
 http/tests/lockdown-mode [ Skip ]
 js/dom/lockdown-mode [ Skip ]
+
+webkit.org/b/289382 fast/canvas/offscreen-no-script-context-crash.html [ Skip ]

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -264,9 +264,10 @@ RefPtr<ImageBuffer> CanvasBase::setImageBuffer(RefPtr<ImageBuffer>&& buffer) con
     }
     m_imageBufferMemoryCost.store(newMemoryCost, std::memory_order_relaxed);
     if (newMemoryCost) {
-        RefPtr scriptExecutionContext = this->scriptExecutionContext();
-        JSC::JSLockHolder lock(scriptExecutionContext->vm());
-        scriptExecutionContext->vm().heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), newMemoryCost);
+        if (RefPtr scriptExecutionContext = this->scriptExecutionContext()) {
+            JSC::JSLockHolder lock(scriptExecutionContext->vm());
+            scriptExecutionContext->vm().heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), newMemoryCost);
+        }
     }
     if (auto* context = renderingContext()) {
         if (oldSize != m_size)

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -415,10 +415,10 @@ void OffscreenCanvas::commitToPlaceholderCanvas()
 
 void OffscreenCanvas::scheduleCommitToPlaceholderCanvas()
 {
-    if (!m_hasScheduledCommit && m_placeholderSource) {
-        auto& scriptContext = *scriptExecutionContext();
+    RefPtr scriptContext = scriptExecutionContext();
+    if (scriptContext && !m_hasScheduledCommit && m_placeholderSource) {
         m_hasScheduledCommit = true;
-        scriptContext.postTask([protectedThis = Ref { *this }, this] (ScriptExecutionContext&) {
+        scriptContext->postTask([protectedThis = Ref { *this }, this] (ScriptExecutionContext&) {
             m_hasScheduledCommit = false;
             commitToPlaceholderCanvas();
         });


### PR DESCRIPTION
#### 288b83d4056fe4f3f043d9a4404cc12c1fca8e60
<pre>
ASAN_SEGV | WebCore::CanvasBase::setImageBuffer; WebCore::OffscreenCanvas::setImageBufferAndMarkDirty; WebCore::ImageBitmapRenderingContext::setBlank
<a href="https://bugs.webkit.org/show_bug.cgi?id=289380">https://bugs.webkit.org/show_bug.cgi?id=289380</a>

Reviewed by Ryosuke Niwa.

The OffscreenCanvas DOM object can be detached from its script execution context so
add checks to see if it is available.

* LayoutTests/fast/canvas/offscreen-no-script-context-crash-expected.txt: Added.
* LayoutTests/fast/canvas/offscreen-no-script-context-crash.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::setImageBuffer const):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::scheduleCommitToPlaceholderCanvas):

Originally-landed-as: 292955.7@webkit-2025.4-embargoed (44fc00a2610d). <a href="https://rdar.apple.com/157792218">rdar://157792218</a>
Canonical link: <a href="https://commits.webkit.org/298454@main">https://commits.webkit.org/298454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c06f09535f93cbe99262ca3ee1ae8f117c267005

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66051 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5dce05b2-a7d7-4740-88f3-c4ef2128be21) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7f310a8-a4db-49f9-b025-27e9e8c4b2ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68133 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21773 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65224 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96517 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96303 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24510 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19396 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47857 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/141963 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41795 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/141963 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45123 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->