### PR TITLE
AX: AXObjectCache should have an Inlines header file

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -725,16 +725,20 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Scripts/generate-log-declarations.py
 
+    accessibility/AXAttributeCacheScope.h
     accessibility/AXCoreObject.h
     accessibility/AXGeometryManager.h
     accessibility/AXLogger.h
     accessibility/AXLoggerBase.h
     accessibility/AXObjectCache.h
+    accessibility/AXObjectCacheInlines.h
     accessibility/AXSearchManager.h
     accessibility/AXTextMarker.h
     accessibility/AXTextRun.h
     accessibility/AXTextStateChangeIntent.h
     accessibility/AXTreeStore.h
+    accessibility/AXTreeStoreInlines.h
+    accessibility/AXUtilities.h
     accessibility/AccessibilityListBox.h
     accessibility/AccessibilityMenuListPopup.h
     accessibility/AccessibilityMockObject.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -23,7 +23,6 @@ Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
 Modules/webdatabase/SQLCallbackWrapper.h
-accessibility/AXObjectCache.h
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilityTable.cpp
 accessibility/isolatedtree/AXIsolatedObject.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -552,6 +552,7 @@ Modules/webxr/XRSessionEvent.cpp
 Modules/webxr/XRSubImage.cpp
 Modules/webxr/XRWebGLBinding.cpp
 Modules/webxr/XRWebGLSubImage.cpp
+accessibility/AXAttributeCacheScope.cpp
 accessibility/AXCoreObject.cpp
 accessibility/AXGeometryManager.cpp
 accessibility/AXLogger.cpp
@@ -562,6 +563,7 @@ accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
 accessibility/AXTextRun.cpp
 accessibility/AXTreeStore.cpp
+accessibility/AXUtilities.cpp
 accessibility/AccessibilityAttachment.cpp
 accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityLabel.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -141,6 +141,7 @@ accessibility/cocoa/AXCoreObjectCocoa.mm
 accessibility/cocoa/AXTextMarkerCocoa.mm
 accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/ios/AXObjectCacheIOS.mm
+accessibility/ios/AXRemoteTokenIOS.mm
 accessibility/ios/AccessibilityObjectIOS.mm
 accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
 accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm

--- a/Source/WebCore/accessibility/AXAttributeCacheScope.cpp
+++ b/Source/WebCore/accessibility/AXAttributeCacheScope.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXAttributeCacheScope.h"
+
+#include "AXObjectCache.h"
+
+namespace WebCore {
+
+AXAttributeCacheScope::AXAttributeCacheScope(AXObjectCache* cache)
+    : m_cache(cache)
+{
+    if (CheckedPtr protectedCache = m_cache.get()) {
+        if (protectedCache->computedObjectAttributeCache())
+            m_wasAlreadyCaching = true;
+        else
+            protectedCache->startCachingComputedObjectAttributesUntilTreeMutates();
+    }
+}
+
+AXAttributeCacheScope::~AXAttributeCacheScope()
+{
+    if (CheckedPtr protectedCache = m_cache.get(); protectedCache && !m_wasAlreadyCaching)
+        protectedCache->stopCachingComputedObjectAttributes();
+}
+
+} // WebCore

--- a/Source/WebCore/accessibility/AXAttributeCacheScope.h
+++ b/Source/WebCore/accessibility/AXAttributeCacheScope.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class AXObjectCache;
+
+class AXAttributeCacheScope final {
+public:
+    explicit AXAttributeCacheScope(AXObjectCache *);
+    ~AXAttributeCacheScope();
+
+private:
+    const WeakPtr<AXObjectCache> m_cache;
+    bool m_wasAlreadyCaching { false };
+};
+
+} // WebCore

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -35,6 +35,7 @@
 #include "AXObjectCache.h"
 #include "AXSearchManager.h"
 #include "AXTextRun.h"
