### PR TITLE
Implement Permissions API integration with the Storage Access API

### DIFF
--- a/LayoutTests/http/tests/permissions/resources/storage-access-permission-query-iframe.html
+++ b/LayoutTests/http/tests/permissions/resources/storage-access-permission-query-iframe.html
@@ -1,0 +1,62 @@
+<script>
+function postTestResult(message, expected, actual) {
+    parent.postMessage({
+        type: 'test-result',
+        message: message,
+        expected: expected,
+        actual: actual
+    }, '*');
+}
+
+function postTestComplete() {
+    parent.postMessage({
+        type: 'test-complete'
+    }, '*');
+}
+
+async function runTest()
+{
+    await testRunner.setStorageAccessPermission(false, location.href);
+    navigator.permissions.query({ name: "storage-access" }).then(async (status) => {
+        window.state = status.state;
+        postTestResult("state", "prompt", state);
+        await grantTest();
+    });
+}
+
+async function grantTest() 
+{
+    await testRunner.setStorageAccessPermission(true, location.href);
+    navigator.permissions.query({ name: "storage-access" }).then(async (status) => {
+        window.state = status.state;
+        postTestResult("state", "granted", state);
+        await denyTest();
+    });
+}
+
+async function denyTest() 
+{
+    await testRunner.setStorageAccessPermission(false, location.href);
+    navigator.permissions.query({ name: "storage-access" }).then((status) => {
+        window.state = status.state;
+        postTestResult("state", "prompt", state);
+        changeListenerTest();
+    });
+}
+
+function changeListenerTest()
+{
+    navigator.permissions.query({ name: "storage-access" }).then((permissionStatus) => {
+        permissionStatus.onchange = () => {
+            postTestComplete();
+        };
+
+        testRunner.setStorageAccessPermission(true, location.href);
+    });
+}
+
+window.onload = async () => {
+    await testRunner.setStorageAccessPermission(false, location.href);
+    await runTest();
+}
+</script>

--- a/LayoutTests/http/tests/permissions/storage-access-permissions-query-expected.txt
+++ b/LayoutTests/http/tests/permissions/storage-access-permissions-query-expected.txt
@@ -1,0 +1,12 @@
+This test checks that navigator.permissions.query() works for storage-access permission.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS state is "prompt"
+PASS state is "granted"
+PASS state is "prompt"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/permissions/storage-access-permissions-query.html
+++ b/LayoutTests/http/tests/permissions/storage-access-permissions-query.html
@@ -1,0 +1,15 @@
+<script src="/js-test-resources/js-test.js"></script>
+<iframe src="http://localhost:8000/permissions/resources/storage-access-permission-query-iframe.html"></iframe>
+<script>
+description("This test checks that navigator.permissions.query() works for storage-access permission.");
+jsTestIsAsync = true;
+
+window.addEventListener('message', function(event) {
+    if (event.data.type === 'test-result') {
+        window[event.data.message] = event.data.actual;
+        shouldBeEqualToString(event.data.message, event.data.expected);
+    } else if (event.data.type === 'test-complete')
+        finishJSTest();
+});
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: URL is not valid or contains user credentials.
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLDedicatedWorker.sub.https.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLDedicatedWorker.sub.https.tentative.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify that if the third-party context creates a blob URL using the StorageAccessHandle and sends it to the dedicated worker, the dedicated worker fetch succeeds. Test timed out
+FAIL Verify that if the third-party context creates a blob URL using the StorageAccessHandle and sends it to the dedicated worker, the dedicated worker fetch succeeds. assert_equals: expected "Blob URL DedicatedWorker tests completed successfully." but got "Unable to load handle in same-origin context for BlobURLDedicatedWorker"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLSharedWorker.sub.https.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLSharedWorker.sub.https.tentative.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify a blob URL created via URL.createObjectURL from the third-party context shouldn't be useable as the shared worker script when it's passed to saa_handle.SharedWorker. Test timed out
+FAIL Verify a blob URL created via URL.createObjectURL from the third-party context shouldn't be useable as the shared worker script when it's passed to saa_handle.SharedWorker. assert_equals: expected "Blob URL SharedWorker tests completed successfully." but got "Unable to load handle in same-origin context for BlobURLSharedWorker"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.thirdPartyBlobStorage.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.thirdPartyBlobStorage.sub.https.window-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unsupported permission name "storage-access".
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Verify StorageAccessAPIBeyondCookies for third-party context accessing first-party Blob URLs Test timed out
+PASS Verify StorageAccessAPIBeyondCookies for third-party context accessing first-party Blob URLs
 

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp
@@ -66,4 +66,16 @@ void MainThreadPermissionObserver::stateChanged(PermissionState newPermissionSta
     });
 }
 
