### PR TITLE
Safari becomes unresponsive randomly and have to force quit

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -94,6 +94,7 @@ public:
     double knobAlpha();
     double trackAlpha();
     bool hasScrollerImp();
+    RecursiveLock& scrollerImpLock() const { return m_scrollerImpLock; }
 
 private:
     int m_minimumKnobLength { 0 };

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -389,7 +389,6 @@ void ScrollerMac::updateScrollbarStyle()
     Locker locker { m_scrollerImpLock };
 
     RefPtr pair = m_pair.get();
-
     setScrollerImp([NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(pair->scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(pair->scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil]);
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
 
@@ -491,6 +490,7 @@ void ScrollerMac::setScrollbarLayoutDirection(UserInterfaceLayoutDirection scrol
 
     if (m_scrollbarLayoutDirection == scrollbarLayoutDirection)
         return;
+
     m_scrollbarLayoutDirection = scrollbarLayoutDirection;
     updateScrollbarStyle();
     [m_scrollerImp setUserInterfaceLayoutDirection: scrollbarLayoutDirection == UserInterfaceLayoutDirection::RTL ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight];

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -125,6 +125,7 @@ public:
 
     void setScrollbarWidth(ScrollbarWidth);
 
+    void updateScrollbarPainters();
 private:
     ScrollerPairMac(ScrollingTreeScrollingNode&);
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -31,6 +31,7 @@
 #import "Logging.h"
 #import "ScrollTypesMac.h"
 #import "ScrollingTreeFrameScrollingNode.h"
+#import <QuartzCore/QuartzCore.h>
 #import <WebCore/FloatPoint.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/NSScrollerImpDetails.h>
@@ -448,6 +449,24 @@ void ScrollerPairMac::scrollbarColorChanged(const std::optional<ScrollbarColor>&
 {
     checkedHorizontalScroller()->scrollbarColorChanged(scrollbarColor);
     checkedVerticalScroller()->scrollbarColorChanged(scrollbarColor);
+}
+
+void ScrollerPairMac::updateScrollbarPainters()
+{
+    Locker lockerHorizontal { horizontalScroller().scrollerImpLock() };
+    Locker lockerVertical { verticalScroller().scrollerImpLock() };
+
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    [CATransaction lock];
+
+    auto horizontalValues = valuesForOrientation(ScrollbarOrientation::Horizontal);
+    setHorizontalScrollbarPresentationValue(horizontalValues.value);
+
+    auto verticalValues = valuesForOrientation(ScrollbarOrientation::Vertical);
+    setVerticalScrollbarPresentationValue(verticalValues.value);
+
+    [CATransaction unlock];
+    END_BLOCK_OBJC_EXCEPTIONS
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -313,19 +313,8 @@ void ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged(bool inRub
 
 void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters()
 {
-    if (m_inMomentumPhase && m_scrollerPair->hasScrollerImp() && m_scrollerPair->isUsingPresentationValues()) {
-        BEGIN_BLOCK_OBJC_EXCEPTIONS
-        [CATransaction lock];
-
-        auto horizontalValues = m_scrollerPair->valuesForOrientation(ScrollbarOrientation::Horizontal);
-        m_scrollerPair->setHorizontalScrollbarPresentationValue(horizontalValues.value);
-
-        auto verticalValues = m_scrollerPair->valuesForOrientation(ScrollbarOrientation::Vertical);
-        m_scrollerPair->setVerticalScrollbarPresentationValue(verticalValues.value);
-
-        [CATransaction unlock];
-        END_BLOCK_OBJC_EXCEPTIONS
-    }
+    if (m_inMomentumPhase && m_scrollerPair->hasScrollerImp() && m_scrollerPair->isUsingPresentationValues())
+        m_scrollerPair->updateScrollbarPainters();
 }
 
 void ScrollingTreeScrollingNodeDelegateMac::initScrollbars()


### PR DESCRIPTION
#### eccf91f3259b012fae8a0f9dc443203613a0f49c
<pre>
Safari becomes unresponsive randomly and have to force quit
<a href="https://bugs.webkit.org/show_bug.cgi?id=295725">https://bugs.webkit.org/show_bug.cgi?id=295725</a>
<a href="https://rdar.apple.com/155476877">rdar://155476877</a>

Reviewed by Simon Fraser.

Fix deadlock by ensuring that the scroller imp lock is aquired before
aquiring the CATransaction lock.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::updateScrollbarPainters):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters):

Originally-landed-as: 289651.602@safari-7621-branch (b3d23a36bb4b). <a href="https://rdar.apple.com/157788100">rdar://157788100</a>
Canonical link: <a href="https://commits.webkit.org/298868@main">https://commits.webkit.org/298868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c37b0a0f008b33ca286545848794a2605a06dba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68910 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d1d3730-71b0-47a0-aba3-f0d9d65bffdd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88769 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1dc3f903-0d66-4476-810c-2dff01d1a67a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69228 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22957 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66624 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97436 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97235 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42560 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40176 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49264 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43135 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44840 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->