### PR TITLE
[AX]: check-webkit-style - resolve (almost) all remaining warnings

### DIFF
--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "AXGeometryManager.h"
+
 #include "AXLoggerBase.h"
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -604,7 +604,8 @@ TextStream& operator<<(TextStream& stream, AXNotification notification)
     case AXNotification::name: \
         stream << #name; \
         break;
-    WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_LOG_AXNOTIFICATION)
+
+        WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_LOG_AXNOTIFICATION)
 #undef WEBCORE_LOG_AXNOTIFICATION
     }
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -27,7 +27,6 @@
  */
 
 #include "config.h"
-
 #include "AXObjectCache.h"
 
 #include "AXIsolatedObject.h"
@@ -3101,8 +3100,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     else if (attrName == contenteditableAttr) {
         if (RefPtr axObject = get(*element))
             axObject->updateRole();
-    }
-    else if (attrName == disabledAttr)
+    } else if (attrName == disabledAttr)
         postNotification(element, AXNotification::DisabledStateChanged);
     else if (attrName == forAttr) {
         if (RefPtr label = dynamicDowncast<HTMLLabelElement>(element)) {
@@ -3211,8 +3209,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
                 axObject->updateRole();
         }
         handleTextChanged(axObject.get());
-    }
-    else if (attrName == aria_checkedAttr)
+    } else if (attrName == aria_checkedAttr)
         checkedStateChanged(*element);
     else if (attrName == aria_colcountAttr) {
         postNotification(element, AXNotification::ColumnCountChanged);
@@ -3225,8 +3222,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
     } else if (attrName == aria_colspanAttr) {
         postNotification(element, AXNotification::ColumnSpanChanged);
         recomputeParentTableProperties(element, { TableProperty::CellSlots, TableProperty::Exposed });
-    }
-    else if (attrName == aria_describedbyAttr)
+    } else if (attrName == aria_describedbyAttr)
         postNotification(element, AXNotification::DescribedByChanged);
     else if (attrName == aria_descriptionAttr)
         postNotification(element, AXNotification::ExtendedDescriptionChanged);
@@ -3251,8 +3247,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
                 removeLiveRegion(*object);
         }
 #endif // PLATFORM(MAC)
-    }
-    else if (attrName == aria_placeholderAttr)
+    } else if (attrName == aria_placeholderAttr)
         postNotification(element, AXNotification::PlaceholderChanged);
     else if (attrName == aria_rowindexAttr) {
         postNotification(element, AXNotification::ARIARowIndexChanged);
@@ -3269,8 +3264,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
             if (axObject->role() == AccessibilityRole::TextArea || axObject->role() == AccessibilityRole::TextField)
                 axObject->updateRole();
         }
-    }
-    else if (attrName == aria_multiselectableAttr)
+    } else if (attrName == aria_multiselectableAttr)
         postNotification(element, AXNotification::MultiSelectableStateChanged);
     else if (attrName == aria_orientationAttr)
         postNotification(element, AXNotification::OrientationChanged);
@@ -3300,8 +3294,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
 
         if (m_currentModalElement && m_currentModalElement->isDescendantOf(element))
             deferModalChange(*m_currentModalElement);
-    }
-    else if (attrName == aria_invalidAttr)
+    } else if (attrName == aria_invalidAttr)
         postNotification(element, AXNotification::InvalidStatusChanged);
     else if (attrName == aria_modalAttr) {
         // aria-modal changed, so the element may have become modal or un-modal.
@@ -3310,8 +3303,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         else
             m_modalElements.removeAll(element);
         deferModalChange(*element);
-    }
-    else if (attrName == aria_currentAttr)
+    } else if (attrName == aria_currentAttr)
         postNotification(element, AXNotification::CurrentStateChanged);
     else if (attrName == aria_disabledAttr)
         postNotification(element, AXNotification::DisabledStateChanged);
@@ -3782,9 +3774,9 @@ CharacterOffset AXObjectCache::characterOffsetForNodeAndOffset(Node& node, int o
         while (offset >= 0 && charOffset.offset <= offset) {
             offset -= charOffset.offset;
             domNode = previousNode(domNode.get());
-            if (domNode) {
+            if (domNode)
                 charOffset = characterOffsetForNodeAndOffset(*domNode, 0, TraverseOptionToNodeEnd);
-            } else
+            else
                 return CharacterOffset();
             if (charOffset.offset == offset)
                 break;
@@ -4031,7 +4023,6 @@ std::optional<TextMarkerData> AXObjectCache::textMarkerDataForVisiblePosition(co
                 object->isIgnored(),
                 origin
             });
-
         };
 
         if (isRendererReplacedElement(node->renderer()) || is<RenderLineBreak>(node->renderer()))
