### PR TITLE
[field-sizing] Larger placeholder font-size should expand the field

### DIFF
--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -218,8 +218,11 @@ void RenderTextControl::layoutExcludedChildren(RelayoutChildren relayoutChildren
 {
     RenderBlockFlow::layoutExcludedChildren(relayoutChildren);
 
-    HTMLElement* placeholder = textFormControlElement().placeholderElement();
-    RenderElement* placeholderRenderer = placeholder ? placeholder->renderer() : 0;
+    if (style().fieldSizing() == FieldSizing::Content)
+        return;
+
+    auto* placeholder = textFormControlElement().placeholderElement();
+    auto* placeholderRenderer = placeholder ? placeholder->renderer() : 0;
     if (!placeholderRenderer)
         return;
     placeholderRenderer->setIsExcludedFromNormalLayout(true);

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -219,8 +219,8 @@ void RenderTextControlSingleLine::layout()
 
     bool innerTextSizeChanged = innerTextRenderer && innerTextRenderer->size() != oldInnerTextSize;
 
-    HTMLElement* placeholderElement = inputElement().placeholderElement();
-    if (RenderBox* placeholderBox = placeholderElement ? placeholderElement->renderBox() : 0) {
+    auto* placeholderElement = inputElement().placeholderElement();
+    if (auto* placeholderBox = placeholderElement ? placeholderElement->renderBox() : 0) {
         auto innerTextWidth = LayoutUnit { };
         if (innerTextRenderer)
             innerTextWidth = innerTextRenderer->logicalWidth();
@@ -232,26 +232,31 @@ void RenderTextControlSingleLine::layout()
             placeholderBox->setChildNeedsLayout(MarkOnlyThis);
         }
         placeholderBox->layoutIfNeeded();
-        auto placeholderTopLeft = containerRenderer ? containerRenderer->location() : LayoutPoint { };
-        auto* innerBlockRenderer = innerBlockElement() ? innerBlockElement()->renderBox() : nullptr;
-        if (innerBlockRenderer)
-            placeholderTopLeft += toLayoutSize(innerBlockRenderer->location());
-        if (innerTextRenderer)
-            placeholderTopLeft += toLayoutSize(innerTextRenderer->location());
-        placeholderBox->setLogicalLeft(placeholderTopLeft.x());
-        // Here the container box indicates the renderer that the placeholder content is aligned with (no parent and/or containing block relationship).
-        auto* containerBox = innerTextRenderer ? innerTextRenderer : innerBlockRenderer ? innerBlockRenderer : containerRenderer;
-        if (containerBox) {
-            auto placeholderHeight = [&] {
-                if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(*placeholderBox)) {
-                    if (auto placeholderLineBox = InlineIterator::firstLineBoxFor(*blockFlow))
-                        return LayoutUnit { std::max(placeholderLineBox->logicalHeight(), placeholderLineBox->contentLogicalHeight()) };
-                }
-                return placeholderBox->logicalHeight();
-            };
-            // Center vertical align the placeholder content.
-            auto logicalTop = placeholderTopLeft.y() + (containerBox->logicalHeight() / 2 - placeholderHeight() / 2);
-            placeholderBox->setLogicalTop(logicalTop);
+        if (style().fieldSizing() == FieldSizing::Content) {
+            placeholderBox->setX(borderLeft() + paddingLeft());
+            placeholderBox->setY(borderTop() + paddingTop());
+        } else {
+            auto placeholderTopLeft = containerRenderer ? containerRenderer->location() : LayoutPoint { };
+            auto* innerBlockRenderer = innerBlockElement() ? innerBlockElement()->renderBox() : nullptr;
+            if (innerBlockRenderer)
+                placeholderTopLeft += toLayoutSize(innerBlockRenderer->location());
+            if (innerTextRenderer)
+                placeholderTopLeft += toLayoutSize(innerTextRenderer->location());
+            placeholderBox->setLogicalLeft(placeholderTopLeft.x());
+            // Here the container box indicates the renderer that the placeholder content is aligned with (no parent and/or containing block relationship).
+            auto* containerBox = innerTextRenderer ? innerTextRenderer : innerBlockRenderer ? innerBlockRenderer : containerRenderer;
+            if (containerBox) {
+                auto placeholderHeight = [&] {
+                    if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(*placeholderBox)) {
+                        if (auto placeholderLineBox = InlineIterator::firstLineBoxFor(*blockFlow))
+                            return LayoutUnit { std::max(placeholderLineBox->logicalHeight(), placeholderLineBox->contentLogicalHeight()) };
+                    }
+                    return placeholderBox->logicalHeight();
+                };
+                // Center vertical align the placeholder content.
+                auto logicalTop = placeholderTopLeft.y() + (containerBox->logicalHeight() / 2 - placeholderHeight() / 2);
+                placeholderBox->setLogicalTop(logicalTop);
+            }
         }
         if (!placeholderBoxHadLayout && placeholderBox->checkForRepaintDuringLayout()) {
             // This assumes a shadow tree without floats. If floats are added, the


### PR DESCRIPTION
#### 0e1f4a6427577c022887be33dc8f2e92413c839e
<pre>
[field-sizing] Larger placeholder font-size should expand the field
<a href="https://bugs.webkit.org/show_bug.cgi?id=269127">https://bugs.webkit.org/show_bug.cgi?id=269127</a>
<a href="https://rdar.apple.com/123125836">rdar://123125836</a>

Reviewed by NOBODY (OOPS!).

probably not the right fix, fails a lot of tests

* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::layoutExcludedChildren):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::layout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e1f4a6427577c022887be33dc8f2e92413c839e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66112 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bab8010f-e71c-4ab0-82a4-d33ece9f2a5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43852 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87816 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42448 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bee2cd1e-4b4b-44e1-ad56-15729c31a7fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68215 "Passed tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27816 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21869 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98055 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/21990 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124802 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42501 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31861 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96572 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96359 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41615 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19472 "Found 3 new test failures: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-number.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38365 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47964 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41865 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->