+void MainThreadPermissionObserver::addChangeListener(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain)
+{
+    ASSERT(isMainThread());
+    PermissionController::singleton().addChangeListener(m_descriptor.name, topFrameDomain, subFrameDomain);
+}
+
+void MainThreadPermissionObserver::removeChangeListener(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain)
+{
+    ASSERT(isMainThread());
+    PermissionController::singleton().removeChangeListener(m_descriptor.name, topFrameDomain, subFrameDomain);
+}
+
 }

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class Page;
+class RegistrableDomain;
 
 class MainThreadPermissionObserver final : public PermissionObserver {
     WTF_MAKE_NONCOPYABLE(MainThreadPermissionObserver);
@@ -45,6 +46,9 @@ class MainThreadPermissionObserver final : public PermissionObserver {
 public:
     MainThreadPermissionObserver(ThreadSafeWeakPtr<PermissionStatus>&&, ScriptExecutionContextIdentifier, PermissionState, PermissionDescriptor, PermissionQuerySource, WeakPtr<Page>&&, ClientOrigin&&);
     ~MainThreadPermissionObserver();
+
+    void addChangeListener(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) final;
+    void removeChangeListener(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) final;
 
 private:
     // PermissionObserver

--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -38,19 +38,23 @@ enum class PermissionQuerySource : uint8_t;
 enum class PermissionState : uint8_t;
 class Page;
 class PermissionObserver;
-struct ClientOrigin;
+class RegistrableDomain;
 class SecurityOriginData;
+struct ClientOrigin;
 
 class PermissionController : public ThreadSafeRefCounted<PermissionController> {
 public:
-    static PermissionController& singleton();
+    WEBCORE_EXPORT static PermissionController& singleton();
     WEBCORE_EXPORT static void setSharedController(Ref<PermissionController>&&);
     
     virtual ~PermissionController() = default;
     virtual void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
     virtual void addObserver(PermissionObserver&) = 0;
     virtual void removeObserver(PermissionObserver&) = 0;
+    virtual void storageAccessPermissionChanged(const RegistrableDomain&, const RegistrableDomain&) = 0;
     virtual void permissionChanged(PermissionName, const SecurityOriginData&) = 0;
+    virtual void addChangeListener(PermissionName, const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) = 0;
+    virtual void removeChangeListener(PermissionName, const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) = 0;
 protected:
     PermissionController() = default;
 };
@@ -63,7 +67,10 @@ private:
     void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
     void addObserver(PermissionObserver&) final { }
     void removeObserver(PermissionObserver&) final { }
+    void storageAccessPermissionChanged(const RegistrableDomain&, const RegistrableDomain&) final { }
     void permissionChanged(PermissionName, const SecurityOriginData&) final { }
+    void addChangeListener(PermissionName, const RegistrableDomain&, const RegistrableDomain&) final { }
+    void removeChangeListener(PermissionName, const RegistrableDomain&, const RegistrableDomain&) final { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/PermissionName.h
+++ b/Source/WebCore/Modules/permissions/PermissionName.h
@@ -42,7 +42,8 @@ enum class PermissionName : uint8_t {
     Notifications,
     Push,
     ScreenWakeLock,
-    SpeakerSelection
+    SpeakerSelection,
+    StorageAccess
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/PermissionName.idl
+++ b/Source/WebCore/Modules/permissions/PermissionName.idl
@@ -41,5 +41,6 @@ enum PermissionName {
     "notifications",
     "push",
     "screen-wake-lock",
-    "speaker-selection"
+    "speaker-selection",
+    "storage-access"
 };

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -85,6 +85,8 @@ static bool isAllowedByPermissionsPolicy(const Document& document, PermissionNam
         return PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::Geolocation, document, PermissionsPolicy::ShouldReportViolation::No);
     case PermissionName::Microphone:
         return PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::Microphone, document, PermissionsPolicy::ShouldReportViolation::No);
+    case PermissionName::StorageAccess:
+        return PermissionsPolicy::isFeatureEnabled(PermissionsPolicy::Feature::StorageAccess, document, PermissionsPolicy::ShouldReportViolation::No);
     default:
         return true;
     }
@@ -116,6 +118,8 @@ std::optional<PermissionName> Permissions::toPermissionName(const String& name)
         return PermissionName::Notifications;
     if (name == "push"_s)
         return PermissionName::Push;
+    if (name == "storage-access"_s)
+        return PermissionName::StorageAccess;
     return std::nullopt;
 }
 

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -90,6 +90,8 @@ static ASCIILiteral toFeatureNameForLogging(PermissionsPolicy::Feature feature)
 #endif
     case PermissionsPolicy::Feature::PrivateToken:
         return "PrivateToken"_s;
+    case PermissionsPolicy::Feature::StorageAccess:
+        return "StorageAccess"_s;
     case PermissionsPolicy::Feature::Invalid:
         return "Invalid"_s;
     }
