### PR TITLE
Serialize dNR rule identifiers in content extension rule lists

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1014,6 +1014,11 @@
 #define ENABLE_WK_WEB_EXTENSIONS 1
 #endif
 
+// When this is enabled, CurrentContentRuleListFileVersion and currentDeclarativeNetRequestRuleTranslatorVersion need to be bumped.
+#if !defined(ENABLE_DNR_ON_RULE_MATCHED_DEBUG)
+#define ENABLE_DNR_ON_RULE_MATCHED_DEBUG 0
+#endif
+
 #if !defined(ENABLE_WK_WEB_EXTENSIONS_ICON_VARIANTS)
 #define ENABLE_WK_WEB_EXTENSIONS_ICON_VARIANTS ENABLE_WK_WEB_EXTENSIONS
 #endif

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -877,6 +877,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     contentextensions/ContentExtensionStyleSheet.h
     contentextensions/ContentExtensionsBackend.h
     contentextensions/ContentExtensionsDebugging.h
+    contentextensions/ContentRuleListMatchedRule.h
     contentextensions/ContentRuleListResults.h
     contentextensions/DFA.h
     contentextensions/DFABytecode.h

--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -63,10 +63,14 @@ uint32_t ContentExtension::findFirstIgnoreRule() const
         if (serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnorePreviousRulesAction, ActionData> || serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnoreFollowingRulesAction, ActionData>)
             return currentActionIndex;
         currentActionIndex += DeserializedAction::serializedLength(serializedActions, currentActionIndex);
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+        // FIXME: <rdar://157879177> We shouldn't unconditionally add 4 bytes here to accomodate identifiers, as all rule lists do not serialize identifiers.
+        currentActionIndex += sizeof(uint32_t);
+#endif
     }
     return std::numeric_limits<uint32_t>::max();
 }