@@ -4218,10 +4209,10 @@ static char32_t characterForCharacterOffset(const CharacterOffset& characterOffs
     char32_t ch = 0;
     unsigned offset = characterOffset.startIndex + characterOffset.offset;
     if (offset < characterOffset.node->textContent().length()) {
-// FIXME: Remove IGNORE_CLANG_WARNINGS macros once one of <rdar://problem/58615489&58615391> is fixed.
-IGNORE_CLANG_WARNINGS_BEGIN("conditional-uninitialized")
+        // FIXME: Remove IGNORE_CLANG_WARNINGS macros once one of <rdar://problem/58615489&58615391> is fixed.
+        IGNORE_CLANG_WARNINGS_BEGIN("conditional-uninitialized")
         U16_NEXT(characterOffset.node->textContent(), offset, characterOffset.node->textContent().length(), ch);
-IGNORE_CLANG_WARNINGS_END
+        IGNORE_CLANG_WARNINGS_END
     }
     return ch;
 }

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1488,7 +1488,9 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
         auto startMarker = atLineStart() ? *this : previousLineStart();
         auto endMarker = atLineEnd() ? *this : nextLineEnd(includeTrailingLineBreak);
         return AXTextMarkerRange(startMarker, endMarker);
-    } else if (type == LineRangeType::Left) {
+    }
+
+    if (type == LineRangeType::Left) {
         // Move backwards off a line start (because this is a "left-line" request).
         auto startMarker = atLineStart() ? findMarker(AXDirection::Previous) : *this;
         if (!startMarker.atLineStart())
@@ -1496,17 +1498,17 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
 
         auto endMarker = startMarker.nextLineEnd(includeTrailingLineBreak);
         return { WTFMove(startMarker), WTFMove(endMarker) };
-    } else {
-        ASSERT(type == LineRangeType::Right);
-
-        // Move forwards off a line end (because this a "right-line" request).
-        auto startMarker = atLineEnd() ? findMarker(AXDirection::Next) : *this;
-        if (!startMarker.atLineStart())
-            startMarker = startMarker.previousLineStart();
-
-        auto endMarker = startMarker.nextLineEnd(includeTrailingLineBreak);
-        return { WTFMove(startMarker), WTFMove(endMarker) };
     }
+
+    ASSERT(type == LineRangeType::Right);
+
+    // Move forwards off a line end (because this a "right-line" request).
+    auto startMarker = atLineEnd() ? findMarker(AXDirection::Next) : *this;
+    if (!startMarker.atLineStart())
+        startMarker = startMarker.previousLineStart();
+
+    auto endMarker = startMarker.nextLineEnd(includeTrailingLineBreak);
+    return { WTFMove(startMarker), WTFMove(endMarker) };
 
     return { };
 }

