### PR TITLE
[YARR] Remove sentinel-based tracking in Unicode read path

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -92,15 +92,6 @@ static_assert(areCanonicallyEquivalentCharArgReg == GPRInfo::returnValueGPR);
 #endif
 #endif
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-// This enhancement allows us to advance the index by 2 when we read a non-BMP surrogate pair, but fail to match.
-// The way it works is that we initialize the firstCharacterAdditionalReadSize register to an initial sentinal value.
-// When reading a possible surrogate pair, we change firstCharacterAdditionalReadSize from the sentinal to 0 if we read
-// a BMP (16-bit) character or 1 if the read value is a non-BMP. Once changed from the sentinel value, we don't change
-// again during the next read. We add firstCharacterAdditionalReadSize to index for the next iteration on a failed
-// match and when setting the the possible new match start location.
-constexpr static int32_t additionalReadSizeSentinel = 0x4;
-#endif
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreBitmap);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BoyerMooreFastCandidates);
@@ -445,6 +436,17 @@ void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
 
     // if it is surrogate pair, we already handled it in the inlined code.
 
+#if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+        if (useNonBMPOptimization == TryReadUnicodeCharGenFirstNonBMPOptimization::UseOptimization)
+            jit.move(MacroAssembler::TrustedImm32(1), regs.firstCharacterAdditionalReadSize);
+#endif
+
+    if (readUnicodeCharCodeLocation == TryReadUnicodeCharCodeLocation::CompileAsThunk)
+        jit.ret();
+    else
+        haveResult.append(jit.jump());
+
+    notSurrogatePair.link(&jit);
     // Check if we can return the dangling surrogate or if it is part of a valid pair where the leading surrogate
     // that is offset one character before the load pointer.
     jit.and32(MacroAssembler::TrustedImm32(0xffff), regs.unicodeAndSubpatternIdTemp);
@@ -452,7 +454,7 @@ void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
     // If so fall through, otherwise perform other dangling checks.
     checkForDanglingSurrogates.append(jit.branch32(MacroAssembler::Equal, regs.unicodeAndSubpatternIdTemp, MacroAssembler::TrustedImm32(0xdc00)));
 
-    isBMP.link(jit);
+    isBMP.link(&jit);
     jit.and32(MacroAssembler::TrustedImm32(0xffff), resultReg);
 
 #if ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
@@ -462,14 +464,17 @@ void tryReadUnicodeCharSlowImpl(CCallHelpers& jit)
     }
 #endif
 
-    jit.ret();
+    if (readUnicodeCharCodeLocation == TryReadUnicodeCharCodeLocation::CompileAsThunk)
+        jit.ret();
+    else
+        haveResult.append(jit.jump());
 
     checkForDanglingSurrogates.link(&jit);
     // Remove the second character that we loaded.
     jit.and32(MacroAssembler::TrustedImm32(0xffff), resultReg);
     MacroAssembler::Label checkForDanglingSurrogatesLabel(&jit);
 
-    // Can ew read the prior character?
+    // Can we read the prior character?
     jit.subPtr(MacroAssembler::TrustedImm32(2), regs.regUnicodeInputAndTrail);
     // If not, we branch to return the dangling surrogate.
     bmpDone.append(jit.branchPtr(MacroAssembler::Below, regs.regUnicodeInputAndTrail, regs.input));
@@ -3233,6 +3238,12 @@ class YarrGenerator final : public YarrJITInfo {
 
                 termMatchTargets.append(MatchTargets());
 
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                // Always set to zero.
+                if (m_useFirstNonBMPCharacterOptimization)
+                    m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.firstCharacterAdditionalReadSize);
+#endif
+
                 // Upon entry at the head of the set of alternatives, check if input is available
                 // to run the first alternative. (This progresses the input position).
                 op.m_jumps.append(jumpIfNoAvailableInput(alternative->m_minimumSize));
@@ -3241,11 +3252,6 @@ class YarrGenerator final : public YarrJITInfo {
                 // set as appropriate to this alternative.
                 op.m_reentry = m_jit.label();
 
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-                // Clear first character read size so it can be set on the first read.
-                if (m_useFirstNonBMPCharacterOptimization)
-                    m_jit.move(MacroAssembler::TrustedImm32(additionalReadSizeSentinel), m_regs.firstCharacterAdditionalReadSize);
-#endif
 
                 // Emit fast skip path with stride if we have BoyerMooreInfo.
                 if (op.m_bmInfo) {


### PR DESCRIPTION
#### bf455b8caeeb7d009c3edd9a92aea134e845e47f
<pre>
[YARR] Remove sentinel-based tracking in Unicode read path
<a href="https://bugs.webkit.org/show_bug.cgi?id=294182">https://bugs.webkit.org/show_bug.cgi?id=294182</a>
<a href="https://rdar.apple.com/152806201">rdar://152806201</a>

Reviewed by Yusuke Suzuki.

Simplified the logic for tracking additional read size when handling Unicode characters in
Yarr JIT. Previously, a sentinel-based mechanism (0x4) was used to indicate whether a non-BMP
character had been read. This approach required conditional logic that could silently fail
in edge cases like skipped alternatives or control flow changes during backtracking.

This patch:
- Removes the sentinel mechanism entirely.
- Initializes firstCharacterAdditionalReadSize to 0 on alternative entry.
- Always sets it to 1 when reading a non-BMP character, 0 otherwise.
- Removes all conditional writes and checks for the sentinel.

This change ensures the additional read size is always well-defined and simplifies the
backtracking and match start logic. It improves robustness and correctness in Unicode mode
without changing observable RegExp semantics.

* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Originally-landed-as: 289651.563@safari-7621-branch (01d3edddfa1a). rdar://157789826
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf455b8caeeb7d009c3edd9a92aea134e845e47f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116675 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36339 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26901 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122749 "Hash bf455b8c for PR 49146 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b17b7df7-871e-49b8-ac67-5fc9ede9bec2) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37037 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44928 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/122749 "Hash bf455b8c for PR 49146 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e9059efb-8b92-40ec-aa67-cc35e94b53a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119624 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/37037 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/26901 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/122749 "Hash bf455b8c for PR 49146 does not build (failure)") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/37037 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/26901 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66416 "Hash bf455b8c for PR 49146 does not build (failure)") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/108789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/37037 "Hash bf455b8c for PR 49146 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/26901 "Hash bf455b8c for PR 49146 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115203 "Failed to checkout and rebase branch from PR 49146") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/44928 "Hash bf455b8c for PR 49146 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43938 "Build is in progress. Recent messages:") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/26901 "Hash bf455b8c for PR 49146 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/26901 "Hash bf455b8c for PR 49146 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/43460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143901 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->