@@ -129,6 +131,7 @@ static std::pair<PermissionsPolicy::Feature, StringView> readFeatureIdentifier(S
     constexpr auto xrSpatialTrackingToken { "xr-spatial-tracking"_s };
 #endif
     constexpr auto privateTokenToken { "private-token"_s };
+    constexpr auto storageAccessToken { "storage-access"_s };
 
     if (value.startsWith(cameraToken)) {
         feature = PermissionsPolicy::Feature::Camera;
@@ -190,6 +193,9 @@ static std::pair<PermissionsPolicy::Feature, StringView> readFeatureIdentifier(S
     } else if (value.startsWith(privateTokenToken)) {
         feature = PermissionsPolicy::Feature::PrivateToken;
         remainingValue = value.substring(privateTokenToken.length());
+    } else if (value.startsWith(storageAccessToken)) {
+        feature = PermissionsPolicy::Feature::StorageAccess;
+        remainingValue = value.substring(storageAccessToken.length());
     }
 
     // FIXME: webkit.org/b/274159.
@@ -206,6 +212,7 @@ static ASCIILiteral defaultAllowlistValue(PermissionsPolicy::Feature feature)
     switch (feature) {
     case PermissionsPolicy::Feature::Gamepad:
     case PermissionsPolicy::Feature::SyncXHR:
+    case PermissionsPolicy::Feature::StorageAccess:
         return "*"_s;
     case PermissionsPolicy::Feature::Camera:
     case PermissionsPolicy::Feature::Microphone:

--- a/Source/WebCore/html/PermissionsPolicy.h
+++ b/Source/WebCore/html/PermissionsPolicy.h
@@ -70,6 +70,7 @@ public:
         XRSpatialTracking,
 #endif
         PrivateToken,
+        StorageAccess,
         Invalid
     };
     enum class ShouldReportViolation : bool { No, Yes };

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -179,6 +179,7 @@ public:
 
     void hasStorageAccess(SubFrameDomain&&, TopFrameDomain&&, std::optional<WebCore::FrameIdentifier>, WebCore::PageIdentifier, CanRequestStorageAccessWithoutUserInteraction, CompletionHandler<void(bool)>&&);
     void requestStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::StorageAccessScope, CanRequestStorageAccessWithoutUserInteraction, CompletionHandler<void(StorageAccessStatus)>&&);
+    void queryStorageAccessPermission(const SubFrameDomain&, const TopFrameDomain&, CompletionHandler<void(WebCore::PermissionState)>&&);
     enum class AddedRecord : bool { No, Yes };
     std::pair<AddedRecord, std::optional<unsigned>> grantStorageAccessPermission(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain);
     void revokeStorageAccessPermission(const RegistrableDomain&);

--- a/Source/WebKit/NetworkProcess/Classifier/StorageAccessPermissionChangeObserver.h
+++ b/Source/WebKit/NetworkProcess/Classifier/StorageAccessPermissionChangeObserver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,18 @@
 
 #pragma once
 
-#include <wtf/WeakPtr.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
-
-class Page;
 class RegistrableDomain;
-class ScriptExecutionContext;
-enum class PermissionState : uint8_t;
-enum class PermissionQuerySource : uint8_t;
-struct ClientOrigin;
-struct PermissionDescriptor;
+}
 
