### PR TITLE
Allow user configuration of the generic math family.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4670,6 +4670,19 @@ ManagedMediaSourceNeedsAirPlay:
     WebCore:
       default: false
 
+MathFontFamily:
+  type: String
+  status: embedder
+  webKitLegacyPreferenceKey: WebKitMathFont
+  webcoreImplementation: custom
+  defaultValue:
+    WebKitLegacy:
+      default: '""_str'
+    WebKit:
+      default: '""_str'
+    WebCore:
+      default: '""_str'
+
 MathMLEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -186,6 +186,18 @@ void SettingsBase::setPictographFontFamily(const String& family, UScriptCode scr
         invalidateAfterGenericFamilyChange(m_page.get());
 }
 
+const String& SettingsBase::mathFontFamily(UScriptCode script) const
+{
+    return fontGenericFamilies().mathFontFamily(script);
+}
+
+void SettingsBase::setMathFontFamily(const String& family, UScriptCode script)
+{
+    bool changes = fontGenericFamilies().setMathFontFamily(family, script);
+    if (changes)
+        invalidateAfterGenericFamilyChange(m_page.get());
+}
+
 void SettingsBase::setMinimumDOMTimerInterval(Seconds interval)
 {
     auto oldTimerInterval = std::exchange(m_minimumDOMTimerInterval, interval);

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -97,6 +97,9 @@ public:
     WEBCORE_EXPORT void setPictographFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
     WEBCORE_EXPORT const String& pictographFontFamily(UScriptCode = USCRIPT_COMMON) const;
 
+    WEBCORE_EXPORT void setMathFontFamily(const String&, UScriptCode = USCRIPT_COMMON);
+    WEBCORE_EXPORT const String& mathFontFamily(UScriptCode = USCRIPT_COMMON) const;
+
     WEBCORE_EXPORT void setMinimumDOMTimerInterval(Seconds); // Initialized to DOMTimer::defaultMinimumInterval().
     Seconds minimumDOMTimerInterval() const { return m_minimumDOMTimerInterval; }
 

--- a/Source/WebCore/platform/graphics/FontGenericFamilies.cpp
+++ b/Source/WebCore/platform/graphics/FontGenericFamilies.cpp
@@ -76,6 +76,7 @@ FontGenericFamilies FontGenericFamilies::isolatedCopy() const &
     copy.m_cursiveFontFamilyMap = crossThreadCopy(m_cursiveFontFamilyMap);
     copy.m_fantasyFontFamilyMap = crossThreadCopy(m_fantasyFontFamilyMap);
     copy.m_pictographFontFamilyMap = crossThreadCopy(m_pictographFontFamilyMap);
+    copy.m_mathFontFamilyMap = crossThreadCopy(m_mathFontFamilyMap);
     return copy;
 }
 
@@ -89,6 +90,7 @@ FontGenericFamilies FontGenericFamilies::isolatedCopy() &&
     copy.m_cursiveFontFamilyMap = crossThreadCopy(WTFMove(m_cursiveFontFamilyMap));
     copy.m_fantasyFontFamilyMap = crossThreadCopy(WTFMove(m_fantasyFontFamilyMap));
     copy.m_pictographFontFamilyMap = crossThreadCopy(WTFMove(m_pictographFontFamilyMap));
+    copy.m_mathFontFamilyMap = crossThreadCopy(WTFMove(m_mathFontFamilyMap));
     return copy;
 }
 
@@ -127,6 +129,11 @@ const String& FontGenericFamilies::pictographFontFamily(UScriptCode script) cons
     return genericFontFamilyForScript(m_pictographFontFamilyMap, script);
 }
 