--- a/Source/WebCore/accessibility/AXTextRun.cpp
+++ b/Source/WebCore/accessibility/AXTextRun.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "AXTextRun.h"
+
 #include "Logging.h"
 
 #if ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -99,4 +99,3 @@ void AccessibilityAttachment::accessibilityText(Vector<AccessibilityText>& textO
 } // namespace WebCore
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)
-

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.h
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.h
@@ -39,7 +39,6 @@
 namespace WebCore {
 
 class AccessibilityMathMLElement : public AccessibilityRenderObject {
-
 public:
     static Ref<AccessibilityMathMLElement> create(AXID, RenderObject&, AXObjectCache&, bool isAnonymousOperator);
     virtual ~AccessibilityMathMLElement();

--- a/Source/WebCore/accessibility/AccessibilityMockObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.cpp
@@ -40,4 +40,4 @@ bool AccessibilityMockObject::computeIsIgnored() const
     return isIgnoredByDefault();
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityMockObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.h
@@ -30,7 +30,6 @@
 namespace WebCore {
 
 class AccessibilityMockObject : public AccessibilityObject {
-
 public:
     virtual ~AccessibilityMockObject();
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -27,7 +27,6 @@
  */
 
 #include "config.h"
-
 #include "AccessibilityObject.h"
 
 #include "AXLogger.h"
@@ -1635,8 +1634,8 @@ VisiblePositionRange AccessibilityObject::leftLineVisiblePositionRange(const Vis
 
     VisiblePosition startPosition = startOfLine(prevVisiblePos);
 
-    // keep searching for a valid line start position.  Unless the VisiblePosition is at the very beginning, there should
-    // always be a valid line range.  However, startOfLine will return null for position next to a floating object,
+    // keep searching for a valid line start position. Unless the VisiblePosition is at the very beginning, there should
+    // always be a valid line range. However, startOfLine will return null for position next to a floating object,
     // since floating object doesn't really belong to any line.
     // This check will reposition the marker before the floating object, to ensure we get a line start.
     if (startPosition.isNull()) {
@@ -1671,8 +1670,8 @@ VisiblePositionRange AccessibilityObject::rightLineVisiblePositionRange(const Vi
 
     VisiblePosition endPosition = endOfLine(nextVisiblePos);
 
-    // as long as the position hasn't reached the end of the doc,  keep searching for a valid line end position
-    // Unless the VisiblePosition is at the very end, there should always be a valid line range.  However, endOfLine will
+    // as long as the position hasn't reached the end of the doc, keep searching for a valid line end position
+    // Unless the VisiblePosition is at the very end, there should always be a valid line range. However, endOfLine will
     // return null for position by a floating object, since floating object doesn't really belong to any line.
     // This check will reposition the marker after the floating object, to ensure we get a line end.
     while (endPosition.isNull() && nextVisiblePos.isNotNull()) {
@@ -3690,10 +3689,13 @@ void AccessibilityObject::scrollToMakeVisibleWithSubFocus(IntRect&& subfocus) co
 {
     // Search up the parent chain until we find the first one that's scrollable.
     AccessibilityObject* scrollParent = parentObject();
-    ScrollableArea* scrollableArea;
-    for (scrollableArea = nullptr;
-         scrollParent && !(scrollableArea = scrollParent->getScrollableAreaIfScrollable());
-         scrollParent = scrollParent->parentObject()) { }
+    ScrollableArea* scrollableArea = nullptr;
+    while (scrollParent) {
+        scrollableArea = scrollParent->getScrollableAreaIfScrollable();
+        if (scrollableArea)
+            break;
+        scrollParent = scrollParent->parentObject();
+    }
     if (!scrollableArea)
         return;
 
@@ -3791,8 +3793,9 @@ void AccessibilityObject::scrollToGlobalPoint(IntPoint&& point) const
             scrollPosition = scrollableArea->scrollPosition();
             offsetX -= (scrollPosition.x() + point.x());
             offsetY -= (scrollPosition.y() + point.y());
-            point.move(scrollPosition.x() - innerRect.x(),
-                       scrollPosition.y() - innerRect.y());
+            point.move(
+                scrollPosition.x() - innerRect.x(),
+                scrollPosition.y() - innerRect.y());
         } else if (inner->isScrollView()) {
             // Otherwise, if the inner object is a scroll view, reset the coordinate transformation.
             offsetX = 0;
@@ -4071,7 +4074,6 @@ bool AccessibilityObject::isWithinHiddenWebArea() const
         frameRenderer = renderView ? renderView->frameView().frame().ownerRenderer() : nullptr;
     }
     return false;
-
 }
 
 bool AccessibilityObject::isIgnored() const
@@ -4123,8 +4125,7 @@ bool AccessibilityObject::isIgnoredWithoutCache(AXObjectCache* cache) const
             // If a menu became ignored, e.g. because it became display:none, ATs need to be informed.
             postMenuClosedNotificationIfNecessary();
             cache->objectBecameIgnored(*this);
-        }
-        else if (becameUnignored)
+        } else if (becameUnignored)
             cache->objectBecameUnignored(*this);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -170,4 +170,3 @@ String AccessibilityProgressIndicator::gaugeRegionValueDescription() const
 }
 
 } // namespace WebCore
-

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -615,7 +615,7 @@ Element* AccessibilityRenderObject::anchorElement() const
 
     RenderObject* currentRenderer;
 
-    // Search up the render tree for a RenderObject with a DOM node.  Defer to an earlier continuation, though.
+    // Search up the render tree for a RenderObject with a DOM node. Defer to an earlier continuation, though.
     for (currentRenderer = renderer(); currentRenderer && !currentRenderer->node(); currentRenderer = currentRenderer->parent()) {
         if (CheckedPtr blockRenderer = dynamicDowncast<RenderBlock>(*currentRenderer); blockRenderer && blockRenderer->isAnonymousBlock()) {
             if (auto* continuation = blockRenderer->continuation())

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -340,7 +340,6 @@ AccessibilityRole AccessibilitySVGObject::determineAccessibilityRole()
 
 AccessibilityObject* AccessibilitySVGObject::parentObject() const
 {
-
     if (m_parent) {
         // If a parent was set because this is a remote SVG resource, use that.
         ASSERT(m_isSVGRoot);

--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -48,10 +48,9 @@
 #include "RenderTable.h"
 #include "RenderTableCell.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include <queue>
 #include <wtf/Scope.h>
 #include <wtf/WeakRef.h>
-
-#include <queue>
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -141,8 +141,7 @@ void AccessibilityTableRow::addChildren()
             addChild(downcast<AccessibilityObject>(object.get()), DescendIfIgnored::No);
         m_childrenInitialized = true;
         m_subtreeDirty = false;
-    }
-    else
+    } else
         AccessibilityRenderObject::addChildren();
 
     // "ARIA 1.1, If the set of columns which is present in the DOM is contiguous, and if there are no cells which span more than one row or

--- a/Source/WebCore/accessibility/AccessibleSetValueEvent.cpp
+++ b/Source/WebCore/accessibility/AccessibleSetValueEvent.cpp
@@ -40,4 +40,4 @@ AccessibleSetValueEvent::AccessibleSetValueEvent(const AtomString& type, const A
 
 AccessibleSetValueEvent::~AccessibleSetValueEvent() = default;
 
-}
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibleSetValueEvent.h
+++ b/Source/WebCore/accessibility/AccessibleSetValueEvent.h
@@ -48,5 +48,4 @@ private:
     const AtomString m_value;
 };
 
-}
-
+} // namespace WebCore

--- a/Source/WebCore/accessibility/ForcedAccessibilityValue.h
+++ b/Source/WebCore/accessibility/ForcedAccessibilityValue.h
@@ -29,4 +29,4 @@ namespace WebCore {
 
 enum class ForcedAccessibilityValue : uint8_t { System, On, Off };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp
@@ -369,7 +369,6 @@ Vector<Ref<AccessibilityObjectAtspi>> AccessibilityObjectAtspi::matches(Collecti
     case Atspi::CollectionSortOrder::SortOrderReverseTab:
         g_warning("Atspi collection sort method %u not implemented yet", static_cast<uint32_t>(sortOrder));
         break;
-
     }
 
     return matchList;

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -176,6 +176,6 @@ void AXObjectCache::platformPerformDeferredCacheUpdate()
 {
 }
 
-}
+} // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -355,8 +355,8 @@ RetainPtr<NSData> newAccessibilityRemoteToken(NSString *uuidString)
     return [NSKeyedArchiver archivedDataWithRootObject:@{ @"ax-pid" : @(getpid()), @"ax-uuid" : uuidString, @"ax-register" : @YES } requiringSecureCoding:YES error:nullptr];
 }
 