-class PermissionObserver : public CanMakeWeakPtr<PermissionObserver> {
+namespace WebKit {
+
+class StorageAccessPermissionChangeObserver : public AbstractRefCountedAndCanMakeWeakPtr<StorageAccessPermissionChangeObserver> {
 public:
-    virtual ~PermissionObserver() = default;
-
-    virtual PermissionState currentState() const = 0;
-    virtual void stateChanged(PermissionState) = 0;
-    virtual void addChangeListener(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) = 0;
-    virtual void removeChangeListener(const RegistrableDomain& topFrameDomain, const RegistrableDomain& subFrameDomain) = 0;
-    virtual const ClientOrigin& origin() const = 0;
-    virtual PermissionDescriptor descriptor() const = 0;
-    virtual PermissionQuerySource source() const = 0;
-    virtual const WeakPtr<Page>& page() const = 0;
+    virtual ~StorageAccessPermissionChangeObserver() { }
+    virtual void storageAccessPermissionChanged(const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain) = 0;
 };
 
-} // namespace WebCore
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::PermissionObserver> : std::true_type { };
-}
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -61,6 +61,7 @@ enum class ThirdPartyCookieBlockingMode : uint8_t;
 namespace WebKit {
 
 class NetworkSession;
+class StorageAccessPermissionChangeObserver;
 class ResourceLoadStatisticsStore;
 class WebFrameProxy;
 class WebProcessProxy;
@@ -148,6 +149,7 @@ public:
     void hasStorageAccess(SubFrameDomain&&, TopFrameDomain&&, std::optional<WebCore::FrameIdentifier>, WebCore::PageIdentifier, CompletionHandler<void(bool)>&&);
     bool hasStorageAccessForFrame(const SubFrameDomain&, const TopFrameDomain&, WebCore::FrameIdentifier, WebCore::PageIdentifier);
     void requestStorageAccess(SubFrameDomain&&, TopFrameDomain&&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebPageProxyIdentifier, StorageAccessScope, WebCore::HasOrShouldIgnoreUserGesture, CompletionHandler<void(RequestStorageAccessResult)>&&);
+    void queryStorageAccessPermission(SubFrameDomain&&, TopFrameDomain&&, CompletionHandler<void(WebCore::PermissionState)>&&);
     void setLoginStatus(RegistrableDomain&&, IsLoggedIn, std::optional<LoginStatus>&&, CompletionHandler<void()>&&);
     void isLoggedIn(RegistrableDomain&&, CompletionHandler<void(bool)>&&);
     void setLastSeen(RegistrableDomain&&, Seconds, CompletionHandler<void()>&&);
@@ -232,6 +234,10 @@ public:
     void setStorageAccessPermissionForTesting(bool, WebPageProxyIdentifier, RegistrableDomain&& topFrameDomain, RegistrableDomain&& subFrameDomain, CompletionHandler<void()>&&);
     void wasRevokedStorageAccessPermissionInPage(WebPageProxyIdentifier);
 
+    void startListeningForStorageAccessPermissionChanges(StorageAccessPermissionChangeObserver&, TopFrameDomain&&, SubFrameDomain&&);
+    void stopListeningForStorageAccessPermissionChanges(StorageAccessPermissionChangeObserver&, TopFrameDomain&&, SubFrameDomain&&);
+    void stopListeningForStorageAccessPermissionChanges(StorageAccessPermissionChangeObserver&);
+
 private:
     explicit WebResourceLoadStatisticsStore(NetworkSession&, const String&, ShouldIncludeLocalhost, WebCore::ResourceLoadStatistics::IsEphemeral);
 
@@ -280,6 +286,7 @@ private:
     };
     using StorageAccessRequestRecordKey = std::pair<WebCore::FrameIdentifier, RegistrableDomain>;
     HashMap<StorageAccessRequestRecordKey, StorageAccessRequestRecordValue> m_storageAccessRequestRecords;
