### PR TITLE
[WPT] Follow <link rel="match"> reference file

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-hidden-boundingbox-query.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-hidden-boundingbox-query.html
@@ -2,7 +2,6 @@
 <meta charset="utf8">
 <title>Content Visibility: hidden image</title>
 <link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
-<link rel="match" href="content-visibility-024-ref.html">
 <meta name="assert" content="content-visibility hidden content returns uptodate geometry with sibling content requiring layout">
 
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/host-nesting-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/host-nesting-001-expected.html
@@ -1,4 +1,0 @@
-<!DOCTYPE html>
-<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
-<p>Test passes if there is a filled green square.</p>
-<div style="width:100px; height:100px; background:green;"></div>

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -73,6 +73,7 @@ class LayoutTestFinder(object):
             self._port.host.filesystem,
             self._port.layout_tests_dir(),
             self._port.baseline_search_path(device_type),
+            prefer_wpt_link_match=getattr(self._options, 'prefer_wpt_link_match', False),
         )
 
         return list(finder.get_tests(paths))
@@ -82,6 +83,7 @@ class LayoutTestFinder(object):
             self._port.host.filesystem,
             self._port.layout_tests_dir(),
             self._port.baseline_search_path(),
+            prefer_wpt_link_match=getattr(self._options, 'prefer_wpt_link_match', False),
         )
         return finder.is_test_file(
             dirname, filename
@@ -92,6 +94,7 @@ class LayoutTestFinder(object):
             self._port.host.filesystem,
             self._port.layout_tests_dir(),
             self._port.baseline_search_path(),
+            prefer_wpt_link_match=getattr(self._options, 'prefer_wpt_link_match', False),
         )
 
         if dirname:

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -159,6 +159,8 @@ def parse_args(args):
             dest="sample_on_timeout", help="Don't run sample on timeout (OS X only)"),
         optparse.make_option("--no-ref-tests", action="store_true",
             dest="no_ref_tests", help="Skip all ref tests"),
+        optparse.make_option("--prefer-wpt-link-match", action="store_true",
+            default=False, help="Prefer <link rel=\"match\"> references over traditional -expected files for WPT tests"),
         optparse.make_option("--ignore-render-tree-dump-results", action="store_true",
             dest="ignore_render_tree_dump_results",
             help="Don't compare or save results for render tree dump tests (they still run and crashes are reported)"),


### PR DESCRIPTION
#### 5003083cdb313f5fd2d7e3078671f6eb470a1ae4
<pre>
[WPT] Follow &lt;link rel=&quot;match&quot;&gt; reference file
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/host-nesting-001-expected.html: Removed.

First example when there is no -expected file

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-hidden-boundingbox-query.html:

Fix bug in test, should not have a link rel match file

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py:
(LayoutTestFinder.__init__):
(LayoutTestFinder._find_wpt_ref_with_link_match):
(LayoutTestFinder):
(LayoutTestFinder._find_traditional_reference_files):
(LayoutTestFinder._expectations_for_test):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.find_tests_by_path):
(LayoutTestFinder._is_test_file):
(LayoutTestFinder._is_w3c_resource_file):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5003083cdb313f5fd2d7e3078671f6eb470a1ae4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/121562 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/73647 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0bf3f0d9-f434-4f01-a09f-e24e9d299807) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/123438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/41961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/49911 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92347 "Failed to checkout and rebase branch from PR 49222") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61427 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be9f38a1-1e3f-45d5-8b18-763de18a6228) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/124514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/33507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/108889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73020 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f046c5af-f402-424e-b491-ba41d53aee5a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/120919 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/32517 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27054 "26 flakes 5 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/71594 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/130928 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/48490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/36945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100990 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/48858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/100879 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45188 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/48349 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/47820 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/49502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->