-}
+} // namespace Accessibility
 
-} // WebCore
+} // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h
@@ -27,8 +27,8 @@
 
 #import "AXObjectCache.h"
 #import "AccessibilityObject.h"
-#import "WebAccessibilityObjectWrapperBase.h"
 #import "WAKView.h"
+#import "WebAccessibilityObjectWrapperBase.h"
 
 namespace WebCore {
 class VisiblePosition;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -40,11 +40,11 @@
 #import "ChromeClient.h"
 #import "FontCascade.h"
 #import "FrameSelection.h"
-#import "HitTestResult.h"
 #import "HTMLFrameOwnerElement.h"
 #import "HTMLInputElement.h"
 #import "HTMLNames.h"
 #import "HTMLTextAreaElement.h"
+#import "HitTestResult.h"
 #import "IntRect.h"
 #import "LocalFrame.h"
 #import "LocalizedStrings.h"
@@ -57,10 +57,10 @@
 #import "SimpleRange.h"
 #import "TextIterator.h"
 #import "VisiblePosition.h"
+#import "VisibleUnits.h"
 #import "WAKScrollView.h"
 #import "WAKWindow.h"
 #import "WebCoreThread.h"
-#import "VisibleUnits.h"
 #import <CoreText/CoreText.h>
 #import <wtf/RuntimeApplicationChecks.h>
 #import <wtf/cocoa/VectorCocoa.h>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1359,7 +1359,6 @@ void AXIsolatedTree::applyPendingChangesLocked()
         // analysis throws a false-positive compile error when we access m_pendingProtectedFromDeletionIDs in
         // this lambda.
         std::function<void(Ref<AXCoreObject>&&)> deleteSubtree = [&] (Ref<AXCoreObject>&& coreObjectToDelete) WTF_IGNORES_THREAD_SAFETY_ANALYSIS {
-
             auto& objectToDelete = downcast<AXIsolatedObject>(coreObjectToDelete.get());
             while (objectToDelete.m_children.size()) {
                 Ref child = objectToDelete.m_children.takeLast();

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -566,6 +566,6 @@ String AXIsolatedObject::computedRoleString() const
 }
 // End purposely un-cached properties block.
 
-} // WebCore
+} // namespace WebCore
 
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE) && PLATFORM(MAC)

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -44,13 +44,13 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <ApplicationServices/ApplicationServicesPriv.h>
+#endif
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 #import <pal/spi/cocoa/AccessibilitySupportSPI.h>
 #import <pal/spi/cocoa/AccessibilitySupportSoftLink.h>
