### PR TITLE
[WebXR][OpenXR] Add EGL fences for WebGL content

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -107,6 +107,10 @@ public:
 
     void releaseAllDisplayAttachments();
 
+#if USE(OPENXR)
+    WTF::UnixFileDescriptor takeFenceFD();
+#endif
+
 private:
     WebXROpaqueFramebuffer(PlatformXR::LayerHandle, Ref<WebGLFramebuffer>&&, WebGLRenderingContextBase&, Attributes&&, IntSize);
 
@@ -142,6 +146,9 @@ private:
     size_t m_currentDisplayAttachmentIndex { 0 };
 #if PLATFORM(COCOA)
     MachSendRight m_completionSyncEvent;
+#endif
+#if USE(OPENXR)
+    WTF::UnixFileDescriptor m_fenceFD;
 #endif
     uint64_t m_renderingFrameIndex { ~0u };
     bool m_usingFoveation { false };

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -311,7 +311,14 @@ PlatformXR::Device::Layer WebXRWebGLLayer::endFrame()
         { PlatformXR::Eye::Right, m_rightViewportData.viewport->rect() }
     };
 
-    return PlatformXR::Device::Layer { .handle = m_framebuffer->handle(), .visible = true, .views = WTFMove(views) };
+    return PlatformXR::Device::Layer {
+        .handle = m_framebuffer->handle(),
+        .visible = true,
+        .views = WTFMove(views),
+#if USE(OPENXR)
+        .fenceFD = m_framebuffer->takeFenceFD()
+#endif
+    };
 }
 
 void WebXRWebGLLayer::canvasResized(CanvasBase&)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1567,6 +1567,9 @@ public:
 #if ENABLE(WEBXR)
     virtual GCGLExternalSync createExternalSync(ExternalSyncSource&&) = 0;
     virtual void deleteExternalSync(GCGLExternalSync) = 0;
+#if USE(OPENXR)
+    virtual WTF::UnixFileDescriptor exportExternalSync(GCGLExternalSync) { return { }; }
+#endif
 #endif
 
     // ========== Extension related entry points.

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -95,6 +95,14 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
     GL_DeleteFramebuffers(1, &m_fbo);
 
     if (m_contextObj) {
+        for (auto* image : m_eglImages.values()) {
+            bool result = EGL_DestroyImageKHR(m_displayObj, image);
+            ASSERT_UNUSED(result, !!result);
+        }
+        for (auto* sync : m_eglSyncs.values()) {
+            bool result = EGL_DestroySync(m_displayObj, sync);
+            ASSERT_UNUSED(result, !!result);
+        }
         EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         EGL_DestroyContext(m_displayObj, m_contextObj);
     }
@@ -415,6 +423,40 @@ unsigned GraphicsContextGLTextureMapperANGLE::glVersion() const
 }
 
 #if ENABLE(WEBXR)
+GCGLExternalSync GraphicsContextGLTextureMapperANGLE::createExternalSync(ExternalSyncSource&&)
+{
+    const auto& display = PlatformDisplay::sharedDisplay();
+    if (!display.eglCheckVersion(1, 5) || !display.eglExtensions().ANDROID_native_fence_sync)
+        return { };
+
+    auto eglSync = EGL_CreateSync(m_displayObj, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
+    if (!eglSync) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return { };
+    }
+
+    GL_Flush();
+    auto newName = ++m_nextExternalSyncName;
+    m_eglSyncs.add(newName, eglSync);
+    return newName;
+}
+
+#if USE(OPENXR)
+UnixFileDescriptor GraphicsContextGLTextureMapperANGLE::exportExternalSync(GCGLExternalSync sync)
+{
+    if (!sync)
+        return { };
+
+    auto eglSync = m_eglSyncs.get(sync);
+    if (!eglSync) {
+        addError(GCGLErrorCode::InvalidOperation);
+        return { };
+    }
+
+    return UnixFileDescriptor { EGL_DupNativeFenceFDANDROID(m_displayObj, eglSync), UnixFileDescriptor::Adopt };
+}
+#endif
+
 bool GraphicsContextGLTextureMapperANGLE::addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>)
 {
     return false;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -30,6 +30,10 @@
 #include "GLContextWrapper.h"
 #include "GraphicsContextGLANGLE.h"
 
+#if ENABLE(WEBXR) && USE(OPENXR)
+#include <wtf/unix/UnixFileDescriptor.h>
+#endif
+
 namespace WebCore {
 
 class TextureMapperGCGLPlatformLayer;
@@ -51,7 +55,13 @@ public:
 
     bool reshapeDrawingBuffer() override;
     void prepareForDisplay() override;
+
 #if ENABLE(WEBXR)
+    GCGLExternalSync createExternalSync(ExternalSyncSource&&) final;
+#if USE(OPENXR)
+    WTF::UnixFileDescriptor exportExternalSync(GCGLExternalSync) final;
+#endif
+
     bool addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>) final;
     void enableFoveation(GCGLuint) final;
     void disableFoveation() final;

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -426,6 +426,9 @@ public:
         LayerHandle handle { 0 };
         bool visible { true };
         Vector<LayerView> views;
+#if USE(OPENXR)
+        WTF::UnixFileDescriptor fenceFD;
+#endif
     };
 
     struct ViewData {

--- a/Source/WebKit/Shared/XR/XRDeviceLayer.h
+++ b/Source/WebKit/Shared/XR/XRDeviceLayer.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBXR) && USE(OPENXR)
 
 #include <WebCore/PlatformXR.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebKit {
 
