### PR TITLE
REGRESSION(298460@main): [CSS][Clang+libstdc++] error: reference to type 'const WebCore::Style::PositionY' requires an initializer

### DIFF
--- a/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h
@@ -42,7 +42,7 @@ template<typename Keyword> concept PrimitiveKeyword
 
 // Concept for use in generic contexts to filter on keywords that are valid for the provided `Keywords` list.
 template<typename Keyword, typename KeywordsList> concept ValidKeywordForList
-    = KeywordsList::isValidKeyword(Keyword()) && PrimitiveKeyword<Keyword>;
+    = PrimitiveKeyword<Keyword> && KeywordsList::isValidKeyword(Keyword());
 
 // MARK: - Primitive Keywords List
 


### PR DESCRIPTION
#### 4ebc245e2259cf588caace2e4e8dcfa1f2f1085b
<pre>
REGRESSION(298460@main): [CSS][Clang+libstdc++] error: reference to type &apos;const WebCore::Style::PositionY&apos; requires an initializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=297192">https://bugs.webkit.org/show_bug.cgi?id=297192</a>

Reviewed by Sam Weinig.

After &lt;<a href="https://commits.webkit.org/298460@main">https://commits.webkit.org/298460@main</a>&gt;, the combination of
Clang and libstdc++ couldn&apos;t compile WebKit.

&gt; tuple:199:9: error: reference to type &apos;const WebCore::Style::PositionY&apos; requires an initializer

The concept ValidKeywordForList should check Keyword is
PrimitiveKeyword before checking isValidKeyword.

* Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h:

Canonical link: <a href="https://commits.webkit.org/298491@main">https://commits.webkit.org/298491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0b5e211bb405107e305583ecbc05bff21126a92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87857 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42491 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21913 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42551 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31904 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 flakes 1 failures; Uploaded test results; 11 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96612 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96400 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38437 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42442 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48014 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41915 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->