+    HashMap<std::pair<RegistrableDomain, RegistrableDomain>, WeakHashSet<StorageAccessPermissionChangeObserver>> m_storageAccessPermissionChangeObservers;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -35,6 +35,7 @@
 #include "PolicyDecision.h"
 #include "SandboxExtension.h"
 #include "SharedPreferencesForWebProcess.h"
+#include "StorageAccessPermissionChangeObserver.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebPaymentCoordinatorProxy.h"
 #include "WebResourceLoadObserver.h"
@@ -141,6 +142,7 @@ class NetworkConnectionToWebProcess final
     , public WebCore::CookieChangeObserver
 #endif
     , public WebCore::CookiesEnabledStateObserver
+    , public StorageAccessPermissionChangeObserver
     , public IPC::Connection::Client {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkConnectionToWebProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkConnectionToWebProcess);
@@ -394,6 +396,7 @@ private:
     void resourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics>&&, CompletionHandler<void()>&&);
     void hasStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebCore::FrameIdentifier, WebCore::PageIdentifier, CompletionHandler<void(bool)>&&);
     void requestStorageAccess(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebPageProxyIdentifier, WebCore::StorageAccessScope, WebCore::HasOrShouldIgnoreUserGesture, CompletionHandler<void(WebCore::RequestStorageAccessResult)>&&);
+    void queryStorageAccessPermission(RegistrableDomain&& subFrameDomain, RegistrableDomain&& topFrameDomain, CompletionHandler<void(WebCore::PermissionState)>&&);
     void storageAccessQuirkForTopFrameDomain(URL&& topFrameURL, CompletionHandler<void(Vector<RegistrableDomain>)>&&);
     void requestStorageAccessUnderOpener(WebCore::RegistrableDomain&& domainInNeedOfStorageAccess, WebCore::PageIdentifier openerPageID, WebCore::RegistrableDomain&& openerDomain);
 
@@ -417,6 +420,11 @@ private:
     void cookiesDeleted(const String& host, const Vector<WebCore::Cookie>&) final;
     void allCookiesDeleted() final;
 #endif
+
+    void subscribeToStorageAccessPermissionChanges(WebCore::RegistrableDomain&& topFrameDomain, WebCore::RegistrableDomain&& subFrameDomain);
+    void unsubscribeFromStorageAccessPermissionChanges(WebCore::RegistrableDomain&& topFrameDomain, WebCore::RegistrableDomain&& subFrameDomain);
+    void storageAccessPermissionChanged(const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain) final;
+
     // WebCore::CookiesEnabledStateObserver
     void cookieEnabledStateMayHaveChanged() final;
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -61,6 +61,9 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     UnsubscribeFromCookieChangeNotifications(String host) AllowedWhenWaitingForSyncReply
 #endif
 
+    SubscribeToStorageAccessPermissionChanges(WebCore::RegistrableDomain topFrameDomain, WebCore::RegistrableDomain subFrameDomain);
+    UnsubscribeFromStorageAccessPermissionChanges(WebCore::RegistrableDomain topFrameDomain, WebCore::RegistrableDomain subFrameDomain);
+
     RegisterInternalFileBlobURL(URL url, String path, String replacementPath, WebKit::SandboxExtensionHandle extensionHandle, String contentType)
     RegisterInternalBlobURL(URL url, Vector<WebCore::BlobPart> blobParts, String contentType)
     RegisterBlobURL(URL url, URL srcURL, struct WebCore::PolicyContainer policyContainer, std::optional<WebCore::SecurityOriginData> topOrigin)
