### PR TITLE
AX: move AXObjectCache::postNotification code inside the accessibility directory

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -419,13 +419,19 @@ public:
     void childrenChanged(AccessibilityObject*);
     void onDetailsSummarySlotChange(const HTMLDetailsElement&);
     void onDragElementChanged(Element* oldElement, Element* newElement);
+    void onDraggingStarted(Element&);
+    void onDraggingEnded(Element&);
+    void onDraggingEnteredDropZone(Element&);
+    void onDraggingExitedDropZone(Element&);
+    void onDraggingDropped(Element&);
     void onEventListenerAdded(Node&, const AtomString& eventType);
     void onEventListenerRemoved(Node&, const AtomString& eventType);
     void onFocusChange(Element* oldElement, Element* newElement);
     void onInertOrVisibilityChange(RenderElement&);
     void onPopoverToggle(const HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
-    void onSelectedChanged(Element&);
+    void onSelectedOptionChanged(Element&);
+    void onSelectedOptionChanged(RenderObject&, int);
     void onSelectedTextChanged(const VisiblePositionRange&, AccessibilityObject* = nullptr);
     void onSlottedContentChange(const HTMLSlotElement&);
     void onStyleChange(Element&, OptionSet<Style::Change>, const RenderStyle* oldStyle, const RenderStyle* newStyle);
@@ -448,7 +454,6 @@ public:
     void autofillTypeChanged(HTMLInputElement&);
     void handleRoleChanged(AccessibilityObject&, AccessibilityRole previousRole);
     void handleReferenceTargetChanged();
-    void handlePageEditibilityChanged(Document&);
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void columnIndexChanged(AccessibilityObject&);
@@ -465,6 +470,14 @@ public:
     void updateLoadingProgress(double);
     void loadingFinished() { updateLoadingProgress(1); }
     double loadingProgress() const { return m_loadingProgress; }
+
+    void onTopDocumentLoaded(RenderObject&);
+    void onNonTopDocumentLoaded(RenderObject&);
+    void handlePageEditibilityChanged(Document&);
+    void onAutocorrectionOccured(Element&);
+    void onEditableTextValueChanged(Node&);
+    void onDocumentInitialFocus(Node&);
+    void onLayoutComplete(RenderObject&);
 
     struct AttributeChange {
         WeakPtr<Element, WeakPtrImplWithEventTargetData> element { nullptr };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4292,13 +4292,10 @@ void Document::implicitClose()
         // This notification is now called AXNewDocumentLoadComplete because there are other handlers that will
         // catch new AND page history loads, and that uses AXLoadComplete
 
-        axObjectCache()->getOrCreate(renderView());
         if (isTopDocument())
-            axObjectCache()->postNotification(renderView(), AXNotification::NewDocumentLoadComplete);
+            axObjectCache()->onTopDocumentLoaded(*renderView());
         else {
-            // AXLoadComplete can only be posted on the top document, so if it's a document
-            // in an iframe that just finished loading, post AXLayoutComplete instead.
-            axObjectCache()->postNotification(renderView(), AXNotification::LayoutComplete);
+            axObjectCache()->onNonTopDocumentLoaded(*renderView());
         }
     }
 #endif

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -828,7 +828,7 @@ void Editor::respondToChangedContents(const VisibleSelection& endingSelection)
     if (AXObjectCache::accessibilityEnabled()) {
         RefPtr node = endingSelection.start().deprecatedNode();
         if (AXObjectCache* cache = document().existingAXObjectCache())
-            cache->postNotification(node.get(), AXNotification::ValueChanged, PostTarget::ObservableParent);
+            cache->onEditableTextValueChanged(*node.get());
     }
 
     updateMarkersForWordsAffectedByEditing(true);
@@ -3355,7 +3355,7 @@ void Editor::markAndReplaceFor(const SpellCheckRequest& request, const Vector<Te
 
                 if (AXObjectCache* cache = document->existingAXObjectCache()) {
                     if (RefPtr root = document->selection().selection().rootEditableElement())
-                        cache->postNotification(root.get(), AXNotification::AutocorrectionOccured);
+                        cache->onAutocorrectionOccured(*root.get());
                 }
 
                 // Skip all other results for the replaced text.

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -250,7 +250,7 @@ void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation a
     m_isSelected = selected;
 
     if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
-        cache->onSelectedChanged(*this);
+        cache->onSelectedOptionChanged(*this);
 }
 
 void HTMLOptionElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -697,8 +697,8 @@ void HTMLTextFormControlElement::setInnerTextValue(String&& value)
                     previousValue = renderText->textWithoutConvertingBackslashToYenSymbol();
             }
 #endif
