### PR TITLE
[JSC] Include class names in stack traces for method calls

### DIFF
--- a/JSTests/stress/stack-trace-constructor-name-class.js
+++ b/JSTests/stress/stack-trace-constructor-name-class.js
@@ -1,0 +1,112 @@
+function shouldThrow(fn, error, message, stackFunctions) {
+    try {
+        fn();
+        throw new Error('Expected to throw, but succeeded');
+    } catch (e) {
+        if (!(e instanceof error))
+            throw new Error(`Expected to throw ${error.name} but got ${e.name}`);
+        if (e.message !== message)
+            throw new Error(`Expected ${error.name} with '${message}' but got '${e.message}'`);
+
+        const stackLines = e.stack.split('\n').filter(line => line.trim());
+        if (stackLines.length !== stackFunctions.length) {
+            throw new Error(
+                `\nActual stack trace:\n${e.stack}\n`
+            );
+        }
+        for (let i = 0; i < stackFunctions.length; i++) {
+            const expectedFunction = stackFunctions[i];
+            const stackLine = stackLines[i];
+            let found = false;
+            if (stackLine.startsWith(`${expectedFunction}@`))
+                found = true;
+            if (!found) {
+                throw new Error(`Actual stack trace:\n${e.stack}`);
+            }
+        }
+    }
+}
+
+{
+    class SimpleClass {
+        method() {
+            this.innerMethod();
+        }
+        innerMethod() {
+            throw new Error("error from class method");
+        }
+    }
+    const instance = new SimpleClass();
+    shouldThrow(() => instance.method(), Error, "error from class method", [
+        "SimpleClass.innerMethod",
+        "SimpleClass.method",
+        "",
+        "shouldThrow",
+        "global code",
+    ]);
+}
+
+{
+    class BaseClass {
+        method() {
+            this.innerMethod();
+        }
+        innerMethod() {
+            throw new Error("error from class method");
+        }
+    }
+    class Derived extends BaseClass {}
+    const instance = new Derived();
+    shouldThrow(() => instance.method(), Error, "error from class method", [
+        "Derived.innerMethod",
+        "Derived.method",
+        "",
+        "shouldThrow",
+        "global code",
+    ]);
+}
+
+{
+    const AnonymousClass = class {
+        anonMethod() {
+            throw new Error("error from anonymous class");
+        }
+    };
+    const anon = new AnonymousClass();
+    shouldThrow(() => anon.anonMethod(), Error, "error from anonymous class", [
+        "AnonymousClass.anonMethod",
+        "",
+        "shouldThrow",
+        "global code"
+    ]);
+}
+
+{
+    class ClassWithGetter {
+        get prop() {
+            throw new Error("error from getter");
+        }
+    }
+    const withGetter = new ClassWithGetter();
+    shouldThrow(() => withGetter.prop, Error, "error from getter", [
+        "ClassWithGetter.prop",
+        "",
+        "shouldThrow",
+        "global code"
+    ]);
+}
+
+{
+    class ClassWithSetter {
+        set prop(value) {
+            throw new Error("error from setter");
+        }
+    }
+    const withSetter = new ClassWithSetter();
+    shouldThrow(() => { withSetter.prop = 1; }, Error, "error from setter", [
+        "ClassWithSetter.prop",
+        "",
+        "shouldThrow",
+        "global code"
+    ]);
+}

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -527,9 +527,13 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
                 break;
             }
             }