@@ -85,6 +88,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     ResourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics> statistics) -> ()
     [EnabledBy=StorageAccessAPIEnabled] HasStorageAccess(WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID) -> (bool hasStorageAccess)
     [EnabledBy=StorageAccessAPIEnabled] RequestStorageAccess(WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier webPageID, WebKit::WebPageProxyIdentifier webPageProxyID, enum:bool WebCore::StorageAccessScope scope, enum:bool WebCore::HasOrShouldIgnoreUserGesture hasOrShouldIgnoreUserGesture) -> (struct WebCore::RequestStorageAccessResult result)
+    [EnabledBy=StorageAccessAPIEnabled] QueryStorageAccessPermission(WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain) -> (enum:uint8_t WebCore::PermissionState permissionState)
     [EnabledBy=StorageAccessAPIEnabled] StorageAccessQuirkForTopFrameDomain(URL topFrameURL) -> (Vector<WebCore::RegistrableDomain> domains)
     [EnabledBy=StorageAccessAPIEnabled] RequestStorageAccessUnderOpener(WebCore::RegistrableDomain domainInNeedOfStorageAccess, WebCore::PageIdentifier openerPageID, WebCore::RegistrableDomain openerDomain)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9014,6 +9014,7 @@ struct WebCore::OwnerPermissionsPolicyData {
     XRSpatialTracking,
 #endif
     PrivateToken,
+    StorageAccess,
     Invalid
 };
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		0201B9522C238F4800227220 /* WebPageProxyTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0201B9512C238EFE00227220 /* WebPageProxyTesting.h */; };
 		0201B9552C238FA800227220 /* WebPageTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0201B9532C238F8500227220 /* WebPageTesting.h */; };
 		020E13132CA5F2FE002C616E /* WebBackForwardListFrameItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 020E13112CA5F2F1002C616E /* WebBackForwardListFrameItem.h */; };
+		022A83DD2E4405DD00F3E092 /* StorageAccessPermissionChangeObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 022A83DC2E4405DD00F3E092 /* StorageAccessPermissionChangeObserver.h */; };
 		0237F5EA2C4B40E800AD23EF /* WebExtensionSidebarParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */; };
 		0237F5EC2C4EC77300AD23EF /* WebExtensionContextAPISidebarCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0237F5EB2C4EC76800AD23EF /* WebExtensionContextAPISidebarCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
@@ -3201,6 +3202,7 @@
 		020E13122CA5F2F1002C616E /* WebBackForwardListFrameItem.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebBackForwardListFrameItem.cpp; sourceTree = "<group>"; };
 		0214701A2995D2FE0077AFD6 /* DrawingAreaCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DrawingAreaCocoa.mm; sourceTree = "<group>"; };
 		0214701B2995D3860077AFD6 /* DrawingArea.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DrawingArea.cpp; sourceTree = "<group>"; };
+		022A83DC2E4405DD00F3E092 /* StorageAccessPermissionChangeObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = StorageAccessPermissionChangeObserver.h; path = Classifier/StorageAccessPermissionChangeObserver.h; sourceTree = "<group>"; };
 		0237C21428C168D10018A851 /* WebGPUSupportedFeatures.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUSupportedFeatures.serialization.in; sourceTree = "<group>"; };
 		0237F5E82C4B27DC00AD23EF /* WebExtensionSidebarParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionSidebarParameters.serialization.in; sourceTree = "<group>"; };
 		0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSidebarParameters.h; sourceTree = "<group>"; };
@@ -13946,6 +13948,7 @@
 				7ACE82E8221CAE07000DA94C /* ResourceLoadStatisticsStore.cpp */,
 				7ACE82E7221CAE06000DA94C /* ResourceLoadStatisticsStore.h */,
 				7A41E9FA21F81DAC00B88CDB /* ShouldGrandfatherStatistics.h */,
+				022A83DC2E4405DD00F3E092 /* StorageAccessPermissionChangeObserver.h */,
 				7A3FECA121F7C09700F267CD /* StorageAccessStatus.h */,
 				2D1DE3592AFA465300D955D4 /* StorageAccessStatus.serialization.in */,
 				7A843A1A21E41FB200DEF663 /* WebResourceLoadStatisticsStore.cpp */,
