### PR TITLE
[JSC] Improve Compatibility of `String.prototype.replace` Behavior to Align with TC39

### DIFF
--- a/JSTests/stress/string-replace-regex-sticky.js
+++ b/JSTests/stress/string-replace-regex-sticky.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`actual: ${actual}, expected: ${expected}`);
+    }
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var input = "abcdeabcdeabcdefghij";
+    var re1 = new RegExp("abcde", "y");
+
+    re1.test(input);
+    shouldBe(re1.lastIndex, 5);
+
+    var ret = input.replace(re1, "ABCDE");
+    shouldBe(ret, "abcdeABCDEabcdefghij");
+    shouldBe(re1.lastIndex, 10);
+
+    ret = input.replace(re1, "ABCDE");
+    shouldBe(ret, "abcdeabcdeABCDEfghij");
+    shouldBe(re1.lastIndex, 15);
+
+    ret = input.replace(re1, "ABCDE");
+    shouldBe(ret, "abcdeabcdeabcdefghij");
+    shouldBe(re1.lastIndex, 0);
+
+    var re2 = /a/y;
+
+    re2.lastIndex = -1;
+    shouldBe("a".replace(re2, "b"), "b");
+    // shouldBe(re2.lastIndex, 1);
+
+    re2.lastIndex = 0;
+    shouldBe("a".replace(re2, "b"), "b");
+    // shouldBe(re2.lastIndex, 1);
+
+    re2.lastIndex = 1;
+    shouldBe("a".replace(re2, "b"), "a");
+    shouldBe(re2.lastIndex, 0);
+
+    re2.lastIndex = 2;
+    shouldBe("a".replace(re2, "b"), "a");
+    shouldBe(re2.lastIndex, 0);
+
+    re2.lastIndex = Infinity;
+    shouldBe("a".replace(re2, "b"), "a");
+    shouldBe(re2.lastIndex, 0);
+
+    re2.lastIndex = -Infinity;
+    shouldBe("a".replace(re2, "b"), "b");
+    shouldBe(re2.lastIndex, 1);
+
+    re2.lastIndex = NaN;
+    shouldBe("a".replace(re2, "b"), "b");
+    shouldBe(re2.lastIndex, 1);
+
+    re2.lastIndex = "foo";
+    shouldBe("a".replace(re2, "b"), "b");
+    shouldBe(re2.lastIndex, 1);
+
+    re2.lastIndex = "1";
+    shouldBe("a".replace(re2, "b"), "a");
+    shouldBe(re2.lastIndex, 0);
+
+    re2.lastIndex = {};
+    shouldBe("a".replace(re2, "b"), "b");
+    shouldBe(re2.lastIndex, 1);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1350,10 +1350,6 @@ test/staging/sm/RegExp/match-local-tolength-recompilation.js:
   default: 'Test262Error: Expected SameValue(«false», «true») to be true'
 test/staging/sm/RegExp/replace-local-tolength-recompilation.js:
   default: 'Test262Error: Expected SameValue(«"b"», «"pass"») to be true'
-test/staging/sm/RegExp/replace-sticky-lastIndex.js:
-  default: 'Test262Error: Expected SameValue(«"b"», «"a"») to be true'
-test/staging/sm/RegExp/replace-sticky.js:
-  default: 'Test262Error: Expected SameValue(«"ABCDEabcdeabcdefghij"», «"abcdeABCDEabcdefghij"») to be true'
 test/staging/sm/RegExp/split-limit.js:
   default: 'Test262Error: Expected SameValue(«3», «1») to be true'
 test/staging/sm/RegExp/split-trace.js:

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3264,7 +3264,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringProtoFuncReplaceRegExpEmptyStr, JSCell*,
 
     CallData callData;
     String replacementString;
