### PR TITLE
[CoordinatedGraphics] Remove GLContext dependency on PlatformDisplay

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -84,11 +84,9 @@ static HashSet<PlatformDisplay*>& eglDisplays()
     return displays;
 }
 
-PlatformDisplay::PlatformDisplay(std::unique_ptr<GLDisplay>&& glDisplay)
+PlatformDisplay::PlatformDisplay(Ref<GLDisplay>&& glDisplay)
     : m_eglDisplay(WTFMove(glDisplay))
 {
-    RELEASE_ASSERT(m_eglDisplay);
-
     eglDisplays().add(this);
 
 #if !PLATFORM(WIN)

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -31,13 +31,6 @@
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
 
-typedef intptr_t EGLAttrib;
-typedef void *EGLClientBuffer;
-typedef void *EGLContext;
-typedef void *EGLDisplay;
-typedef void *EGLImage;
-typedef unsigned EGLenum;
-
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
 #include "GRefPtrGStreamer.h"
 
@@ -91,6 +84,7 @@ public:
     WEBCORE_EXPORT GLContext* sharingGLContext();
     void clearSharingGLContext();
     EGLDisplay eglDisplay() const;
+    GLDisplay& glDisplay() const { return m_eglDisplay.get(); }
     bool eglCheckVersion(int major, int minor) const;
 
     const GLDisplay::Extensions& eglExtensions() const;
@@ -122,9 +116,9 @@ public:
 #endif
 
 protected:
-    explicit PlatformDisplay(std::unique_ptr<GLDisplay>&&);
+    explicit PlatformDisplay(Ref<GLDisplay>&&);
 
-    std::unique_ptr<GLDisplay> m_eglDisplay;
+    Ref<GLDisplay> m_eglDisplay;
     std::unique_ptr<GLContext> m_sharingGLContext;
 
 #if ENABLE(WEBGL) && !PLATFORM(WIN)

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -19,8 +19,10 @@
 #include "config.h"
 #include "GLContext.h"
 
+#include "GLDisplay.h"
 #include "GraphicsContextGL.h"
 #include "Logging.h"
+#include "PlatformDisplay.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -70,7 +72,7 @@ const char* GLContext::lastErrorString()
     return errorString(eglGetError());
 }
 
