### PR TITLE
[iOS] Remove a workaround added in 297668@main

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1278,14 +1278,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 #if HAVE(LIQUID_GLASS)
 
-@interface _UIScrollPocket : UIView
-- (void)invalidateAllElements;
-@end
-
-@interface UIScrollView (ScrollPocket_IPI)
-- (_UIScrollPocket *)_pocketForEdge:(UIRectEdge)edge makeIfNeeded:(BOOL)makeIfNeeded;
-@end
-
 @interface UIScrollView (Staging_155261419)
 - (void)_setPrefersSolidColorHardPocket:(BOOL)prefersSolidColorHardPocket forEdge:(UIRectEdge)edge;
 @end

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3529,38 +3529,7 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
             [_contentView becomeFirstResponder];
         _contentViewShouldBecomeFirstResponderAfterNavigationGesture = NO;
     }
-
-#if HAVE(LIQUID_GLASS)
-    [self _forceScrollPocketsToRecomputeElementRegions];
-#endif
 }
-
-#if HAVE(LIQUID_GLASS)
-
-- (void)_forceScrollPocketsToRecomputeElementRegions
-{
-    if (![_scrollView respondsToSelector:@selector(_pocketForEdge:makeIfNeeded:)])
-        return;
-
-    // FIXME: This is a temporary workaround for rdar://156271879, where the scroll pocket's
-    // element region does not update after the scroll view is reparented from the live swipe
-    // view back to the web view after a navigation swipe. This can be removed once
-    // rdar://156271879 is fixed.
-
-    for (auto edge : WebKit::allUIRectEdges) {
-        RetainPtr scrollPocket = [_scrollView _pocketForEdge:edge makeIfNeeded:NO];
-        if (!scrollPocket)
-            continue;
-
-        static BOOL canInvalidateAllElements = [scrollPocket respondsToSelector:@selector(invalidateAllElements)];
-        if (!canInvalidateAllElements)
-            return;
-
-        [scrollPocket invalidateAllElements];
-    }
-}
-
-#endif // HAVE(LIQUID_GLASS)
 
 - (void)_showPasswordViewWithDocumentName:(NSString *)documentName passwordHandler:(void (^)(NSString *))passwordHandler
 {


### PR DESCRIPTION
#### b82137bc2438e92ba49fd91ac4225deaa426f881
<pre>
[iOS] Remove a workaround added in 297668@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=297154">https://bugs.webkit.org/show_bug.cgi?id=297154</a>
<a href="https://rdar.apple.com/156271879">rdar://156271879</a>

Reviewed by Abrar Rahman Protyasha.

This workaround is no longer necessary, now that UIKit has disabled the scroll pocket element rect
cache. Remove the related WebKit workaround, along with relevant scroll view method forward
declarations.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _navigationGestureDidEnd]):
(-[WKWebView _forceScrollPocketsToRecomputeElementRegions]): Deleted.

Canonical link: <a href="https://commits.webkit.org/298451@main">https://commits.webkit.org/298451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e4fbc21f781d42ce0a269bcf0e36bb9cf623ef0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121604 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/988b9ee4-478c-4712-9b91-a9057a9e9b39) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43791 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9110420f-1491-4117-a1eb-1f17212161b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68170 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/27770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65277 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21938 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42452 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/31813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/124762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99891 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24506 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/41569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42338 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47901 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/41828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->