### PR TITLE
JSON & XML MIME types should only contain valid HTTP tokens

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any-expected.txt
@@ -11,4 +11,94 @@ PASS Try importing JSON module with MIME type text/json/json+json
 PASS Try importing JSON module with MIME type text/html;+json
 PASS Try importing JSON module with MIME type text/html+json+xml
 PASS Try importing JSON module with MIME type text/json/json
+PASS Try importing JSON module with MIME type applic\0ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic	ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic
+ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic\ration/vnd.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd\0.api+json
+PASS Try importing JSON module with MIME type application/vnd	.api+json
+PASS Try importing JSON module with MIME type application/vnd
+.api+json
+PASS Try importing JSON module with MIME type application/vnd\r.api+json
+PASS Try importing JSON module with MIME type application/vnd .api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic:ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic?ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic@ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd"api"+json
+PASS Try importing JSON module with MIME type application/vnd(api+json
+PASS Try importing JSON module with MIME type application/vnd)api+json
+PASS Try importing JSON module with MIME type application/vnd,api+json
+PASS Try importing JSON module with MIME type application/vnd:api+json
+PASS Try importing JSON module with MIME type application/vnd;api+json
+PASS Try importing JSON module with MIME type application/vnd<api+json
+PASS Try importing JSON module with MIME type application/vnd>api+json
+PASS Try importing JSON module with MIME type application/vnd=api+json
+PASS Try importing JSON module with MIME type application/vnd?api+json
+PASS Try importing JSON module with MIME type application/vnd@api+json
+PASS Try importing JSON module with MIME type application/vnd[api+json
+PASS Try importing JSON module with MIME type application/vnd]api+json
+PASS Try importing JSON module with MIME type application/vnd{api+json
+PASS Try importing JSON module with MIME type application/vnd}api+json
+PASS Try importing JSON module with MIME type aplicación/vnd.api+json
+PASS Try importing JSON module with MIME type 申请/vnd.api+json
+PASS Try importing JSON module with MIME type app™lication/vnd.api+json
+PASS Try importing JSON module with MIME type appli€cation/vnd.api+json
+PASS Try importing JSON module with MIME type 🚀application/vnd.api+json
+PASS Try importing JSON module with MIME type applicatioñ/vnd.api+json
+PASS Try importing JSON module with MIME type application/vñd.api+json
+PASS Try importing JSON module with MIME type application/vnd.apí+json
+PASS Try importing JSON module with MIME type application/vnd.api™+json
+PASS Try importing JSON module with MIME type application/vnd.api€+json
+PASS Try importing JSON module with MIME type application/vnd.中文+json
+PASS Try importing JSON module with MIME type application/vnd.api🚀+json
+PASS Try importing JSON module with MIME type application/café.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd"api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd(api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd)api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd,api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd=api+json
+PASS Try importing JSON module with MIME type 申请/中文.api+json
+PASS Try importing JSON module with MIME type app™/vnd€.api+json
+PASS Try importing JSON module with MIME type applic\0ation/vnd\0api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd;api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd{api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd}api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd[api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd]api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd<api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd>api+json
+PASS Try importing JSON module with MIME type "application/vnd.api+json
+PASS Try importing JSON module with MIME type application"/vnd.api+json
+PASS Try importing JSON module with MIME type application /vnd.api+json
+PASS Try importing JSON module with MIME type /vnd.api+json
+PASS Try importing JSON module with MIME type app\0lication/vnd.api+json
+PASS Try importing JSON module with MIME type application/"vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api"+json
+PASS Try importing JSON module with MIME type application/ vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api +json
+PASS Try importing JSON module with MIME type application/vnd.api+json"
+PASS Try importing JSON module with MIME type "application"/"vnd.api"+json
+PASS Try importing JSON module with MIME type app(lic)ation/vnd(api)+json
+PASS Try importing JSON module with MIME type application\0/\0vnd.api+json
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.js
@@ -13,7 +13,116 @@ const content_types = [
   "text/html;+json",
   "text/html+json+xml",
   "text/json/json",
+
+  // Control Characters and Whitespace - Invalid Type
+  "applic\x00ation/vnd.api+json",     // NULL in type
+  "applic\x09ation/vnd.api+json",     // TAB in type
+  "applic\x0Aation/vnd.api+json",     // Line Feed in type
+  "applic\x0Dation/vnd.api+json",     // Carriage Return in type
+  "applic ation/vnd.api+json",        // SPACE in type
+  "applic\x7Fation/vnd.api+json",     // DEL in type
+  "\x01application/vnd.api+json",     // SOH at start of type
+  "application\x1F/vnd.api+json",     // Unit Separator at end of type
+
+  // Control Characters and Whitespace - Invalid Subtype
+  "application/vnd\x00.api+json",     // NULL in subtype
+  "application/vnd\x09.api+json",     // TAB in subtype
+  "application/vnd\x0A.api+json",     // Line Feed in subtype
+  "application/vnd\x0D.api+json",     // Carriage Return in subtype
+  "application/vnd .api+json",        // SPACE in subtype
+  "application/vnd\x7F.api+json",     // DEL in subtype
+  "application/\x01vnd.api+json",     // SOH at start of subtype
+  "application/vnd.api\x1F+json",     // Unit Separator before +json
+
+  // Separator Characters - Invalid Type
+  "applic\"ation/vnd.api+json",       // Double quote in type
+  "applic(ation/vnd.api+json",        // Left parenthesis in type
+  "applic)ation/vnd.api+json",        // Right parenthesis in type
+  "applic,ation/vnd.api+json",        // Comma in type
+  "applic:ation/vnd.api+json",        // Colon in type
+  "applic;ation/vnd.api+json",        // Semicolon in type
+  "applic<ation/vnd.api+json",        // Left angle bracket in type
+  "applic>ation/vnd.api+json",        // Right angle bracket in type
+  "applic=ation/vnd.api+json",        // Equals in type
+  "applic?ation/vnd.api+json",        // Question mark in type
+  "applic@ation/vnd.api+json",        // At sign in type
+  "applic[ation/vnd.api+json",        // Left square bracket in type
+  "applic]ation/vnd.api+json",        // Right square bracket in type
+  "applic{ation/vnd.api+json",        // Left curly brace in type
+  "applic}ation/vnd.api+json",        // Right curly brace in type
+
+  // Separator Characters - Invalid Subtype
+  "application/vnd\"api\"+json",      // Double quote in subtype
+  "application/vnd(api+json",         // Left parenthesis in subtype
+  "application/vnd)api+json",         // Right parenthesis in subtype
+  "application/vnd,api+json",         // Comma in subtype
+  "application/vnd:api+json",         // Colon in subtype
+  "application/vnd;api+json",         // Semicolon in subtype
+  "application/vnd<api+json",         // Left angle brackets in subtype
+  "application/vnd>api+json",         // Right angle brackets in subtype
+  "application/vnd=api+json",         // Equals in subtype
+  "application/vnd?api+json",         // Question mark in subtype
+  "application/vnd@api+json",         // At sign in subtype
+  "application/vnd[api+json",         // Left square brackets in subtype
+  "application/vnd]api+json",         // Right square brackets in subtype
+  "application/vnd{api+json",         // Left curly brace in subtype
+  "application/vnd}api+json",         // Right curly brace in subtype
+
+  // Non-ASCII Characters - Invalid Type
+  "aplicación/vnd.api+json",          // Latin small letter o with acute
+  "申请/vnd.api+json",                 // Chinese characters
+  "app™lication/vnd.api+json",        // Trade mark sign
+  "appli€cation/vnd.api+json",        // Euro sign
+  "🚀application/vnd.api+json",       // Rocket emoji
+  "applicatioñ/vnd.api+json",         // Latin small letter n with tilde
+
+  // Non-ASCII Characters - Invalid Subtype
+  "application/vñd.api+json",         // Latin small letter n with tilde
+  "application/vnd.apí+json",         // Latin small letter i with acute
+  "application/vnd.api™+json",        // Trade mark sign
+  "application/vnd.api€+json",        // Euro sign
+  "application/vnd.中文+json",         // Chinese characters
+  "application/vnd.api🚀+json",       // Rocket emoji
+  "application/café.api+json",        // Latin small letter e with acute
+
+  // Mixed Invalid Characters (Both Type and Subtype)
+  "applic ation/vnd api+json",        // Spaces in both
+  "applic\"ation/vnd\"api+json",      // Quotes in both
+  "applic(ation/vnd(api+json",        // Left parentheses in both
+  "applic)ation/vnd)api+json",        // Right parentheses in both
+  "applic,ation/vnd,api+json",        // Commas in both
+  "applic=ation/vnd=api+json",        // Equals in both
+  "申请/中文.api+json",                 // Chinese in both
+  "app™/vnd€.api+json",               // Unicode symbols in both
+  "applic\x00ation/vnd\x00api+json",  // NULL in both
+  "applic;ation/vnd;api+json",        // Semicolons in both
+  "applic{ation/vnd{api+json",        // Left curly brace in both
+  "applic}ation/vnd}api+json",        // Right curly brace in both
+  "applic[ation/vnd[api+json",        // Left square bracket in both
+  "applic]ation/vnd]api+json",        // Right square bracket in both
+  "applic<ation/vnd<api+json",        // Left angle bracket in both
+  "applic>ation/vnd>api+json",        // Right angle bracket in both
+
+  // Edge Cases - Type
+  "\"application/vnd.api+json",       // Quote at start of type
+  "application\"/vnd.api+json",       // Quote at end of type
+  "application /vnd.api+json",        // Trailing space in type
+  "/vnd.api+json",                    // Empty type
+  "app\x00lication/vnd.api+json",     // NULL in middle of type
+
+  // Edge Cases - Subtype
+  "application/\"vnd.api+json",       // Quote at start of subtype
+  "application/vnd.api\"+json",       // Quote before +json
+  "application/ vnd.api+json",        // Leading space in subtype
+  "application/vnd.api +json",        // Space before +json
+  "application/vnd.api+json\"",       // Quote at end
+
+  // Edge Cases - Multiple Invalid Positions
+  "\"application\"/\"vnd.api\"+json", // Quotes in multiple positions
+  "app(lic)ation/vnd(api)+json",      // Parentheses in multiple positions
+  "application\x00/\x00vnd.api+json",  // NULL in both parts
 ];
