### PR TITLE
HDR 2D Canvas: Support for Float16 backend with put/getImageData

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2614,6 +2614,7 @@ fast/images/animated-jpegxl-loop-count.html [ Skip ]
 
 # Only applicable on platforms with HDR support
 compositing/hdr [ Skip ]
+fast/canvas/hdr [ Skip ]
 fast/images/hdr-basic-image.html [ Skip ]
 fast/images/hdr-basic-image-dynamic-range-limit.html [ Skip ]
 fast/images/hdr-background-image.html [ Skip ]

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt
@@ -1,0 +1,58 @@
+Tests that put/getImageData work with float16 canvas.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS created_imageData_float16.width is 1
+PASS created_imageData_float16.height is 1
+PASS created_imageData_float16.data.constructor is Float16Array
+PASS created_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS created_imageData_float16.data.length is 4
+PASS created_imageData_float16.data.byteLength is 8
+PASS created_imageData_float16.data.at(0) is 0
+PASS created_imageData_float16.data.at(1) is 0
+PASS created_imageData_float16.data.at(2) is 0
+PASS created_imageData_float16.data.at(3) is 0
+PASS gotten_imageData_float16.width is 1
+PASS gotten_imageData_float16.height is 1
+PASS gotten_imageData_float16.data.constructor is Float16Array
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is 2
+PASS gotten_imageData_float16.data.length is 4
+PASS gotten_imageData_float16.data.byteLength is 8
+PASS gotten_imageData_float16.data.at(0) is within 0.001953125 of 0
+PASS gotten_imageData_float16.data.at(1) is within 0.001953125 of 0.5019607843137255
+PASS gotten_imageData_float16.data.at(2) is within 0.001953125 of 1
+PASS gotten_imageData_float16.data.at(3) is within 0.001953125 of 1
+PASS created_imageData_uint8.width is 1
+PASS created_imageData_uint8.height is 1
+PASS created_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS created_imageData_uint8.data.BYTES_PER_ELEMENT is 1
+PASS created_imageData_uint8.data.length is 4
+PASS created_imageData_uint8.data.byteLength is 4
+PASS created_imageData_uint8.data.at(0) is 0
+PASS created_imageData_uint8.data.at(1) is 0
+PASS created_imageData_uint8.data.at(2) is 0
+PASS created_imageData_uint8.data.at(3) is 0
+PASS gotten_imageData_uint8.width is 1
+PASS gotten_imageData_uint8.height is 1
+PASS gotten_imageData_uint8.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8.data.length is 4
+PASS gotten_imageData_uint8.data.byteLength is 4
+PASS gotten_imageData_uint8.data.at(0) is 0
+PASS gotten_imageData_uint8.data.at(1) is 128
+PASS gotten_imageData_uint8.data.at(2) is 255
+PASS gotten_imageData_uint8.data.at(3) is 255
+PASS gotten_imageData_uint8_from_float16.width is 1
+PASS gotten_imageData_uint8_from_float16.height is 1
+PASS gotten_imageData_uint8_from_float16.data.constructor is Uint8ClampedArray
+PASS gotten_imageData_uint8_from_float16.data.BYTES_PER_ELEMENT is 1
+PASS gotten_imageData_uint8_from_float16.data.length is 4
+PASS gotten_imageData_uint8_from_float16.data.byteLength is 4
+PASS gotten_imageData_uint8_from_float16.data.at(0) is 0
+PASS gotten_imageData_uint8_from_float16.data.at(1) is 128
+PASS gotten_imageData_uint8_from_float16.data.at(2) is 255
+PASS gotten_imageData_uint8_from_float16.data.at(3) is 255
+PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html
@@ -2,20 +2,21 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test-pre.js"></script>
 </head>
 <body>
 <script>
-description("Tests that ImageDataSettings contains storageFormat.");
+description("Tests that put/getImageData work with float16 canvas.");
 
 var canvas = document.createElement("canvas");
 canvas.width = 10;
 canvas.height = 10;
-var context = canvas.getContext("2d");
+var context = canvas.getContext("2d", { pixelFormat: "float16" });
 var r = 0;
 var g = 128;
 var b = 255;
 var a = 255;
+// FIXME: Fill still only works in SRGB/uint8, adapt when extended/float16 support is available.
 context.fillStyle = `rgb(${r} ${g} ${b})`;
 context.fillRect(0, 0, 1, 1);
 
@@ -44,30 +45,30 @@ const float16_bytes_per_element = 2;
 // Less than half the range of a color component [0..255]/255 unit.
 const float16_nonzero_tolerance = (1 / 256) / 2;
 
