### PR TITLE
[Navigation API] Fix URL update timing for intercepted traverse navigations.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_no-currententrychange-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
 
 Harness Error (FAIL), message = Unhandled rejection: boo
 
-FAIL event and promise ordering for same-document navigation.back() intercepted by passing a rejected promise to intercept() assert_equals: event 2 (handler run): location.hash value expected "" but got "#1"
+PASS event and promise ordering for same-document navigation.back() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept_no-currententrychange-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event and promise ordering for same-document navigation.back() intercepted by intercept() assert_equals: event 2 (handler run): location.hash value expected "" but got "#1"
+PASS event and promise ordering for same-document navigation.back() intercepted by intercept()
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -337,11 +337,11 @@ public:
 
     std::optional<Ref<HistoryItem>> findBackForwardItemByKey(const LocalFrame& localFrame)
     {
-        auto entry = localFrame.window()->navigation().findEntryByKey(m_key);
+        RefPtr entry = localFrame.window()->protectedNavigation()->findEntryByKey(m_key);
         if (!entry)
             return std::nullopt;
 
-        return entry.value()->associatedHistoryItem();
+        return entry->associatedHistoryItem();
     }
 
     void fire(Frame& frame) override

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -156,7 +156,7 @@ public:
 
     void abortOngoingNavigationIfNeeded();
 
-    std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
+    NavigationHistoryEntry* findEntryByKey(const String&) const;
     bool suppressNormalScrollRestoration() const { return m_suppressNormalScrollRestorationDuringOngoingNavigation; }
 
     void setFocusChanged(FocusDidChange changed) { m_focusChangedDuringOngoingNavigation = changed; }
@@ -208,6 +208,9 @@ private:
     void promoteUpcomingAPIMethodTracker(const String& destinationKey);
     void notifyCommittedToEntry(NavigationAPIMethodTracker*, NavigationHistoryEntry*, NavigationNavigationType);
     Result apiMethodTrackerDerivedResult(const NavigationAPIMethodTracker&);
+
+    size_t entryIndexOfKey(const String&) const;
+    bool hasEntryWithKey(const String&) const;
 
     std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;


### PR DESCRIPTION
#### c82d7711129c02517cfc2fadf34330955c9d76b8
<pre>
[Navigation API] Fix URL update timing for intercepted traverse navigations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297000">https://bugs.webkit.org/show_bug.cgi?id=297000</a>
<a href="https://rdar.apple.com/157325299">rdar://157325299</a>

Reviewed by Alex Christensen.

Intercepted traverse navigations don&apos;t update document URL before handlers run.
When traverse navigations (back/forward) are intercepted in the Navigation API,
the document URL should be updated before navigation handlers execute. This ensures
handlers see the correct URL state during same-document traversals.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept_no-currententrychange-expected.txt:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::entryIndexOfKey const):
(WebCore::Navigation::hasEntryWithKey const):
(WebCore::Navigation::findEntryByKey const):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::findEntryByKey): Deleted.
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/298548@main">https://commits.webkit.org/298548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bae900a4b8be0498abc93163b509b6c6fb797f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66107 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3484ca9d-c577-4bcc-b751-a412ea4b74c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87806 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42440 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6a53e52-21b7-4b1e-978a-2aefad216e82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68204 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21858 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65321 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96565 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96351 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38360 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42381 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47953 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41855 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43568 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->