+
 for (const content_type of content_types) {
   promise_test(async test => {
     await promise_rejects_js(test, TypeError,

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker-expected.txt
@@ -11,4 +11,94 @@ PASS Try importing JSON module with MIME type text/json/json+json
 PASS Try importing JSON module with MIME type text/html;+json
 PASS Try importing JSON module with MIME type text/html+json+xml
 PASS Try importing JSON module with MIME type text/json/json
+PASS Try importing JSON module with MIME type applic\0ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic	ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic
+ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic\ration/vnd.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd\0.api+json
+PASS Try importing JSON module with MIME type application/vnd	.api+json
+PASS Try importing JSON module with MIME type application/vnd
+.api+json
+PASS Try importing JSON module with MIME type application/vnd\r.api+json
+PASS Try importing JSON module with MIME type application/vnd .api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic:ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic?ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic@ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd"api"+json
+PASS Try importing JSON module with MIME type application/vnd(api+json
+PASS Try importing JSON module with MIME type application/vnd)api+json
+PASS Try importing JSON module with MIME type application/vnd,api+json
+PASS Try importing JSON module with MIME type application/vnd:api+json
+PASS Try importing JSON module with MIME type application/vnd;api+json
+PASS Try importing JSON module with MIME type application/vnd<api+json
+PASS Try importing JSON module with MIME type application/vnd>api+json
+PASS Try importing JSON module with MIME type application/vnd=api+json
+PASS Try importing JSON module with MIME type application/vnd?api+json
+PASS Try importing JSON module with MIME type application/vnd@api+json
+PASS Try importing JSON module with MIME type application/vnd[api+json
+PASS Try importing JSON module with MIME type application/vnd]api+json
+PASS Try importing JSON module with MIME type application/vnd{api+json
+PASS Try importing JSON module with MIME type application/vnd}api+json
+PASS Try importing JSON module with MIME type aplicación/vnd.api+json
+PASS Try importing JSON module with MIME type 申请/vnd.api+json
+PASS Try importing JSON module with MIME type app™lication/vnd.api+json
+PASS Try importing JSON module with MIME type appli€cation/vnd.api+json
+PASS Try importing JSON module with MIME type 🚀application/vnd.api+json
+PASS Try importing JSON module with MIME type applicatioñ/vnd.api+json
+PASS Try importing JSON module with MIME type application/vñd.api+json
+PASS Try importing JSON module with MIME type application/vnd.apí+json
+PASS Try importing JSON module with MIME type application/vnd.api™+json
+PASS Try importing JSON module with MIME type application/vnd.api€+json
+PASS Try importing JSON module with MIME type application/vnd.中文+json
+PASS Try importing JSON module with MIME type application/vnd.api🚀+json
+PASS Try importing JSON module with MIME type application/café.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd"api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd(api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd)api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd,api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd=api+json
+PASS Try importing JSON module with MIME type 申请/中文.api+json
+PASS Try importing JSON module with MIME type app™/vnd€.api+json
+PASS Try importing JSON module with MIME type applic\0ation/vnd\0api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd;api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd{api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd}api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd[api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd]api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd<api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd>api+json
+PASS Try importing JSON module with MIME type "application/vnd.api+json
+PASS Try importing JSON module with MIME type application"/vnd.api+json
+PASS Try importing JSON module with MIME type application /vnd.api+json
+PASS Try importing JSON module with MIME type /vnd.api+json
+PASS Try importing JSON module with MIME type app\0lication/vnd.api+json
+PASS Try importing JSON module with MIME type application/"vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api"+json
+PASS Try importing JSON module with MIME type application/ vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api +json
+PASS Try importing JSON module with MIME type application/vnd.api+json"
+PASS Try importing JSON module with MIME type "application"/"vnd.api"+json
+PASS Try importing JSON module with MIME type app(lic)ation/vnd(api)+json
+PASS Try importing JSON module with MIME type application\0/\0vnd.api+json
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker-expected.txt
@@ -11,4 +11,94 @@ PASS Try importing JSON module with MIME type text/json/json+json
 PASS Try importing JSON module with MIME type text/html;+json
 PASS Try importing JSON module with MIME type text/html+json+xml
 PASS Try importing JSON module with MIME type text/json/json
+PASS Try importing JSON module with MIME type applic\0ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic	ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic
+ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic\ration/vnd.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd\0.api+json
+PASS Try importing JSON module with MIME type application/vnd	.api+json
+PASS Try importing JSON module with MIME type application/vnd
+.api+json
+PASS Try importing JSON module with MIME type application/vnd\r.api+json
+PASS Try importing JSON module with MIME type application/vnd .api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic:ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic?ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic@ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd"api"+json
+PASS Try importing JSON module with MIME type application/vnd(api+json
+PASS Try importing JSON module with MIME type application/vnd)api+json
+PASS Try importing JSON module with MIME type application/vnd,api+json
+PASS Try importing JSON module with MIME type application/vnd:api+json
+PASS Try importing JSON module with MIME type application/vnd;api+json
+PASS Try importing JSON module with MIME type application/vnd<api+json
+PASS Try importing JSON module with MIME type application/vnd>api+json
+PASS Try importing JSON module with MIME type application/vnd=api+json
+PASS Try importing JSON module with MIME type application/vnd?api+json
+PASS Try importing JSON module with MIME type application/vnd@api+json
+PASS Try importing JSON module with MIME type application/vnd[api+json
+PASS Try importing JSON module with MIME type application/vnd]api+json
+PASS Try importing JSON module with MIME type application/vnd{api+json
+PASS Try importing JSON module with MIME type application/vnd}api+json
+PASS Try importing JSON module with MIME type aplicación/vnd.api+json
+PASS Try importing JSON module with MIME type 申请/vnd.api+json
+PASS Try importing JSON module with MIME type app™lication/vnd.api+json
+PASS Try importing JSON module with MIME type appli€cation/vnd.api+json
+PASS Try importing JSON module with MIME type 🚀application/vnd.api+json
+PASS Try importing JSON module with MIME type applicatioñ/vnd.api+json
+PASS Try importing JSON module with MIME type application/vñd.api+json
+PASS Try importing JSON module with MIME type application/vnd.apí+json
+PASS Try importing JSON module with MIME type application/vnd.api™+json
+PASS Try importing JSON module with MIME type application/vnd.api€+json
+PASS Try importing JSON module with MIME type application/vnd.中文+json
+PASS Try importing JSON module with MIME type application/vnd.api🚀+json
+PASS Try importing JSON module with MIME type application/café.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd"api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd(api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd)api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd,api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd=api+json
+PASS Try importing JSON module with MIME type 申请/中文.api+json
+PASS Try importing JSON module with MIME type app™/vnd€.api+json
+PASS Try importing JSON module with MIME type applic\0ation/vnd\0api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd;api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd{api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd}api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd[api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd]api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd<api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd>api+json
+PASS Try importing JSON module with MIME type "application/vnd.api+json
+PASS Try importing JSON module with MIME type application"/vnd.api+json
+PASS Try importing JSON module with MIME type application /vnd.api+json
+PASS Try importing JSON module with MIME type /vnd.api+json
+PASS Try importing JSON module with MIME type app\0lication/vnd.api+json
+PASS Try importing JSON module with MIME type application/"vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api"+json
+PASS Try importing JSON module with MIME type application/ vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api +json
+PASS Try importing JSON module with MIME type application/vnd.api+json"
+PASS Try importing JSON module with MIME type "application"/"vnd.api"+json
+PASS Try importing JSON module with MIME type app(lic)ation/vnd(api)+json
+PASS Try importing JSON module with MIME type application\0/\0vnd.api+json
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any-expected.txt
@@ -11,4 +11,94 @@ PASS Try importing JSON module with MIME type text/json/json+json
 PASS Try importing JSON module with MIME type text/html;+json
 PASS Try importing JSON module with MIME type text/html+json+xml
 PASS Try importing JSON module with MIME type text/json/json
+FAIL Try importing JSON module with MIME type applic\0ation/vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type applic\0ation/vnd.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type applic	ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic
+ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic\ration/vnd.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+FAIL Try importing JSON module with MIME type application/vnd\0.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type application/vnd\0.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type application/vnd	.api+json
+PASS Try importing JSON module with MIME type application/vnd
+.api+json
+PASS Try importing JSON module with MIME type application/vnd\r.api+json
+PASS Try importing JSON module with MIME type application/vnd .api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic:ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic?ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic@ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd"api"+json
+PASS Try importing JSON module with MIME type application/vnd(api+json
+PASS Try importing JSON module with MIME type application/vnd)api+json
+PASS Try importing JSON module with MIME type application/vnd,api+json
+PASS Try importing JSON module with MIME type application/vnd:api+json
+PASS Try importing JSON module with MIME type application/vnd;api+json
+PASS Try importing JSON module with MIME type application/vnd<api+json
+PASS Try importing JSON module with MIME type application/vnd>api+json
+PASS Try importing JSON module with MIME type application/vnd=api+json
+PASS Try importing JSON module with MIME type application/vnd?api+json
+PASS Try importing JSON module with MIME type application/vnd@api+json
+PASS Try importing JSON module with MIME type application/vnd[api+json
+PASS Try importing JSON module with MIME type application/vnd]api+json
+PASS Try importing JSON module with MIME type application/vnd{api+json
+PASS Try importing JSON module with MIME type application/vnd}api+json
+PASS Try importing JSON module with MIME type aplicación/vnd.api+json
+PASS Try importing JSON module with MIME type 申请/vnd.api+json
+PASS Try importing JSON module with MIME type app™lication/vnd.api+json
+PASS Try importing JSON module with MIME type appli€cation/vnd.api+json
+PASS Try importing JSON module with MIME type 🚀application/vnd.api+json
+PASS Try importing JSON module with MIME type applicatioñ/vnd.api+json
+PASS Try importing JSON module with MIME type application/vñd.api+json
+PASS Try importing JSON module with MIME type application/vnd.apí+json
+PASS Try importing JSON module with MIME type application/vnd.api™+json
+PASS Try importing JSON module with MIME type application/vnd.api€+json
+PASS Try importing JSON module with MIME type application/vnd.中文+json
+PASS Try importing JSON module with MIME type application/vnd.api🚀+json
+PASS Try importing JSON module with MIME type application/café.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd"api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd(api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd)api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd,api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd=api+json
+PASS Try importing JSON module with MIME type 申请/中文.api+json
+PASS Try importing JSON module with MIME type app™/vnd€.api+json
+FAIL Try importing JSON module with MIME type applic\0ation/vnd\0api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type applic\0ation/vnd\0api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type applic;ation/vnd;api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd{api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd}api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd[api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd]api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd<api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd>api+json
+PASS Try importing JSON module with MIME type "application/vnd.api+json
+PASS Try importing JSON module with MIME type application"/vnd.api+json
+PASS Try importing JSON module with MIME type application /vnd.api+json
+PASS Try importing JSON module with MIME type /vnd.api+json
+FAIL Try importing JSON module with MIME type app\0lication/vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type app\0lication/vnd.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type application/"vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api"+json
+PASS Try importing JSON module with MIME type application/ vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api +json
+PASS Try importing JSON module with MIME type application/vnd.api+json"
+PASS Try importing JSON module with MIME type "application"/"vnd.api"+json
+PASS Try importing JSON module with MIME type app(lic)ation/vnd(api)+json
+FAIL Try importing JSON module with MIME type application\0/\0vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type application\0/\0vnd.api+json should fail Reached unreachable code
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker-expected.txt
@@ -7,8 +7,98 @@ PASS Try importing JSON module with MIME type application/blahjson
 PASS Try importing JSON module with MIME type image/json
 PASS Try importing JSON module with MIME type text+json
 PASS Try importing JSON module with MIME type json+json
-FAIL Try importing JSON module with MIME type text/json/json+json assert_unreached: Should have rejected: Import of a JSON module with MIME type text/json/json+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type text/json/json+json
 PASS Try importing JSON module with MIME type text/html;+json
 PASS Try importing JSON module with MIME type text/html+json+xml
 PASS Try importing JSON module with MIME type text/json/json
+FAIL Try importing JSON module with MIME type applic\0ation/vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type applic\0ation/vnd.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type applic	ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic
+ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic\ration/vnd.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+FAIL Try importing JSON module with MIME type application/vnd\0.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type application/vnd\0.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type application/vnd	.api+json
+PASS Try importing JSON module with MIME type application/vnd
+.api+json
+PASS Try importing JSON module with MIME type application/vnd\r.api+json
+PASS Try importing JSON module with MIME type application/vnd .api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic:ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic?ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic@ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd"api"+json
+PASS Try importing JSON module with MIME type application/vnd(api+json
+PASS Try importing JSON module with MIME type application/vnd)api+json
+PASS Try importing JSON module with MIME type application/vnd,api+json
+PASS Try importing JSON module with MIME type application/vnd:api+json
+PASS Try importing JSON module with MIME type application/vnd;api+json
+PASS Try importing JSON module with MIME type application/vnd<api+json
+PASS Try importing JSON module with MIME type application/vnd>api+json
+PASS Try importing JSON module with MIME type application/vnd=api+json
+PASS Try importing JSON module with MIME type application/vnd?api+json
+PASS Try importing JSON module with MIME type application/vnd@api+json
+PASS Try importing JSON module with MIME type application/vnd[api+json
+PASS Try importing JSON module with MIME type application/vnd]api+json
+PASS Try importing JSON module with MIME type application/vnd{api+json
+PASS Try importing JSON module with MIME type application/vnd}api+json
+PASS Try importing JSON module with MIME type aplicación/vnd.api+json
+PASS Try importing JSON module with MIME type 申请/vnd.api+json
+PASS Try importing JSON module with MIME type app™lication/vnd.api+json
+PASS Try importing JSON module with MIME type appli€cation/vnd.api+json
+PASS Try importing JSON module with MIME type 🚀application/vnd.api+json
+PASS Try importing JSON module with MIME type applicatioñ/vnd.api+json
+PASS Try importing JSON module with MIME type application/vñd.api+json
+PASS Try importing JSON module with MIME type application/vnd.apí+json
+PASS Try importing JSON module with MIME type application/vnd.api™+json
+PASS Try importing JSON module with MIME type application/vnd.api€+json
+PASS Try importing JSON module with MIME type application/vnd.中文+json
+PASS Try importing JSON module with MIME type application/vnd.api🚀+json
+PASS Try importing JSON module with MIME type application/café.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd"api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd(api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd)api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd,api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd=api+json
+PASS Try importing JSON module with MIME type 申请/中文.api+json
+PASS Try importing JSON module with MIME type app™/vnd€.api+json
+FAIL Try importing JSON module with MIME type applic\0ation/vnd\0api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type applic\0ation/vnd\0api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type applic;ation/vnd;api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd{api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd}api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd[api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd]api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd<api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd>api+json
+PASS Try importing JSON module with MIME type "application/vnd.api+json
+PASS Try importing JSON module with MIME type application"/vnd.api+json
+PASS Try importing JSON module with MIME type application /vnd.api+json
+PASS Try importing JSON module with MIME type /vnd.api+json
+FAIL Try importing JSON module with MIME type app\0lication/vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type app\0lication/vnd.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type application/"vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api"+json
+PASS Try importing JSON module with MIME type application/ vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api +json
+PASS Try importing JSON module with MIME type application/vnd.api+json"
+PASS Try importing JSON module with MIME type "application"/"vnd.api"+json
+PASS Try importing JSON module with MIME type app(lic)ation/vnd(api)+json
+FAIL Try importing JSON module with MIME type application\0/\0vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type application\0/\0vnd.api+json should fail Reached unreachable code
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker-expected.txt
@@ -7,8 +7,98 @@ PASS Try importing JSON module with MIME type application/blahjson
 PASS Try importing JSON module with MIME type image/json
 PASS Try importing JSON module with MIME type text+json
 PASS Try importing JSON module with MIME type json+json
-FAIL Try importing JSON module with MIME type text/json/json+json assert_unreached: Should have rejected: Import of a JSON module with MIME type text/json/json+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type text/json/json+json
 PASS Try importing JSON module with MIME type text/html;+json
 PASS Try importing JSON module with MIME type text/html+json+xml
 PASS Try importing JSON module with MIME type text/json/json
+FAIL Try importing JSON module with MIME type applic\0ation/vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type applic\0ation/vnd.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type applic	ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic
+ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic\ration/vnd.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+FAIL Try importing JSON module with MIME type application/vnd\0.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type application/vnd\0.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type application/vnd	.api+json
+PASS Try importing JSON module with MIME type application/vnd
+.api+json
+PASS Try importing JSON module with MIME type application/vnd\r.api+json
+PASS Try importing JSON module with MIME type application/vnd .api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic:ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic;ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic?ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic@ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd.api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd"api"+json
+PASS Try importing JSON module with MIME type application/vnd(api+json
+PASS Try importing JSON module with MIME type application/vnd)api+json
+PASS Try importing JSON module with MIME type application/vnd,api+json
+PASS Try importing JSON module with MIME type application/vnd:api+json
+PASS Try importing JSON module with MIME type application/vnd;api+json
+PASS Try importing JSON module with MIME type application/vnd<api+json
+PASS Try importing JSON module with MIME type application/vnd>api+json
+PASS Try importing JSON module with MIME type application/vnd=api+json
+PASS Try importing JSON module with MIME type application/vnd?api+json
+PASS Try importing JSON module with MIME type application/vnd@api+json
+PASS Try importing JSON module with MIME type application/vnd[api+json
+PASS Try importing JSON module with MIME type application/vnd]api+json
+PASS Try importing JSON module with MIME type application/vnd{api+json
+PASS Try importing JSON module with MIME type application/vnd}api+json
+PASS Try importing JSON module with MIME type aplicación/vnd.api+json
+PASS Try importing JSON module with MIME type 申请/vnd.api+json
+PASS Try importing JSON module with MIME type app™lication/vnd.api+json
+PASS Try importing JSON module with MIME type appli€cation/vnd.api+json
+PASS Try importing JSON module with MIME type 🚀application/vnd.api+json
+PASS Try importing JSON module with MIME type applicatioñ/vnd.api+json
+PASS Try importing JSON module with MIME type application/vñd.api+json
+PASS Try importing JSON module with MIME type application/vnd.apí+json
+PASS Try importing JSON module with MIME type application/vnd.api™+json
+PASS Try importing JSON module with MIME type application/vnd.api€+json
+PASS Try importing JSON module with MIME type application/vnd.中文+json
+PASS Try importing JSON module with MIME type application/vnd.api🚀+json
+PASS Try importing JSON module with MIME type application/café.api+json
+PASS Try importing JSON module with MIME type applic ation/vnd api+json
+PASS Try importing JSON module with MIME type applic"ation/vnd"api+json
+PASS Try importing JSON module with MIME type applic(ation/vnd(api+json
+PASS Try importing JSON module with MIME type applic)ation/vnd)api+json
+PASS Try importing JSON module with MIME type applic,ation/vnd,api+json
+PASS Try importing JSON module with MIME type applic=ation/vnd=api+json
+PASS Try importing JSON module with MIME type 申请/中文.api+json
+PASS Try importing JSON module with MIME type app™/vnd€.api+json
+FAIL Try importing JSON module with MIME type applic\0ation/vnd\0api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type applic\0ation/vnd\0api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type applic;ation/vnd;api+json
+PASS Try importing JSON module with MIME type applic{ation/vnd{api+json
+PASS Try importing JSON module with MIME type applic}ation/vnd}api+json
+PASS Try importing JSON module with MIME type applic[ation/vnd[api+json
+PASS Try importing JSON module with MIME type applic]ation/vnd]api+json
+PASS Try importing JSON module with MIME type applic<ation/vnd<api+json
+PASS Try importing JSON module with MIME type applic>ation/vnd>api+json
+PASS Try importing JSON module with MIME type "application/vnd.api+json
+PASS Try importing JSON module with MIME type application"/vnd.api+json
+PASS Try importing JSON module with MIME type application /vnd.api+json
+PASS Try importing JSON module with MIME type /vnd.api+json
+FAIL Try importing JSON module with MIME type app\0lication/vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type app\0lication/vnd.api+json should fail Reached unreachable code
+PASS Try importing JSON module with MIME type application/"vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api"+json
+PASS Try importing JSON module with MIME type application/ vnd.api+json
+PASS Try importing JSON module with MIME type application/vnd.api +json
+PASS Try importing JSON module with MIME type application/vnd.api+json"
+PASS Try importing JSON module with MIME type "application"/"vnd.api"+json
+PASS Try importing JSON module with MIME type app(lic)ation/vnd(api)+json
+FAIL Try importing JSON module with MIME type application\0/\0vnd.api+json assert_unreached: Should have rejected: Import of a JSON module with MIME type application\0/\0vnd.api+json should fail Reached unreachable code
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1536,8 +1536,6 @@ webkit.org/b/143153 imported/w3c/web-platform-tests/css/css-text/text-transform/
 # mime-type is different due to different networking implementation.
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/integrity.html [ Failure ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker.html [ Failure ]
-imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker.html [ Failure ]
 
 webkit.org/b/245900 [ Debug ] fast/inline/inline-box-adjust-position-crash2.html [ Skip ]
 

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -176,8 +176,12 @@ static bool isValidMIMETypeWithSuffix(const String& mimeType, const ASCIILiteral
     if (slashPosition == notFound || slashPosition <= 0)
         return false;
 
-    // FIXME: Also check if type is a valid HTTP token.
-    auto subtypeExcludingSuffix = mimeType.substring(slashPosition + 1, mimeType.length() - suffix.length() - 1 - slashPosition);
+    auto type = mimeType.substring(0, slashPosition);
+    if (!isValidHTTPToken(type))
+        return false;
+
+    // Assume the suffix is already a valid HTTP token and avoid checking it.
+    auto subtypeExcludingSuffix = mimeType.substring(slashPosition + 1, mimeType.length() - slashPosition - suffix.length());
     return isValidHTTPToken(subtypeExcludingSuffix);
 }
 


### PR DESCRIPTION
#### 5ffc74139bd2e7b51a074ba43d1c961386fe4786
<pre>
JSON &amp; XML MIME types should only contain valid HTTP tokens
<a href="https://bugs.webkit.org/show_bug.cgi?id=297161">https://bugs.webkit.org/show_bug.cgi?id=297161</a>
<a href="https://rdar.apple.com/157897532">rdar://157897532</a>

Reviewed by Ryosuke Niwa.

<a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a>

Types should only have HTTP token code points.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.js:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.worker-expected.txt:
* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::isValidMIMETypeWithSuffix):

Canonical link: <a href="https://commits.webkit.org/298472@main">https://commits.webkit.org/298472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6abd47c71adfb1b13678dff5eea4d00c497c5cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1663f2c9-5860-4928-8a1a-9a585707fe13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87823 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65ebe30d-715b-47b8-b62d-1b308065afc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68222 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21875 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124808 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96577 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96365 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24522 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41621 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19478 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 7 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42398 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47970 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41871 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->