+#include "AXUtilities.h"
 #include "DocumentInlines.h"
 #include "LocalFrameView.h"
 #include "LogInitialization.h"

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AXGeometryManager.h"
+
+namespace WebCore {
+
+template<typename U>
+inline Vector<Ref<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs) const
+{
+    ASSERT(isMainThread());
+
+    CheckedPtr cache = this;
+    return WTF::compactMap(axIDs, [cache](auto& axID) -> std::optional<Ref<AXCoreObject>> {
+        if (auto* object = cache->objectForID(axID))
+            return Ref { *object };
+        return std::nullopt;
+    });
+}
+
+inline Node* AXObjectCache::nodeForID(std::optional<AXID> axID) const
+{
+    if (!axID)
+        return nullptr;
+
+    RefPtr object = m_objects.get(*axID);
+    return object ? object->node() : nullptr;
+}
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+inline void AXObjectCache::scheduleObjectRegionsUpdate(bool scheduleImmediately)
+{
+    m_geometryManager->scheduleObjectRegionsUpdate(scheduleImmediately);
+}
+
+inline void AXObjectCache::willUpdateObjectRegions()
+{
+    m_geometryManager->willUpdateObjectRegions();
+}
+
+inline void AXObjectCache::objectBecameIgnored(const AccessibilityObject& object)
+{
+    if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
+        tree->objectBecameIgnored(object);
+}
+
+inline void AXObjectCache::objectBecameUnignored(const AccessibilityObject& object)
+{
+#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+    if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
+        tree->objectBecameUnignored(object);
+#else
+    UNUSED_PARAM(object);
+#endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+}
+
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+
+} // WebCore

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -29,6 +29,8 @@
 #include "AXLogger.h"
 #include "AXObjectCache.h"
 #include "AXTreeStore.h"
+#include "AXTreeStoreInlines.h"
+#include "AXUtilities.h"
 #include "BoundaryPointInlines.h"
 #include "HTMLInputElement.h"
 #include "Logging.h"

