### PR TITLE
Fixes ModelProcess entity transform restoration after reload

### DIFF
--- a/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt
@@ -4,4 +4,5 @@ PASS <model> jump back to deferred when quickly scrolled through
 PASS <model> invalid state if usdz does not exist
 PASS <model> invalid state for incorrect usdz file
 PASS <model> reload visible model after source change
+PASS <model> stage-mode orbit survives multiple unload-reload cycles
 

--- a/LayoutTests/model-element/model-element-lazy-loading-unloading.html
+++ b/LayoutTests/model-element/model-element-lazy-loading-unloading.html
@@ -103,6 +103,46 @@ promise_test(async t => {
     await model.ready;
 }, `<model> reload visible model after source change`);
 
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/heart.usdz");
+    model.className = "model-element";
+    model.setAttribute("stage-mode", "orbit");
+
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    assert_true(internals.isModelElementIntersectingViewport(model), "first load viewport check");
+
+    await sleepForSeconds(0.5); // make sure entityTransform is synced
+    const firstLoadTransform = model.entityTransform;
+    assert_not_equals(firstLoadTransform, null, "entityTransform should not be null after first load");
+
+    window.scrollTo(0, 0);
+    await waitForModelState(model, "Unloaded");
+    assert_false(internals.isModelElementIntersectingViewport(model), "first unload viewport check");
+
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    assert_true(internals.isModelElementIntersectingViewport(model), "second load viewport check");
+
+    await sleepForSeconds(0.5); // make sure entityTransform is synced
+    const secondLoadTransform = model.entityTransform;
+    assert_not_equals(secondLoadTransform, null, "entityTransform should not be null after second load");
+    assert_equals(firstLoadTransform.toString(), secondLoadTransform.toString(), "entityTransform should be preserved after second load");
+
+    window.scrollTo(0, 0);
+    await waitForModelState(model, "Unloaded");
+    assert_false(internals.isModelElementIntersectingViewport(model), "second unload viewport check");
+
+    scrollElementIntoView(model);
+    await waitForModelState(model, "Loaded");
+    assert_true(internals.isModelElementIntersectingViewport(model), "third load viewport check");
+
+    await sleepForSeconds(0.5); // make sure entityTransform is synced
+    const thirdLoadTransform = model.entityTransform;
+    assert_not_equals(thirdLoadTransform, null, "entityTransform should not be null after third load");
+    assert_equals(firstLoadTransform.toString(), thirdLoadTransform.toString(), "entityTransform should be preserved after third load");
+
+}, `<model> stage-mode orbit survives multiple unload-reload cycles`);
 
 </script>
 </body>

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -634,6 +634,7 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
 
     if (m_entityTransformToRestore) {
         setEntityTransform(*m_entityTransformToRestore);
+        notifyModelPlayerOfEntityTransformChange();
         m_entityTransformToRestore = std::nullopt;
     } else {
         computeTransform(true);


### PR DESCRIPTION
#### f61a3c15f3268bed9cffd47a9853fe45d84a0b39
<pre>
Fixes ModelProcess entity transform restoration after reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=297152">https://bugs.webkit.org/show_bug.cgi?id=297152</a>
<a href="https://rdar.apple.com/157549103">rdar://157549103</a>

Reviewed by Ada Chan.

Add notifyModelPlayerOfEntityTransformChange() call after restoring
the entity transform to ensure proper synchronization between ModelProcess
and Web Content Process.

* LayoutTests/model-element/model-element-lazy-loading-unloading-expected.txt:
* LayoutTests/model-element/model-element-lazy-loading-unloading.html:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):

Canonical link: <a href="https://commits.webkit.org/298487@main">https://commits.webkit.org/298487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e0932be134ac5d6859f84614efb896404d6d27e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66102 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87799 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42434 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21848 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124784 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41595 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19452 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38355 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42371 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47943 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41848 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->