### PR TITLE
RemoteGraphicsContextGL should copy GLenum arrays

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -443,6 +443,41 @@ void RemoteGraphicsContextGL::multiDrawElementsInstancedBaseVertexBaseInstanceAN
     protectedContext()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), baseVertices.span().data(), baseInstances.span().data(), counts.size() }, type);
 }
 
+void RemoteGraphicsContextGL::drawBuffers(std::span<const uint32_t> bufs)
+{
+    assertIsCurrent(workQueue());
+    protectedContext()->drawBuffers(Vector(bufs));
+}
+
+void RemoteGraphicsContextGL::drawBuffersEXT(std::span<const uint32_t> bufs)
+{
+    assertIsCurrent(workQueue());
+    protectedContext()->drawBuffersEXT(Vector(bufs));
+}
+
+void RemoteGraphicsContextGL::invalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
+{
+    assertIsCurrent(workQueue());
+    protectedContext()->invalidateFramebuffer(target, Vector(attachments));
+}
+
+void RemoteGraphicsContextGL::invalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    assertIsCurrent(workQueue());
+    protectedContext()->invalidateSubFramebuffer(target, Vector(attachments), x, y, width, height);
+}
+
+#if ENABLE(WEBXR)
+
+void RemoteGraphicsContextGL::framebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
+{
+    assertIsCurrent(workQueue());
+    messageCheck(webXRPromptAccepted());
+    protectedContext()->framebufferDiscard(target, Vector(attachments));
+}
+
+#endif
+
 RefPtr<RemoteGraphicsContextGL::GCGLContext> RemoteGraphicsContextGL::protectedContext()
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -148,6 +148,13 @@ protected:
     void multiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t>&& countsOffsetsAndInstanceCounts, uint32_t type);
     void multiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t>&& firstsCountsInstanceCountsAndBaseInstances);
     void multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t>&& countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type);
+    void drawBuffers(std::span<const uint32_t>);
+    void drawBuffersEXT(std::span<const uint32_t>);
+    void invalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments);
+    void invalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height);
+#if ENABLE(WEBXR)
+    void framebufferDiscard(uint32_t target, std::span<const uint32_t> attachments);
+#endif
 
 #if ENABLE(VIDEO)
     Ref<RemoteVideoFrameObjectHeap> protectedVideoFrameObjectHeap() const;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -65,6 +65,13 @@ messages -> RemoteGraphicsContextGL Stream {
     void MultiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> countsOffsetsAndInstanceCounts, uint32_t type)
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
+    void DrawBuffers(std::span<const uint32_t> bufs)
+    void DrawBuffersEXT(std::span<const uint32_t> bufs)
+    void InvalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
+    void InvalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
+#if ENABLE(WEBXR)
+    void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
+#endif
 
     void ActiveTexture(uint32_t texture)
     void AttachShader(uint32_t program, uint32_t shader)