--- a/Source/WebCore/accessibility/AXTreeStoreInlines.h
+++ b/Source/WebCore/accessibility/AXTreeStoreInlines.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AXIsolatedTree.h"
+
+namespace WebCore {
+
+template<typename T>
+inline void AXTreeStore<T>::set(AXID axID, const AXTreeWeakPtr& tree)
+{
+    ASSERT(isMainThread());
+
+    switchOn(tree,
+        [&] (const WeakPtr<AXObjectCache>& typedTree) {
+            liveTreeMap().set(axID, typedTree);
+        }
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        , [&] (const ThreadSafeWeakPtr<AXIsolatedTree>& typedTree) {
+            Locker locker { s_storeLock };
+            isolatedTreeMap().set(axID, typedTree.get());
+        }
+#endif
+    );
+}
+
+template<typename T>
+inline void AXTreeStore<T>::add(AXID axID, const AXTreeWeakPtr& tree)
+{
+    ASSERT(isMainThread());
+
+    switchOn(tree,
+        [&] (const WeakPtr<AXObjectCache>& typedTree) {
+            liveTreeMap().add(axID, typedTree);
+        }
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        , [&] (const ThreadSafeWeakPtr<AXIsolatedTree>& typedTree) {
+            Locker locker { s_storeLock };
+            isolatedTreeMap().add(axID, typedTree.get());
+        }
+#endif
+    );
+}
+
+template<typename T>
+inline void AXTreeStore<T>::remove(AXID axID)
+{
+    if (isMainThread()) {
+        liveTreeMap().remove(axID);
+        return;
+    }
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Locker locker { s_storeLock };
+    isolatedTreeMap().remove(axID);
+#endif
+}
+
+template<typename T>
+inline bool AXTreeStore<T>::contains(AXID axID)
+{
+    if (isMainThread())
+        return liveTreeMap().contains(axID);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    Locker locker { s_storeLock };
+    return isolatedTreeMap().contains(axID);
+#endif
+}
+
+template<typename T>
+inline WeakPtr<AXObjectCache> AXTreeStore<T>::axObjectCacheForID(std::optional<AXID> axID)
+{
+    return axID ? liveTreeMap().get(*axID) : nullptr;
+}
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+template<typename T>
+inline RefPtr<AXIsolatedTree> AXTreeStore<T>::isolatedTreeForID(std::optional<AXID> axID)
+{
+    if (!axID)
+        return nullptr;
+
+    Locker locker { s_storeLock };
+    return isolatedTreeMap().get(*axID).get();
+}
+#endif
+
+template<typename T>
+inline HashMap<AXID, WeakPtr<AXObjectCache>>& AXTreeStore<T>::liveTreeMap()
+{
+    ASSERT(isMainThread());
+
+    static NeverDestroyed<HashMap<AXID, WeakPtr<AXObjectCache>>> map;
+    return map;
+}
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+template<typename T>
+inline HashMap<AXID, ThreadSafeWeakPtr<AXIsolatedTree>>& AXTreeStore<T>::isolatedTreeMap()
+{
+    static NeverDestroyed<HashMap<AXID, ThreadSafeWeakPtr<AXIsolatedTree>>> map;
+    return map;
+}
+#endif
+
+template<typename T>
+Lock AXTreeStore<T>::s_storeLock;
+
+inline AXTreePtr axTreeForID(std::optional<AXID> axID)
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (!isMainThread())
+        return AXTreeStore<AXIsolatedTree>::isolatedTreeForID(axID);
+#endif
+    return AXTreeStore<AXObjectCache>::axObjectCacheForID(axID);
+}
+
+} // WebCore

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXUtilities.h"
+
+#include "AXLoggerBase.h"
+#include "AXObjectCache.h"
+#include "Document.h"
+#include "Element.h"
+#include "HTMLImageElement.h"
+#include "HTMLMediaElement.h"
+#include "HTMLNames.h"
+#include "Node.h"
+#include "RenderImage.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+using namespace HTMLNames;
+
+ContainerNode* composedParentIgnoringDocumentFragments(const Node& node)
+{
+    RefPtr ancestor = node.parentInComposedTree();
+    while (is<DocumentFragment>(ancestor.get()))
+        ancestor = ancestor->parentInComposedTree();
+    return ancestor.get();
+}
+
+ContainerNode* composedParentIgnoringDocumentFragments(const Node* node)
+{
+    return node ? composedParentIgnoringDocumentFragments(*node) : nullptr;
+}
+
+ElementName elementName(Node* node)
+{
+    auto* element = dynamicDowncast<Element>(node);
+    return element ? element->elementName() : ElementName::Unknown;
+}
+
+ElementName elementName(Node& node)
+{
+    auto* element = dynamicDowncast<Element>(node);
+    return element ? element->elementName() : ElementName::Unknown;
+}
+
+bool hasAccNameAttribute(Element& element)
+{
+    auto trimmed = [&] (const auto& attribute) {
+        const auto& value = element.attributeWithDefaultARIA(attribute);
+        if (value.isEmpty())
+            return emptyString();
+        auto copy = value.string();
+        return copy.trim(isASCIIWhitespace);
+    };
+
+    // Avoid calculating the actual description here (e.g. resolving aria-labelledby), as it's expensive.
+    // The spec is generally permissive in allowing user agents to not ensure complete validity of these attributes.
+    // For example, https://w3c.github.io/svg-aam/#include_elements:
+    // "It has an ‘aria-labelledby’ attribute or ‘aria-describedby’ attribute containing valid IDREF tokens. User agents MAY include elements with these attributes without checking for validity."
+    if (trimmed(aria_labelAttr).length() || trimmed(aria_labelledbyAttr).length() || trimmed(aria_labeledbyAttr).length() || trimmed(aria_descriptionAttr).length() || trimmed(aria_describedbyAttr).length())
+        return true;
+
+    return element.attributeWithoutSynchronization(titleAttr).length();
+}
+
+RenderImage* toSimpleImage(RenderObject& renderer)
+{
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer);
+    if (!renderImage)
+        return nullptr;
+
+    // Exclude ImageButtons because they are treated as buttons, not as images.
+    RefPtr node = renderer.node();
+    if (is<HTMLInputElement>(node))
+        return nullptr;
+
+    // ImageMaps are not simple images.
+    if (renderImage->imageMap())
+        return nullptr;
+
+    if (RefPtr imgElement = dynamicDowncast<HTMLImageElement>(node); imgElement && imgElement->hasAttributeWithoutSynchronization(usemapAttr))
+        return nullptr;
+
+#if ENABLE(VIDEO)
+    // Exclude video and audio elements.
+    if (is<HTMLMediaElement>(node))
+        return nullptr;
+#endif // ENABLE(VIDEO)
+
+    return renderImage.get();
+}
+
+// FIXME: This probably belongs on Element.
+bool hasRole(Element& element, StringView role)
+{
+    auto roleValue = element.attributeWithDefaultARIA(roleAttr);
+    if (role.isNull())
+        return roleValue.isEmpty();
+    if (roleValue.isEmpty())
+        return false;
+
+    return SpaceSplitString::spaceSplitStringContainsValue(roleValue, role, SpaceSplitString::ShouldFoldCase::Yes);
+}
+
+bool hasAnyRole(Element& element, Vector<StringView>&& roles)
+{
+    auto roleValue = element.attributeWithDefaultARIA(roleAttr);
+    if (roleValue.isEmpty())
+        return false;
+
+    for (const auto& role : roles) {
+        AX_DEBUG_ASSERT(!role.isEmpty());
+        if (SpaceSplitString::spaceSplitStringContainsValue(roleValue, role, SpaceSplitString::ShouldFoldCase::Yes))
+            return true;
+    }
+    return false;
+}
+
+bool hasAnyRole(Element* element, Vector<StringView>&& roles)
+{
+    return element ? hasAnyRole(*element, WTFMove(roles)) : false;
+}
+
+bool hasTableRole(Element& element)
+{
+    return hasAnyRole(element, { "grid"_s, "table"_s, "treegrid"_s });
+}
+
+bool hasCellARIARole(Element& element)
+{
+    return hasAnyRole(element, { "gridcell"_s, "cell"_s, "columnheader"_s, "rowheader"_s });
+}
+
+bool hasPresentationRole(Element& element)
+{
+    return hasAnyRole(element, { "presentation"_s, "none"_s });
+}
+
+bool isRowGroup(Element& element)
+{
+    auto name = element.elementName();
+    return name == ElementName::HTML_thead || name == ElementName::HTML_tbody || name == ElementName::HTML_tfoot || hasRole(element, "rowgroup"_s);
+}
+
+bool isRowGroup(Node* node)
+{
+    auto* element = dynamicDowncast<Element>(node);
+    return element && isRowGroup(*element);
+}
+
+void dumpAccessibilityTreeToStderr(Document& document)
+{
+    if (CheckedPtr cache = document.existingAXObjectCache()) {
+        AXTreeData data = cache->treeData();
+        SAFE_FPRINTF(stderr, "==AX Trees==\n%s\n%s\n", data.liveTree.utf8(), data.isolatedTree.utf8());
+    }
+}
+
+} // WebCore
+

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+bool hasRole(Element&, StringView role);
+bool hasAnyRole(Element&, Vector<StringView>&& roles);
+bool hasAnyRole(Element*, Vector<StringView>&& roles);
+bool hasCellARIARole(Element&);
+bool hasPresentationRole(Element&);
+bool hasTableRole(Element&);
+bool isRowGroup(Element&);
+bool isRowGroup(Node*);
+ContainerNode* composedParentIgnoringDocumentFragments(const Node&);
+ContainerNode* composedParentIgnoringDocumentFragments(const Node*);
+
+ElementName elementName(Node*);
+ElementName elementName(Node&);
+
+RenderImage* toSimpleImage(RenderObject&);
+
+// Returns true if the element has an attribute that will result in an accname being computed.
+// https://www.w3.org/TR/accname-1.2/
+bool hasAccNameAttribute(Element&);
+
+bool isNodeFocused(Node&);
+
+bool isRenderHidden(const RenderStyle*);
+// Checks both CSS display properties, and CSS visibility properties.
+bool isRenderHidden(const RenderStyle&);
+// Only checks CSS visibility properties.
+bool isVisibilityHidden(const RenderStyle&);
+
+WTF::TextStream& operator<<(WTF::TextStream&, AXNotification);
+
+void dumpAccessibilityTreeToStderr(Document&);
+
+} // WebCore

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityList.h"
 
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "ContainerNodeInlines.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -31,6 +31,7 @@
 #include "AccessibilityMathMLElement.h"
 
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "MathMLNames.h"
 #include "NodeInlines.h"
 #include "RenderStyleInlines.h"

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
@@ -31,6 +31,7 @@
 #if PLATFORM(IOS_FAMILY)
 #include "AccessibilityMediaObject.h"
 