+const String& FontGenericFamilies::mathFontFamily(UScriptCode script) const
+{
+    return genericFontFamilyForScript(m_mathFontFamilyMap, script);
+}
+
 bool FontGenericFamilies::setStandardFontFamily(const String& family, UScriptCode script)
 {
     return setGenericFontFamilyForScript(m_standardFontFamilyMap, family, script);
@@ -162,6 +169,11 @@ bool FontGenericFamilies::setPictographFontFamily(const String& family, UScriptC
     return setGenericFontFamilyForScript(m_pictographFontFamilyMap, family, script);
 }
 
+bool FontGenericFamilies::setMathFontFamily(const String& family, UScriptCode script)
+{
+    return setGenericFontFamilyForScript(m_mathFontFamilyMap, family, script);
+}
+
 const String* FontGenericFamilies::fontFamily(FamilyNamesIndex family, UScriptCode script) const
 {
     switch (family) {
@@ -169,6 +181,8 @@ const String* FontGenericFamilies::fontFamily(FamilyNamesIndex family, UScriptCo
         return &cursiveFontFamily(script);
     case FamilyNamesIndex::FantasyFamily:
         return &fantasyFontFamily(script);
+    case FamilyNamesIndex::MathFamily:
+        return &mathFontFamily(script);
     case FamilyNamesIndex::MonospaceFamily:
         return &fixedFontFamily(script);
     case FamilyNamesIndex::PictographFamily:
@@ -180,7 +194,6 @@ const String* FontGenericFamilies::fontFamily(FamilyNamesIndex family, UScriptCo
     case FamilyNamesIndex::StandardFamily:
         return &standardFontFamily(script);
     case FamilyNamesIndex::SystemUiFamily:
-    case FamilyNamesIndex::MathFamily:
         return nullptr;
     }
 

--- a/Source/WebCore/platform/graphics/FontGenericFamilies.h
+++ b/Source/WebCore/platform/graphics/FontGenericFamilies.h
@@ -60,6 +60,7 @@ public:
     const String& cursiveFontFamily(UScriptCode = USCRIPT_COMMON) const;
     const String& fantasyFontFamily(UScriptCode = USCRIPT_COMMON) const;
     const String& pictographFontFamily(UScriptCode = USCRIPT_COMMON) const;
+    const String& mathFontFamily(UScriptCode = USCRIPT_COMMON) const;
 
     const String* fontFamily(WebKitFontFamilyNames::FamilyNamesIndex, UScriptCode = USCRIPT_COMMON) const;
 
@@ -70,6 +71,7 @@ public:
     bool setCursiveFontFamily(const String&, UScriptCode);
     bool setFantasyFontFamily(const String&, UScriptCode);
     bool setPictographFontFamily(const String&, UScriptCode);
+    bool setMathFontFamily(const String&, UScriptCode);
 
 private:
     ScriptFontFamilyMap m_standardFontFamilyMap;
@@ -79,6 +81,7 @@ private:
     ScriptFontFamilyMap m_cursiveFontFamilyMap;
     ScriptFontFamilyMap m_fantasyFontFamilyMap;
     ScriptFontFamilyMap m_pictographFontFamilyMap;
+    ScriptFontFamilyMap m_mathFontFamilyMap;
 };
 
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -254,6 +254,16 @@ WKStringRef WKPreferencesCopyPictographFontFamily(WKPreferencesRef preferencesRe
     return toCopiedAPI(toProtectedImpl(preferencesRef)->pictographFontFamily());
 }
 
+void WKPreferencesSetMathFontFamily(WKPreferencesRef preferencesRef, WKStringRef family)
+{
+    toProtectedImpl(preferencesRef)->setMathFontFamily(toWTFString(family));
+}
+
+WKStringRef WKPreferencesCopyMathFontFamily(WKPreferencesRef preferencesRef)
+{
+    return toCopiedAPI(toProtectedImpl(preferencesRef)->mathFontFamily());
+}
+
 void WKPreferencesSetDefaultFontSize(WKPreferencesRef preferencesRef, uint32_t size)
 {
     toProtectedImpl(preferencesRef)->setDefaultFontSize(size);

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
@@ -112,6 +112,9 @@ WK_EXPORT WKStringRef WKPreferencesCopyFantasyFontFamily(WKPreferencesRef prefer
 WK_EXPORT void WKPreferencesSetPictographFontFamily(WKPreferencesRef preferencesRef, WKStringRef family);
 WK_EXPORT WKStringRef WKPreferencesCopyPictographFontFamily(WKPreferencesRef preferencesRef);
 
+WK_EXPORT void WKPreferencesSetMathFontFamily(WKPreferencesRef preferencesRef, WKStringRef family);
+WK_EXPORT WKStringRef WKPreferencesCopyMathFontFamily(WKPreferencesRef preferencesRef);
+
 // Defaults to 16.
 WK_EXPORT void WKPreferencesSetDefaultFontSize(WKPreferencesRef preferencesRef, uint32_t);
 WK_EXPORT uint32_t WKPreferencesGetDefaultFontSize(WKPreferencesRef preferencesRef);

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -232,6 +232,13 @@ WEBKIT_API void
 webkit_settings_set_pictograph_font_family                     (WebKitSettings *settings,
                                                                 const gchar    *pictograph_font_family);
 
+WEBKIT_API const gchar *
+webkit_settings_get_math_font_family                           (WebKitSettings *settings);
+
+WEBKIT_API void
+webkit_settings_set_math_font_family                           (WebKitSettings *settings,
+                                                                const gchar    *math_font_family);
+
 WEBKIT_API guint32
 webkit_settings_get_default_font_size                          (WebKitSettings *settings);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -133,6 +133,14 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_pictograph_font_family(settings, "sans-serif");
     g_assert_cmpstr(webkit_settings_get_pictograph_font_family(settings), ==, "sans-serif");
 
+    // Default math font family is nullptr.
+    g_assert_null(webkit_settings_get_math_font_family(settings));
+    webkit_settings_set_math_font_family(settings, "sans-serif");
+    g_assert_cmpstr(webkit_settings_get_math_font_family(settings), ==, "sans-serif");
+    // Can be reset to default by passing nullptr again.
+    webkit_settings_set_math_font_family(settings, nullptr);
+    g_assert_null(webkit_settings_get_math_font_family(settings));
+
     // Default font size is 16.
     g_assert_cmpuint(webkit_settings_get_default_font_size(settings), ==, 16);
     webkit_settings_set_default_font_size(settings, 14);


### PR DESCRIPTION
#### 3efcbb374ccb9d7984b3905c1de6fee737c8637d
<pre>
Allow user configuration of the generic math family.
bugs.webkit.org/show_bug.cgi?id=209595

Reviewed by Carlos Garcia Campos, Michael Catanzaro, and Adrian Perez de Castro.

Adds a configuration option so that the user can specify their preferred
math font family. If it is blank (default) the fallback math font list
will be used instead.

Depends-On: #48510

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::mathFontFamily const):
(WebCore::SettingsBase::setMathFontFamily):
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/platform/graphics/FontGenericFamilies.cpp:
(WebCore::FontGenericFamilies::isolatedCopy const):
(WebCore::FontGenericFamilies::isolatedCopy):
(WebCore::FontGenericFamilies::mathFontFamily const):
(WebCore::FontGenericFamilies::setMathFontFamily):
(WebCore::FontGenericFamilies::fontFamily const):
* Source/WebCore/platform/graphics/FontGenericFamilies.h:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetMathFontFamily):
(WKPreferencesCopyMathFontFamily):
* Source/WebKit/UIProcess/API/C/WKPreferencesRef.h:
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(_WebKitSettingsPrivate::_WebKitSettingsPrivate):
(webKitSettingsSetProperty):
(webKitSettingsGetProperty):
(webkit_settings_class_init):
(webkit_settings_get_math_font_family):
(webkit_settings_set_math_font_family):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):

Canonical link: <a href="https://commits.webkit.org/299434@main">https://commits.webkit.org/299434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c260b27c16138baf0f5b87a76e5b1aaebf5b761

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90205 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59723 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68710 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128099 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/117373 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45766 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34564 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/body-window-destroy.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98864 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44091 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22096 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42331 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51314 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146071 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45101 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37573 "Found 1 new JSC binary failure: testapi, Found 18633 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Basics/typeofcombi.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->