### PR TITLE
[JSC] Fix duplicate `iterator.next` property access in `Set#union`

### DIFF
--- a/JSTests/stress/set-prototype-union-accessor-order.js
+++ b/JSTests/stress/set-prototype-union-accessor-order.js
@@ -1,0 +1,86 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldBeArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(
+            `bad array length: ${actual.length}, expected: ${expected.length}`,
+        );
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(
+                `bad value at index ${i}: ${actual[i]}, expected: ${expected[i]}`,
+            );
+    }
+}
+
+let observedOrder = [];
+
+let setLikeObject = {
+    size: 3,
+    has: function () {
+        observedOrder.push('has()');
+        return false;
+    },
+    keys: function () {
+        observedOrder.push('keys()');
+        let values = ['a', 'b', 'c'];
+        let index = 0;
+        return {
+            get next() {
+                observedOrder.push('getting next');
+                return function () {
+                    observedOrder.push('calling next');
+                    if (index < values.length) {
+                        return {
+                            get done() {
+                                observedOrder.push('getting done');
+                                return false;
+                            },
+                            get value() {
+                                observedOrder.push('getting value');
+                                return values[index++];
+                            },
+                        };
+                    }
+                    return {
+                        get done() {
+                            observedOrder.push('getting done');
+                            return true;
+                        },
+                    };
+                };
+            },
+        };
+    },
+};
+
+let set = new Set([1, 2]);
+let result = set.union(setLikeObject);
+
+shouldBe(result.size, 5);
+shouldBe(result.has(1), true);
+shouldBe(result.has(2), true);
+shouldBe(result.has('a'), true);
+shouldBe(result.has('b'), true);
+shouldBe(result.has('c'), true);
+
+let expectedOrder = [
+    'keys()',
+    'getting next',
+    'calling next',
+    'getting done',
+    'getting value',
+    'calling next',
+    'getting done',
+    'getting value',
+    'calling next',
+    'getting done',
+    'getting value',
+    'calling next',
+    'getting done',
+];
+
+shouldBeArray(observedOrder, expectedOrder);

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -423,15 +423,14 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
     JSValue iterator = call(globalObject, keys, keysCallData, otherValue, args);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // unused but iterator.get call is observable
-    iterator.get(globalObject, vm.propertyNames->next);
+    IterationRecord iterationRecord = iteratorDirect(globalObject, iterator);
     RETURN_IF_EXCEPTION(scope, { });
 
     JSSet* result = thisSet->clone(globalObject, vm, globalObject->setStructure());
     RETURN_IF_EXCEPTION(scope, { });
 
     scope.release();
-    forEachInIteratorProtocol(globalObject, iterator, [&](VM&, JSGlobalObject* globalObject, JSValue key) -> void {
+    forEachInIterationRecord(globalObject, iterationRecord, [&](VM&, JSGlobalObject* globalObject, JSValue key) -> void {
         result->add(globalObject, key);
         RETURN_IF_EXCEPTION(scope, void());
     });


### PR DESCRIPTION
#### a56c848d924c3928c10db66a92017424a3dcc75a
<pre>
[JSC] Fix duplicate `iterator.next` property access in `Set#union`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297194">https://bugs.webkit.org/show_bug.cgi?id=297194</a>

Reviewed by Yusuke Suzuki.

`Set#union` C++ implementation added by <a href="https://commits.webkit.org/298316@main">https://commits.webkit.org/298316@main</a>
was accessing `iterator.next` twice instead of once, causing test262 failures[1].

This patch fixes by using `iteratorDirect` with `forEachInIterationRecord` to
access the property only once.

[1]: <a href="https://build.webkit.org/#/builders/1232/builds/9714">https://build.webkit.org/#/builders/1232/builds/9714</a>

* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/298486@main">https://commits.webkit.org/298486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dd4ff995c17f5629bc42850818f8ae0be56de40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87864 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42502 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21920 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65387 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124859 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114189 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38457 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42449 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48021 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41922 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->