@@ -219,8 +226,6 @@ messages -> RemoteGraphicsContextGL Stream {
     void CopyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
     void BlitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     void FramebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
-    void InvalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
-    void InvalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
     void ReadBuffer(uint32_t src)
     void RenderbufferStorageMultisample(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
     void TexStorage2D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height)
@@ -255,7 +260,6 @@ messages -> RemoteGraphicsContextGL Stream {
     void VertexAttribI4uiv(uint32_t index, std::span<const uint32_t, 4> values)
     void VertexAttribIPointer(uint32_t index, int32_t size, uint32_t type, int32_t stride, uint64_t offset)
     void DrawRangeElements(uint32_t mode, uint32_t start, uint32_t end, int32_t count, uint32_t type, uint64_t offset)
-    void DrawBuffers(std::span<const uint32_t> bufs)
     void ClearBufferiv(uint32_t buffer, int32_t drawbuffer, std::span<const int32_t> values)
     void ClearBufferuiv(uint32_t buffer, int32_t drawbuffer, std::span<const uint32_t> values)
     void ClearBufferfv(uint32_t buffer, int32_t drawbuffer, std::span<const float> values)
@@ -300,7 +304,6 @@ messages -> RemoteGraphicsContextGL Stream {
     void UniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
     void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize) -> (std::span<const int32_t> params) Synchronous
     void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (String returnValue) Synchronous
-    void DrawBuffersEXT(std::span<const uint32_t> bufs)
     void CreateQueryEXT(uint32_t queryEXT)
     void DeleteQueryEXT(uint32_t query)
     void IsQueryEXT(uint32_t query) -> (bool returnValue) Synchronous
@@ -339,7 +342,6 @@ messages -> RemoteGraphicsContextGL Stream {
     [EnabledBy=WebXREnabled] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
     [EnabledBy=WebXREnabled] void EnableFoveation(uint32_t arg0)
     [EnabledBy=WebXREnabled] void DisableFoveation()
-    [EnabledBy=WebXREnabled] void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
     [EnabledBy=WebXREnabled] void FramebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
 #endif
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1188,16 +1188,6 @@
             texture = m_objectNames.get(texture);
         protectedContext()->framebufferTextureLayer(target, attachment, texture, level, layer);
     }
-    void invalidateFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments)
-    {
-        assertIsCurrent(workQueue());
-        protectedContext()->invalidateFramebuffer(target, attachments);
-    }
-    void invalidateSubFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments, int32_t x, int32_t y, int32_t width, int32_t height)
-    {
-        assertIsCurrent(workQueue());
-        protectedContext()->invalidateSubFramebuffer(target, attachments, x, y, width, height);
-    }
     void readBuffer(uint32_t src)
     {
         assertIsCurrent(workQueue());
@@ -1375,11 +1365,6 @@
     {
         assertIsCurrent(workQueue());
         protectedContext()->drawRangeElements(mode, start, end, count, type, static_cast<GCGLintptr>(offset));
-    }
-    void drawBuffers(std::span<const uint32_t>&& bufs)
-    {
-        assertIsCurrent(workQueue());
-        protectedContext()->drawBuffers(bufs);
     }
     void clearBufferiv(uint32_t buffer, int32_t drawbuffer, std::span<const int32_t>&& values)
     {
@@ -1810,11 +1795,6 @@
         returnValue = protectedContext()->getTranslatedShaderSourceANGLE(arg0);
         completionHandler(WTFMove(returnValue));
     }
-    void drawBuffersEXT(std::span<const uint32_t>&& bufs)
-    {
-        assertIsCurrent(workQueue());
-        protectedContext()->drawBuffersEXT(bufs);
-    }
     void createQueryEXT(uint32_t name)
     {
         assertIsCurrent(workQueue());
@@ -2100,12 +2080,6 @@
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
         protectedContext()->disableFoveation();
-    }
-    void framebufferDiscard(uint32_t target, std::span<const uint32_t>&& attachments)
-    {
-        assertIsCurrent(workQueue());
-        messageCheck(webXRPromptAccepted());
-        protectedContext()->framebufferDiscard(target, attachments);
     }
     void framebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -461,6 +461,63 @@ void RemoteGraphicsContextGLProxy::multiDrawElementsInstancedBaseVertexBaseInsta
     }
 }
 
+void RemoteGraphicsContextGLProxy::drawBuffers(std::span<const GCGLenum> bufs)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(bufs));
+    if (sendResult != IPC::Error::NoError) {
+        markContextLost();
+        return;
+    }
+}
+
+void RemoteGraphicsContextGLProxy::drawBuffersEXT(std::span<const GCGLenum> bufs)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(bufs));
+    if (sendResult != IPC::Error::NoError) {
+        markContextLost();
+        return;
+    }
+}
+
+void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, attachments));
+    if (sendResult != IPC::Error::NoError) {
+        markContextLost();
+        return;
+    }
+}
+
+void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, attachments, x, y, width, height));
+    if (sendResult != IPC::Error::NoError) {
+        markContextLost();
+        return;
+    }
+}
+
+#if ENABLE(WEBXR)
+void RemoteGraphicsContextGLProxy::framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferDiscard(target, attachments));
+    if (sendResult != IPC::Error::NoError) {
+        markContextLost();
+        return;
+    }
+}
+#endif
+
 void RemoteGraphicsContextGLProxy::wasCreated(IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore, std::optional<RemoteGraphicsContextGLInitializationState>&& initializationState)
 {
     if (isContextLost())

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -98,6 +98,13 @@ public:
     void multiDrawElementsInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei> countsOffsetsAndInstanceCounts, GCGLenum type) final;
     void multiDrawArraysInstancedBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei, const GCGLuint> firstsCountsInstanceCountsAndBaseInstances) final;
     void multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei, const GCGLint, const GCGLuint> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, GCGLenum type) final;
+    void drawBuffers(std::span<const GCGLenum> bufs) final;
+    void drawBuffersEXT(std::span<const GCGLenum> bufs) final;
+    void invalidateFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments) final;
+    void invalidateSubFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height) final;
+#if ENABLE(WEBXR)
+    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) final;
+#endif
 
     // Functions with a generated implementation. This list is used by generate-gpup-webgl script.
     void activeTexture(GCGLenum texture) final;
