### PR TITLE
Only schedule selectionchange on text controls outside shadow trees

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-document-if-textcontrol-element-is-in-shadow-tree-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-document-if-textcontrol-element-is-in-shadow-tree-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL selectionchange event fired on the document in case TextControl element is in Shadow Tree assert_equals: expected 0 but got 1
+PASS selectionchange event fired on the document in case TextControl element is in Shadow Tree
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -457,7 +457,7 @@ bool FrameSelection::setSelectionWithoutUpdatingAppearance(const VisibleSelectio
         document->editor().respondToChangedSelection(oldSelection, options);
 
     if (shouldScheduleSelectionChangeEvent) {
-        if (textControl)
+        if (textControl && !textControl->isInShadowTree())
             textControl->scheduleSelectionChangeEvent();
         else if (!m_hasScheduledSelectionChangeEventOnDocument) {
             m_hasScheduledSelectionChangeEventOnDocument = true;


### PR DESCRIPTION
#### 4111a479715f3c69a13dabd09d40f76fc9df1469
<pre>
Only schedule selectionchange on text controls outside shadow trees
<a href="https://bugs.webkit.org/show_bug.cgi?id=297200">https://bugs.webkit.org/show_bug.cgi?id=297200</a>

Reviewed by Wenson Hsieh.

Currently, WebKit schedules a selectionchange on the text control
regardless of whether it was in a shadow tree, causing incorrect event
targets.

This patch adds a !textControl-&gt;isInShadowTree() check before scheduling
the control-level event, ensuring shadow tree cases fall back to the
document-level scheduling path.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance):
* LayoutTests/imported/w3c/web-platform-tests/selection/fire-selectionchange-event-on-document-if-textcontrol-element-is-in-shadow-tree-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/298631@main">https://commits.webkit.org/298631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c275ad7cc72bdc06587c36c07f70906a5da0427a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66212 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f324d049-0380-4f14-803c-1a2410be2683) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87876 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42519 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25db7eea-2849-4bff-9e7f-443cb8fa3660) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68276 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21933 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65409 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124881 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96632 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96420 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19537 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38488 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48043 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41944 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->