+#include "AXObjectCache.h"
 #include "HTMLMediaElement.h"
 #include "HTMLNames.h"
 #include "HTMLVideoElement.h"

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -32,6 +32,7 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityLabel.h"
 #include "AccessibilityList.h"

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -29,11 +29,16 @@
 #include "config.h"
 #include "AccessibilityObject.h"
 
+#include "AXAttributeCacheScope.h"
+#include "AXIsolatedTree.h"
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXRemoteFrame.h"
 #include "AXSearchManager.h"
 #include "AXTextMarker.h"
+#include "AXUtilities.h"
 #include "AccessibilityMockObject.h"
 #include "AccessibilityRenderObject.h"
 #include "AccessibilityScrollView.h"
@@ -2285,7 +2290,7 @@ void AccessibilityObject::updateChildrenIfNecessary()
 {
     if (!childrenInitialized()) {
         // Enable the cache in case we end up adding a lot of children, we don't want to recompute axIsIgnored each time.
-        AXAttributeCacheEnabler enableCache(axObjectCache());
+        AXAttributeCacheScope enableCache(axObjectCache());
         addChildren();
     }
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -948,6 +948,11 @@ private:
 #endif
 };
 
+inline AXObjectCache* AccessibilityObject::axObjectCache() const
+{
+    return m_axObjectCache.get();
+}
+
 inline bool AccessibilityObject::hasDisplayContents() const
 {
     RefPtr element = this->element();
@@ -992,13 +997,6 @@ inline bool AccessibilityObject::hasAttributedText() const
 #endif
 
 AccessibilityObject* firstAccessibleObjectFromNode(const Node*, NOESCAPE const Function<bool(const AccessibilityObject&)>& isAccessible);
-
-namespace Accessibility {
-
-#if PLATFORM(IOS_FAMILY)
-WEBCORE_EXPORT RetainPtr<NSData> newAccessibilityRemoteToken(NSString *);
-#endif
-} // namespace Accessibility
 
 class AXChildIterator {
 public:

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -32,6 +32,7 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityListBox.h"
 #include "AccessibilitySVGObject.h"

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityTable.h"
 
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "AccessibilityTableCell.h"
 #include "AccessibilityTableColumn.h"
 #include "AccessibilityTableHeaderContainer.h"

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityTableCell.h"
 
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "AccessibilityTable.h"
 #include "AccessibilityTableRow.h"
 #include "HTMLParserIdioms.h"

--- a/Source/WebCore/accessibility/AccessibilityTree.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTree.cpp
@@ -30,6 +30,7 @@
 #include "AccessibilityTree.h"
 
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "AccessibilityTreeItem.h"
 #include "Element.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -27,6 +27,7 @@
 #import "AXCoreObject.h"
 
 #import "AXObjectCache.h"
+#import "AXTreeStoreInlines.h"
 #import "ColorCocoa.h"
 #import "RenderObjectInlines.h"
 #import "WebAccessibilityObjectWrapperBase.h"

--- a/Source/WebCore/accessibility/ios/AXRemoteTokenIOS.h
+++ b/Source/WebCore/accessibility/ios/AXRemoteTokenIOS.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RetainPtr.h>
+
+namespace WebCore {
+
+namespace Accessibility {
+
+#if PLATFORM(IOS_FAMILY)
+WEBCORE_EXPORT RetainPtr<NSData> newAccessibilityRemoteToken(NSString *);
+#endif
+
+} // namespace Accessibility
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/ios/AXRemoteTokenIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXRemoteTokenIOS.mm
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "AXRemoteTokenIOS.h"
+
+namespace WebCore {
+
+namespace Accessibility {
+
+#if PLATFORM(IOS_FAMILY)
+
+RetainPtr<NSData> newAccessibilityRemoteToken(NSString *uuidString)
+{
+    if (!uuidString)
+        return nil;
+    return [NSKeyedArchiver archivedDataWithRootObject:@{ @"ax-pid" : @(getpid()), @"ax-uuid" : uuidString, @"ax-register" : @YES } requiringSecureCoding:YES error:nullptr];
+}
+
+#endif
+
+} // namespace Accessibility
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -29,6 +29,8 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "AXRemoteFrame.h"
+#import "AXRemoteTokenIOS.h"
+#import "AXUtilities.h"
 #import "AccessibilityRenderObject.h"
 #import "EventNames.h"
 #import "EventTargetInlines.h"
@@ -339,17 +341,6 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node& node, StringView text
 
     return result;
 }
-
-namespace Accessibility {
-
-RetainPtr<NSData> newAccessibilityRemoteToken(NSString *uuidString)
-{
-    if (!uuidString)
-        return nil;
-    return [NSKeyedArchiver archivedDataWithRootObject:@{ @"ax-pid" : @(getpid()), @"ax-uuid" : uuidString, @"ax-register" : @YES } requiringSecureCoding:YES error:nullptr];
-}
-
-} // namespace Accessibility
 
 } // namespace WebCore
 

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -28,8 +28,12 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "AXAttributeCacheScope.h"
 #import "AXLogger.h"
+#import "AXObjectCache.h"
+#import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
+#import "AXUtilities.h"
 #import "AccessibilityAttachment.h"
 #import "AccessibilityMediaObject.h"
 #import "AccessibilityRenderObject.h"
@@ -348,7 +352,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     // Try a fuzzy hit test first to find an accessible element.
     AXCoreObject *axObject = nullptr;
     {
-        AXAttributeCacheEnabler enableCache(self.axBackingObject->axObjectCache());
+        AXAttributeCacheScope enableCache(self.axBackingObject->axObjectCache());
         axObject = self.axBackingObject->accessibilityHitTest(IntPoint(point));
     }
 
@@ -1837,7 +1841,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    AXAttributeCacheEnabler enableCache(self.axBackingObject->axObjectCache());
+    AXAttributeCacheScope enableCache(self.axBackingObject->axObjectCache());
 
     // As long as there's a parent wrapper, that's the correct chain to climb.
     AXCoreObject* parent = self.axBackingObject->parentObjectUnignored();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -32,6 +32,8 @@
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
+#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AXSearchManager.h"
 #include "AXTextMarker.h"
 #include "AXTextRun.h"

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -28,8 +28,12 @@
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 #include "AXIsolatedTree.h"
 
+#include "AXAttributeCacheScope.h"
 #include "AXIsolatedObject.h"
 #include "AXLogger.h"
+#include "AXTreeStore.h"
+#include "AXTreeStoreInlines.h"
+#include "AXUtilities.h"
 #include "AccessibilityTable.h"
 #include "AccessibilityTableCell.h"
 #include "AccessibilityTableRow.h"
@@ -282,7 +286,7 @@ void AXIsolatedTree::generateSubtree(AccessibilityObject& axObject)
         return;
 
     // We're about to a lot of read-only work, so start the attribute cache.
-    AXAttributeCacheEnabler enableCache(axObject.axObjectCache());
+    AXAttributeCacheScope enableCache(axObject.axObjectCache());
     collectNodeChangesForSubtree(axObject);
     queueRemovalsAndUnresolvedChanges();
 }
@@ -949,7 +953,7 @@ void AXIsolatedTree::updateChildren(AccessibilityObject& axObject, ResolveNodeCh
         return;
 
     // We're about to do a lot of work, so start the attribute cache.
-    AXAttributeCacheEnabler enableCache(axObject.axObjectCache());
+    AXAttributeCacheScope enableCache(axObject.axObjectCache());
 
     // updateChildren may be called as the result of a children changed
     // notification for an axObject that has no associated isolated object.
@@ -1083,7 +1087,7 @@ void AXIsolatedTree::updateChildrenForObjects(const ListHashSet<Ref<Accessibilit
     if (isUpdatingSubtree())
         return;
 
-    AXAttributeCacheEnabler enableCache(axObjectCache());
+    AXAttributeCacheScope enableCache(axObjectCache());
     for (auto& axObject : axObjects)
         queueNodeUpdate(axObject->objectID(), NodeUpdateOptions::childrenUpdate());
 

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -24,6 +24,7 @@
  */
 
 #import "config.h"
+#import "AXGeometryManager.h"
 #import "AXIsolatedObject.h"
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE) && PLATFORM(MAC)

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "AXIsolatedObject.h"
+#import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
 #import "AccessibilityObject.h"
 #import "AccessibilityTable.h"
@@ -753,7 +754,7 @@ void AXObjectCache::initializeAXThreadIfNeeded()
         // Initialize the role map before the accessibility thread starts so that it's safe for both threads
         // to use (the only thing that needs to be thread-safe about it is initialization since it's not modified
         // after creation and is never destroyed).
-        initializeRoleMap();
+        Accessibility::initializeRoleMap();
 
         _AXUIElementUseSecondaryAXThread(true);
         axThreadInitialized = true;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -29,14 +29,19 @@
 #import "config.h"
 #import "WebAccessibilityObjectWrapperMac.h"
 
+#import "AXIsolatedTree.h"
+#import "AXObjectCache.h"
+#import "AXObjectCacheInlines.h"
+
 #if PLATFORM(MAC)
 
 #import "AXIsolatedObject.h"
 #import "AXLogger.h"
-#import "AXObjectCache.h"
 #import "AXRemoteFrame.h"
 #import "AXSearchManager.h"
 #import "AXTextMarker.h"
+#import "AXTreeStore.h"
+#import "AXTreeStoreInlines.h"
 #import "AccessibilityLabel.h"
 #import "AccessibilityList.h"
 #import "AccessibilityListBox.h"

--- a/Source/WebCore/accessibility/playstation/AccessibilityObjectPlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AccessibilityObjectPlayStation.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "AccessibilityObject.h"
+#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -28,7 +28,9 @@
 #include "config.h"
 #include "Document.h"
 
+#include "AXIsolatedTree.h"
 #include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "AnimationTimelinesController.h"
 #include "ApplicationManifest.h"
 #include "AsyncNodeDeletionQueueInlines.h"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -20,7 +20,10 @@
 #include "config.h"
 #include "Page.h"
 
+#include "AXIsolatedTree.h"
 #include "AXLogger.h"
+#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "ActivityStateChangeObserver.h"
 #include "AdvancedPrivacyProtections.h"
 #include "AlternativeTextClient.h"

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -21,6 +21,9 @@
 #include "config.h"
 #include "PrintContext.h"
 
+#include "AXIsolatedTree.h"
+#include "AXObjectCache.h"
+#include "AXObjectCacheInlines.h"
 #include "CommonAtomStrings.h"
 #include "ContainerNodeInlines.h"
 #include "ElementTraversal.h"

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -28,6 +28,7 @@
 #include "RenderObject.h"
 
 #include "AXObjectCache.h"
+#include "AXUtilities.h"
 #include "BoundaryPointInlines.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentInlines.h"

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -59,7 +59,7 @@
 #import "_WKFrameHandleInternal.h"
 #import "_WKWebViewPrintFormatterInternal.h"
 #import <CoreGraphics/CoreGraphics.h>
-#import <WebCore/AccessibilityObject.h>
+#import <WebCore/AXRemoteTokenIOS.h>
 #import <WebCore/FloatConversion.h>
 #import <WebCore/FloatQuad.h>
 #import <WebCore/InspectorOverlay.h>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -70,6 +70,7 @@
 #import "WebProcess.h"
 #import "WebTouchEvent.h"
 #import <CoreText/CTFont.h>
+#import <WebCore/AXRemoteTokenIOS.h>
 #import <WebCore/Autofill.h>
 #import <WebCore/AutofillElements.h>
 #import <WebCore/BoundaryPointInlines.h>


### PR DESCRIPTION
#### d1b4185336e13076de8c32629e46916a87a0a107
<pre>
AX: AXObjectCache should have an Inlines header file
<a href="https://rdar.apple.com/158049733">rdar://158049733</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297217">https://bugs.webkit.org/show_bug.cgi?id=297217</a>

Reviewed by Tyler Wilcock and Ryosuke Niwa.

AXObjectCache is included by dozens of files outside of
accessibility. To make it compile faster, we should put
implementations of inline functions in AXObjectCacheInlines, following
the same pattern used elsewhere in WebCore.

Other classes defined in AXObjectCache.h that aren&apos;t actually needed
anywhere outside of accessibility should be moved to their own files.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXAttributeCacheScope.cpp: Added.
(WebCore::AXAttributeCacheScope::AXAttributeCacheScope):
(WebCore::AXAttributeCacheScope::~AXAttributeCacheScope):
* Source/WebCore/accessibility/AXAttributeCacheScope.h: Added.
* Source/WebCore/accessibility/AXLogger.cpp:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::traverseToOffsetInRange):
(WebCore::composedParentIgnoringDocumentFragments): Deleted.
(WebCore::elementName): Deleted.
(WebCore::hasAccNameAttribute): Deleted.
(WebCore::toSimpleImage): Deleted.
(WebCore::hasRole): Deleted.
(WebCore::hasAnyRole): Deleted.
(WebCore::hasTableRole): Deleted.
(WebCore::hasCellARIARole): Deleted.
(WebCore::hasPresentationRole): Deleted.
(WebCore::isRowGroup): Deleted.
(WebCore::dumpAccessibilityTreeToStderr): Deleted.
(WebCore::AXAttributeCacheEnabler::AXAttributeCacheEnabler): Deleted.
(WebCore::AXAttributeCacheEnabler::~AXAttributeCacheEnabler): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AccessibilityObject::axObjectCache const): Deleted.
(WebCore::AXObjectCache::objectsForIDs const): Deleted.
(WebCore::AXObjectCache::nodeForID const): Deleted.
* Source/WebCore/accessibility/AXObjectCacheInlines.h: Added.
(WebCore::AXObjectCache::objectsForIDs const):
(WebCore::AXObjectCache::nodeForID const):
(WebCore::AXObjectCache::scheduleObjectRegionsUpdate):
(WebCore::AXObjectCache::willUpdateObjectRegions):
(WebCore::AXObjectCache::objectBecameIgnored):
(WebCore::AXObjectCache::objectBecameUnignored):
* Source/WebCore/accessibility/AXTextMarker.cpp:
* Source/WebCore/accessibility/AXTreeStore.h:
(WebCore::AXTreeStore&lt;T&gt;::set): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::add): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::remove): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::contains): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::axObjectCacheForID): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeForID): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::liveTreeMap): Deleted.
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeMap): Deleted.
(WebCore::axTreeForID): Deleted.
* Source/WebCore/accessibility/AXTreeStoreInlines.h: Copied from Source/WebCore/accessibility/AXTreeStore.h.
(WebCore::AXTreeStore&lt;T&gt;::set):
(WebCore::AXTreeStore&lt;T&gt;::add):
(WebCore::AXTreeStore&lt;T&gt;::remove):
(WebCore::AXTreeStore&lt;T&gt;::contains):
(WebCore::AXTreeStore&lt;T&gt;::axObjectCacheForID):
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeForID):
(WebCore::AXTreeStore&lt;T&gt;::liveTreeMap):
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeMap):
(WebCore::axTreeForID):
* Source/WebCore/accessibility/AXUtilities.cpp: Added.
(WebCore::composedParentIgnoringDocumentFragments):
(WebCore::elementName):
(WebCore::hasAccNameAttribute):
(WebCore::toSimpleImage):
(WebCore::hasRole):
(WebCore::hasAnyRole):
(WebCore::hasTableRole):
(WebCore::hasCellARIARole):
(WebCore::hasPresentationRole):
(WebCore::isRowGroup):
(WebCore::dumpAccessibilityTreeToStderr):
* Source/WebCore/accessibility/AXUtilities.h: Added.
* Source/WebCore/accessibility/AccessibilityList.cpp:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
* Source/WebCore/accessibility/AccessibilityMediaObject.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::updateChildrenIfNecessary):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::axObjectCache const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/AccessibilityTable.cpp:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
* Source/WebCore/accessibility/AccessibilityTree.cpp:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
* Source/WebCore/accessibility/ios/AXRemoteTokenIOS.h: Added.
* Source/WebCore/accessibility/ios/AXRemoteTokenIOS.mm: Added.
(WebCore::Accessibility::newAccessibilityRemoteToken):
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::Accessibility::newAccessibilityRemoteToken): Deleted.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityHitTest:]):
(-[WebAccessibilityObjectWrapper accessibilityContainer]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::generateSubtree):
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::updateChildrenForObjects):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::initializeAXThreadIfNeeded):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:

Canonical link: <a href="https://commits.webkit.org/298642@main">https://commits.webkit.org/298642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0e46fe44ae383753e7fbf395c9a833774b2a5c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88223 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65860 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32297 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96739 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38963 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48495 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->