### PR TITLE
Reveal algorithm should be called asynchronously from find-in-page

### DIFF
--- a/Source/WebCore/dom/FindRevealAlgorithms.cpp
+++ b/Source/WebCore/dom/FindRevealAlgorithms.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "ElementInlines.h"
 #include "EventNames.h"
+#include "GCReachableRef.h"
 #include "HTMLDetailsElement.h"
 #include "HTMLSlotElement.h"
 #include "NodeRenderStyle.h"
@@ -88,6 +89,14 @@ void revealClosedDetailsAndHiddenUntilFoundAncestors(Node& node)
             break;
         }
     }
+}
+
+// https://html.spec.whatwg.org/#interaction-with-details-and-hidden=until-found
+void queueTaskToRevealClosedDetailsAndHiddenUntilFoundAncestors(Node& node)
+{
+    node.document().eventLoop().queueTask(TaskSource::UserInteraction, [node = GCReachableRef { node }] {
+        revealClosedDetailsAndHiddenUntilFoundAncestors(node);
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/FindRevealAlgorithms.h
+++ b/Source/WebCore/dom/FindRevealAlgorithms.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class Node;
 
-WEBCORE_EXPORT void revealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
+void revealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
+WEBCORE_EXPORT void queueTaskToRevealClosedDetailsAndHiddenUntilFoundAncestors(Node&);
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -507,7 +507,7 @@ void FindController::didFindString()
 
     CheckedRef selection = selectedFrame->selection();
     selection->revealSelection();
-    revealClosedDetailsAndHiddenUntilFoundAncestors(*selection->selection().start().protectedAnchorNode());
+    queueTaskToRevealClosedDetailsAndHiddenUntilFoundAncestors(*selection->selection().start().protectedAnchorNode());
 }
 
 void FindController::didHideFindIndicator()

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -161,7 +161,7 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
         case FindDecorationStyle::Highlighted: {
             m_highlightedRange = range;
 
-            revealClosedDetailsAndHiddenUntilFoundAncestors(simpleRange->protectedStartContainer());
+            queueTaskToRevealClosedDetailsAndHiddenUntilFoundAncestors(simpleRange->protectedStartContainer());
 
             if (m_findPageOverlay)
                 setTextIndicatorWithRange(*simpleRange);

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -181,7 +181,7 @@ void FindController::didFindString()
     // text, so we reveal the text at the center of the viewport.
     // FIXME: Find a better way to estimate the obscured area (https://webkit.org/b/183889).
     frame->selection().revealSelection({ SelectionRevealMode::RevealUpToMainFrame, ScrollAlignment::alignCenterAlways, WebCore::RevealExtentOption::DoNotRevealExtent });
-    revealClosedDetailsAndHiddenUntilFoundAncestors(*frame->selection().selection().start().anchorNode());
+    queueTaskToRevealClosedDetailsAndHiddenUntilFoundAncestors(*frame->selection().selection().start().anchorNode());
 }
 
 void FindController::didFailToFindString()


### PR DESCRIPTION
#### 7d36ef9310514ce039bf67dd4dc4ca329d427ec9
<pre>
Reveal algorithm should be called asynchronously from find-in-page
<a href="https://bugs.webkit.org/show_bug.cgi?id=297158">https://bugs.webkit.org/show_bug.cgi?id=297158</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/dom/FindRevealAlgorithms.cpp:
(WebCore::queueTaskToRevealClosedDetailsAndHiddenUntilFoundAncestors):
* Source/WebCore/dom/FindRevealAlgorithms.h:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::didFindString):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindController::didFindString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d36ef9310514ce039bf67dd4dc4ca329d427ec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66089 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae1b10a2-6eee-415d-864b-804f8bcc2fdf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87780 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42432 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/20e2c1f6-0404-4919-93a5-7bea71166200) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68175 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124768 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96547 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96333 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38343 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42346 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47914 "Found 4 new failures in dom/FindRevealAlgorithms.cpp") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41834 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43550 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->