-        } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction())
-            results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
-        else
+        } else if (!!visitor->codeBlock() && !visitor->codeBlock()->unlinkedCodeBlock()->isBuiltinFunction()) {
+            if (CallFrame* callFrame = visitor->callFrame()) {
+                JSValue thisValue = callFrame->thisValue();
+                results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex(), thisValue));
+            } else
+                results.append(StackFrame(vm, owner, visitor->callee().asCell(), visitor->codeBlock(), visitor->bytecodeIndex()));
+        } else
             results.append(StackFrame(vm, owner, visitor->callee().asCell()));
         return IterationStatus::Continue;
     });

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -44,6 +44,7 @@ struct JSFrameData {
     WriteBarrier<JSCell> callee;
     WriteBarrier<CodeBlock> codeBlock;
     BytecodeIndex bytecodeIndex;
+    AtomString constructorName;
 };
 
 struct WasmFrameData {
@@ -57,6 +58,7 @@ public:
 
     StackFrame(VM&, JSCell* owner, JSCell* callee);
     StackFrame(VM&, JSCell* owner, JSCell* callee, CodeBlock*, BytecodeIndex);
+    StackFrame(VM&, JSCell* owner, JSCell* callee, CodeBlock*, BytecodeIndex, JSValue thisValue);
     StackFrame(VM&, JSCell* owner, CodeBlock*, BytecodeIndex);
     StackFrame(Wasm::IndexOrName);
     StackFrame(Wasm::IndexOrName, size_t functionIndex);
@@ -92,6 +94,8 @@ public:
     bool isMarked(VM&) const;
 
 private:
+    static const AtomString& getConstructorName(VM&, JSValue, CodeBlock*);
+
     FrameData m_frameData { JSFrameData { } };
 };
 


### PR DESCRIPTION
#### 64fd1c6d3da8255e8d12cfd306495b3324d719b1
<pre>
[JSC] Include class names in stack traces for method calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=297171">https://bugs.webkit.org/show_bug.cgi?id=297171</a>

Reviewed by NOBODY (OOPS!).

This patch adds support for including class names in stack traces
when methods are called on class instances. This improves debugging
experience by making it clearer which class&apos;s method is being called
in the stack trace.

However, suupport for ES5 function-style constructors is outside the
scope of this patch.

For example, consider code using a class like this:

  class Foo {
      method() { throw new Error(); }
  }
  const foo = new Foo();
  foo.method();

Before this change, the following stack trace was displayed:

  method@./test.js:2:33
  global code@./test.js:5:13

After this change, the following stack trace will be displayed:

  Foo.method@./test.js:2:33
  global code@./test.js:5:13

V8 displays stack traces like this.

* JSTests/stress/stack-trace-constructor-name-class.js: Added.
(shouldThrow):
(throw.new.Error.prototype.method):
(throw.new.Error.prototype.innerMethod):
(throw.new.Error):
(shouldThrow.prototype.method):
(shouldThrow.prototype.innerMethod):
(shouldThrow.Derived):
(shouldThrow.const.AnonymousClass):
(shouldThrow.prototype.get prop):
(shouldThrow.prototype.set prop):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getStackTrace):
* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::StackFrame::StackFrame):
(JSC::StackFrame::getConstructorName):
(JSC::StackFrame::functionName const):
* Source/JavaScriptCore/runtime/StackFrame.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64fd1c6d3da8255e8d12cfd306495b3324d719b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125383 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71225 "Failed to checkout and rebase branch from PR 49180") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90521 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/71225 "Failed to checkout and rebase branch from PR 49180") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69032 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111280 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100966 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25115 "Found 1 new test failure: http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128403 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117677 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46069 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34815 "Found 46 new test failures: http/tests/webgpu/webgpu/api/operation/adapter/requestDevice.html http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/single_buffer.html http/tests/webgpu/webgpu/api/operation/memory_sync/texture/readonly_depth_stencil.html http/tests/webgpu/webgpu/api/operation/uncapturederror.html http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.html http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.html http/tests/webgpu/webgpu/api/validation/createPipelineLayout.html http/tests/webgpu/webgpu/api/validation/encoding/cmds/render/dynamic_state.html http/tests/webgpu/webgpu/api/validation/encoding/encoder_open_state.html http/tests/webgpu/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99086 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98866 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22329 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42648 "Failed to checkout and rebase branch from PR 49180") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45939 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51619 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146375 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45406 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37642 "Found 1 new JSC binary failure: testapi, Found 18644 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->