-bool GLContext::getEGLConfig(PlatformDisplay& platformDisplay, EGLConfig* config, EGLSurfaceType surfaceType)
+bool GLContext::getEGLConfig(EGLDisplay display, EGLConfig* config, int surfaceType)
 {
     std::array<EGLint, 4> rgbaSize = { 8, 8, 8, 8 };
     if (const char* environmentVariable = getenv("WEBKIT_EGL_PIXEL_LAYOUT")) {
@@ -88,31 +90,12 @@ bool GLContext::getEGLConfig(PlatformDisplay& platformDisplay, EGLConfig* config
         EGL_BLUE_SIZE, rgbaSize[2],
         EGL_ALPHA_SIZE, rgbaSize[3],
         EGL_STENCIL_SIZE, 8,
-        EGL_SURFACE_TYPE, EGL_NONE,
+        EGL_SURFACE_TYPE, surfaceType,
         EGL_DEPTH_SIZE, 0,
         EGL_NONE
     };
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    switch (surfaceType) {
-    case GLContext::Surfaceless:
-        if (platformDisplay.type() == PlatformDisplay::Type::Surfaceless)
-            attributeList[13] = EGL_PBUFFER_BIT;
-        else
-            attributeList[13] = EGL_WINDOW_BIT;
-        break;
-    case GLContext::PbufferSurface:
-        attributeList[13] = EGL_PBUFFER_BIT;
-        break;
-    case GLContext::PixmapSurface:
-        attributeList[13] = EGL_PIXMAP_BIT;
-        break;
-    case GLContext::WindowSurface:
-        attributeList[13] = EGL_WINDOW_BIT;
-        break;
-    }
-
-    EGLDisplay display = platformDisplay.eglDisplay();
     EGLint count;
     if (!eglChooseConfig(display, attributeList, nullptr, 0, &count)) {
         RELEASE_LOG_INFO(Compositing, "Cannot get count of available EGL configurations: %s.", lastErrorString());
@@ -145,35 +128,32 @@ bool GLContext::getEGLConfig(PlatformDisplay& platformDisplay, EGLConfig* config
     return false;
 }
 
-std::unique_ptr<GLContext> GLContext::createWindowContext(GLNativeWindowType window, PlatformDisplay& platformDisplay, EGLContext sharingContext)
+std::unique_ptr<GLContext> GLContext::createWindowContext(GLDisplay& display, Target target, GLNativeWindowType window, EGLContext sharingContext)
 {
+    EGLDisplay eglDisplay = display.eglDisplay();
     EGLConfig config;
-    if (!getEGLConfig(platformDisplay, &config, WindowSurface)) {
+    if (!getEGLConfig(eglDisplay, &config, EGL_WINDOW_BIT)) {
         RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL window context configuration: %s\n", lastErrorString());
         return nullptr;
     }
 
-    EGLContext context = createContextForEGLVersion(platformDisplay, config, sharingContext);
+    EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
     if (context == EGL_NO_CONTEXT) {
         RELEASE_LOG_INFO(Compositing, "Cannot create EGL window context: %s\n", lastErrorString());
         return nullptr;
     }
 
-    EGLDisplay display = platformDisplay.eglDisplay();
     EGLSurface surface = EGL_NO_SURFACE;
-    switch (platformDisplay.type()) {
+    switch (target) {
 #if USE(WPE_RENDERER)
-    case PlatformDisplay::Type::WPE:
-        surface = createWindowSurfaceWPE(display, config, window);
+    case Target::WPE:
+        surface = createWindowSurfaceWPE(eglDisplay, config, window);
         break;
 #endif // USE(WPE_RENDERER)
 #if USE(GBM)
-    case PlatformDisplay::Type::GBM:
+    case Target::GBM:
 #endif
-#if PLATFORM(GTK)
-    case PlatformDisplay::Type::Default:
-#endif
-    case PlatformDisplay::Type::Surfaceless:
+    case Target::Surfaceless:
         RELEASE_ASSERT_NOT_REACHED();
         break;
     default:
@@ -185,194 +165,159 @@ std::unique_ptr<GLContext> GLContext::createWindowContext(GLNativeWindowType win
         // EGLNativeWindowType changes depending on the EGL implementation, reinterpret_cast
         // would work for pointers, and static_cast for numeric types only; so use a plain
         // C cast expression which works in all possible cases.
-        surface = eglCreateWindowSurface(display, config, (EGLNativeWindowType) window, nullptr);
+        surface = eglCreateWindowSurface(eglDisplay, config, (EGLNativeWindowType) window, nullptr);
     }
 
     if (surface == EGL_NO_SURFACE) {
         RELEASE_LOG_INFO(Compositing, "Cannot create EGL window surface: %s\n", lastErrorString());
-        eglDestroyContext(display, context);
+        eglDestroyContext(eglDisplay, context);
         return nullptr;
     }
 
-    return makeUnique<GLContext>(platformDisplay, context, surface, config, WindowSurface);
+    return makeUnique<GLContext>(display, context, surface, config);
 }
 
-std::unique_ptr<GLContext> GLContext::createPbufferContext(PlatformDisplay& platformDisplay, EGLContext sharingContext)
+std::unique_ptr<GLContext> GLContext::createSurfacelessContext(GLDisplay& display, Target target, EGLContext sharingContext)
 {
-    EGLConfig config;
-    if (!getEGLConfig(platformDisplay, &config, PbufferSurface)) {
-        RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL Pbuffer configuration: %s\n", lastErrorString());
-        return nullptr;
-    }
-
-    EGLContext context = createContextForEGLVersion(platformDisplay, config, sharingContext);
-    if (context == EGL_NO_CONTEXT) {
-        RELEASE_LOG_INFO(Compositing, "Cannot create EGL Pbuffer context: %s\n", lastErrorString());
-        return nullptr;
-    }
-
-    EGLDisplay display = platformDisplay.eglDisplay();
-    static const int pbufferAttributes[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
-    EGLSurface surface = eglCreatePbufferSurface(display, config, pbufferAttributes);
-    if (surface == EGL_NO_SURFACE) {
-        RELEASE_LOG_INFO(Compositing, "Cannot create EGL Pbuffer surface: %s\n", lastErrorString());
-        eglDestroyContext(display, context);
-        return nullptr;
-    }
-
-    return makeUnique<GLContext>(platformDisplay, context, surface, config, PbufferSurface);
-}
-
-std::unique_ptr<GLContext> GLContext::createSurfacelessContext(PlatformDisplay& platformDisplay, EGLContext sharingContext)
-{
-    EGLDisplay display = platformDisplay.eglDisplay();
-    if (display == EGL_NO_DISPLAY) {
-        RELEASE_LOG_INFO(Compositing, "Cannot create surfaceless EGL context: invalid display (last error: %s)\n", lastErrorString());
-        return nullptr;
-    }
-
-    const char* extensions = eglQueryString(display, EGL_EXTENSIONS);
+    EGLDisplay eglDisplay = display.eglDisplay();
+    const char* extensions = eglQueryString(eglDisplay, EGL_EXTENSIONS);
     if (!GLContext::isExtensionSupported(extensions, "EGL_KHR_surfaceless_context") && !GLContext::isExtensionSupported(extensions, "EGL_KHR_surfaceless_opengl")) {
         RELEASE_LOG_INFO(Compositing, "Cannot create surfaceless EGL context: required extensions missing.");
         return nullptr;
     }
 
     EGLConfig config;
-    if (!getEGLConfig(platformDisplay, &config, Surfaceless)) {
+    if (!getEGLConfig(eglDisplay, &config, target == Target::Surfaceless ? EGL_PBUFFER_BIT : EGL_WINDOW_BIT)) {
         RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL surfaceless configuration: %s\n", lastErrorString());
         return nullptr;
     }
 
-    EGLContext context = createContextForEGLVersion(platformDisplay, config, sharingContext);
+    EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
     if (context == EGL_NO_CONTEXT) {
         RELEASE_LOG_INFO(Compositing, "Cannot create EGL surfaceless context: %s\n", lastErrorString());
         return nullptr;
     }
 
-    return makeUnique<GLContext>(platformDisplay, context, EGL_NO_SURFACE, config, Surfaceless);
+    return makeUnique<GLContext>(display, context, EGL_NO_SURFACE, config);
 }
 
-std::unique_ptr<GLContext> GLContext::create(GLNativeWindowType window, PlatformDisplay& platformDisplay)
+std::unique_ptr<GLContext> GLContext::createPbufferContext(GLDisplay& display, EGLContext sharingContext)
 {
-    if (!window)
-        return GLContext::createOffscreen(platformDisplay);
-
-    if (platformDisplay.eglDisplay() == EGL_NO_DISPLAY) {
-        WTFLogAlways("Cannot create EGL context: invalid display (last error: %s)\n", lastErrorString());
+    EGLDisplay eglDisplay = display.eglDisplay();
+    EGLConfig config;
+    if (!getEGLConfig(eglDisplay, &config, EGL_PBUFFER_BIT)) {
+        RELEASE_LOG_INFO(Compositing, "Cannot obtain EGL Pbuffer configuration: %s\n", lastErrorString());
         return nullptr;
     }
+
+    EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
+    if (context == EGL_NO_CONTEXT) {
+        RELEASE_LOG_INFO(Compositing, "Cannot create EGL Pbuffer context: %s\n", lastErrorString());
+        return nullptr;
+    }
+
+    static const int pbufferAttributes[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
+    EGLSurface surface = eglCreatePbufferSurface(eglDisplay, config, pbufferAttributes);
+    if (surface == EGL_NO_SURFACE) {
+        RELEASE_LOG_INFO(Compositing, "Cannot create EGL Pbuffer surface: %s\n", lastErrorString());
+        eglDestroyContext(eglDisplay, context);
+        return nullptr;
+    }
+
+    return makeUnique<GLContext>(display, context, surface, config);
+}
+
+std::unique_ptr<GLContext> GLContext::createOffscreenContext(GLDisplay& display, Target target, EGLContext sharingContext)
+{
+    if (auto context = createSurfacelessContext(display, target, sharingContext))
+        return context;
+
+    switch (target) {
+#if USE(WPE_RENDERER)
+    case Target::WPE:
+        if (auto context = createWPEContext(display, sharingContext))
+            return context;
+        break;
+#endif
+#if USE(GBM)
+    case Target::GBM:
+#endif
+    case Target::Surfaceless:
+        // Do not fallback to pbuffers.
+        RELEASE_LOG_INFO(Compositing, "Could not create EGL surfaceless context: %s.", lastErrorString());
+        return nullptr;
+    default:
+        break;
+    }
+
+    RELEASE_LOG_INFO(Compositing, "Could not create platform context: %s. Using Pbuffer as fallback.", lastErrorString());
+    if (auto context = createPbufferContext(display, sharingContext))
+        return context;
+
+    RELEASE_LOG_INFO(Compositing, "Could not create Pbuffer context: %s.", lastErrorString());
+    return nullptr;
+}
+
+std::unique_ptr<GLContext> GLContext::create(GLDisplay& display, Target target, GLContext* sharingGLContext, GLNativeWindowType window)
+{
+    RELEASE_ASSERT(display.eglDisplay() != EGL_NO_DISPLAY);
 
     if (eglBindAPI(EGL_OPENGL_ES_API) == EGL_FALSE) {
-        WTFLogAlways("Cannot create EGL context: error binding OpenGL ES API (%s)\n", lastErrorString());
+        RELEASE_LOG_INFO(Compositing, "Cannot create EGL context: error binding OpenGL ES API (%s)\n", lastErrorString());
         return nullptr;
     }
 
-    EGLContext eglSharingContext = platformDisplay.sharingGLContext() ? static_cast<GLContext*>(platformDisplay.sharingGLContext())->m_context : EGL_NO_CONTEXT;
-    auto context = createWindowContext(window, platformDisplay, eglSharingContext);
+    EGLContext eglSharingContext = sharingGLContext ? sharingGLContext->m_context : EGL_NO_CONTEXT;
+    auto context = window ? createWindowContext(display, target, window, eglSharingContext) : createOffscreenContext(display, target, eglSharingContext);
     if (!context)
-        WTFLogAlways("Could not create EGL context.");
+        RELEASE_LOG_INFO(Compositing, "Could not create EGL context.");
     return context;
+}
+
+static GLContext::Target targetForPlatformDisplay(PlatformDisplay& platformDisplay)
+{
+    switch (platformDisplay.type()) {
+    case PlatformDisplay::Type::Surfaceless:
+        return GLContext::Target::Surfaceless;
+#if USE(WPE_RENDERER)
+    case PlatformDisplay::Type::WPE:
+        return GLContext::Target::WPE;
+#endif
+#if USE(GBM)
+    case PlatformDisplay::Type::GBM:
+        return GLContext::Target::GBM;
+#endif
+    default:
+        break;
+    }
+    return GLContext::Target::Default;
+}
+
+std::unique_ptr<GLContext> GLContext::create(PlatformDisplay& platformDisplay, GLNativeWindowType window)
+{
+    return GLContext::create(platformDisplay.glDisplay(), targetForPlatformDisplay(platformDisplay), platformDisplay.sharingGLContext(), window);
 }
 
 std::unique_ptr<GLContext> GLContext::createOffscreen(PlatformDisplay& platformDisplay)
 {
-    if (platformDisplay.eglDisplay() == EGL_NO_DISPLAY) {
-        WTFLogAlways("Cannot create EGL context: invalid display (last error: %s)\n", lastErrorString());
-        return nullptr;
-    }
-
-    if (eglBindAPI(EGL_OPENGL_ES_API) == EGL_FALSE) {
-        WTFLogAlways("Cannot create EGL context: error binding OpenGL ES API (%s)\n", lastErrorString());
-        return nullptr;
-    }
-
-    EGLContext eglSharingContext = platformDisplay.sharingGLContext() ? static_cast<GLContext*>(platformDisplay.sharingGLContext())->m_context : EGL_NO_CONTEXT;
-    auto context = createSurfacelessContext(platformDisplay, eglSharingContext);
-    if (!context) {
-        switch (platformDisplay.type()) {
-#if USE(WPE_RENDERER)
-        case PlatformDisplay::Type::WPE:
-            context = createWPEContext(platformDisplay, eglSharingContext);
-            break;
-#endif
-#if USE(GBM)
-        case PlatformDisplay::Type::GBM:
-#endif
-        case PlatformDisplay::Type::Surfaceless:
-            // Do not fallback to pbuffers.
-            WTFLogAlways("Could not create EGL surfaceless context: %s.", lastErrorString());
-            return nullptr;
-        default:
-            break;
-        }
-    }
-    if (!context) {
-        RELEASE_LOG_INFO(Compositing, "Could not create platform context: %s. Using Pbuffer as fallback.", lastErrorString());
-        context = createPbufferContext(platformDisplay, eglSharingContext);
-        if (!context)
-            RELEASE_LOG_INFO(Compositing, "Could not create Pbuffer context: %s.", lastErrorString());
-    }
-
-    return context;
+    return GLContext::create(platformDisplay.glDisplay(), targetForPlatformDisplay(platformDisplay), platformDisplay.sharingGLContext());
 }
 
 std::unique_ptr<GLContext> GLContext::createSharing(PlatformDisplay& platformDisplay)
 {
-    if (platformDisplay.eglDisplay() == EGL_NO_DISPLAY) {
-        WTFLogAlways("Cannot create EGL sharing context: invalid display (last error: %s)", lastErrorString());
-        return nullptr;
-    }
-
-    if (eglBindAPI(EGL_OPENGL_ES_API) == EGL_FALSE) {
-        WTFLogAlways("Cannot create EGL sharing context: error binding OpenGL ES API (%s)\n", lastErrorString());
-        return nullptr;
-    }
-
-    auto context = createSurfacelessContext(platformDisplay);
-    if (!context) {
-        switch (platformDisplay.type()) {
-#if USE(WPE_RENDERER)
-        case PlatformDisplay::Type::WPE:
-            context = createWPEContext(platformDisplay);
-            break;
-#endif
-#if USE(GBM)
-        case PlatformDisplay::Type::GBM:
-#endif
-        case PlatformDisplay::Type::Surfaceless:
-            // Do not fallback to pbuffers.
-            WTFLogAlways("Could not create EGL surfaceless context: %s.", lastErrorString());
-            return nullptr;
-        default:
-            break;
-        }
-    }
-    if (!context) {
-        RELEASE_LOG_INFO(Compositing, "Could not create platform context: %s. Using Pbuffer as fallback.", lastErrorString());
-        context = createPbufferContext(platformDisplay);
-        if (!context)
-            RELEASE_LOG_INFO(Compositing, "Could not create Pbuffer context: %s.", lastErrorString());
-    }
-
-    if (!context)
-        WTFLogAlways("Could not create EGL sharing context.");
-    return context;
+    return GLContext::create(platformDisplay.glDisplay(), targetForPlatformDisplay(platformDisplay));
 }
 
-GLContext::GLContext(PlatformDisplay& display, EGLContext context, EGLSurface surface, EGLConfig config, EGLSurfaceType type)
+GLContext::GLContext(GLDisplay& display, EGLContext context, EGLSurface surface, EGLConfig config)
     : m_display(display)
     , m_context(context)
     , m_surface(surface)
     , m_config(config)
-    , m_type(type)
 {
-    ASSERT(type != PixmapSurface);
-    ASSERT(type == Surfaceless || surface != EGL_NO_SURFACE);
-    RELEASE_ASSERT(m_display.eglDisplay() != EGL_NO_DISPLAY);
     RELEASE_ASSERT(context != EGL_NO_CONTEXT);
 
 #if ENABLE(MEDIA_TELEMETRY)
-    if (m_type == WindowSurface) {
+    if (m_surface != EGL_NO_SURFACE) {
         MediaTelemetryReport::singleton().reportWaylandInfo(*this, MediaTelemetryReport::WaylandAction::InitGfx,
             MediaTelemetryReport::WaylandGraphicsState::GfxInitialized, MediaTelemetryReport::WaylandInputsState::InputsInitialized);
     }
@@ -381,28 +326,35 @@ GLContext::GLContext(PlatformDisplay& display, EGLContext context, EGLSurface su
 
 GLContext::~GLContext()
 {
-    EGLDisplay display = m_display.eglDisplay();
-    if (m_context) {
-        eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-        eglDestroyContext(display, m_context);
-    }
+    if (auto display = m_display.get()) {
+        EGLDisplay eglDisplay = display->eglDisplay();
+        if (m_context) {
+            eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+            eglDestroyContext(eglDisplay, m_context);
+        }
 
-    if (m_surface)
-        eglDestroySurface(display, m_surface);
+        if (m_surface)
+            eglDestroySurface(eglDisplay, m_surface);
+    }
 
 #if USE(WPE_RENDERER)
     destroyWPETarget();
 #endif
 
 #if ENABLE(MEDIA_TELEMETRY)
-    if (m_type == WindowSurface) {
+    if (m_surface != EGL_NO_SURFACE) {
         MediaTelemetryReport::singleton().reportWaylandInfo(*this, MediaTelemetryReport::WaylandAction::DeinitGfx,
             MediaTelemetryReport::WaylandGraphicsState::GfxNotInitialized, MediaTelemetryReport::WaylandInputsState::InputsInitialized);
     }
 #endif
 }
 
-EGLContext GLContext::createContextForEGLVersion(PlatformDisplay& platformDisplay, EGLConfig config, EGLContext sharingContext)
+RefPtr<GLDisplay> GLContext::display() const
+{
+    return m_display.get();
+}
+
+EGLContext GLContext::createContextForEGLVersion(EGLDisplay eglDisplay, EGLConfig config, EGLContext sharingContext)
 {
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib / Windows ports.
     static EGLint contextAttributes[3];
@@ -417,18 +369,20 @@ EGLContext GLContext::createContextForEGLVersion(PlatformDisplay& platformDispla
         contextAttributes[2] = EGL_NONE;
     }
 
-    return eglCreateContext(platformDisplay.eglDisplay(), config, sharingContext, contextAttributes);
+    return eglCreateContext(eglDisplay, config, sharingContext, contextAttributes);
 }
 
 bool GLContext::makeCurrentImpl()
 {
     ASSERT(m_context);
-    return eglMakeCurrent(m_display.eglDisplay(), m_surface, m_surface, m_context);
+    auto display = m_display.get();
+    return display ? eglMakeCurrent(display->eglDisplay(), m_surface, m_surface, m_context) : false;
 }
 
 bool GLContext::unmakeCurrentImpl()
 {
-    return eglMakeCurrent(m_display.eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    auto display = m_display.get();
+    return display ? eglMakeCurrent(display->eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT) : false;
 }
 
 bool GLContext::makeContextCurrent()
@@ -445,7 +399,8 @@ bool GLContext::makeContextCurrent()
     if (isSwitchingFromANGLE)
         context->unmakeCurrentImpl();
 
-    if (eglMakeCurrent(m_display.eglDisplay(), m_surface, m_surface, m_context)) {
+    auto display = m_display.get();
+    if (display && eglMakeCurrent(display->eglDisplay(), m_surface, m_surface, m_context)) {
         didMakeContextCurrent();
         return true;
     }
@@ -462,7 +417,8 @@ bool GLContext::unmakeContextCurrent()
     if (!isCurrent())
         return true;
 
-    if (eglMakeCurrent(m_display.eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+    auto display = m_display.get();
+    if (display && eglMakeCurrent(display->eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
         didUnmakeContextCurrent();
         return true;
     }
@@ -480,11 +436,11 @@ GLContext* GLContext::current()
 
 void GLContext::swapBuffers()
 {
-    if (m_type == Surfaceless)
+    if (m_surface == EGL_NO_SURFACE)
         return;
 
-    ASSERT(m_surface);
-    eglSwapBuffers(m_display.eglDisplay(), m_surface);
+    if (auto display = m_display.get())
+        eglSwapBuffers(display->eglDisplay(), m_surface);
 }
 
 GCGLContext GLContext::platformContext() const
@@ -611,14 +567,18 @@ GLContext::ScopedGLContextCurrent::~ScopedGLContextCurrent()
 #if ENABLE(MEDIA_TELEMETRY)
 EGLDisplay GLContext::eglDisplay() const
 {
-    return m_display.eglDisplay();
+    auto display = m_display.get();
+    return display ? display->eglDisplay() : EGL_NO_DISPLAY;
 }
 
 EGLConfig GLContext::eglConfig() const
 {
     EGLConfig config = nullptr;
+    auto display = m_display.get();
+    if (!display)
+        return nullptr;
 
-    if (!getEGLConfig(m_display, &config, WindowSurface)) {
+    if (!getEGLConfig(display->eglDisplay(), &config, WindowSurface)) {
         WTFLogAlways("Cannot obtain EGL window context configuration: %s\n", lastErrorString());
         config = nullptr;
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.cpp
@@ -21,6 +21,7 @@
 #include "GLDisplay.h"
 
 #include "GLContext.h"
+#include <wtf/MainThread.h>
 #include <wtf/text/StringView.h>
 
 #if USE(LIBEPOXY)
@@ -47,15 +48,16 @@ typedef EGLBoolean (EGLAPIENTRYP PFNEGLDESTROYIMAGEKHRPROC) (EGLDisplay, EGLImag
 
 namespace WebCore {
 
-std::unique_ptr<GLDisplay> GLDisplay::create(EGLDisplay eglDisplay)
+RefPtr<GLDisplay> GLDisplay::create(EGLDisplay eglDisplay)
 {
+    ASSERT(isMainThread());
     if (eglDisplay == EGL_NO_DISPLAY)
         return nullptr;
 
     if (eglInitialize(eglDisplay, nullptr, nullptr) == EGL_FALSE)
         return nullptr;
 
-    return makeUnique<GLDisplay>(eglDisplay);
+    return adoptRef(new GLDisplay(eglDisplay));
 }
 
 GLDisplay::GLDisplay(EGLDisplay eglDisplay)

--- a/Source/WebCore/platform/graphics/egl/GLDisplay.h
+++ b/Source/WebCore/platform/graphics/egl/GLDisplay.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,12 +35,10 @@ typedef unsigned EGLenum;
 
 namespace WebCore {
 
-class GLDisplay {
+class GLDisplay final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GLDisplay, WTF::DestructionThread::MainRunLoop> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(GLDisplay);
-    WTF_MAKE_NONCOPYABLE(GLDisplay);
 public:
-    static std::unique_ptr<GLDisplay> create(EGLDisplay);
-    explicit GLDisplay(EGLDisplay);
+    static RefPtr<GLDisplay> create(EGLDisplay);
     ~GLDisplay() = default;
 
     EGLDisplay eglDisplay() const { return m_display; }
@@ -74,6 +73,8 @@ public:
 #endif
 
 private:
+    explicit GLDisplay(EGLDisplay);
+
     EGLDisplay m_display { nullptr };
     struct {
         int major { 0 };

--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -23,6 +23,7 @@
 #include "GLContext.h"
 #include "GLFenceEGL.h"
 #include "GLFenceGL.h"
+#include "PlatformDisplay.h"
 #include <wtf/TZoneMallocInlines.h>
 
 #if USE(LIBEPOXY)

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.cpp
@@ -41,10 +41,10 @@ std::unique_ptr<PlatformDisplayDefault> PlatformDisplayDefault::create()
         CRASH();
     }
 
-    return std::unique_ptr<PlatformDisplayDefault>(new PlatformDisplayDefault(WTFMove(glDisplay)));
+    return std::unique_ptr<PlatformDisplayDefault>(new PlatformDisplayDefault(glDisplay.releaseNonNull()));
 }
 
-PlatformDisplayDefault::PlatformDisplayDefault(std::unique_ptr<GLDisplay>&& glDisplay)
+PlatformDisplayDefault::PlatformDisplayDefault(Ref<GLDisplay>&& glDisplay)
     : PlatformDisplay(WTFMove(glDisplay))
 {
 #if ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.h
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplayDefault.h
@@ -37,7 +37,7 @@ public:
 
     virtual ~PlatformDisplayDefault();
 private:
-    explicit PlatformDisplayDefault(std::unique_ptr<GLDisplay>&&);
+    explicit PlatformDisplayDefault(Ref<GLDisplay>&&);
 
     Type type() const override { return PlatformDisplay::Type::Default; }
 };

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<PlatformDisplaySurfaceless> PlatformDisplaySurfaceless::create()
     if (!GLContext::isExtensionSupported(extensions, "EGL_MESA_platform_surfaceless"))
         return nullptr;
 
-    std::unique_ptr<GLDisplay> glDisplay;
+    RefPtr<GLDisplay> glDisplay;
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
         glDisplay = GLDisplay::create(eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr));
     else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
@@ -48,10 +48,10 @@ std::unique_ptr<PlatformDisplaySurfaceless> PlatformDisplaySurfaceless::create()
         CRASH();
     }
 
-    return std::unique_ptr<PlatformDisplaySurfaceless>(new PlatformDisplaySurfaceless(WTFMove(glDisplay)));
+    return std::unique_ptr<PlatformDisplaySurfaceless>(new PlatformDisplaySurfaceless(glDisplay.releaseNonNull()));
 }
 
-PlatformDisplaySurfaceless::PlatformDisplaySurfaceless(std::unique_ptr<GLDisplay>&& glDisplay)
+PlatformDisplaySurfaceless::PlatformDisplaySurfaceless(Ref<GLDisplay>&& glDisplay)
     : PlatformDisplay(WTFMove(glDisplay))
 {
 #if ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.h
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.h
@@ -35,7 +35,7 @@ public:
 
     virtual ~PlatformDisplaySurfaceless();
 private:
-    explicit PlatformDisplaySurfaceless(std::unique_ptr<GLDisplay>&&);
+    explicit PlatformDisplaySurfaceless(Ref<GLDisplay>&&);
 
     Type type() const override { return PlatformDisplay::Type::Surfaceless; }
 };

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<PlatformDisplayGBM> PlatformDisplayGBM::create(struct gbm_device
     if (!GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_gbm"))
         return nullptr;
 
-    std::unique_ptr<GLDisplay> glDisplay;
+    RefPtr<GLDisplay> glDisplay;
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
         glDisplay = GLDisplay::create(eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR, device, nullptr));
     else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
@@ -50,10 +50,10 @@ std::unique_ptr<PlatformDisplayGBM> PlatformDisplayGBM::create(struct gbm_device
         CRASH();
     }
 
-    return std::unique_ptr<PlatformDisplayGBM>(new PlatformDisplayGBM(WTFMove(glDisplay), device));
+    return std::unique_ptr<PlatformDisplayGBM>(new PlatformDisplayGBM(glDisplay.releaseNonNull(), device));
 }
 
-PlatformDisplayGBM::PlatformDisplayGBM(std::unique_ptr<GLDisplay>&& glDisplay, struct gbm_device* device)
+PlatformDisplayGBM::PlatformDisplayGBM(Ref<GLDisplay>&& glDisplay, struct gbm_device* device)
     : PlatformDisplay(WTFMove(glDisplay))
 {
 #if ENABLE(WEBGL)

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
@@ -38,7 +38,7 @@ public:
 
     virtual ~PlatformDisplayGBM();
 private:
-    PlatformDisplayGBM(std::unique_ptr<GLDisplay>&&, struct gbm_device*);
+    PlatformDisplayGBM(Ref<GLDisplay>&&, struct gbm_device*);
 
     Type type() const override { return PlatformDisplay::Type::GBM; }
 };

--- a/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<PlatformDisplayLibWPE> PlatformDisplayLibWPE::create(int hostFd)
 
     EGLNativeDisplayType eglNativeDisplay = wpe_renderer_backend_egl_get_native_display(backend);
 
-    std::unique_ptr<GLDisplay> glDisplay;
+    RefPtr<GLDisplay> glDisplay;
 #if WPE_CHECK_VERSION(1, 1, 0)
     uint32_t eglPlatform = wpe_renderer_backend_egl_get_platform(backend);
     if (eglPlatform) {
@@ -93,10 +93,10 @@ std::unique_ptr<PlatformDisplayLibWPE> PlatformDisplayLibWPE::create(int hostFd)
         CRASH();
     }
 
-    return std::unique_ptr<PlatformDisplayLibWPE>(new PlatformDisplayLibWPE(WTFMove(glDisplay), backend));
+    return std::unique_ptr<PlatformDisplayLibWPE>(new PlatformDisplayLibWPE(glDisplay.releaseNonNull(), backend));
 }
 
-PlatformDisplayLibWPE::PlatformDisplayLibWPE(std::unique_ptr<GLDisplay>&& glDisplay, struct wpe_renderer_backend_egl* backend)
+PlatformDisplayLibWPE::PlatformDisplayLibWPE(Ref<GLDisplay>&& glDisplay, struct wpe_renderer_backend_egl* backend)
     : PlatformDisplay(WTFMove(glDisplay))
     , m_backend(backend)
 {

--- a/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h
+++ b/Source/WebCore/platform/graphics/libwpe/PlatformDisplayLibWPE.h
@@ -42,7 +42,7 @@ public:
     struct wpe_renderer_backend_egl* backend() const { return m_backend; }
 
 private:
-    PlatformDisplayLibWPE(std::unique_ptr<GLDisplay>&&, struct wpe_renderer_backend_egl*);
+    PlatformDisplayLibWPE(Ref<GLDisplay>&&, struct wpe_renderer_backend_egl*);
 
     Type type() const override { return PlatformDisplay::Type::WPE; }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -30,6 +30,7 @@
 #include "ImageBuffer.h"
 #include "LengthFunctions.h"
 #include "NativeImage.h"
+#include "PlatformDisplay.h"
 #include "TextureMapper.h"
 #include "TextureMapperFlags.h"
 #include "TextureMapperShaderProgram.h"

--- a/Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp
+++ b/Source/WebCore/platform/graphics/win/PlatformDisplayWin.cpp
@@ -48,10 +48,10 @@ std::unique_ptr<PlatformDisplayWin> PlatformDisplayWin::create()
         CRASH();
     }
 
-    return std::unique_ptr<PlatformDisplayWin>(new PlatformDisplayWin(WTFMove(glDisplay)));
+    return std::unique_ptr<PlatformDisplayWin>(new PlatformDisplayWin(glDisplay.releaseNonNull()));
 }
 
-PlatformDisplayWin::PlatformDisplayWin(std::unique_ptr<GLDisplay>&& glDisplay)
+PlatformDisplayWin::PlatformDisplayWin(Ref<GLDisplay>&& glDisplay)
     : PlatformDisplay(WTFMove(glDisplay))
 {
 }

--- a/Source/WebCore/platform/graphics/win/PlatformDisplayWin.h
+++ b/Source/WebCore/platform/graphics/win/PlatformDisplayWin.h
@@ -38,7 +38,7 @@ public:
     virtual ~PlatformDisplayWin() = default;
 
 private:
-    explicit PlatformDisplayWin(std::unique_ptr<GLDisplay>&&);
+    explicit PlatformDisplayWin(Ref<GLDisplay>&&);
 
     Type type() const override { return PlatformDisplay::Type::Windows; }
 };

--- a/Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp
@@ -29,6 +29,7 @@
 #if USE(GRAPHICS_LAYER_WC)
 
 #include <WebCore/GLContext.h>
+#include <WebCore/PlatformDisplay.h>
 #include <WebCore/TextureMapper.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -38,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WCSceneContext);
 
 WCSceneContext::WCSceneContext(uint64_t nativeWindow)
 {
-    m_glContext = WebCore::GLContext::create(reinterpret_cast<GLNativeWindowType>(nativeWindow), WebCore::PlatformDisplay::sharedDisplay());
+    m_glContext = WebCore::GLContext::create(WebCore::PlatformDisplay::sharedDisplay(), reinterpret_cast<GLNativeWindowType>(nativeWindow));
 }
 
 WCSceneContext::~WCSceneContext() = default;

--- a/Source/WebKit/UIProcess/gtk/Display.h
+++ b/Source/WebKit/UIProcess/gtk/Display.h
@@ -64,7 +64,7 @@ private:
 #endif
 
     GRefPtr<GdkDisplay> m_gdkDisplay;
-    mutable std::unique_ptr<WebCore::GLDisplay> m_glDisplay;
+    mutable RefPtr<WebCore::GLDisplay> m_glDisplay;
     mutable bool m_glInitialized { false };
     mutable bool m_glDisplayOwned { false };
 };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/Page.h>
+#include <WebCore/PlatformDisplay.h>
 #include <WebCore/Settings.h>
 #include <WebCore/TextureMapper.h>
 #include <WebCore/TextureMapperLayer.h>
@@ -124,7 +125,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
     applyDeviceScaleFactor();
 
     // The creation of the TextureMapper needs an active OpenGL context.
-    m_context = GLContext::create(window(), PlatformDisplay::sharedDisplay());
+    m_context = GLContext::create(PlatformDisplay::sharedDisplay(), window());
 
     if (!m_context)
         return;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -129,7 +129,7 @@ ThreadedCompositor::ThreadedCompositor(LayerTreeHost& layerTreeHost, ThreadedDis
         // a plain C cast expression in this one instance works in all cases.
         static_assert(sizeof(GLNativeWindowType) <= sizeof(uint64_t), "GLNativeWindowType must not be longer than 64 bits.");
         auto nativeSurfaceHandle = (GLNativeWindowType)m_surface->window();
-        m_context = GLContext::create(nativeSurfaceHandle, PlatformDisplay::sharedDisplay());
+        m_context = GLContext::create(PlatformDisplay::sharedDisplay(), nativeSurfaceHandle);
         if (m_context && m_context->makeContextCurrent()) {
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;


### PR DESCRIPTION
#### 9969537eb29168a65c55e44cba724d3cd1319ff1
<pre>
[CoordinatedGraphics] Remove GLContext dependency on PlatformDisplay
<a href="https://bugs.webkit.org/show_bug.cgi?id=297215">https://bugs.webkit.org/show_bug.cgi?id=297215</a>

Reviewed by Miguel Gomez.

GLContext is keeping a plain reference to PlatformDisplay because it was
assumed that global shared display was the only possible
PlatformDisplay. This patch makes GLDisplay reference counted and
GLContext now takes a weak reference of a GLDisplay instead of a plain
reference of a PlatformDisplay. We still keep the constructors taking a
PlatformDisplay for convenience.

Canonical link: <a href="https://commits.webkit.org/298560@main">https://commits.webkit.org/298560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b21c70833359a89862323d108d3cf2ea40187f64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115901 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125102 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96792 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43154 "Failed to checkout and rebase branch from PR 49216") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96579 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38711 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18523 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42677 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48266 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42144 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->