-    
+
 StyleSheetContents* ContentExtension::globalDisplayNoneStyleSheet()
 {
     return m_globalDisplayNoneStyleSheet.get();

--- a/Source/WebCore/contentextensions/ContentExtensionError.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionError.cpp
@@ -56,6 +56,12 @@ const std::error_category& contentExtensionErrorCategory()
                 return "Invalid object in the top level array.";
             case ContentExtensionError::JSONInvalidRule:
                 return "Invalid rule.";
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+            case ContentExtensionError::JSONInvalidRuleIdentifier:
+                return "Invalid rule identifier, which must be an integer.";
+            case ContentExtensionError::JSONRulesMissingIdentifier:
+                return "All rules must have an identifier or no identifiers.";
+#endif
             case ContentExtensionError::JSONContainsNoRules:
                 return "Empty extension.";
             case ContentExtensionError::JSONInvalidTrigger:

--- a/Source/WebCore/contentextensions/ContentExtensionError.h
+++ b/Source/WebCore/contentextensions/ContentExtensionError.h
@@ -37,13 +37,17 @@ namespace ContentExtensions {
 enum class ContentExtensionError {
     // JSON parser error
     JSONInvalid = 1,
-    
+
     // JSON semantics error
     JSONTopLevelStructureNotAnArray,
     JSONInvalidObjectInTopLevelArray,
     JSONInvalidRule,
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    JSONInvalidRuleIdentifier,
+    JSONRulesMissingIdentifier,
+#endif
     JSONContainsNoRules,
-    
+
     JSONInvalidTrigger,
     JSONInvalidURLFilterInTrigger,
     JSONInvalidTriggerFlagsArray,
@@ -53,7 +57,7 @@ enum class ContentExtensionError {
     JSONMultipleConditions,
     JSONTooManyRules,
     JSONInvalidRequestMethod,
-    
+
     JSONInvalidAction,
     JSONInvalidActionType,
     JSONInvalidCSSDisplayNoneActionType,

--- a/Source/WebCore/contentextensions/ContentExtensionRule.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.cpp
@@ -32,9 +32,16 @@
 
 namespace WebCore::ContentExtensions {
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+ContentExtensionRule::ContentExtensionRule(Trigger&& trigger, Action&& action, uint32_t identifier)
+#else
 ContentExtensionRule::ContentExtensionRule(Trigger&& trigger, Action&& action)
+#endif
     : m_trigger(WTFMove(trigger))
     , m_action(WTFMove(action))
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    , m_identifier(identifier)
+#endif
 {
     ASSERT(!m_trigger.urlFilter.isEmpty());
 }
@@ -87,7 +94,17 @@ DeserializedAction DeserializedAction::deserialize(std::span<const uint8_t> seri
 {
     auto serializedActionSize = serializedActions.size();
     RELEASE_ASSERT(location < serializedActionSize, location, serializedActionSize);
-    return { location, VariantDeserializer<ActionData>::deserialize(serializedActions.subspan(location + 1), serializedActions[location]) };
+
+    uint32_t identifier = location;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    // FIXME: <rdar://157879177> We shouldn't unconditionally deserialize an identifier here, as all rule lists do not serialize identifiers.
+    size_t identifierLocation = location + serializedLength(serializedActions, location);
+    RELEASE_ASSERT(identifierLocation < serializedActionSize);
+
+    identifier = reinterpretCastSpanStartTo<uint32_t>(serializedActions.subspan(identifierLocation));
+#endif
+
+    return { identifier, VariantDeserializer<ActionData>::deserialize(serializedActions.subspan(location + 1), serializedActions[location]) };
 }
 
 size_t DeserializedAction::serializedLength(std::span<const uint8_t> serializedActions, uint32_t location)

--- a/Source/WebCore/contentextensions/ContentExtensionRule.h
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.h
@@ -146,18 +146,32 @@ private:
 
 class ContentExtensionRule {
 public:
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    WEBCORE_EXPORT ContentExtensionRule(Trigger&&, Action&&, uint32_t identifier);
+
+    uint32_t identifier() const { return m_identifier; }
+
+    ContentExtensionRule isolatedCopy() const & { return { m_trigger.isolatedCopy(), m_action.isolatedCopy(), m_identifier }; }
+    ContentExtensionRule isolatedCopy() && { return { WTFMove(m_trigger).isolatedCopy(), WTFMove(m_action).isolatedCopy(), m_identifier }; }
+#else
     WEBCORE_EXPORT ContentExtensionRule(Trigger&&, Action&&);
+
+    ContentExtensionRule isolatedCopy() const & { return { m_trigger.isolatedCopy(), m_action.isolatedCopy() }; }
+    ContentExtensionRule isolatedCopy() && { return { WTFMove(m_trigger).isolatedCopy(), WTFMove(m_action).isolatedCopy() }; }
+#endif
 
     const Trigger& trigger() const { return m_trigger; }
     const Action& action() const { return m_action; }
 
-    ContentExtensionRule isolatedCopy() const & { return { m_trigger.isolatedCopy(), m_action.isolatedCopy() }; }
-    ContentExtensionRule isolatedCopy() && { return { WTFMove(m_trigger).isolatedCopy(), WTFMove(m_action).isolatedCopy() }; }
     friend bool operator==(const ContentExtensionRule&, const ContentExtensionRule&) = default;
 
 private:
     Trigger m_trigger;
     Action m_action;
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    uint32_t m_identifier;
+#endif
 };
 
 } // namespace WebCore::ContentExtensions

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -54,6 +54,10 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+#include "ContentRuleListMatchedRule.h"
+#endif
+
 namespace WebCore::ContentExtensions {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentExtensionsBackend);
@@ -316,6 +320,15 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
                     results.summary.redirectActions.append({ redirectAction, m_contentExtensions.get(contentRuleListIdentifier)->extensionBaseURL() });
                 }
             }), action.data());
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+            // FIXME: <rdar://157880177> Include the rest of the parameters on the ContentRuleListMatchedRule struct.
+            ContentRuleListMatchedRule matchedRule;
+            matchedRule.request.url = url.string();
+            matchedRule.rule.extensionId = contentRuleListIdentifier;
+            matchedRule.rule.ruleId = action.actionID();
+            page.chrome().client().contentRuleListMatchedRule(matchedRule);
+#endif
         }
 
         if (!actionsFromContentRuleList.sawIgnorePreviousRules) {

--- a/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
+++ b/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
@@ -1,0 +1,38 @@
+// Copyright © 2025  All rights reserved.
+
+#pragma once
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+
+#include <optional>
+
+namespace WebCore {
+
+struct ContentRuleListMatchedRule {
+    struct Request {
+        std::optional<String> documentId;
+        std::optional<String> documentLifecycle;
+        std::optional<double> frameId;
+        std::optional<String> frameType;
+        std::optional<String> initiator;
+        std::optional<String> method;
+        std::optional<String> parentDocumentId;
+        std::optional<double> parentFrameId;
+        std::optional<String> requestId;
+        std::optional<String> type;
+        std::optional<String> url;
+    };
+
+    struct MatchedRule {
+        std::optional<String> extensionId;
+        std::optional<double> ruleId;
+        std::optional<String> rulesetId;
+    };
+
+    Request request;
+    MatchedRule rule;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -145,6 +145,9 @@ struct AppHighlight;
 struct ApplePayAMSUIRequest;
 struct CharacterRange;
 struct ContactsRequestData;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
 struct ContentRuleListResults;
 struct DataDetectorElementInfo;
 struct DateTimeChooserParameters;
@@ -554,6 +557,10 @@ public:
     virtual void disableSuddenTermination() { }
 
     virtual void contentRuleListNotification(const URL&, const ContentRuleListResults&) { };
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    virtual void contentRuleListMatchedRule(const ContentRuleListMatchedRule&) { };
+#endif
 
 #if PLATFORM(WIN)
     virtual void AXStartFrameLoad() = 0;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6136,6 +6136,35 @@ struct WebCore::ContentRuleListResults {
 
 #endif
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+
+struct WebCore::ContentRuleListMatchedRule {
+    WebCore::ContentRuleListMatchedRule::Request request;
+    WebCore::ContentRuleListMatchedRule::MatchedRule rule;
+};
+
+[Nested] struct WebCore::ContentRuleListMatchedRule::Request {
+    std::optional<String> documentId;
+    std::optional<String> documentLifecycle;
+    std::optional<double> frameId;
+    std::optional<String> frameType;
+    std::optional<String> initiator;
+    std::optional<String> method;
+    std::optional<String> parentDocumentId;
+    std::optional<double> parentFrameId;
+    std::optional<String> requestId;
+    std::optional<String> type;
+    std::optional<String> url;
+};
+
+[Nested] struct WebCore::ContentRuleListMatchedRule::MatchedRule {
+    std::optional<String> extensionId;
+    std::optional<double> ruleId;
+    std::optional<String> rulesetId;
+};
+
+#endif
+
 enum class WebCore::PolicyAction : uint8_t {
     Use,
     Download,

--- a/Source/WebKit/UIProcess/API/APINavigationClient.h
+++ b/Source/WebKit/UIProcess/API/APINavigationClient.h
@@ -44,6 +44,9 @@
 #endif
 
 namespace WebCore {
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
 struct ContentRuleListResults;
 class ResourceError;
 class ResourceRequest;
@@ -133,8 +136,12 @@ public:
     {
         listener->use();
     }
-    
+
     virtual void contentRuleListNotification(WebKit::WebPageProxy&, WTF::URL&&, WebCore::ContentRuleListResults&&) { };
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    virtual void contentRuleListMatchedRule(WebKit::WebPageProxy&, WebCore::ContentRuleListMatchedRule&&) { };
+#endif
 
     virtual void shouldGoToBackForwardListItem(WebKit::WebPageProxy&, WebKit::WebBackForwardListItem&, bool inBackForwardCache, CompletionHandler<void(bool)>&& completionHandler)
     {

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -49,6 +49,9 @@ class Navigation;
 
 namespace WebCore {
 class SecurityOriginData;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
 }
 
 namespace WebKit {
@@ -154,6 +157,9 @@ private:
 
 #if ENABLE(CONTENT_EXTENSIONS)
         void contentRuleListNotification(WebPageProxy&, URL&&, WebCore::ContentRuleListResults&&) final;
+#endif
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+        void contentRuleListMatchedRule(WebPageProxy&, WebCore::ContentRuleListMatchedRule&&) final;
 #endif
         void decidePolicyForNavigationAction(WebPageProxy&, Ref<API::NavigationAction>&&, Ref<WebFramePolicyListenerProxy>&&) override;
         void decidePolicyForNavigationResponse(WebPageProxy&, Ref<API::NavigationResponse>&&, Ref<WebFramePolicyListenerProxy>&&) override;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -93,6 +93,10 @@
 #import "WebExtensionController.h"
 #endif
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+#import <WebCore/ContentRuleListMatchedRule.h>
+#endif
+
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
 #import <pal/ios/ManagedConfigurationSoftLink.h>
 #import <pal/spi/ios/ManagedConfigurationSPI.h>
@@ -756,6 +760,16 @@ void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy
         for (auto&& pair : WTFMove(results.results))
             [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() contentRuleListWithIdentifier:pair.first.createNSString().get() performedAction:wrapper(API::ContentRuleListAction::create(WTFMove(pair.second)).get()) forURL:url.createNSURL().get()];
     }
+}
+#endif
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+void NavigationState::NavigationClient::contentRuleListMatchedRule(WebPageProxy& page, WebCore::ContentRuleListMatchedRule&& matchedRule)
+{
+    if (!m_navigationState)
+        return;
+
+    // FIXME: rdar://157878200 (dNR: send a message from the navigation client to the web extensions controllers when a content extension rule matches)
 }
 #endif
     

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -449,6 +449,10 @@
 #include "ModelPresentationManagerProxy.h"
 #endif
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+#include <WebCore/ContentRuleListMatchedRule.h>
+#endif
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_URL_COROUTINE(process, url) MESSAGE_CHECK_BASE_COROUTINE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
@@ -8534,6 +8538,13 @@ void WebPageProxy::willSubmitForm(IPC::Connection& connection, FrameInfoData&& f
 void WebPageProxy::contentRuleListNotification(URL&& url, ContentRuleListResults&& results)
 {
     m_navigationClient->contentRuleListNotification(*this, WTFMove(url), WTFMove(results));
+}
+#endif
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+void WebPageProxy::contentRuleListMatchedRule(WebCore::ContentRuleListMatchedRule&& matchedRule)
+{
+    m_navigationClient->contentRuleListMatchedRule(*this, WTFMove(matchedRule));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -254,6 +254,9 @@ struct CompositionHighlight;
 struct CompositionUnderline;
 struct ContactInfo;
 struct ContactsRequestData;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
 struct ContentRuleListResults;
 struct CryptoKeyData;
 struct DataDetectorElementInfo;
@@ -2894,6 +2897,10 @@ private:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void contentRuleListNotification(URL&&, WebCore::ContentRuleListResults&&);
+#endif
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    void contentRuleListMatchedRule(WebCore::ContentRuleListMatchedRule&&);
 #endif
 
     // History client

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -483,6 +483,10 @@ messages -> WebPageProxy {
     ContentRuleListNotification(URL url, struct WebCore::ContentRuleListResults results)
 #endif
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    ContentRuleListMatchedRule(struct WebCore::ContentRuleListMatchedRule matchedRule)
+#endif
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
     AddPlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)
     RemovePlaybackTargetPickerClient(WebCore::PlaybackTargetClientContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -175,6 +175,10 @@
 #include <WebCore/Damage.h>
 #endif
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+#include <WebCore/ContentRuleListMatchedRule.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
@@ -1358,6 +1362,14 @@ void WebChromeClient::contentRuleListNotification(const URL& url, const ContentR
         page->send(Messages::WebPageProxy::ContentRuleListNotification(url, results));
 #endif
 }
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+void WebChromeClient::contentRuleListMatchedRule(const WebCore::ContentRuleListMatchedRule& matchedRule)
+{
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::ContentRuleListMatchedRule(matchedRule));
+}
+#endif
 
 bool WebChromeClient::layerTreeStateIsFrozen() const
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -40,6 +40,9 @@ enum class IsLoggedIn : uint8_t;
 enum class PointerLockRequestResult : uint8_t;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : uint8_t;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
 struct SystemPreviewInfo;
 struct TextRecognitionOptions;
 }
@@ -248,6 +251,10 @@ private:
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&) final;
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    void contentRuleListMatchedRule(const WebCore::ContentRuleListMatchedRule&) final;
+#endif
 
     bool testProcessIncomingSyncMessagesWhenWaitingForSyncReply() final;
 


### PR DESCRIPTION
#### 2c0f6fd37a286e28225a59ea83c9e6fb15a43298
<pre>
Serialize dNR rule identifiers in content extension rule lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=297155">https://bugs.webkit.org/show_bug.cgi?id=297155</a>
<a href="https://rdar.apple.com/157890918">rdar://157890918</a>

Reviewed by Brian Weinstein.

This patch makes it possible to specify an identifier for a content extension rule. This is working
toward implementing the onRuleMatchedDebug API for dNR, which isn&apos;t currently possible because the
rule identifiers are destroyed when the dNR rules are converted into content extension rules.

The idea behind this patch is that we store the rule identifier with its serialized action, meaning
that we cannot combine actions, which does have slight memory implications. However, most dNR rules
contain conditions and wouldn&apos;t have their actions combined during compilation anyways. As for the
identifiers themselves, we have a 100k rule limit, and each identifier is a 32 bit unsigned integer,
so at most, we&apos;re using 0.4MB more memory.

The serialized actions now have the form:

[
  one byte for the variant,
  X bytes for extra information (like string size and selector for css-display-none actions),
  four bytes for the identifier,
  ...
]

There&apos;s a lot more to do to get this to work, like implementing the dNR API and wiring up this new
notification. Also, there are smaller things such as conditional serializing of the identifiers and
adding more information to the object that&apos;s included with the published notification.

See sub-tasks of: <a href="https://rdar.apple.com/71867958">rdar://71867958</a>

Wrote new tests to validate that the rules are being serialized as expected. Tests for the
notification will be written once we wire up the functionality to the web extensions controller.
See: <a href="https://rdar.apple.com/157878200">rdar://157878200</a>.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::findFirstIgnoreRule const):
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::serializeActions):
(WebCore::ContentExtensions::compileRuleList):
* Source/WebCore/contentextensions/ContentExtensionError.cpp:
(WebCore::ContentExtensions::contentExtensionErrorCategory):
* Source/WebCore/contentextensions/ContentExtensionError.h:
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadRule):
(WebCore::ContentExtensions::loadEncodedRules):
* Source/WebCore/contentextensions/ContentExtensionRule.cpp:
(WebCore::ContentExtensions::ContentExtensionRule::ContentExtensionRule):
(WebCore::ContentExtensions::DeserializedAction::deserialize):
* Source/WebCore/contentextensions/ContentExtensionRule.h:
(WebCore::ContentExtensions::ContentExtensionRule::identifier const):
(WebCore::ContentExtensions::ContentExtensionRule::isolatedCopy const):
(WebCore::ContentExtensions::ContentExtensionRule::isolatedCopy):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
* Source/WebCore/contentextensions/ContentRuleListMatchedRule.h: Added.
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::contentRuleListMatchedRule):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APINavigationClient.h:
(API::NavigationClient::contentRuleListMatchedRule):
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::contentRuleListMatchedRule):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::contentRuleListMatchedRule):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::contentRuleListMatchedRule):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, InvalidJSON)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RuleIdentifiers)):

Canonical link: <a href="https://commits.webkit.org/298570@main">https://commits.webkit.org/298570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90b3915bf505892e91d14e9dec931be860f29d5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66476 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd921333-fe47-426c-bc90-9db557cd00df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87989 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42610 "Exiting early after 60 failures. 20791 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9707d063-72d1-4649-b27f-39233c9322ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68394 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22062 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65553 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107943 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125035 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114362 "Found 1 new JSC stress test failure: stress/catch-from-function-inlining-simd-function.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96745 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38643 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18526 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48199 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/142692 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42077 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36884 "Found 7354 new JSC stress test failures: airjs-tests.yaml/stress-test.js.lockdown, basic-tests.yaml/stress-test.js.lockdown, cdjs-tests.yaml/main.js.lockdown, cdjs-tests.yaml/motion_test.js.lockdown, cdjs-tests.yaml/red_black_tree_test.js.lockdown, cdjs-tests.yaml/reduce_collision_set_test.js.lockdown, microbenchmarks/Float32Array-matrix-mult.js.lockdown, microbenchmarks/Int16Array-bubble-sort-with-byteLength.js.lockdown, microbenchmarks/Int16Array-bubble-sort.js.lockdown, microbenchmarks/Int16Array-load-int-mul.js.lockdown ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->