-#endif
-
-#if USE(APPLE_INTERNAL_SDK)
-#import <ApplicationServices/ApplicationServicesPriv.h>
 #endif
 
 // Very large strings can negatively impact the performance of notifications, so this length is chosen to try to fit an average paragraph or line of text, but not allow strings to be large enough to hurt performance.
@@ -235,9 +235,10 @@ static void exerciseIsIgnored(AccessibilityObject& object)
 {
     object.updateBackingStore();
     if (object.isAttachment()) {
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         [[object.wrapper() attachmentView] accessibilityIsIgnored];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        ALLOW_DEPRECATED_DECLARATIONS_END
+
         return;
     }
     object.isIgnored();
@@ -1088,6 +1089,6 @@ std::optional<SimpleRange> rangeForTextMarkerRange(AXObjectCache* cache, AXTextM
     return cache->rangeForUnorderedCharacterOffsets(startCharacterOffset, endCharacterOffset);
 }
 
-}
+} // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -105,9 +105,11 @@ FloatRect AccessibilityObject::convertRectToPlatformSpace(const FloatRect& rect,
 
         NSRect nsRect = NSRectFromCGRect(cgRect);
         NSView *view = frameView->documentView();
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         nsRect = [[view window] convertRectToScreen:[view convertRect:nsRect toView:nil]];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        ALLOW_DEPRECATED_DECLARATIONS_END
+
         return NSRectToCGRect(nsRect);
     }
 
@@ -205,10 +207,11 @@ String AccessibilityObject::subrolePlatformString() const
 
     if (isAttachment()) {
         NSView* attachView = [wrapper() attachmentView];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if ([[attachView accessibilityAttributeNames] containsObject:NSAccessibilitySubroleAttribute])
             return [attachView accessibilityAttributeValue:NSAccessibilitySubroleAttribute];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     if (isMeter())
@@ -533,6 +536,6 @@ void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uin
         cache->onRemoteFrameInitialized(*this);
 }
 
-} // WebCore
+} // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -64,13 +64,14 @@
 #import <Accessibility/Accessibility.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
-#import <pal/cocoa/AccessibilitySoftLink.h>
 
 #if PLATFORM(MAC)
 #import "WebAccessibilityObjectWrapperMac.h"
 #else
 #import "WebAccessibilityObjectWrapperIOS.h"
 #endif
+
+#import <pal/cocoa/AccessibilitySoftLink.h>
 
 using namespace WebCore;
 
