### PR TITLE
[iOS 26] UIScriptControllerIOS fails to retrieve preview rect for context menu

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8141,7 +8141,6 @@ imported/w3c/web-platform-tests/shadow-dom/reference-target/tentative/interestta
 imported/w3c/web-platform-tests/uievents/mouse/mousemove_after_mouseover_target_removed.html [ Failure ]
 platform/ipad/fast/viewport/viewport-overriden-by-minimum-effective-width-if-ignore-meta-viewport.html [ Failure ]
 editing/selection/ios/selection-handles-in-readonly-input.html [ Timeout ]
-fast/events/ios/dragstart-hang-does-not-dismiss-context-menu.html [ Timeout ]
 media/modern-media-controls/tracks-support/show-contextmenu-then-double-click-on-tracks-button.html [ Timeout ]
 fast/css/accent-color/button.html [ ImageOnlyFailure ]
 fast/css/accent-color/date.html [ ImageOnlyFailure ]

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1342,11 +1342,16 @@ JSObjectRef UIScriptControllerIOS::menuRect() const
 
 JSObjectRef UIScriptControllerIOS::contextMenuPreviewRect() const
 {
-    auto *container = findAllViewsInHierarchyOfType(webView().window, internalClassNamed(@"_UIMorphingPlatterView")).firstObject;
+#if HAVE(LIQUID_GLASS)
+    RetainPtr platterName = @"_UIContentPlatterView";
+#else
+    RetainPtr platterName = @"_UIMorphingPlatterView";
+#endif
+    RetainPtr<UIView> container = findAllViewsInHierarchyOfType(webView().window, internalClassNamed(platterName.get())).firstObject;
     if (!container)
         return nullptr;
 
-    return toObject([container convertRect:container.bounds toView:nil]);
+    return toObject([container convertRect:container.get().bounds toView:nil]);
 }
 
 JSObjectRef UIScriptControllerIOS::contextMenuRect() const


### PR DESCRIPTION
#### 53225a2bef1164ddab87f8ce3cbe913ce226ee90
<pre>
[iOS 26] UIScriptControllerIOS fails to retrieve preview rect for context menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=297207">https://bugs.webkit.org/show_bug.cgi?id=297207</a>
<a href="https://rdar.apple.com/156722147">rdar://156722147</a>

Reviewed by Wenson Hsieh.

Use the correct view type name when the platform has liquid glass.

* LayoutTests/platform/ios/TestExpectations:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::contextMenuPreviewRect const):

Canonical link: <a href="https://commits.webkit.org/298514@main">https://commits.webkit.org/298514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933aefb93b120506df9847c7ca668a5f59459439

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66252 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5d9bfb4-db98-4e3c-8eee-036be4bccda6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87901 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42546 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16bae48d-58f4-42ce-aa03-55b61f70ef86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68302 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21960 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65440 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124918 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96658 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38538 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42507 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45311 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43688 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->