@@ -17771,6 +17774,7 @@
 				93D6B784254CCD0E0058DD3A /* SpeechRecognitionServerMessages.h in Headers */,
 				93E799DA276121080074008A /* SQLiteStorageArea.h in Headers */,
 				EEFE72792D64FE5600DC6214 /* StageModeInteractionState.h in Headers */,
+				022A83DD2E4405DD00F3E092 /* StorageAccessPermissionChangeObserver.h in Headers */,
 				7A3FECA221F7C09700F267CD /* StorageAccessStatus.h in Headers */,
 				93E799DC276121080074008A /* StorageAreaBase.h in Headers */,
 				932CA81C283C35EC00C20BEB /* StorageAreaIdentifier.h in Headers */,

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -71,6 +71,7 @@
 #include <WebCore/MessagePort.h>
 #include <WebCore/NavigationScheduler.h>
 #include <WebCore/Page.h>
+#include <WebCore/PermissionController.h>
 #include <WebCore/SharedBuffer.h>
 #include <pal/SessionID.h>
 
@@ -353,5 +354,10 @@ void NetworkProcessConnection::connectToRTCDataChannelRemoteSource(WebCore::RTCD
     callback(RTCDataChannelRemoteManager::singleton().connectToRemoteSource(localIdentifier, remoteIdentifier));
 }
 #endif
+
+void NetworkProcessConnection::storageAccessPermissionChanged(const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain)
+{
+    WebCore::PermissionController::singleton().storageAccessPermissionChanged(topFrameDomain, subFrameDomain);
+}
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -38,6 +38,7 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+class RegistrableDomain;
 class ResourceError;
 class ResourceRequest;
 class ResourceResponse;
@@ -125,6 +126,8 @@ private:
 #endif
 
     void broadcastConsoleMessage(MessageSource, MessageLevel, const String& message);
+
+    void storageAccessPermissionChanged(const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain);
 
     // The connection from the web process to the network process.
     const Ref<IPC::Connection> m_connection;

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
@@ -50,4 +50,6 @@ messages -> NetworkProcessConnection WantsDispatchMessage {
 
     BroadcastConsoleMessage(enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message)
     LoadCancelledDownloadRedirectRequestInFrame(WebCore::ResourceRequest request, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID)
+
+    StorageAccessPermissionChanged(WebCore::RegistrableDomain topFrameDomain, WebCore::RegistrableDomain subFrameDomain)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
@@ -62,7 +62,13 @@ private:
     void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, const WeakPtr<WebCore::Page>&, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
     void addObserver(WebCore::PermissionObserver&) final;
     void removeObserver(WebCore::PermissionObserver&) final;
+    void storageAccessPermissionChanged(const WebCore::RegistrableDomain&, const WebCore::RegistrableDomain&) final;
     void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&) final;
+    void addChangeListener(WebCore::PermissionName, const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain) final;
+    void removeChangeListener(WebCore::PermissionName, const WebCore::RegistrableDomain& topFrameDomain, const WebCore::RegistrableDomain& subFrameDomain) final;
+
+    template<typename ObserverFilter>
+    void notifyObserversIfNeeded(WebCore::PermissionName, ObserverFilter&&);
 
     WeakHashSet<WebCore::PermissionObserver> m_observers;
 };


### PR DESCRIPTION
#### 4164839ade95d9e06b82d50edb8adf491af98069
<pre>
Implement Permissions API integration with the Storage Access API
<a href="https://bugs.webkit.org/show_bug.cgi?id=297181">https://bugs.webkit.org/show_bug.cgi?id=297181</a>
<a href="https://rdar.apple.com/147948198">rdar://147948198</a>

Reviewed by BJ Burg.

This patch enables Permissions API query and onchange functionality to work with the Storage Access API.
More details below.

This progresses the following WPT, but it cannot be tested in CI since we don&apos;t have a local DNS resolver:
imported/w3c/web-platform-tests/storage-access-api/storage-access-permission.sub.https.window.html

