### PR TITLE
[Form Control Refresh] Button elements with `submit` type appear as normal buttons, color well bleeds slightly outside paint rect

### DIFF
--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode-expected.html
@@ -3,7 +3,7 @@
     <head>
         <meta name="color-scheme" content="dark">
         <style>
-            input {
+            input, button {
                 display: block;
             }
         </style>
@@ -16,6 +16,7 @@
         <input type="range" min="0" max="4" step="1" list="datalist">
         <input type="text" list="datalist">
         <input type="submit" value="Submit">
+        <button type="submit">Submit</button>
         <datalist id="datalist">
             <option>0</option>
             <option>1</option>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html
@@ -3,7 +3,7 @@
     <head>
         <meta name="color-scheme" content="dark">
         <style>
-            input {
+            input, button {
                 accent-color: black;
                 display: block;
             }
@@ -17,6 +17,7 @@
         <input type="range" min="0" max="4" step="1" list="datalist">
         <input type="text" list="datalist">
         <input type="submit" value="Submit">
+        <button type="submit">Submit</button>
         <datalist id="datalist">
             <option>0</option>
             <option>1</option>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode-expected.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <style>
-            input {
+            input, button {
                 display: block;
             }
         </style>
@@ -15,6 +15,7 @@
         <input type="range" min="0" max="4" step="1" list="datalist">
         <input type="text" list="datalist">
         <input type="submit" value="Submit">
+        <button type="submit">Submit</button>
         <datalist id="datalist">
             <option>0</option>
             <option>1</option>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <style>
-            input {
+            input, button {
                 accent-color: white;
                 display: block;
             }
@@ -16,6 +16,7 @@
         <input type="range" min="0" max="4" step="1" list="datalist">
         <input type="text" list="datalist">
         <input type="submit" value="Submit">
+        <button type="submit">Submit</button>
         <datalist id="datalist">
             <option>0</option>
             <option>1</option>

--- a/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html
+++ b/LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
 <html>
     <input type="submit" style="accent-color: white; zoom:5;">
+    <button type="submit" style="accent-color: white; zoom:5;">Submit</button>
 </html>

--- a/LayoutTests/fast/forms/form-control-refresh/button-like-controls-text-color-matches-expected.txt
+++ b/LayoutTests/fast/forms/form-control-refresh/button-like-controls-text-color-matches-expected.txt
@@ -3,7 +3,10 @@ This tests that buttons, submit buttons, and select buttons all have the same CS
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS select.style.color == submit.style.color && submit.style.color == button.style.color is true
+PASS select.style.color == input_submit.style.color is true
+PASS select.style.color == input_button.style.color is true
+PASS select.style.color == submit.style.color is true
+PASS select.style.color == button.style.color is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/form-control-refresh/button-like-controls-text-color-matches.html
+++ b/LayoutTests/fast/forms/form-control-refresh/button-like-controls-text-color-matches.html
@@ -3,11 +3,16 @@
 <body>
 <script src="../../../resources/js-test.js"></script>
 <input id="select" type="select">
-<input id="submit" type="submit">
-<input id="button" type="button">
+<input id="input_submit" type="submit">
+<input id="input_button" type="button">
+<button id="submit" type="submit"></button>
+<button id="button"></button>
 <script>
     description("This tests that buttons, submit buttons, and select buttons all have the same CSS color.");
-    shouldBeTrue("select.style.color == submit.style.color && submit.style.color == button.style.color");
+    shouldBeTrue("select.style.color == input_submit.style.color");
+    shouldBeTrue("select.style.color == input_button.style.color");
+    shouldBeTrue("select.style.color == submit.style.color");
+    shouldBeTrue("select.style.color == button.style.color");
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive-expected.html
@@ -4,6 +4,8 @@
     <p>This tests that the appearance of submit buttons matches normal buttons when the window is inactive.</p>
     <input type="button" value="Submit">
     <input type="button" value="Submit" disabled>
+    <input type="button" value="Submit">
+    <input type="button" value="Submit" disabled>
 </body>
 <script>
 if (window.testRunner)

--- a/LayoutTests/fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive.html
+++ b/LayoutTests/fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive.html
@@ -4,6 +4,8 @@
     <p>This tests that the appearance of submit buttons matches normal buttons when the window is inactive.</p>
     <input type="submit">
     <input type="submit" disabled>
+    <button type="submit">Submit</button>
+    <button type="submit" disabled>Submit</button>
 </body>
 <script>
 if (window.testRunner)

--- a/LayoutTests/fast/forms/form-control-refresh/submit-button-text-color-disabled-state-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/submit-button-text-color-disabled-state-expected.html
@@ -2,6 +2,7 @@
 <html>
 <body>
     <p>This tests that the submit button's text color displays with the correct color when the input is disabled.</p>
-    <input type="submit" style="color: rgba(255, 255, 255, 0.8);" disabled>
+    <input type="submit" value="Submit" style="color: rgba(255, 255, 255, 0.6);" disabled>
+    <button type="submit" style="color: rgba(255, 255, 255, 0.6);" disabled>Submit</button>
 </body>
 </html>

--- a/LayoutTests/fast/forms/form-control-refresh/submit-button-text-color-disabled-state.html
+++ b/LayoutTests/fast/forms/form-control-refresh/submit-button-text-color-disabled-state.html
@@ -2,6 +2,7 @@
 <html>
 <body>
     <p>This tests that the submit button's text color displays with the correct color when the input is disabled.</p>
-    <input type="submit" disabled>
+    <input type="submit" value="Submit" disabled>
+    <button type="submit" disabled>Submit</button>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8146,8 +8146,6 @@ fast/css/accent-color/button.html [ ImageOnlyFailure ]
 fast/css/accent-color/date.html [ ImageOnlyFailure ]
 fast/css/accent-color/select.html [ ImageOnlyFailure ]
 fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive.html [ ImageOnlyFailure ]
-fast/forms/ios/form-control-refresh/button/button-type-submit.html [ ImageOnlyFailure ]
-fast/forms/ios/form-control-refresh/color/paint-within-box.html [ ImageOnlyFailure ]
 fast/forms/ios/form-control-refresh/select/decoration-color.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fractional-translation-from-position.html [ ImageOnlyFailure ]
 
@@ -8218,6 +8216,10 @@ webkit.org/b/297081 http/tests/resourceLoadStatistics/exemptDomains/managed-doma
 webkit.org/b/297122 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/spec-examples/shape-outside-010.html [ Pass Failure ]
 
 webkit.org/b/297141 [ Debug ] fast/eventsource/eventsource-attribute-listeners.html [ Pass Crash ]
+
+# Inactive window appearance for form controls is not supported on iOS.
+fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html [ Skip ]
+fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html [ Skip ]
 
 webkit.org/b/297144 fast/forms/state-restore-to-non-edited-controls.html [ Pass Timeout ]
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1224,9 +1224,9 @@ bool RenderTheme::isIndeterminate(const RenderObject& renderer) const
     return input && input->isCheckbox() && input->matchesIndeterminatePseudoClass();
 }
 
-bool RenderTheme::isSubmitButton(const RenderObject& renderer) const
+bool RenderTheme::isSubmitButton(const Node* node) const
 {
-    RefPtr element = dynamicDowncast<HTMLFormControlElement>(renderer.node());
+    RefPtr element = dynamicDowncast<HTMLFormControlElement>(node);
     return element && element->isSubmitButton();
 }
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -414,7 +414,7 @@ public:
     bool isWindowActive(const RenderObject&) const;
     bool isChecked(const RenderObject&) const;
     bool isIndeterminate(const RenderObject&) const;
-    bool isSubmitButton(const RenderObject&) const;
+    bool isSubmitButton(const Node*) const;
     bool isEnabled(const RenderObject&) const;
     bool isFocused(const RenderObject&) const;
     bool isPressed(const RenderObject&) const;


### PR DESCRIPTION
#### f6ee2494e651377db563faac1a0c2a76efe6dd79
<pre>
[Form Control Refresh] Button elements with `submit` type appear as normal buttons, color well bleeds slightly outside paint rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=297205">https://bugs.webkit.org/show_bug.cgi?id=297205</a>
<a href="https://rdar.apple.com/156546077">rdar://156546077</a>

Reviewed by Abrar Rahman Protyasha, Megan Gardner, and Wenson Hsieh.

During style adjustment and control painting for buttons, detect submit buttons
using `RenderTheme::isSubmitButton(const Node*)` instead of attempting to downcast
to an input element and checking `HTMLInputElement::isSubmitButton`. All
fast/forms/form-control-refresh/* tests which contain an input with type `submit`
now contain a button with type `submit` as well to improve test comprehensiveness.

Due to antialiasing, color-well controls bleed slightly outside their bounding rect.
Clip to the paint rect before performing any painting to resolve the issue.

`submit-button-text-color-disabled-state.html` erroneously lacked any text, resulting
in the test not actually checking text color. Updated the test &amp; expectation to include
text, and to account for the new disabled text-color added in 298318@main.

Skip the following tests on iOS since the window inactive appearance is not supported:
fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html
fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html

* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode-expected.html:
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-dark-mode.html:
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode-expected.html:
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-does-not-affect-inactive-window-light-mode.html:
* LayoutTests/fast/forms/form-control-refresh/accent-color-contrast-submit-does-not-disappear.html:
* LayoutTests/fast/forms/form-control-refresh/button-like-controls-text-color-matches-expected.txt:
* LayoutTests/fast/forms/form-control-refresh/button-like-controls-text-color-matches.html:
* LayoutTests/fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive-expected.html:
* LayoutTests/fast/forms/form-control-refresh/submit-button-appearance-matches-button-window-inactive.html:
* LayoutTests/fast/forms/form-control-refresh/submit-button-text-color-disabled-state-expected.html:
* LayoutTests/fast/forms/form-control-refresh/submit-button-text-color-disabled-state.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::isSubmitButton const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::controlSupportsTints const):
(WebCore::RenderThemeCocoa::paintButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::paintColorWellDecorationsForVectorBasedControls):
(WebCore::RenderThemeCocoa::adjustButtonStyleForVectorBasedControls const):

Canonical link: <a href="https://commits.webkit.org/298517@main">https://commits.webkit.org/298517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13099e2d0909ef3e233d7b3275f2c5ae90a2f9ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66273 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e171817e-6547-4ac5-b94b-4d92d3755860) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87894 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42567 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37130d4f-2228-4920-9eb2-f0dddc94aedf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68295 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21953 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65432 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124908 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96650 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96437 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38525 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48069 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45301 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->