@@ -458,22 +459,19 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
     CGMutablePathRef newPath = conversion.path;
     FloatRect rect;
     switch (element.type) {
-    case PathElement::Type::MoveToPoint:
-    {
+    case PathElement::Type::MoveToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
         CGPoint newPoint = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
         CGPathMoveToPoint(newPath, nil, newPoint.x, newPoint.y);
         break;
     }
-    case PathElement::Type::AddLineToPoint:
-    {
+    case PathElement::Type::AddLineToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
         CGPoint newPoint = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
         CGPathAddLineToPoint(newPath, nil, newPoint.x, newPoint.y);
         break;
     }
-    case PathElement::Type::AddQuadCurveToPoint:
-    {
+    case PathElement::Type::AddQuadCurveToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
         CGPoint newPoint1 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
 
@@ -482,8 +480,7 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
         CGPathAddQuadCurveToPoint(newPath, nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y);
         break;
     }
-    case PathElement::Type::AddCurveToPoint:
-    {
+    case PathElement::Type::AddCurveToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
         CGPoint newPoint1 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
 
@@ -495,8 +492,7 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
         CGPathAddCurveToPoint(newPath, nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y, newPoint3.x, newPoint3.y);
         break;
     }
-    case PathElement::Type::CloseSubpath:
-    {
+    case PathElement::Type::CloseSubpath: {
         CGPathCloseSubpath(newPath);
         break;
     }
@@ -517,7 +513,6 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
 // advancing forward by line from top and backwards by line from the bottom, until we have a visible range.
 - (NSRange)accessibilityVisibleCharacterRange
 {
-
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (AXObjectCache::useAXThreadTextApis()) {
         RefPtr<AXCoreObject> backingObject = self.baseUpdateBackingStore;
@@ -638,7 +633,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
         if (end <= start)
             break;
 
-        auto rect = backingObject->boundsForVisiblePositionRange({start, end});
+        auto rect = backingObject->boundsForVisiblePositionRange({ start, end });
 
         auto lineRange = makeSimpleRange(start, end);
         if (!lineRange)
@@ -681,7 +676,7 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
                 [text appendAttributedString:attributedLabel.get()];
             }
         }
-        lines.append({rect, text});
+        lines.append({ rect, text });
 
         start = end;
         // If start is at a hard breakline "\n", move to the beginning of the next line.
@@ -702,8 +697,10 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
     if (lines.isEmpty())
         return nil;
     return createNSArray(lines, [self] (const auto& line) {
-        return @{ @"rect": [NSValue valueWithRect:[self convertRectToSpace:FloatRect(line.first) space:AccessibilityConversionSpace::Screen]],
-                  @"text": line.second.get() };
+        return @{
+            @"rect": [NSValue valueWithRect:[self convertRectToSpace:FloatRect(line.first) space:AccessibilityConversionSpace::Screen]],
+            @"text": line.second.get()
+        };
     }).autorelease();
 }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -392,7 +392,6 @@ static NSAttributedString *attributedStringForTextMarkerRange(const AXCoreObject
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray*)accessibilityActionNames
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
@@ -426,6 +425,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     return actions;
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSArray *)_additionalAccessibilityAttributeNames:(const RefPtr<AXCoreObject>&)backingObject
 {
@@ -574,7 +574,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray *)accessibilityAttributeNames
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     AXTRACE("WebAccessibilityObjectWrapper accessibilityAttributeNames"_s);
 
@@ -946,8 +945,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             objectAttributes = compositeSpinButtonAttributes.get().get();
         else
             objectAttributes = spinButtonCommonAttributes.get().get();
-    }
-    else if (backingObject->isMenu())
+    } else if (backingObject->isMenu())
         objectAttributes = menuAttrs.get().get();
     else if (backingObject->isMenuBar())
         objectAttributes = menuBarAttrs.get().get();
@@ -964,6 +962,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     return objectAttributes;
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)remoteAccessibilityParentObject
 {
@@ -1154,9 +1153,9 @@ static id scrollViewParent(AXCoreObject& axObject)
 - (id)windowElement:(NSString *)attributeName
 {
     if (id remoteParent = self.remoteAccessibilityParentObject) {
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return [remoteParent accessibilityAttributeValue:attributeName];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     RefPtr axScrollView = self.axBackingObject->axScrollView();
@@ -1168,7 +1167,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 // or maybe pointers to member functions
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attributeName
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityAttributeValue:"_s, String(attributeName)));
 
@@ -1562,9 +1560,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             // Find the index of this item by iterating the parents.
             auto rowsCopy = parent->ariaTreeRows();
             size_t count = rowsCopy.size();
-            for (size_t k = 0; k < count; ++k)
+            for (size_t k = 0; k < count; ++k) {
                 if (rowsCopy[k]->wrapper() == self)
                     return @(k);
+            }
 
             return nil;
         }
@@ -1889,6 +1888,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return attributeValueForTesting(backingObject, attributeName);
     return nil;
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString *attributeName)
 {
@@ -2101,7 +2101,6 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
         hit = self;
 
     return NSAccessibilityUnignoredAncestor(hit);
-
 }
 
 - (void)_accessibilityHitTestResolvingRemoteFrame:(NSPoint)point callback:(void(^)(NSString *))callback
@@ -2143,7 +2142,6 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (BOOL)accessibilityIsAttributeSettable:(NSString*)attributeName
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
@@ -2185,10 +2183,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     return NO;
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (BOOL)accessibilityIsIgnored
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
@@ -2198,10 +2196,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return [[self attachmentView] accessibilityIsIgnored];
     return backingObject->isIgnored();
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSArray *)accessibilityParameterizedAttributeNames
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
@@ -2301,6 +2299,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     return paramAttrs;
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
@@ -2451,7 +2450,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)accessibilityPerformAction:(NSString*)action
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
     if (!backingObject)
