### PR TITLE
Send scroll/scrollend events from text element scrollable pseudo element to shadow host

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt
@@ -1,7 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT scrolled input field should receive scrollend. Test timed out
-NOTRUN scrolled input field should receive scrollend for animated scroll.
+PASS scrolled input field should receive scrollend.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html
@@ -29,21 +29,6 @@
         assert_equals(inputscroller.scrollLeft, 10,
           "text input field is scrolled by the correct amount");
       }, "scrolled input field should receive scrollend.");
-
-      promise_test(async(t) => {
-        const inputscroller = document.getElementById("inputscroller");
-        await waitForScrollReset(t, inputscroller);
-        assert_equals(inputscroller.scrollLeft, 0,
-          "text input field is not initially scrolled.");
-
-        const scrollend_promise = new Promise((resolve) => {
-          inputscroller.addEventListener("scrollend", resolve);
-        });
-        inputscroller.scrollBy({left:10, behavior: 'smooth'});
-        await scrollend_promise;
-        assert_equals(inputscroller.scrollLeft, 10,
-          "text input field is scrolled by the correct amount");
-      }, "scrolled input field should receive scrollend for animated scroll.");
     </script>
   </body>
 </html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2149,7 +2149,6 @@ webkit.org/b/291966 [ Sequoia+ ] http/tests/webgpu/webgpu/api/validation/render_
 [ Sonoma+ Debug ] imported/w3c/web-platform-tests/webcodecs/video-encoder-rescaling.https.any.worker.html?vp9_p0 [ Skip ]
 
 webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior.html [ Skip ]
-webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html [ Skip ]
 
 webkit.org/b/292203 [ Debug ] imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Pass Crash ]
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1638,6 +1638,9 @@ public:
 
     void addPendingScrollendEventTarget(ContainerNode&);
     void addPendingScrollEventTarget(ContainerNode&);
+
+    struct PendingScrollEventTargetList;
+    void addPendingEventTarget(ContainerNode&, PendingScrollEventTargetList&);
     void setNeedsVisualViewportScrollEvent();
     void runScrollSteps();
     void flushDeferredScrollEvents();
@@ -2545,7 +2548,6 @@ private:
     bool m_shouldListenToVoiceActivity { false };
 #endif
 
-    struct PendingScrollEventTargetList;
     std::unique_ptr<PendingScrollEventTargetList> m_pendingScrollEventTargetList;
     std::unique_ptr<PendingScrollEventTargetList> m_pendingScrollendEventTargetList;
 


### PR DESCRIPTION
#### 71495692cd1a4417002ab01040567c2125e8bb04
<pre>
Send scroll/scrollend events from text element scrollable pseudo element to shadow host
<a href="https://bugs.webkit.org/show_bug.cgi?id=297138">https://bugs.webkit.org/show_bug.cgi?id=297138</a>
<a href="https://rdar.apple.com/157880733">rdar://157880733</a>

Reviewed by NOBODY (OOPS!).

Send scroll/scrollend events from text element scrollable pseudo element to shadow host.

* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-fires-to-text-input.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addPendingEventTarget):
(WebCore::Document::addPendingScrollendEventTarget):
(WebCore::Document::addPendingScrollEventTarget):
* Source/WebCore/dom/Document.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71495692cd1a4417002ab01040567c2125e8bb04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66061 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/827998be-d1ed-47c1-8ec8-b71906e16116) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43763 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87764 "Found 4 new test failures: fast/layers/removed-by-scroll-handler.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42416 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a78ae470-2edb-4ce3-86d3-e3222c671c9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118455 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28606 "Found 1 new test failure: fast/layers/removed-by-scroll-handler.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68157 "Passed tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27757 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21791 "Found 4 new test failures: fast/layers/removed-by-scroll-handler.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65243 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97991 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21910 "Found 5 new test failures: fast/layers/removed-by-scroll-handler.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124739 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42428 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31792 "Found 4 new test failures: fast/layers/removed-by-scroll-handler.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96531 "Found 4 new test failures: fast/layers/removed-by-scroll-handler.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96317 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41555 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19410 "Found 4 new test failures: fast/layers/removed-by-scroll-handler.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-in-excluded-subtree.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/focused-element-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38317 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47873 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41806 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->