-    OPERATION_RETURN(scope, replaceOneWithStringUsingRegExpSearch(vm, globalObject, thisValue, source, regExp, replacementString));
+    OPERATION_RETURN(scope, replaceOneWithStringUsingRegExpSearch(vm, globalObject, thisValue, source, searchValue, replacementString));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationStringProtoFuncReplaceAllRegExpEmptyStr, JSCell*, (JSGlobalObject* globalObject, JSString* thisValue, RegExpObject* searchValue))

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1229,13 +1229,31 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
     RELEASE_AND_RETURN(scope, jsSpliceSubstringsWithSeparators(globalObject, string, source, sourceRanges.span().data(), sourceRanges.size(), replacements.span().data(), replacements.size()));
 }
 
-ALWAYS_INLINE JSString* replaceOneWithStringUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSString* string, const String& source, RegExp* regExp, const String& replacementString)
+ALWAYS_INLINE JSString* replaceOneWithStringUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSString* string, const String& source, RegExpObject* regExpObject, const String& replacementString)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     int* ovector;
-    MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, string, source, 0, &ovector);
+    RegExp* regExp = regExpObject->regExp();
+    bool sticky = regExp->sticky();
+
+    double lastIndex = regExpObject->getLastIndex().toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
+
+    if (sticky && std::signbit(lastIndex)) {
+        regExpObject->setLastIndex(globalObject, 0);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
+
+    int startOffset = sticky ? static_cast<int>(regExpObject->getLastIndex().toIntegerOrInfinity(globalObject)) : 0;
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp, string, source, startOffset, &ovector);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    if (sticky) {
+        regExpObject->setLastIndex(globalObject, result.end);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+    }
     if (!result)
         return string;
 
@@ -1306,7 +1324,7 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
 
         if (global)
             RELEASE_AND_RETURN(scope, replaceAllWithStringUsingRegExpSearch(vm, globalObject, string, source, regExp, replacementString));
-        RELEASE_AND_RETURN(scope, replaceOneWithStringUsingRegExpSearch(vm, globalObject, string, source, regExp, replacementString));
+        RELEASE_AND_RETURN(scope, replaceOneWithStringUsingRegExpSearch(vm, globalObject, string, source, regExpObject, replacementString));
     }
 
     size_t lastIndex = 0;


### PR DESCRIPTION
#### 34c4b19dbf57fd33eb5bd9a02ac1afad1df4d3ca
<pre>
[JSC] Improve Compatibility of `String.prototype.replace` Behavior to Align with TC39
<a href="https://bugs.webkit.org/show_bug.cgi?id=297193">https://bugs.webkit.org/show_bug.cgi?id=297193</a>

Reviewed by NOBODY (OOPS!).

This patch improves the compatibility of `String.prototype.replace` behavior to align with TC39 [1].

[1]: <a href="https://tc39.es/ecma262/#sec-string.prototype.replace">https://tc39.es/ecma262/#sec-string.prototype.replace</a>

* JSTests/stress/string-replace-regex-sticky.js: Added.
(shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::replaceOneWithStringUsingRegExpSearch):
(JSC::replaceUsingRegExpSearch):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34c4b19dbf57fd33eb5bd9a02ac1afad1df4d3ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66584 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88016 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42709 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22088 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65596 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107986 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125078 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114405 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96769 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96555 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41815 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19689 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38686 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48242 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/142735 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42120 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36897 "Found 7355 new JSC stress test failures: airjs-tests.yaml/stress-test.js.lockdown, basic-tests.yaml/stress-test.js.lockdown, cdjs-tests.yaml/main.js.lockdown, cdjs-tests.yaml/motion_test.js.lockdown, cdjs-tests.yaml/red_black_tree_test.js.lockdown, cdjs-tests.yaml/reduce_collision_set_test.js.lockdown, microbenchmarks/Float32Array-matrix-mult.js.lockdown, microbenchmarks/Int16Array-bubble-sort-with-byteLength.js.lockdown, microbenchmarks/Int16Array-bubble-sort.js.lockdown, microbenchmarks/Int16Array-load-int-mul.js.lockdown ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->