@@ -2479,6 +2477,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     else if (AXObjectCache::clientIsInTestMode() && [action isEqualToString:@"AXLogTrees"])
         [self _accessibilityPrintTrees];
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 // Internal method to print the accessibility trees to standard error.
 - (void)_accessibilityPrintTrees
@@ -2511,7 +2510,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)accessibilitySetValue:(id)value forAttribute:(NSString*)attributeName
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
 #if PLATFORM(MAC)
 
@@ -2532,6 +2530,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     [self _accessibilitySetValue:value forAttribute:attributeName];
 #endif
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_accessibilitySetValue:(id)value forAttribute:(NSString *)attributeName
 {
@@ -2544,10 +2543,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     AXTextMarkerRangeRef textMarkerRange = nil;
-    NSNumber*               number = nil;
-    NSString*               string = nil;
-    NSRange                 range = {0, 0};
-    NSArray*                array = nil;
+    NSNumber* number = nil;
+    NSString* string = nil;
+    NSRange range = { 0, 0 };
+    NSArray* array = nil;
 
     // decode the parameter
     if (AXObjectIsTextMarkerRange(value))
@@ -2637,11 +2636,11 @@ static RenderObject* rendererForView(NSView* view)
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (NSString*)accessibilityActionDescription:(NSString*)action
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     // we have no custom actions
     return NSAccessibilityActionDescription(action);
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (NSInteger)_indexForTextMarker:(AXTextMarkerRef)markerRef
 {
@@ -2922,7 +2921,6 @@ static NSRect computeTextBoundsForRange(NSRange range, const AXCoreObject& backi
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString*)attribute forParameter:(id)parameter
-ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     AXTRACE(makeString("WebAccessibilityObjectWrapper accessibilityAttributeValue:"_s, String(attribute)));
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
@@ -2941,11 +2939,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     RefPtr<AXCoreObject> uiElement;
     NSPoint point = NSZeroPoint;
     bool pointSet = false;
-    NSRange range = {0, 0};
+    NSRange range = { 0, 0 };
     bool rangeSet = false;
     NSRect rect = NSZeroRect;
 
-    // common parameter type check/casting.  Nil checks in handlers catch wrong type case.
+    // common parameter type check/casting. Nil checks in handlers catch wrong type case.
     // NOTE: This assumes nil is not a valid parameter, because it is indistinguishable from
     // a parameter of the wrong type.
     if (AXObjectIsTextMarker(parameter))
@@ -2957,8 +2955,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         // The parameter wrapper object has lost its AX object since being given to the client, so bail early.
         if (!uiElement)
             return nil;
-    }
-    else if ([parameter isKindOfClass:[NSNumber class]])
+    } else if ([parameter isKindOfClass:[NSNumber class]])
         number = parameter;
     else if ([parameter isKindOfClass:[NSArray class]])
         array = parameter;