<a href="https://privacycg.github.io/storage-access/#permissions-integration">https://privacycg.github.io/storage-access/#permissions-integration</a>

* LayoutTests/http/tests/permissions/resources/storage-access-permission-query-iframe.html: Added.
* LayoutTests/http/tests/permissions/storage-access-permissions-query-expected.txt: Added.
* LayoutTests/http/tests/permissions/storage-access-permissions-query.html: Added.
Add a layout test for coverage since the WPT will fail in CI.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLDedicatedWorker.sub.https.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.BlobURLSharedWorker.sub.https.tentative.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.thirdPartyBlobStorage.sub.https.window-expected.txt:

* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.cpp:
(WebCore::MainThreadPermissionObserver::addChangeListener):
(WebCore::MainThreadPermissionObserver::removeChangeListener):
* Source/WebCore/Modules/permissions/MainThreadPermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionController.h:
* Source/WebCore/Modules/permissions/PermissionObserver.h:
* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::eventListenersDidChange):
Add or remove listeners from the network process when change event listeners are modified.

* Source/WebCore/Modules/permissions/PermissionName.h:
* Source/WebCore/Modules/permissions/PermissionName.idl:
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::isAllowedByPermissionsPolicy):
(WebCore::Permissions::toPermissionName):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::toFeatureNameForLogging):
(WebCore::readFeatureIdentifier):
(WebCore::defaultAllowlistValue):
* Source/WebCore/html/PermissionsPolicy.h:
Add permissions policy support for storage-access permission.

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::queryStorageAccessPermission):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/StorageAccessPermissionChangeObserver.h:
(WebKit::StorageAccessPermissionChangeObserver::~StorageAccessPermissionChangeObserver):
Add an observer to listen for storage access permission changes for a web process, similar to
CookieChangeObserver.

* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::queryStorageAccessPermission):
(WebKit::WebResourceLoadStatisticsStore::startListeningForStorageAccessPermissionChanges):
(WebKit::WebResourceLoadStatisticsStore::stopListeningForStorageAccessPermissionChanges):
Both stop listening functions are needed to remove listeners when the web process terminates or when
change listeners are removed.

(WebKit::WebResourceLoadStatisticsStore::wasGrantedStorageAccessPermissionInPage):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
Add a list to track observers for web processes listening to storage access permission changes.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::~NetworkConnectionToWebProcess):
Remove the observer stored on WebResourceLoadStatisticsStore when a web process terminates.

(WebKit::NetworkConnectionToWebProcess::subscribeToStorageAccessPermissionChanges):
(WebKit::NetworkConnectionToWebProcess::unsubscribeFromStorageAccessPermissionChanges):
(WebKit::NetworkConnectionToWebProcess::storageAccessPermissionChanged):
(WebKit::NetworkConnectionToWebProcess::queryStorageAccessPermission):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::storageAccessPermissionChanged):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
Storage access permissions are controlled by the network process, not the client, so we need to add a new
IPC message to query permissions from the network process.

(WebKit::WebPermissionController::notifyObserversIfNeeded):
(WebKit::WebPermissionController::storageAccessPermissionChanged):
(WebKit::WebPermissionController::permissionChanged):
Storage access permissions are keyed by top-level site and subframe site, not top-level origin. So I
added storageAccessPermissionChanged for storage access permission changes and notifyObserversIfNeeded to
reduce code duplication.

(WebKit::WebPermissionController::addChangeListener):
(WebKit::WebPermissionController::removeChangeListener):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h:
Notify the network process when change listeners are added or removed so it only notifies web processes
of permission changes when listeners exist.

Canonical link: <a href="https://commits.webkit.org/298532@main">https://commits.webkit.org/298532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7c5c28f2a58db248054e60d5edfdae543b11cc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115806 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121854 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c139c11c-1acf-4fed-96dc-93d985678c2d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44047 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/87972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd3bd7c5-0b87-468a-bcca-f5101d167235) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68374 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/27983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65525 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125005 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/42693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96511 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/41772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18507 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48172 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->