### PR TITLE
[Liquid Glass] [iOS] images.google.com: there should not be a bottom gap after tapping on a search result

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container-expected.txt
@@ -1,6 +1,6 @@
 PASS colors.top is null
-PASS colors.left is null
-PASS colors.right is null
+PASS colors.left is "rgb(238, 238, 238)"
+PASS colors.right is "rgb(238, 238, 238)"
 PASS colors.bottom is null
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container.html
@@ -34,8 +34,8 @@
 
         colors = await UIHelper.fixedContainerEdgeColors();
         shouldBeNull("colors.top");
-        shouldBeNull("colors.left");
-        shouldBeNull("colors.right");
+        shouldBeEqualToString("colors.left", "rgb(238, 238, 238)");
+        shouldBeEqualToString("colors.right", "rgb(238, 238, 238)");
         shouldBeNull("colors.bottom");
 
         finishJSTest();

--- a/LayoutTests/fast/page-color-sampling/color-sampling-with-full-viewport-modal-container-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-with-full-viewport-modal-container-expected.txt
@@ -1,0 +1,8 @@
+PASS initialColors.top is "rgb(255, 99, 71)"
+PASS initialColors.bottom is null
+PASS finalColors.top is "rgb(255, 99, 71)"
+PASS finalColors.bottom is "rgb(200, 100, 100)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/color-sampling-with-full-viewport-modal-container.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-with-full-viewport-modal-container.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ContentInsetBackgroundFillEnabled=true pageTopColorSamplingEnabled=true useFlexibleViewport=true obscuredInset.top=50 ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            font-family: system-ui;
+        }
+
+        .header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 60px;
+            background: tomato;
+            z-index: 100;
+        }
+
+        .overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgb(200, 100, 100);
+            z-index: 1000;
+            visibility: hidden;
+        }
+
+        .tall {
+            padding-top: 60px;
+            height: 2000px;
+            background: white;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.setObscuredInsets(50, 0, 50, 0);
+        await UIHelper.ensurePresentationUpdate();
+
+        initialColors = await UIHelper.fixedContainerEdgeColors();
+
+        await UIHelper.delayFor(100);
+        document.querySelector(".overlay").style.visibility = "visible";
+        await UIHelper.ensurePresentationUpdate();
+
+        finalColors = await UIHelper.fixedContainerEdgeColors();
+
+        shouldBeEqualToString("initialColors.top", "rgb(255, 99, 71)");
+        shouldBeNull("initialColors.bottom");
+        shouldBeEqualToString("finalColors.top", "rgb(255, 99, 71)");
+        shouldBeEqualToString("finalColors.bottom", "rgb(200, 100, 100)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div class="header"></div>
+    <div class="tall"></div>
+    <div class="overlay"></div>
+</body>
+</html>


### PR DESCRIPTION
#### 8b209a7da992cc5728c936b41afc2ae5dbafd2e5
<pre>
[Liquid Glass] [iOS] images.google.com: there should not be a bottom gap after tapping on a search result
<a href="https://bugs.webkit.org/show_bug.cgi?id=297182">https://bugs.webkit.org/show_bug.cgi?id=297182</a>
<a href="https://rdar.apple.com/154323236">rdar://154323236</a>

Reviewed by Tim Horton.

Make another adjustment to the color sampling heuristic, to avoid a gap below the fixed-position
container that appears after tapping on a search result. This happens because of the heuristics
added in <a href="https://commits.webkit.org/295724@main">https://commits.webkit.org/295724@main</a>, which enforces stability for sampled edge colors
when the sampled element is &quot;large&quot; (about the size of the viewport, or larger, on both axes). This
change is intended to avoid thrashing sampled colors when fixed popups or containers (e.g. menus)
temporarily show up, usually when interacting with the page. This change also makes sure that large
sticky containers (i.e. taller than the viewport) don&apos;t trigger color extensions.

An exception to this rule was already implemented in <a href="https://commits.webkit.org/296056@main">https://commits.webkit.org/296056@main</a> to
handle semi-transparent dimming views, but there are additional cases where we&apos;re currently missing
color extensions, like on Google Images. To fix this, we introduce a bit more nuance into this rule
by allowing viewport-constrained containers that are (almost) the same size as the viewport to get
color extensions — however, we don&apos;t allow viewport-sized containers like this to _replace_ existing
color extensions, to mitigate the color thrashing problems that were addressed in 295724@main.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container-expected.txt:
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-large-sticky-container.html:

Rebaseline this test — the top and bottom fixed container edges should remain null, but the left and
right edges now get color extensions because the sticky container is precisely edge-to-edge only on
the horizontal axis.

* LayoutTests/fast/page-color-sampling/color-sampling-with-full-viewport-modal-container-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-with-full-viewport-modal-container.html: Added.

Add a new layout test to exercise this change, by showing a fixed-position overlay over a fixed top
header element. The top sampled color shouldn&apos;t change, but the bottom color should match the
popup&apos;s background color.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

See comments above. Make viewport-constrained containers that are (nearly) the same size as the
viewport to get color extensions, by adding a new type (`IsViewportSizedCandidate`) to represent
this case. However, don&apos;t replace existing sampled colors for these viewport-sized containers, to
mitigate color thrashing.

Canonical link: <a href="https://commits.webkit.org/298506@main">https://commits.webkit.org/298506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbbca44fc7a8355bd024e3be5b0aa68ac1228299

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66164 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ebee868-5ff9-4746-bab7-23dec41422ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87851 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42478 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38883263-41d7-466e-91f5-eaa8495257f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68251 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65374 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124846 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96606 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99980 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48008 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41909 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->