-var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
-verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, 0, 0, 0, 0);
-
-var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
-
 var created_imageData_float16 = context.createImageData(1, 1, { storageFormat: "float16" });
 verifyImageData('created_imageData_float16', 'Float16Array', float16_bytes_per_element, 0, 0, 0, 0, 0);
 
-// This verifies the basic uint8->float16 conversion.
 var gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
 verifyImageData('gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance);
 
-// Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
+var created_imageData_uint8 = context.createImageData(1, 1, { storageFormat: "uint8" });
+verifyImageData('created_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, 0, 0, 0, 0);
+
 // This verifies the basic float16->uint8 conversion:
+var gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
+verifyImageData('gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
+
+// Put the float16 ImageData back into the (uint8-backed) canvas, and get a default (uint8) ImageData.
+// This verifies the basic uint8->float16 conversion.
 context.clearRect(0, 0, 1, 1);
 context.putImageData(gotten_imageData_float16, 0, 0);
 var gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, 1, 1);
 verifyImageData('gotten_imageData_uint8_from_float16', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
-// Exhaustive uint8->float16->uint8 round-trip test for all possible individual component values. Only log errors.
+// Exhaustive uint8->float16->uint8 round-trip test for all possible individual SRGB/uint8 component values. Only log errors.
+const quiet = true;
 for (let v = 0; v < 256; ++v) {
     for (component = 0; component < 4; ++component) {
-        const quiet = true;
         r = g = b = 0;
         a = 255;
         switch (component) {
@@ -80,7 +81,7 @@ for (let v = 0; v < 256; ++v) {
         created_imageData_uint8.data[1] = g;
         created_imageData_uint8.data[2] = b;
         created_imageData_uint8.data[3] = a;
-        const prefix = '/* ' + r + "," + g + "," + b + "," + a + " */ ";
+        const prefix = '/* #' + v + "-" + component + ": " + r + "," + g + "," + b + "," + a + " */ ";
 
         context.putImageData(created_imageData_uint8, 0, 0);
         gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
@@ -94,6 +95,55 @@ for (let v = 0; v < 256; ++v) {
         verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
         gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
         verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
+    }
+}
+
+// Deeper float16->(same)float16->uint8->(nearby)float16 round-trip test for many possible individual component values. Only log errors.
+const divisions = 512;
+const maxValue = 2;
+// A few extras:      largest subnormal    smallest normal  largest <1     smallest >1  largest ...
+const extraValues = [ 6.097555160522461e-5, 6.103515625e-5, 0.99951171875, 1.0009765625, 65504, -1, -65504, Infinity, -Infinity ];
+for (let division = -extraValues.length; division < divisions; ++division) {
+    const floatValue = (division >= 0) ? (maxValue * division / divisions) : extraValues[extraValues.length + division];
+    for (component = 0; component < 3; ++component) {
+        r = g = b = 0;
+        a = 1;
+        switch (component) {
+        case 0: r = floatValue; break;
+        case 1: g = floatValue; break;
+        case 2: b = floatValue; break;
+        }
+        created_imageData_float16.data[0] = r;
+        created_imageData_float16.data[1] = g;
+        created_imageData_float16.data[2] = b;
+        created_imageData_float16.data[3] = a;
+        const prefix = '/* #' + ((division >= 0) ? division : ((extraValues.length + division) + "extra")) + "-" + component + ": " + r + "," + g + "," + b + "," + a + " */ ";
+
+        context.putImageData(created_imageData_float16, 0, 0);
+        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r, g, b, a, 0, quiet);
+
+        // Convert float16 [0,1] to expected [0,255] value, with a tolerance of half a unit.
+        const uint8_nonzero_tolerance = 1 / 2;
+        let clamp01 = (x) => Math.min(Math.max(x, 0), 1);
+        r = clamp01(r) * 255;
+        g = clamp01(g) * 255;
+        b = clamp01(b) * 255;
+        a = clamp01(a) * 255;
+        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
+        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, uint8_nonzero_tolerance, quiet);
+
+        // Convert rounded uint8 back to float.
+        context.clearRect(0, 0, 1, 1);
+        context.putImageData(gotten_imageData_uint8, 0, 0);
+        r = Math.round(r);
+        g = Math.round(g);
+        b = Math.round(b);
+        a = Math.round(a);
+        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
+        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
+        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
+        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
     }
 }
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4588,6 +4588,7 @@ fast/images/pagewide-play-pause-offscreen-animations.html [ Pass ]
 
 # Only applicable on platforms with HDR support
 compositing/hdr [ Pass ]
+fast/canvas/hdr [ Pass ]
 fast/images/hdr-basic-image.html [ Pass ]
 fast/images/hdr-basic-image-dynamic-range-limit.html [ Pass ]
 fast/images/hdr-background-image.html [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1478,6 +1478,7 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 
 # Only applicable on platforms with HDR support
 [ Sequoia+ ] compositing/hdr [ Pass ]
+[ Sequoia+ ] fast/canvas/hdr [ Pass ]
 [ Sequoia+ ] fast/images/hdr-basic-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-basic-image-dynamic-range-limit.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-background-image.html [ Pass ]

--- a/LayoutTests/storage/indexeddb/modern/objectstore-autoincrement-types-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/objectstore-autoincrement-types-expected.txt
@@ -27,6 +27,7 @@ PASS request.result.primaryKey is imageData.primaryKey
 PASS request.result.width is imageData.width
 PASS request.result.height is imageData.height
 PASS request.result.colorSpace is imageData.colorSpace
+PASS request.result.storageFormat is imageData.storageFormat
 PASS key is 4
 PASS request.result.primaryKey is fileList.primaryKey
 PASS request.result.length is fileList.length
@@ -42,6 +43,7 @@ PASS request.result[2].primaryKey is imageData.primaryKey
 PASS request.result[2].width is imageData.width
 PASS request.result[2].height is imageData.height
 PASS request.result[2].colorSpace is imageData.colorSpace
+PASS request.result[2].storageFormat is imageData.storageFormat
 PASS request.result[3].primaryKey is fileList.primaryKey
 PASS request.result[3].length is fileList.length
 PASS successfullyParsed is true

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1682,7 +1682,7 @@ CanvasLayersEnabled:
 
 CanvasPixelFormatEnabled:
   type: bool
-  status: unstable
+  status: testable
   category: dom
   humanReadableName: "CanvasRenderingContext2DSettings.pixelFormat"
   humanReadableDescription: "Allow different pixel formats in 2D canvas"

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include "ImageDataArray.h"
 #include "ImageDataSettings.h"
 #include "IntSize.h"
@@ -43,6 +44,10 @@ template<typename> class ExceptionOr;
 class ImageData : public RefCounted<ImageData> {
 public:
     WEBCORE_EXPORT static Ref<ImageData> create(Ref<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    WEBCORE_EXPORT static Ref<ImageData> create(Ref<Float16ArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
+#endif
+    WEBCORE_EXPORT static RefPtr<ImageData> create(Ref<PixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(RefPtr<ByteArrayPixelBuffer>&&, std::optional<ImageDataStorageFormat> = { });
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, PredefinedColorSpace, ImageDataStorageFormat = ImageDataStorageFormat::Uint8);
     WEBCORE_EXPORT static RefPtr<ImageData> create(const IntSize&, ImageDataArray&&, PredefinedColorSpace);
@@ -64,6 +69,10 @@ public:
     ImageDataStorageFormat storageFormat() const { return m_data.storageFormat(); }
 
     Ref<ByteArrayPixelBuffer> byteArrayPixelBuffer() const;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    Ref<Float16ArrayPixelBuffer> float16ArrayPixelBuffer() const;
+#endif
+    Ref<PixelBuffer> pixelBuffer() const;
 
 private:
     explicit ImageData(const IntSize&, ImageDataArray&&, PredefinedColorSpace);

--- a/Source/WebCore/platform/graphics/ImageBufferAllocator.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferAllocator.cpp
@@ -27,6 +27,7 @@
 #include "ImageBufferAllocator.h"
 
 #include "ByteArrayPixelBuffer.h"
+#include "Float16ArrayPixelBuffer.h"
 #include "ImageBuffer.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -44,6 +45,10 @@ RefPtr<ImageBuffer> ImageBufferAllocator::createImageBuffer(const FloatSize& siz
 
 RefPtr<PixelBuffer> ImageBufferAllocator::createPixelBuffer(const PixelBufferFormat& format, const IntSize& size) const
 {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (format.pixelFormat == PixelFormat::RGBA16F)
+        return Float16ArrayPixelBuffer::tryCreate(format, size);
+#endif
     return ByteArrayPixelBuffer::tryCreate(format, size);
 }
 

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -42,6 +42,10 @@ namespace WebCore {
 class PixelBuffer : public RefCounted<PixelBuffer> {
     WTF_MAKE_NONCOPYABLE(PixelBuffer);
 public:
+    static constexpr uint32_t bytesPerPixelComponent(PixelFormat);
+    static constexpr uint32_t componentsPerPixel(PixelFormat);
+    static constexpr uint32_t bytesPerPixel(PixelFormat);
+
     static CheckedUint32 computePixelCount(const IntSize&);
     static CheckedUint32 computePixelComponentCount(PixelFormat, const IntSize&);
     WEBCORE_EXPORT static CheckedUint32 computeBufferSize(PixelFormat, const IntSize&);
@@ -74,7 +78,7 @@ public:
 
 protected:
     WEBCORE_EXPORT PixelBuffer(const PixelBufferFormat&, const IntSize&, std::span<uint8_t> bytes);
-    
+
     PixelBufferFormat m_format;
     IntSize m_size;
 
@@ -116,5 +120,25 @@ private:
     IntSize m_size;
     std::span<const uint8_t> m_bytes;
 };
+
+constexpr uint32_t PixelBuffer::bytesPerPixelComponent(PixelFormat pixelFormat)
+{
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    return (pixelFormat == PixelFormat::RGBA16F) ? 2 : 1;
+#else
+    UNUSED_PARAM(pixelFormat);
+    return 1;
+#endif
+}
+
+constexpr uint32_t PixelBuffer::componentsPerPixel(PixelFormat)
+{
+    return 4;
+}
+
+constexpr uint32_t PixelBuffer::bytesPerPixel(PixelFormat pixelFormat)
+{
+    return bytesPerPixelComponent(pixelFormat) * componentsPerPixel(pixelFormat);
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -29,6 +29,7 @@
 #if USE(CG)
 
 #include "IntRect.h"
+#include "PixelBuffer.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -60,10 +61,10 @@ ImageBufferCGBackend::ImageBufferCGBackend(const Parameters& parameters, std::un
 
 ImageBufferCGBackend::~ImageBufferCGBackend() = default;
 
-unsigned ImageBufferCGBackend::calculateBytesPerRow(const IntSize& backendSize)
+unsigned ImageBufferCGBackend::calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat imageBufferPixelFormat)
 {
     ASSERT(!backendSize.isEmpty());
-    return CheckedUint32(backendSize.width()) * 4;
+    return CheckedUint32(backendSize.width()) * PixelBuffer::bytesPerPixel(convertToPixelFormat(imageBufferPixelFormat));
 }
 
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlusher()

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class WEBCORE_EXPORT ImageBufferCGBackend : public ImageBufferBackend {
 public:
     ~ImageBufferCGBackend() override;
-    static unsigned calculateBytesPerRow(const IntSize& backendSize);
+    static unsigned calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat);
 
 protected:
     ImageBufferCGBackend(const Parameters&, std::unique_ptr<GraphicsContextCG>&& = nullptr);

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ImageBufferCGBitmapBackend);
 
 size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
 }
 
 std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
@@ -104,7 +104,7 @@ GraphicsContext& ImageBufferCGBitmapBackend::context()
 
 unsigned ImageBufferCGBitmapBackend::bytesPerRow() const
 {
-    return calculateBytesPerRow(m_parameters.backendSize);
+    return calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
 }
 
 bool ImageBufferCGBitmapBackend::canMapBackingStore() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
@@ -40,7 +40,7 @@ size_t ImageBufferCGPDFDocumentBackend::calculateMemoryCost(const Parameters& pa
 {
     // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
     // should really be based on the PDF document size.
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
 }
 
 std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -58,16 +58,16 @@ IntSize ImageBufferIOSurfaceBackend::calculateSafeBackendSize(const Parameters& 
     return backendSize;
 }
 
-unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backendSize)
+unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat imageBufferPixelFormat)
 {
-    unsigned bytesPerRow = ImageBufferCGBackend::calculateBytesPerRow(backendSize);
+    unsigned bytesPerRow = ImageBufferCGBackend::calculateBytesPerRow(backendSize, imageBufferPixelFormat);
     size_t alignmentMask = IOSurface::bytesPerRowAlignment() - 1;
     return (bytesPerRow + alignmentMask) & ~alignmentMask;
 }
 
 size_t ImageBufferIOSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
 }
 
 std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -40,7 +40,7 @@ class WEBCORE_EXPORT ImageBufferIOSurfaceBackend : public ImageBufferCGBackend {
     WTF_MAKE_NONCOPYABLE(ImageBufferIOSurfaceBackend);
 public:
     static IntSize calculateSafeBackendSize(const Parameters&);
-    static unsigned calculateBytesPerRow(const IntSize& backendSize);
+    static unsigned calculateBytesPerRow(const IntSize& backendSize, ImageBufferPixelFormat);
     static size_t calculateMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferIOSurfaceBackend> create(const Parameters&, const ImageBufferCreationContext&);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5994,8 +5994,8 @@ static bool rendererHasHDRContent(const RenderElement& renderer)
                 return true;
         }
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    } else if (CheckedPtr canavsRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer)) {
-        if (auto* renderingContext = canavsRenderer->canvasElement().renderingContext()) {
+    } else if (CheckedPtr canvasRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer)) {
+        if (auto* renderingContext = canvasRenderer->canvasElement().renderingContext()) {
             if (renderingContext->isHDR())
                 return true;
         }

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
@@ -49,12 +49,12 @@ ShareablePixelBuffer::ShareablePixelBuffer(const PixelBufferFormat& format, cons
     : PixelBuffer(format, size, data->mutableSpan())
     , m_data(WTFMove(data))
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_size.area() * 4 <= bytes().size());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(computeBufferSize(format.pixelFormat, size).value() <= bytes().size());
 }
 
 RefPtr<PixelBuffer> ShareablePixelBuffer::createScratchPixelBuffer(const IntSize& size) const
 {
-    return ShareablePixelBuffer::tryCreate(m_format, size);
+    return ShareablePixelBuffer::tryCreate(format(), size);
 }
 
 Ref<WebCore::SharedMemory> ShareablePixelBuffer::protectedData() const

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -98,7 +98,7 @@ GraphicsContext& ImageBufferRemoteIOSurfaceBackend::context()
 
 unsigned ImageBufferRemoteIOSurfaceBackend::bytesPerRow() const
 {
-    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(m_parameters.backendSize);
+    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
 }
 
 RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage()


### PR DESCRIPTION
#### 7a7acedd6de93309eae61d40394f0fbbb886541e
<pre>
HDR 2D Canvas: Support for Float16 backend with put/getImageData
<a href="https://bugs.webkit.org/show_bug.cgi?id=297212">https://bugs.webkit.org/show_bug.cgi?id=297212</a>
<a href="https://rdar.apple.com/158032286">rdar://158032286</a>

Reviewed by Mike Wyrzykowski.

ImageBufferBackend&apos;s support for Float16 image data, including
conversions between uint8 and float16.

In this initial &quot;testable&quot; implementation, setting the canvas pixel
format to float16 is enough to engage the display of HDR pixels.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt: Added.
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html: Added.
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/storage/indexeddb/modern/objectstore-autoincrement-types-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/ImageData.cpp:
(WebCore::ImageData::create):
(WebCore::ImageData::float16ArrayPixelBuffer const):
(WebCore::ImageData::pixelBuffer const):
* Source/WebCore/html/ImageData.h:
(WebCore::ImageData::create):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
* Source/WebCore/platform/graphics/ImageBufferAllocator.cpp:
(WebCore::ImageBufferAllocator::createPixelBuffer const):
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::getPixelBuffer):
(WebCore::ImageBufferBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::computeRawPixelComponentCount):
(WebCore::PixelBuffer::computeBufferSize):
(WebCore::PixelBuffer::PixelBuffer):
* Source/WebCore/platform/graphics/PixelBuffer.h:
(WebCore::PixelBuffer::bytesPerPixelComponent):
(WebCore::PixelBuffer::componentsPerPixel):
(WebCore::PixelBuffer::bytesPerPixel):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::readFloat16):
(WebCore::writeFloat16):
(WebCore::convertImagePixelsFromFloat16ToFloat16):
(WebCore::convertImagePixelsFromFloat16):
(WebCore::convertImagePixelsToFloat16):
(WebCore::convertImagePixels):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::calculateBytesPerRow):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::calculateMemoryCost):
(WebCore::ImageBufferCGBitmapBackend::bytesPerRow const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp:
(WebCore::ImageBufferCGPDFDocumentBackend::calculateMemoryCost):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::calculateBytesPerRow):
(WebCore::ImageBufferIOSurfaceBackend::calculateMemoryCost):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForCanvas const):
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp:
(WebKit::ShareablePixelBuffer::ShareablePixelBuffer):
(WebKit::ShareablePixelBuffer::createScratchPixelBuffer const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::bytesPerRow const):

Canonical link: <a href="https://commits.webkit.org/298618@main">https://commits.webkit.org/298618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d44b8891fad44e7c8ea398890d9375a42a8cba32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116057 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66606 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8391745a-a7e3-4673-ac9a-77b6af23178e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88168 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1cc40df-3b64-4510-bec3-b346dbe6fd71) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68579 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22248 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65795 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125263 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114585 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96905 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19844 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48430 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143269 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42305 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36934 "Found 1 new JSC stress test failure: stress/dont-link-virtual-calls-on-compiler-thread.js.no-llint (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45640 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->