### PR TITLE
[macOS] Several API tests interacting with the PDF HUD are failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1372,7 +1372,8 @@ TEST(WebKit, TabDoesNotTakeFocusFromEditableWebView)
 
 @end
 
-TEST(WebKit, SaveDataToFile)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+TEST(WebKit, DISABLED_SaveDataToFile)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
     RetainPtr delegate = adoptNS([[SaveDataToFileDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -341,7 +341,8 @@ UNIFIED_PDF_TEST(PrintSize)
     TestWebKitAPI::Util::run(&receivedSize);
 }
 
-UNIFIED_PDF_TEST(SetPageZoomFactorDoesNotBailIncorrectly)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_SetPageZoomFactorDoesNotBailIncorrectly)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF(true).get()]);
     [webView loadData:testPDFData().get() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.apple.com/testPath"]];
@@ -372,7 +373,8 @@ static void checkFrame(NSRect frame, CGFloat x, CGFloat y, CGFloat width, CGFloa
     EXPECT_EQ(frame.size.height, height);
 }
 
-UNIFIED_PDF_TEST(PDFHUDMainResourcePDF)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_PDFHUDMainResourcePDF)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF(true).get()]);
     [webView loadData:testPDFData().get() MIMEType:@"application/pdf" characterEncodingName:@"" baseURL:[NSURL URLWithString:@"https://www.apple.com/testPath"]];
@@ -400,7 +402,8 @@ UNIFIED_PDF_TEST(PDFHUDMainResourcePDF)
         TestWebKitAPI::Util::spinRunLoop();
 }
 
-UNIFIED_PDF_TEST(PDFHUDMoveIFrame)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_PDFHUDMoveIFrame)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -459,7 +462,8 @@ UNIFIED_PDF_TEST(PDFHUDMoveIFrame)
     checkFrame([webView _pdfHUDs].anyObject.frame, 14, 40, 560, 210);
 }
 
-UNIFIED_PDF_TEST(PDFHUDNestedIFrames)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_PDFHUDNestedIFrames)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -498,7 +502,8 @@ UNIFIED_PDF_TEST(PDFHUDNestedIFrames)
         TestWebKitAPI::Util::spinRunLoop();
 }
 
-UNIFIED_PDF_TEST(PDFHUDIFrame3DTransform)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_PDFHUDIFrame3DTransform)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -528,7 +533,8 @@ UNIFIED_PDF_TEST(PDFHUDIFrame3DTransform)
     checkFrame([webView _pdfHUDs].anyObject.frame, 403, 10, 500, 500);
 }
 
-UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_PDFHUDMultipleIFrames)
 {
     RetainPtr handler = adoptNS([TestURLSchemeHandler new]);
     [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
@@ -570,7 +576,8 @@ UNIFIED_PDF_TEST(PDFHUDMultipleIFrames)
     EXPECT_TRUE(hadRightFrame);
 }
 
-UNIFIED_PDF_TEST(PDFHUDLoadPDFTypeWithPluginsBlocked)
+// FIXME: <webkit.org/b/296970> [macOS] Several API tests interacting with the PDF HUD are failing
+UNIFIED_PDF_TEST(DISABLED_PDFHUDLoadPDFTypeWithPluginsBlocked)
 {
     RetainPtr configuration = configurationForWebViewTestingUnifiedPDF(true);
     [configuration _setOverrideContentSecurityPolicy:@"object-src 'none'"];


### PR DESCRIPTION
#### fae5b697f3b3b87294069d1c175e5c2ad2bef35c
<pre>
[macOS] Several API tests interacting with the PDF HUD are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=296970">https://bugs.webkit.org/show_bug.cgi?id=296970</a>
<a href="https://rdar.apple.com/157605203">rdar://157605203</a>

Unreviewed test gardening.

Something about the plugin visibility is not in order. We should
investigate this. However, make TestWebKitAPI less disruptive by
skipping these tests for now.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((WebKit, DISABLED_SaveDataToFile)):
((WebKit, SaveDataToFile)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/298442@main">https://commits.webkit.org/298442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08cfc188bcecd4eb73f6d2a0f32280cbcacb1912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115552 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/35217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25738 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/121609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d373956-d840-4627-a1d8-5c1ab0af1405) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117441 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/35897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43800 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/121609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f19cd893-4703-48da-ba56-490b82454cd5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118500 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/35897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/103706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/121609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/35897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/21822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65284 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/35897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/21943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/42457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/31819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/124766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/42824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/99896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/124766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18476 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/42343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/41832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->