@@ -3558,6 +3555,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     // In that case it must be passed to super.
     return [super accessibilityAttributeValue:attribute forParameter:parameter];
 }
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (BOOL)accessibilitySupportsOverriddenAttributes
 {

--- a/Source/WebCore/accessibility/win/AccessibilityObjectWrapperWin.h
+++ b/Source/WebCore/accessibility/win/AccessibilityObjectWrapperWin.h
@@ -30,26 +30,30 @@
 
 namespace WebCore {
 
-    class AccessibilityObject;
+class AccessibilityObject;
 
-    class AccessibilityObjectWrapper : public IUnknown {
-    public:
-        // IUnknown
-        virtual HRESULT STDMETHODCALLTYPE QueryInterface(_In_ REFIID riid, _COM_Outptr_ void** ppvObject) = 0;
-        virtual ULONG STDMETHODCALLTYPE AddRef() = 0;
-        virtual ULONG STDMETHODCALLTYPE Release(void) = 0;
+class AccessibilityObjectWrapper : public IUnknown {
+public:
+    // IUnknown
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(_In_ REFIID riid, _COM_Outptr_ void** ppvObject) = 0;
+    virtual ULONG STDMETHODCALLTYPE AddRef() = 0;
+    virtual ULONG STDMETHODCALLTYPE Release(void) = 0;
 
-        virtual void detach() = 0;
-        bool attached() const { return m_object; }
-        AccessibilityObject* accessibilityObject() const { return m_object; }
+    virtual void detach() = 0;
+    bool attached() const { return m_object; }
+    AccessibilityObject* accessibilityObject() const { return m_object; }
 
-        WEBCORE_EXPORT void accessibilityAttributeValue(const AtomString&, VARIANT*);
+    WEBCORE_EXPORT void accessibilityAttributeValue(const AtomString&, VARIANT*);
 
-    protected:
-        AccessibilityObjectWrapper(AccessibilityObject* obj) : m_object(obj) { }
-        AccessibilityObjectWrapper() : m_object(nullptr) { }
+protected:
+    AccessibilityObjectWrapper(AccessibilityObject* obj)
+        : m_object(obj)
+    { }
+    AccessibilityObjectWrapper()
+        : m_object(nullptr)
+    { }
 
-        AccessibilityObject* m_object;
-    };
+    AccessibilityObject* m_object;
+};
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1cf8ec92362b6115f9d21b5a6d1a85fd30c2cfba
<pre>
[AX]: check-webkit-style - resolve (almost) all remaining warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=297230">https://bugs.webkit.org/show_bug.cgi?id=297230</a>

Reviewed by Tyler Wilcock.

Reduces number of warnings in accessibility implementation to just 12:
$ Tools/Scripts/check-webkit-style Source/WebCore/accessibility
[...]
Total errors found: 12 in 152 files

Further 2 will be fixed as part of <a href="https://github.com/WebKit/WebKit/pull/49218">https://github.com/WebKit/WebKit/pull/49218</a>
(and respective changes were removed from this commit just to avoid conflict).

The remaining 10 warnings feel like (or I found they actually are) bugs
in check-webkit-style (or code style documentation)  which I will report
as such (and through that might learn if they indeed are or if
accessibility code needs to be further fixed).

The PR (linked in bug) tries to provide diff comments for changes that
might not be obvious.

* Source/WebCore/accessibility/AXGeometryManager.cpp:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::characterOffsetForNodeAndOffset):
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
(WebCore::characterForCharacterOffset):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineRange const):
* Source/WebCore/accessibility/AXTextRun.cpp:
* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
* Source/WebCore/accessibility/AccessibilityMathMLElement.h:
* Source/WebCore/accessibility/AccessibilityMockObject.cpp:
* Source/WebCore/accessibility/AccessibilityMockObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::leftLineVisiblePositionRange const):
(WebCore::AccessibilityObject::rightLineVisiblePositionRange const):
(WebCore::AccessibilityObject::scrollToMakeVisibleWithSubFocus const):
(WebCore::AccessibilityObject::scrollToGlobalPoint const):
(WebCore::AccessibilityObject::isWithinHiddenWebArea const):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::anchorElement const):
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::parentObject const):
* Source/WebCore/accessibility/AccessibilityTable.cpp:
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::addChildren):
* Source/WebCore/accessibility/AccessibleSetValueEvent.cpp:
* Source/WebCore/accessibility/AccessibleSetValueEvent.h:
* Source/WebCore/accessibility/ForcedAccessibilityValue.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectCollectionAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::matches):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::exerciseIsIgnored):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::convertRectToPlatformSpace const):
(WebCore::AccessibilityObject::subrolePlatformString const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(convertPathToScreenSpaceFunction):
(-[WebAccessibilityObjectWrapperBase accessibilityVisibleCharacterRange]):
(-[WebAccessibilityObjectWrapperBase lineRectsAndText]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityActionNames]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):
(-[WebAccessibilityObjectWrapper windowElement:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(-[WebAccessibilityObjectWrapper _accessibilityHitTest:returnPlatformElements:]):
(-[WebAccessibilityObjectWrapper accessibilityIsAttributeSettable:]):
(-[WebAccessibilityObjectWrapper accessibilityIsIgnored]):
(-[WebAccessibilityObjectWrapper accessibilityParameterizedAttributeNames]):
(-[WebAccessibilityObjectWrapper accessibilityPerformAction:]):
(-[WebAccessibilityObjectWrapper accessibilitySetValue:forAttribute:]):
(-[WebAccessibilityObjectWrapper _accessibilitySetValue:forAttribute:]):
(-[WebAccessibilityObjectWrapper accessibilityActionDescription:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]): Deleted.
* Source/WebCore/accessibility/win/AccessibilityObjectWrapperWin.h:
(WebCore::AccessibilityObjectWrapper::attached const):
(WebCore::AccessibilityObjectWrapper::accessibilityObject const):
(WebCore::AccessibilityObjectWrapper::AccessibilityObjectWrapper):

Canonical link: <a href="https://commits.webkit.org/298549@main">https://commits.webkit.org/298549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c7873c13eeaff9e8444f8b8be21c243cb19a527

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68389 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22051 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125024 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96523 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24562 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41785 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19657 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38633 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48189 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->