### PR TITLE
[JSC] add support for `Iterator.prototype.sliding`

### DIFF
--- a/JSTests/stress/iterator-prototype-sliding.js
+++ b/JSTests/stress/iterator-prototype-sliding.js
@@ -1,0 +1,176 @@
+//@ requireOptions("--useIteratorChunking=1")
+
+function assert(a, text) {
+    if (!a)
+        throw new Error(`Failed assertion: ${text}`);
+}
+
+function sameValue(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function sameArray(a, b) {
+    sameValue(JSON.stringify(a), JSON.stringify(b));
+}
+
+function shouldThrow(fn, error, message) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+    }
+}
+
+{
+    class Iter extends Iterator {
+        i = 1;
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        }
+    }
+    const iter = new Iter();
+    const result = Array.from(iter.sliding(1));
+    sameArray(result, [[1], [2], [3], [4], [5]]);
+}
+
+{
+    const iter = {
+        i: 1,
+        next() {
+            if (this.i > 5)
+                return { value: this.i, done: true }
+            return { value: this.i++, done: false }
+        },
+    };
+    const result = Array.from(Iterator.prototype.sliding.call(iter, 2));
+    sameArray(result, [[1, 2], [2, 3], [3, 4], [4, 5]]);
+}
+
+{
+    let nextGetCount = 0;
+    class Iter extends Iterator {
+        get next() {
+            nextGetCount++;
+            let i = 1;
+            return function() {
+                if (i > 5)
+                    return { value: i, done: true }
+                return { value: i++, done: false }
+            }
+        };
+    };
+    const iter = new Iter();
+    sameValue(nextGetCount, 0);
+    const result = Array.from(iter.sliding(3));
+    sameValue(nextGetCount, 1);
+    sameArray(result, [[1, 2, 3], [2, 3, 4], [3, 4, 5]]);
+}
+
+{
+    function* gen() {
+        yield 1;
+        yield 2;
+        yield 3;
+        yield 4;
+        yield 5;
+    }
+    const iter = gen();
+    const result = Array.from(iter.sliding(4));
+    sameArray(result, [[1, 2, 3, 4], [2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.sliding === Iterator.prototype.sliding);
+    const result = Array.from(iter.sliding(5));
+    sameArray(result, [[1, 2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.sliding === Iterator.prototype.sliding);
+    const result = Array.from(iter.sliding(6));
+    sameArray(result, [[1, 2, 3, 4, 5]]);
+}
+
+{
+    const arr = [1, 2, 3, 4, 5];
+    const iter = arr[Symbol.iterator]();
+    assert(iter.sliding === Iterator.prototype.sliding);
+    const sliding = iter.sliding(2);
+    const result1 = sliding.next().value;
+    sameArray(result1, [1, 2]);
+    result1.pop();
+    sameArray(result1, [1]);
+    const result2 = sliding.next().value;
+    sameArray(result2, [2, 3]);
+    result2.pop();
+    sameArray(result2, [2]);
+    assert(result1 !== result2);
+    const result3 = sliding.next().value;
+    sameArray(result3, [3, 4]);
+    result3.pop();
+    sameArray(result3, [3]);
+    assert(result2 !== result3);
+    const result4 = sliding.next().value;
+    sameArray(result4, [4, 5]);
+    result4.pop();
+    sameArray(result4, [4]);
+    assert(result3 !== result4);
+    assert(sliding.next().done);
+}
+
+{
+    const invalidIterators = [
+        1,
+        1n,
+        true,
+        false,
+        null,
+        undefined,
+        Symbol("symbol"),
+    ];
+    for (const invalidIterator of invalidIterators) {
+        shouldThrow(function () {
+            Iterator.prototype.sliding.call(invalidIterator);
+        }, TypeError, "Iterator.prototype.sliding requires that |this| be an Object.");
+    }
+}
+
+{
+    const invalidWindowSizes = [
+        undefined,
+        "test",
+        {},
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidWindowSize of invalidWindowSizes) {
+        shouldThrow(function () {
+            Iterator.prototype.sliding.call(validIter, invalidWindowSize);
+        }, RangeError, "Iterator.prototype.sliding requires that argument not be NaN.");
+    }
+}
+
+{
+    const invalidWindowSizes = [
+        -1,
+        0,
+        2 ** 32,
+        null,
+    ];
+    const validIter = (function* gen() {})();
+    for (const invalidWindowSize of invalidWindowSizes) {
+        shouldThrow(function () {
+            Iterator.prototype.sliding.call(validIter, invalidWindowSize);
+        }, RangeError, "Iterator.prototype.sliding requires that argument be between 1 and 2**32 - 1.");
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -86,6 +86,8 @@ void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     if (Options::useIteratorChunking()) {
         // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.chunks
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("chunks"_s, jsIteratorPrototypeChunksCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+        // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.sliding
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("sliding"_s, jsIteratorPrototypeSlidingCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
         // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.windows
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("windows"_s, jsIteratorPrototypeWindowsCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     }


### PR DESCRIPTION
#### 131ab02a49787e17a714c936056d84e56682b749
<pre>
[JSC] add support for `Iterator.prototype.sliding`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297163">https://bugs.webkit.org/show_bug.cgi?id=297163</a>

Reviewed by Yusuke Suzuki.

If the number given to `Iterator.prototype.windows` is larger than the number of items in the iterator, the resulting resulting &quot;window&quot; will be empty.
```js
([ 1, 2, 3 ]).values().windows(5) // [ ]
```

Instead using `Iterator.prototype.sliding` it would contain all of the items.
```js
([ 1, 2, 3 ]).values().windows(5) // [ 1, 2, 3 ]
```

Other than that one difference, `Iterator.prototype.sliding` has the same behavior as `Iterator.prototype.windows`.

* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(sliding): Added.
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
(JSC::JSIteratorPrototype::finishCreation):

* JSTests/stress/iterator-prototype-sliding.js: Added.

Canonical link: <a href="https://commits.webkit.org/298471@main">https://commits.webkit.org/298471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf93af454f6d2d6d78a8df2784306cad1b3c38d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87789 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21838 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65300 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107711 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124775 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114098 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96555 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24521 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41584 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19444 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38347 "Hash cf93af45 for PR 49172 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47930 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41840 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->