@@ -253,8 +260,6 @@ public:
     void copyBufferSubData(GCGLenum readTarget, GCGLenum writeTarget, GCGLintptr readOffset, GCGLintptr writeOffset, GCGLsizeiptr) final;
     void blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLint srcX1, GCGLint srcY1, GCGLint dstX0, GCGLint dstY0, GCGLint dstX1, GCGLint dstY1, GCGLbitfield mask, GCGLenum filter) final;
     void framebufferTextureLayer(GCGLenum target, GCGLenum attachment, PlatformGLObject texture, GCGLint level, GCGLint layer) final;
-    void invalidateFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments) final;
-    void invalidateSubFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height) final;
     void readBuffer(GCGLenum src) final;
     void renderbufferStorageMultisample(GCGLenum target, GCGLsizei samples, GCGLenum internalformat, GCGLsizei width, GCGLsizei height) final;
     void texStorage2D(GCGLenum target, GCGLsizei levels, GCGLenum internalformat, GCGLsizei width, GCGLsizei height) final;
@@ -289,7 +294,6 @@ public:
     void vertexAttribI4uiv(GCGLuint index, std::span<const GCGLuint, 4> values) final;
     void vertexAttribIPointer(GCGLuint index, GCGLint size, GCGLenum type, GCGLsizei stride, GCGLintptr offset) final;
     void drawRangeElements(GCGLenum mode, GCGLuint start, GCGLuint end, GCGLsizei count, GCGLenum type, GCGLintptr offset) final;
-    void drawBuffers(std::span<const GCGLenum> bufs) final;
     void clearBufferiv(GCGLenum buffer, GCGLint drawbuffer, std::span<const GCGLint> values) final;
     void clearBufferuiv(GCGLenum buffer, GCGLint drawbuffer, std::span<const GCGLuint> values) final;
     void clearBufferfv(GCGLenum buffer, GCGLint drawbuffer, std::span<const GCGLfloat> values) final;
@@ -334,7 +338,6 @@ public:
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
     void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
     String getTranslatedShaderSourceANGLE(PlatformGLObject arg0) final;
-    void drawBuffersEXT(std::span<const GCGLenum> bufs) final;
     PlatformGLObject createQueryEXT() final;
     void deleteQueryEXT(PlatformGLObject query) final;
     GCGLboolean isQueryEXT(PlatformGLObject query) final;
@@ -375,7 +378,6 @@ public:
     bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
     void enableFoveation(PlatformGLObject arg0) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
     void disableFoveation() IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
-    void framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
     void framebufferResolveRenderbuffer(GCGLenum target, GCGLenum attachment, GCGLenum renderbuffertarget, PlatformGLObject arg3) IPC_MESSAGE_CHECK(webXRPromptAccepted()) final;
 #endif
     // End of list used by generate-gpup-webgl script.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -1803,28 +1803,6 @@ void RemoteGraphicsContextGLProxy::framebufferTextureLayer(GCGLenum target, GCGL
     }
 }
 
-void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments)
-{
-    if (isContextLost())
-        return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, attachments));
-    if (sendResult != IPC::Error::NoError) {
-        markContextLost();
-        return;
-    }
-}
-
-void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments, GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height)
-{
-    if (isContextLost())
-        return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, attachments, x, y, width, height));
-    if (sendResult != IPC::Error::NoError) {
-        markContextLost();
-        return;
-    }
-}
-
 void RemoteGraphicsContextGLProxy::readBuffer(GCGLenum src)
 {
     if (isContextLost())
@@ -2195,17 +2173,6 @@ void RemoteGraphicsContextGLProxy::drawRangeElements(GCGLenum mode, GCGLuint sta
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
-        markContextLost();
-        return;
-    }
-}
-
-void RemoteGraphicsContextGLProxy::drawBuffers(std::span<const GCGLenum> bufs)
-{
-    if (isContextLost())
-        return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(bufs));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2738,17 +2705,6 @@ String RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLOb
     return returnValue;
 }
 