@@ -35,6 +36,7 @@ struct XRDeviceLayer {
     PlatformXR::LayerHandle handle;
     bool visible;
     Vector<PlatformXR::Device::LayerView> views;
+    WTF::UnixFileDescriptor fenceFD;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -38,6 +38,7 @@ struct WebKit::XRDeviceLayer {
     PlatformXR::LayerHandle handle;
     bool visible;
     Vector<PlatformXR::Device::LayerView> views;
+    WTF::UnixFileDescriptor fenceFD;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -36,6 +36,7 @@
 #endif
 #include <WebCore/GLContext.h>
 #include <WebCore/GLDisplay.h>
+#include <WebCore/GLFence.h>
 #include <openxr/openxr_platform.h>
 #include <wtf/RunLoop.h>
 #include <wtf/WorkQueue.h>
@@ -789,6 +790,12 @@ void OpenXRCoordinator::endFrame(Box<RenderState> renderState, Vector<XRDeviceLa
             LOG(XR, "Didn't find a OpenXRLayer with %d handle", layer.handle);
             continue;
         }
+
+        if (layer.fenceFD) {
+            if (auto fence = WebCore::GLFence::importFD(*m_glDisplay, WTFMove(layer.fenceFD)))
+                fence->serverWait();
+        }
+
         auto header = it->value->endFrame(layer, m_localSpace, m_views);
         if (!header) {
             LOG(XR, "endFrame() call failed in OpenXRLayer with %d handle", layer.handle);

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -130,7 +130,8 @@ void PlatformXRSystemProxy::submitFrame(Vector<PlatformXR::Device::Layer>&& laye
         deviceLayers.append(WebKit::XRDeviceLayer {
             .handle = layer.handle,
             .visible = layer.visible,
-            .views = layer.views
+            .views = layer.views,
+            .fenceFD = WTFMove(layer.fenceFD)
         });
     }
     protectedPage()->send(Messages::PlatformXRSystem::SubmitFrame(WTFMove(deviceLayers)));


### PR DESCRIPTION
#### b50c48fd07c7c53424ac797ef8bafc11a81f2b7c
<pre>
[WebXR][OpenXR] Add EGL fences for WebGL content
<a href="https://bugs.webkit.org/show_bug.cgi?id=297140">https://bugs.webkit.org/show_bug.cgi?id=297140</a>

Reviewed by Nikolas Zimmermann.

Currently there is no guarantee that the WebXR WebGL frames are
completely rendered before they&apos;re submitted to the OpenXR compositor.
That&apos;s why the WebXROpaqueFramebuffer does a glFinish(), blocking the
WebProcess before returning from endFrame.

A much better solution is to use EGL fences. The WebProcess will
create a fence in endFrame(). Then that fence is exported and shared
to the UI process (via a file descriptor) in the submitFrame() call.

The UI process then will call wait in the fence before submitting
the frame to OpenXR. Although OpenXR runtimes guarantee that all the
GPU commands are finished before displaying the contents of the
textures, that does not apply to the cases in which there are multiple
contexts accessing the texture, as it happens in WebKit due to the
multiprocess architecture.

Co-authored-by: Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;
Canonical link: <a href="https://commits.webkit.org/299154@main">https://commits.webkit.org/299154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46b6c50b5dca20e9b835bafc57ae145b55d428da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89582 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23969 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127279 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98040 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41387 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18813 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50497 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->