-            if (AXObjectCache* cache = document().existingAXObjectCache())
-                cache->postNotification(this, AXNotification::ValueChanged, PostTarget::ObservableParent);
+            if (CheckedPtr cache = document().existingAXObjectCache())
+                cache->onEditableTextValueChanged(*this);
         }
 #endif
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2605,15 +2605,15 @@ bool EventHandler::dispatchDragEvent(const AtomString& eventType, Element& dragT
     if (CheckedPtr cache = frame->document()->existingAXObjectCache()) {
         auto& eventNames = WebCore::eventNames();
         if (eventType == eventNames.dragstartEvent)
-            cache->postNotification(&dragTarget, AXNotification::DraggingStarted);
+            cache->onDraggingStarted(dragTarget);
         else if (eventType == eventNames.dragendEvent)
-            cache->postNotification(&dragTarget, AXNotification::DraggingEnded);
+            cache->onDraggingEnded(dragTarget);
         else if (eventType == eventNames.dragenterEvent)
-            cache->postNotification(&dragTarget, AXNotification::DraggingEnteredDropZone);
+            cache->onDraggingEnteredDropZone(dragTarget);
         else if (eventType == eventNames.dragleaveEvent)
-            cache->postNotification(&dragTarget, AXNotification::DraggingExitedDropZone);
+            cache->onDraggingExitedDropZone(dragTarget);
         else if (eventType == eventNames.dropEvent)
-            cache->postNotification(&dragTarget, AXNotification::DraggingDropped);
+            cache->onDraggingDropped(dragTarget);
     }
 
     return dragEvent->defaultPrevented();

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -577,7 +577,7 @@ bool FocusController::setInitialFocus(FocusDirection direction, KeyboardEvent* p
     // of handleFocusedUIElementChanged, because this will send the notification even if the element is the same.
     RefPtr focusedOrMainFrame = this->focusedOrMainFrame();
     if (CheckedPtr cache = focusedOrMainFrame ? focusedOrMainFrame->document()->existingAXObjectCache() : nullptr)
-        cache->postNotification(focusedOrMainFrame->document(), AXNotification::FocusedUIElementChanged);
+        cache->onDocumentInitialFocus(*focusedOrMainFrame->document());
 
     return didAdvanceFocus;
 }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1302,7 +1302,7 @@ void LocalFrameView::didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bo
 
 #if PLATFORM(COCOA) || PLATFORM(WIN) || PLATFORM(GTK)
     if (CheckedPtr cache = document->existingAXObjectCache())
-        cache->postNotification(layoutRoot.get(), AXNotification::LayoutComplete);
+        cache->onLayoutComplete(*layoutRoot.get());
 #else
     UNUSED_PARAM(layoutRoot);
 #endif

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -453,9 +453,7 @@ void RenderMenuList::didUpdateActiveOption(int optionIndex)
     if (listIndex < 0 || listIndex >= static_cast<int>(selectElement().listItems().size()))
         return;
 
-    auto* axObject = axCache->get(this);
-    if (RefPtr menuList = dynamicDowncast<AccessibilityMenuList>(axObject))
-        menuList->didUpdateActiveOption(optionIndex);
+    axCache->onSelectedOptionChanged(*this, optionIndex);
 }
 
 String RenderMenuList::itemText(unsigned listIndex) const


### PR DESCRIPTION
#### 89801b35ee043e7e168adc2c19bb5d14704a7910
<pre>
AX: move AXObjectCache::postNotification code inside the accessibility directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=297150">https://bugs.webkit.org/show_bug.cgi?id=297150</a>
<a href="https://rdar.apple.com/157888495">rdar://157888495</a>

Reviewed by Tyler Wilcock.

Knowing which accessibility notification to fire is logic that belongs
in the accessibility module. Let&apos;s take the small amount of code that
posts a notification from somewhere else in WebCore, and change it to
call a specific, narrow function on AXObjectCache, and let
AXObjectCache post the notification.

As a follow-up, we&apos;ll be able to reduce the number of accessibility
files that much of the codebase needs to import.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onDraggingStarted):
(WebCore::AXObjectCache::onDraggingEnded):
(WebCore::AXObjectCache::onDraggingEnteredDropZone):
(WebCore::AXObjectCache::onDraggingExitedDropZone):
(WebCore::AXObjectCache::onDraggingDropped):
(WebCore::AXObjectCache::onTopDocumentLoaded):
(WebCore::AXObjectCache::onNonTopDocumentLoaded):
(WebCore::AXObjectCache::onAutocorrectionOccured):
(WebCore::AXObjectCache::onEditableTextValueChanged):
(WebCore::AXObjectCache::onDocumentInitialFocus):
(WebCore::AXObjectCache::onLayoutComplete):
(WebCore::AXObjectCache::onSelectedOptionChanged):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::onSelectedChanged): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::respondToChangedContents):
(WebCore::Editor::markAndReplaceFor):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::setSelectedState):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setInnerTextValue):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchDragEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setInitialFocus):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didLayout):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::didUpdateActiveOption):

Canonical link: <a href="https://commits.webkit.org/298476@main">https://commits.webkit.org/298476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b8c3d7e74ad79df2dc7abd3683d500fef5fdbc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35942 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124794 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96567 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41606 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19462 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38363 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47956 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41858 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->