-void RemoteGraphicsContextGLProxy::drawBuffersEXT(std::span<const GCGLenum> bufs)
-{
-    if (isContextLost())
-        return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(bufs));
-    if (sendResult != IPC::Error::NoError) {
-        markContextLost();
-        return;
-    }
-}
-
 PlatformGLObject RemoteGraphicsContextGLProxy::createQueryEXT()
 {
     if (isContextLost())
@@ -3153,17 +3109,6 @@ void RemoteGraphicsContextGLProxy::disableFoveation()
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableFoveation());
-    if (sendResult != IPC::Error::NoError) {
-        markContextLost();
-        return;
-    }
-}
-
-void RemoteGraphicsContextGLProxy::framebufferDiscard(GCGLenum target, std::span<const GCGLenum> attachments)
-{
-    if (isContextLost())
-        return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferDiscard(target, attachments));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -86,8 +86,12 @@ context_messages_template = (
     template_preamble
     + """#if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
-[EnabledBy=WebGLEnabled && UseGPUProcessForWebGLEnabled]
-messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
+[
+    DispatchedFrom=WebContent,
+    DispatchedTo=GPU,
+    EnabledBy=WebGLEnabled && UseGPUProcessForWebGLEnabled
+]
+messages -> RemoteGraphicsContextGL Stream {{
     void Reshape(int32_t width, int32_t height)
 #if PLATFORM(COCOA)
     void PrepareForDisplay(IPC::Semaphore finishedFence) -> (MachSendRight displayBuffer) Synchronous NotStreamEncodable NotStreamEncodableReply
@@ -105,7 +109,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void DrawSurfaceBufferToImageBuffer(enum:bool WebCore::GraphicsContextGLSurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    void SurfaceBufferToVideoFrame(enum:bool WebCore::GraphicsContextGLSurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxyProperties> properties) Synchronous
+    void SurfaceBufferToVideoFrame(enum:bool WebCore::GraphicsContextGLSurfaceBuffer buffer) -> (struct std::optional<WebKit::RemoteVideoFrameProxyProperties> properties) Synchronous
 #endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
@@ -123,6 +127,13 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void MultiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t> countsOffsetsAndInstanceCounts, uint32_t type)
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
+    void DrawBuffers(std::span<const uint32_t> bufs)
+    void DrawBuffersEXT(std::span<const uint32_t> bufs)
+    void InvalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
+    void InvalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
+#if ENABLE(WEBXR)
+    [EnabledBy=WebXREnabled] void FramebufferDiscard(uint32_t target, std::span<const uint32_t> attachments)
+#endif
 {}
 }}
 
@@ -136,6 +147,8 @@ context_proxy_functions_template = (
     + """
 #include "config.h"
 #include "RemoteGraphicsContextGLProxy.h"
+
+#include <wtf/StdLibExtras.h>
 
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
@@ -761,7 +774,7 @@ class webkit_ipc_cpp_proxy_impl(object):
                 if o.type.is_dynamic_span():
                     self.in_exprs += [cpp_expr(get_cpp_type("size_t"), f"{o.name}.size()")]
                 self.post_call_stmts += [
-                    f"memcpy({o.name}.data(), {v.name}.data(), {o.name}.size() * sizeof({str(webkit_ipc_type.get_contained_type())}));"
+                    f"memcpySpan({o.name}, {v.name});"
                 ]
             else:
                 self.out_exprs += [cpp_expr(o.type, o.name)]


### PR DESCRIPTION
#### 5a63340b38600e28b633d722122e87857dda3f27
<pre>
RemoteGraphicsContextGL should copy GLenum arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=293116">https://bugs.webkit.org/show_bug.cgi?id=293116</a>
<a href="https://rdar.apple.com/148500598">rdar://148500598</a>

Reviewed by Mike Wyrzykowski.

Move drawBuffers, drawBuffersEXT, invalidateFramebuffer,
invalidateSubFramebuffer, framebufferDiscard to manual functions and
copy the enum arrays to Vectors before calling into ANGLE.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::drawBuffers):
(WebKit::RemoteGraphicsContextGL::drawBuffersEXT):
(WebKit::RemoteGraphicsContextGL::invalidateFramebuffer):
(WebKit::RemoteGraphicsContextGL::invalidateSubFramebuffer):
(WebKit::RemoteGraphicsContextGL::framebufferDiscard):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(framebufferTextureLayer):
(drawRangeElements):
(getTranslatedShaderSourceANGLE):
(disableFoveation):
(invalidateFramebuffer): Deleted.
(invalidateSubFramebuffer): Deleted.
(drawBuffers): Deleted.
(drawBuffersEXT): Deleted.
(framebufferDiscard): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::drawBuffers):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffersEXT):
(WebKit::RemoteGraphicsContextGLProxy::invalidateFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::invalidateSubFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::framebufferDiscard):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::invalidateFramebuffer): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::invalidateSubFramebuffer): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::drawBuffers): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::drawBuffersEXT): Deleted.
(WebKit::RemoteGraphicsContextGLProxy::framebufferDiscard): Deleted.
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_cpp_proxy_impl.process_out_args):

Originally-landed-as: 289651.532@safari-7621-branch (726be12b8c74). <a href="https://rdar.apple.com/157791727">rdar://157791727</a>
Canonical link: <a href="https://commits.webkit.org/298468@main">https://commits.webkit.org/298468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b14752ef99298fe7fc05dbb288cefbc189dc4479

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66070 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fa4cec44-7ede-4271-aa6a-5afbe8c4ae12) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87759 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5be1bc7b-700d-448a-bde5-ad0f8f474de8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68152 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21798 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65251 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/97989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124747 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96536 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24519 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19417 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42319 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47881 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41814 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43530 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->