### PR TITLE
[TestWebKitAPI] Use makeVector() in WebKit.LoadAndDecodeImage

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm
@@ -48,21 +48,20 @@ static bool done;
 
 TEST(WebKit, LoadAndDecodeImage)
 {
-    auto contentsToVector = [] (NSURL *url) {
-        NSData *data = [NSData dataWithContentsOfURL:url];
-        Vector<uint8_t> result;
-        for (NSUInteger i = 0; i < data.length; i++)
-            result.append(static_cast<const uint8_t*>(data.bytes)[i]);
-        return result;
+    auto resourceToVector = [] (NSString *resource, NSString *extension) {
+        @autoreleasepool {
+            NSURL *url = [NSBundle.test_resourcesBundle URLForResource:resource withExtension:extension];
+            return makeVector([NSData dataWithContentsOfURL:url]);
+        }
     };
     auto pngData = [&] {
-        return contentsToVector([NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]);
+        return resourceToVector(@"icon", @"png");
     };
     auto untaggedPNGData = [&] {
-        return contentsToVector([NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]);
+        return resourceToVector(@"400x400-green", @"png");
     };
     auto gifData = [&] {
-        return contentsToVector([NSBundle.test_resourcesBundle URLForResource:@"apple" withExtension:@"gif"]);
+        return resourceToVector(@"apple", @"gif");
     };
 
     HTTPServer server {


### PR DESCRIPTION
#### ba856c7858e1b2489c1554fd5aca1f2dfdabe92f
<pre>
[TestWebKitAPI] Use makeVector() in WebKit.LoadAndDecodeImage
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=297195">https://bugs.webkit.org/show_bug.cgi?id=297195</a>&gt;
&lt;<a href="https://rdar.apple.com/157984825">rdar://157984825</a>&gt;

Reviewed by Darin Adler.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm:
(TestWebKitAPI::TEST(WebKit, LoadAndDecodeImage)):
- Replace custom conversion loop in contentsToVector() lambda with
  makeVector().
- Rename contentsToVector() to resourceToVector() and take two arguments
  so the call to -[NSBundle URLForResource:withExtension:] can be moved
  into this method.
- Add @autoreleasepool { } block to resourceToVector() to clean up
  autoreleased objects sooner.
- Change calls from contentsToVector() to resourceToVector().

Canonical link: <a href="https://commits.webkit.org/298489@main">https://commits.webkit.org/298489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64bf6071e2e2812801b6e54361a6723fd5696e1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66199 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65b6636a-70a4-4706-b923-6eaca617790d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87870 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42508 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c9e2982-a7b9-457d-9c5b-13b0da9d10de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68270 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21926 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65399 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124871 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96625 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41671 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38473 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42461 "Built successfully") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41934 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45265 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->