### PR TITLE
Add performJITMemcpyAtomic and simplify jit copying code [2].

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -2343,29 +2343,31 @@ public:
     
     enum BranchTargetType { DirectBranch, IndirectBranch  };
 
-    template<MachineCodeCopyMode copy>
+    template<RepatchingInfo repatch>
     ALWAYS_INLINE static void fillNops(void* base, size_t size)
     {
+        static_assert(!(*repatch).contains(RepatchingFlag::Flush));
         RELEASE_ASSERT(!(size % sizeof(int32_t)));
         size_t n = size / sizeof(int32_t);
         int32_t* ptr = static_cast<int32_t*>(base);
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(ptr) == ptr);
         for (; n--;) {
             int insn = nopPseudo();
-            machineCodeCopy<copy>(ptr++, &insn, sizeof(int));
+            machineCodeCopy<repatch>(ptr++, &insn, sizeof(int));
         }
     }
 
-    template<MachineCodeCopyMode copy>
+    template<RepatchingInfo repatch>
     ALWAYS_INLINE static void fillNearTailCall(void* from, void* to)
     {
+        static_assert((*repatch).contains(RepatchingFlag::Flush));
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
         intptr_t offset = (std::bit_cast<intptr_t>(to) - std::bit_cast<intptr_t>(from)) >> 2;
         ASSERT(static_cast<int>(offset) == offset);
         ASSERT(isInt<26>(offset));
         constexpr bool isCall = false;
         int insn = unconditionalBranchImmediate(isCall, static_cast<int>(offset));
-        machineCodeCopy<copy>(from, &insn, sizeof(int));
+        machineCodeCopy<noFlush(repatch)>(from, &insn, sizeof(int));
         cacheFlush(from, sizeof(int));
     }
 
@@ -3596,7 +3598,7 @@ public:
 
     static void linkPointer(void* code, AssemblerLabel where, void* valuePtr)
     {
-        linkPointer(addressOf(code, where), valuePtr);
+        linkPointer<jitMemcpyRepatch>(addressOf(code, where), valuePtr);
     }
 
     static void replaceWithVMHalt(void* where)
@@ -3604,7 +3606,7 @@ public:
         // This should try to write to null which should always Segfault.
         int insn = dataCacheZeroVirtualAddress(ARM64Registers::zr);
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
-        performJITMemcpy(where, &insn, sizeof(int));
+        performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
         cacheFlush(where, sizeof(int));
     }
 
@@ -3623,13 +3625,13 @@ public:
 
         int insn = unconditionalBranchImmediate(false, static_cast<int>(offset));
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(where) == where);
-        performJITMemcpy(where, &insn, sizeof(int));
+        performJITMemcpy<jitMemcpyRepatchAtomic>(where, &insn, sizeof(int));
         cacheFlush(where, sizeof(int));
     }
 
     static void replaceWithNops(void* where, size_t memoryToFillWithNopsInBytes)
     {
-        fillNops<MachineCodeCopyMode::JITMemcpy>(where, memoryToFillWithNopsInBytes);
+        fillNops<jitMemcpyRepatch>(where, memoryToFillWithNopsInBytes);
         cacheFlush(where, memoryToFillWithNopsInBytes);
     }
 
@@ -3645,10 +3647,11 @@ public:
 
     static void repatchPointer(void* where, void* valuePtr)
     {
-        linkPointer(static_cast<int*>(where), valuePtr, true);
+        linkPointer<jitMemcpyRepatchFlush>(static_cast<int*>(where), valuePtr);
     }
 
-    static void setPointer(int* address, void* valuePtr, RegisterID rd, bool flush)
+    template<RepatchingInfo repatch>
+    static void setPointer(int* address, void* valuePtr, RegisterID rd)
     {
         uintptr_t value = reinterpret_cast<uintptr_t>(valuePtr);
         int buffer[NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS];
@@ -3659,9 +3662,9 @@ public:
         if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
             buffer[3] = moveWideImediate(Datasize_64, MoveWideOp_K, 3, getHalfword(value, 3), rd);
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(address) == address);
-        performJITMemcpy(address, buffer, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
+        performJITMemcpy<noFlush(repatch)>(address, buffer, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
 
-        if (flush)
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
             cacheFlush(address, sizeof(int) * NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
     }
 
@@ -3872,7 +3875,7 @@ public:
         return m_jumpsToLink;
     }
 
-    template<MachineCodeCopyMode copy>
+    template<RepatchingInfo repatch>
     static void ALWAYS_INLINE link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction8, uint8_t* to)
     {
         const int* fromInstruction = reinterpret_cast<const int*>(fromInstruction8);
@@ -3880,10 +3883,10 @@ public:
         case LinkJumpNoCondition: {
             switch (record.branchType()) {
             case BranchType_JMP:
-                linkJumpOrCall<BranchType_JMP, copy>(reinterpret_cast<int*>(from), fromInstruction, to);
+                linkJumpOrCall<BranchType_JMP, repatch>(reinterpret_cast<int*>(from), fromInstruction, to);
                 break;
             case BranchType_CALL:
-                linkJumpOrCall<BranchType_CALL, copy>(reinterpret_cast<int*>(from), fromInstruction, to);
+                linkJumpOrCall<BranchType_CALL, repatch>(reinterpret_cast<int*>(from), fromInstruction, to);
                 break;
             case BranchType_RET:
                 ASSERT_NOT_REACHED();
@@ -3892,22 +3895,22 @@ public:
             break;
         }
         case LinkJumpConditionDirect:
-            linkConditionalBranch<DirectBranch, copy>(record.condition(), reinterpret_cast<int*>(from), fromInstruction, to);
+            linkConditionalBranch<DirectBranch, repatch>(record.condition(), reinterpret_cast<int*>(from), fromInstruction, to);
             break;
         case LinkJumpCondition:
-            linkConditionalBranch<IndirectBranch, copy>(record.condition(), reinterpret_cast<int*>(from) - 1, fromInstruction - 1, to);
+            linkConditionalBranch<IndirectBranch, repatch>(record.condition(), reinterpret_cast<int*>(from) - 1, fromInstruction - 1, to);
             break;
         case LinkJumpCompareAndBranchDirect:
-            linkCompareAndBranch<DirectBranch, copy>(record.condition(), record.is64Bit(), record.compareRegister(), reinterpret_cast<int*>(from), fromInstruction, to);
+            linkCompareAndBranch<DirectBranch, repatch>(record.condition(), record.is64Bit(), record.compareRegister(), reinterpret_cast<int*>(from), fromInstruction, to);
             break;
         case LinkJumpCompareAndBranch:
-            linkCompareAndBranch<IndirectBranch, copy>(record.condition(), record.is64Bit(), record.compareRegister(), reinterpret_cast<int*>(from) - 1, fromInstruction - 1, to);
+            linkCompareAndBranch<IndirectBranch, repatch>(record.condition(), record.is64Bit(), record.compareRegister(), reinterpret_cast<int*>(from) - 1, fromInstruction - 1, to);
             break;
         case LinkJumpTestBitDirect:
-            linkTestAndBranch<DirectBranch, copy>(record.condition(), record.bitNumber(), record.compareRegister(), reinterpret_cast<int*>(from), fromInstruction, to);
+            linkTestAndBranch<DirectBranch, repatch>(record.condition(), record.bitNumber(), record.compareRegister(), reinterpret_cast<int*>(from), fromInstruction, to);
             break;
         case LinkJumpTestBit:
-            linkTestAndBranch<IndirectBranch, copy>(record.condition(), record.bitNumber(), record.compareRegister(), reinterpret_cast<int*>(from) - 1, fromInstruction - 1, to);
+            linkTestAndBranch<IndirectBranch, repatch>(record.condition(), record.bitNumber(), record.compareRegister(), reinterpret_cast<int*>(from) - 1, fromInstruction - 1, to);
             break;
         default:
             ASSERT_NOT_REACHED();
@@ -3939,7 +3942,8 @@ protected:
             && rd == _rd;
     }
 
-    static void linkPointer(int* address, void* valuePtr, bool flush = false)
+    template<RepatchingInfo repatch>
+    static void linkPointer(int* address, void* valuePtr)
     {
         Datasize sf;
         MoveWideOp opc;
@@ -3954,10 +3958,10 @@ protected:
         if constexpr (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
             ASSERT(checkMovk<Datasize_64>(address[3], 3, rd));
 
-        setPointer(address, valuePtr, rd, flush);
+        setPointer<repatch>(address, valuePtr, rd);
     }
 
-    template<BranchType type, MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template<BranchType type, RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkJumpOrCall(int* from, const int* fromInstruction, void* to)
     {
         static_assert(type == BranchType_JMP || type == BranchType_CALL);
@@ -3978,7 +3982,7 @@ protected:
 
 #if ENABLE(JUMP_ISLANDS)
         if (!isInt<26>(offset)) {
-            if constexpr (copy == MachineCodeCopyMode::JITMemcpy)
+            if constexpr (!(*repatch).contains(RepatchingFlag::Memcpy))
                 to = ExecutableAllocator::singleton().getJumpIslandToUsingJITMemcpy(std::bit_cast<void*>(fromInstruction), to);
             else
                 to = ExecutableAllocator::singleton().getJumpIslandToUsingMemcpy(std::bit_cast<void*>(fromInstruction), to);
@@ -3989,10 +3993,10 @@ protected:
 
         int insn = unconditionalBranchImmediate(isCall, static_cast<int>(offset));
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
-        machineCodeCopy<copy>(from, &insn, sizeof(int));
+        machineCodeCopy<repatch>(from, &insn, sizeof(int));
     }
 
-    template<BranchTargetType type, MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template<BranchTargetType type, RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkCompareAndBranch(Condition condition, bool is64Bit, RegisterID rt, int* from, const int* fromInstruction, void* to)
     {
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
@@ -4006,19 +4010,19 @@ protected:
         if (useDirect || type == DirectBranch) {
             ASSERT(isInt<19>(offset));
             int insn = compareAndBranchImmediate(is64Bit ? Datasize_64 : Datasize_32, condition == ConditionNE, static_cast<int>(offset), rt);
-            machineCodeCopy<copy>(from, &insn, sizeof(int));
+            machineCodeCopy<repatch>(from, &insn, sizeof(int));
             if (type == IndirectBranch) {
                 insn = nopPseudo();
-                machineCodeCopy<copy>(from + 1, &insn, sizeof(int));
+                machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
             }
         } else {
             int insn = compareAndBranchImmediate(is64Bit ? Datasize_64 : Datasize_32, invert(condition) == ConditionNE, 2, rt);
-            machineCodeCopy<copy>(from, &insn, sizeof(int));
-            linkJumpOrCall<BranchType_JMP, copy>(from + 1, fromInstruction + 1, to);
+            machineCodeCopy<repatch>(from, &insn, sizeof(int));
+            linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
         }
     }
 
-    template<BranchTargetType type, MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template<BranchTargetType type, RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkConditionalBranch(Condition condition, int* from, const int* fromInstruction, void* to)
     {
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
@@ -4032,19 +4036,19 @@ protected:
         if (useDirect || type == DirectBranch) {
             ASSERT(isInt<19>(offset));
             int insn = conditionalBranchImmediate(static_cast<int>(offset), condition);
-            machineCodeCopy<copy>(from, &insn, sizeof(int));
+            machineCodeCopy<repatch>(from, &insn, sizeof(int));
             if (type == IndirectBranch) {
                 insn = nopPseudo();
-                machineCodeCopy<copy>(from + 1, &insn, sizeof(int));
+                machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
             }
         } else {
             int insn = conditionalBranchImmediate(2, invert(condition));
-            machineCodeCopy<copy>(from, &insn, sizeof(int));
-            linkJumpOrCall<BranchType_JMP, copy>(from + 1, fromInstruction + 1, to);
+            machineCodeCopy<repatch>(from, &insn, sizeof(int));
+            linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
         }
     }
 
-    template<BranchTargetType type, MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template<BranchTargetType type, RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkTestAndBranch(Condition condition, unsigned bitNumber, RegisterID rt, int* from, const int* fromInstruction, void* to)
     {
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(from) == from);
@@ -4059,15 +4063,15 @@ protected:
         if (useDirect || type == DirectBranch) {
             ASSERT(isInt<14>(offset));
             int insn = testAndBranchImmediate(condition == ConditionNE, static_cast<int>(bitNumber), static_cast<int>(offset), rt);
-            machineCodeCopy<copy>(from, &insn, sizeof(int));
+            machineCodeCopy<repatch>(from, &insn, sizeof(int));
             if (type == IndirectBranch) {
                 insn = nopPseudo();
-                machineCodeCopy<copy>(from + 1, &insn, sizeof(int));
+                machineCodeCopy<repatch>(from + 1, &insn, sizeof(int));
             }
         } else {
             int insn = testAndBranchImmediate(invert(condition) == ConditionNE, static_cast<int>(bitNumber), 2, rt);
-            machineCodeCopy<copy>(from, &insn, sizeof(int));
-            linkJumpOrCall<BranchType_JMP, copy>(from + 1, fromInstruction + 1, to);
+            machineCodeCopy<repatch>(from, &insn, sizeof(int));
+            linkJumpOrCall<BranchType_JMP, repatch>(from + 1, fromInstruction + 1, to);
         }
     }
 

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -1509,7 +1509,7 @@ public:
             twoWordOp5i6Imm4Reg4EncodedImmSecond(right, hi16),
             static_cast<uint16_t>(static_cast<uint16_t>(OP_CMP_reg_T2) | static_cast<uint16_t>(left))
         };
-        performJITMemcpy(address, instruction, sizeof(uint16_t) * 5);
+        performJITMemcpy<jitMemcpyRepatch>(address, instruction, sizeof(uint16_t) * 5);
         cacheFlush(address, sizeof(uint16_t) * 5);
     }
 #else
@@ -1524,7 +1524,7 @@ public:
             twoWordOp5i6Imm4Reg4EncodedImmFirst(OP_MOV_imm_T3, imm),
             twoWordOp5i6Imm4Reg4EncodedImmSecond(rd, imm)
         };
-        performJITMemcpy(address, instruction, sizeof(uint16_t) * 2);
+        performJITMemcpy<jitMemcpyRepatch>(address, instruction, sizeof(uint16_t) * 2);
         cacheFlush(address, sizeof(uint16_t) * 2);
     }
 #endif
@@ -2426,16 +2426,17 @@ public:
         return OP_NOP_T2a | (OP_NOP_T2b << 16);
     }
 
-    template<MachineCodeCopyMode copy>
+    template<RepatchingInfo repatch>
     ALWAYS_INLINE static void fillNops(void* base, size_t size)
     {
         RELEASE_ASSERT(!(size % sizeof(int16_t)));
+        static_assert(!(*repatch).contains(RepatchingFlag::Flush));
 
         char* ptr = static_cast<char*>(base);
         const size_t num32s = size / sizeof(int32_t);
         for (size_t i = 0; i < num32s; i++) {
             const int32_t insn = nopPseudo32();
-            machineCodeCopy<copy>(ptr, &insn, sizeof(int32_t));
+            machineCodeCopy<repatch>(ptr, &insn, sizeof(int32_t));
             ptr += sizeof(int32_t);
         }
 
@@ -2444,15 +2445,16 @@ public:
         ASSERT(num16s * sizeof(int16_t) + num32s * sizeof(int32_t) == size);
         if (num16s) {
             const int16_t insn = nopPseudo16();
-            machineCodeCopy<copy>(ptr, &insn, sizeof(int16_t));
+            machineCodeCopy<repatch>(ptr, &insn, sizeof(int16_t));
         }
     }
 
-    template<MachineCodeCopyMode copy>
+    template<RepatchingInfo repatch>
     ALWAYS_INLINE static void fillNearTailCall(void* from, void* to)
     {
+        static_assert((*repatch).contains(RepatchingFlag::Flush));
         uint16_t* ptr = reinterpret_cast<uint16_t*>(from) + 2;
-        linkJumpT4<copy>(ptr, ptr, to, BranchWithLink::No);
+        linkJumpT4<noFlush(repatch)>(ptr, ptr, to, BranchWithLink::No);
         cacheFlush(from, sizeof(uint16_t) * 2);
     }
 
@@ -2604,31 +2606,31 @@ public:
         return m_jumpsToLink;
     }
 
-    template<MachineCodeCopyMode copy>
+    template<RepatchingInfo repatch>
     static void ALWAYS_INLINE link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction8, uint8_t* to)
     {
         const uint16_t* fromInstruction = reinterpret_cast_ptr<const uint16_t*>(fromInstruction8);
         switch (record.linkType()) {
         case LinkJumpT1:
-            linkJumpT1<copy>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
+            linkJumpT1<repatch>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
             break;
         case LinkJumpT2:
-            linkJumpT2<copy>(reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
+            linkJumpT2<repatch>(reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
             break;
         case LinkJumpT3:
-            linkJumpT3<copy>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
+            linkJumpT3<repatch>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
             break;
         case LinkJumpT4:
-            linkJumpT4<copy>(reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to, BranchWithLink::No);
+            linkJumpT4<repatch>(reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to, BranchWithLink::No);
             break;
         case LinkConditionalJumpT4:
-            linkConditionalJumpT4<copy>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
+            linkConditionalJumpT4<repatch>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
             break;
         case LinkConditionalBX:
-            linkConditionalBX<copy>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
+            linkConditionalBX<repatch>(record.condition(), reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
             break;
         case LinkBX:
-            linkBX<copy>(reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
+            linkBX<repatch>(reinterpret_cast_ptr<uint16_t*>(from), fromInstruction, to);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -2685,7 +2687,7 @@ public:
 
     static void linkPointer(void* code, AssemblerLabel where, void* value)
     {
-        setPointer(reinterpret_cast<char*>(code) + where.offset(), value, false);
+        setPointer<jitMemcpyRepatch>(reinterpret_cast<char*>(code) + where.offset(), value);
     }
 
     // The static relink and replace methods can use can use |from| for both
@@ -2713,7 +2715,7 @@ public:
             return;
         }
 
-        setPointer(location - 1, to, true);
+        setPointer<jitMemcpyRepatchFlush>(location - 1, to);
     }
 
     static void relinkTailCall(void* from, void* to)
@@ -2757,7 +2759,7 @@ public:
     {
         ASSERT(!(reinterpret_cast<intptr_t>(where) & 1));
         
-        setPointer(where, value, true);
+        setPointer<jitMemcpyRepatchFlush>(where, value);
     }
 
     static void* readPointer(void* where)
@@ -2789,7 +2791,7 @@ public:
 
     static void replaceWithNops(void* instructionStart, size_t memoryToFillWithNopsInBytes)
     {
-        fillNops<MachineCodeCopyMode::JITMemcpy>(instructionStart, memoryToFillWithNopsInBytes);
+        fillNops<jitMemcpyRepatch>(instructionStart, memoryToFillWithNopsInBytes);
         cacheFlush(instructionStart, memoryToFillWithNopsInBytes);
     }
 
@@ -2928,7 +2930,8 @@ private:
         return VFPOperand(op);
     }
 
-    static void setInt32(void* code, uint32_t value, bool flush)
+    template<RepatchingInfo repatch>
+    static void setInt32(void* code, uint32_t value)
     {
         uint16_t* location = reinterpret_cast<uint16_t*>(code);
         ASSERT(isMOV_imm_T3(location - 4) && isMOVT(location - 2));
@@ -2941,8 +2944,8 @@ private:
         instructions[2] = twoWordOp5i6Imm4Reg4EncodedImmFirst(OP_MOVT, hi16);
         instructions[3] = twoWordOp5i6Imm4Reg4EncodedImmSecond((location[-1] >> 8) & 0xf, hi16);
 
-        performJITMemcpy(location - 4, instructions, 4 * sizeof(uint16_t));
-        if (flush)
+        performJITMemcpy<noFlush(repatch)>(location - 4, instructions, 4 * sizeof(uint16_t));
+        if constexpr ((*repatch).contains(RepatchingFlag::Flush))
             cacheFlush(location - 4, 4 * sizeof(uint16_t));
     }
     
@@ -2972,13 +2975,14 @@ private:
         uint16_t instruction;
         instruction = location[0] & ~((static_cast<uint16_t>(0x7f) >> 2) << 6);
         instruction |= (imm.getUInt7() >> 2) << 6;
-        performJITMemcpy(location, &instruction, sizeof(uint16_t));
+        performJITMemcpy<jitMemcpyRepatch>(location, &instruction, sizeof(uint16_t));
         cacheFlush(location, sizeof(uint16_t));
     }
 
-    static void setPointer(void* code, void* value, bool flush)
+    template <RepatchingInfo repatch>
+    static void setPointer(void* code, void* value)
     {
-        setInt32(code, reinterpret_cast<uint32_t>(value), flush);
+        setInt32<repatch>(code, reinterpret_cast<uint32_t>(value));
     }
 
     static bool isB(const void* address)
@@ -3067,7 +3071,7 @@ private:
         return ((relative << 7) >> 7) == relative;
     }
 
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkJumpT1(Condition cond, uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(        
@@ -3084,10 +3088,10 @@ private:
         // All branch offsets should be an even distance.
         ASSERT(!(relative & 1));
         uint16_t newInstruction = OP_B_T1 | ((cond & 0xf) << 8) | ((relative & 0x1fe) >> 1);
-        machineCodeCopy<copy>(writeTarget - 1, &newInstruction, sizeof(uint16_t));
+        machineCodeCopy<repatch>(writeTarget - 1, &newInstruction, sizeof(uint16_t));
     }
 
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkJumpT2(uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(        
@@ -3104,10 +3108,10 @@ private:
         // All branch offsets should be an even distance.
         ASSERT(!(relative & 1));
         uint16_t newInstruction = OP_B_T2 | ((relative & 0xffe) >> 1);
-        machineCodeCopy<copy>(writeTarget - 1, &newInstruction, sizeof(uint16_t));
+        machineCodeCopy<repatch>(writeTarget - 1, &newInstruction, sizeof(uint16_t));
     }
     
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkJumpT3(Condition cond, uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(
@@ -3122,10 +3126,10 @@ private:
         uint16_t instructions[2];
         instructions[0] = OP_B_T3a | ((relative & 0x100000) >> 10) | ((cond & 0xf) << 6) | ((relative & 0x3f000) >> 12);
         instructions[1] = OP_B_T3b | ((relative & 0x80000) >> 8) | ((relative & 0x40000) >> 5) | ((relative & 0xffe) >> 1);
-        machineCodeCopy<copy>(writeTarget - 2, instructions, 2 * sizeof(uint16_t));
+        machineCodeCopy<repatch>(writeTarget - 2, instructions, 2 * sizeof(uint16_t));
     }
     
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkJumpT4(uint16_t* writeTarget, const uint16_t* instruction, void* target, BranchWithLink link)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(        
@@ -3143,10 +3147,10 @@ private:
         uint16_t instructions[2];
         instructions[0] = OP_B_T4a | ((relative & 0x1000000) >> 14) | ((relative & 0x3ff000) >> 12);
         instructions[1] = OP_B_T4b | (static_cast<uint16_t>(link) << 14) | ((relative & 0x800000) >> 10) | ((relative & 0x400000) >> 11) | ((relative & 0xffe) >> 1);
-        machineCodeCopy<copy>(writeTarget - 2, instructions, 2 * sizeof(uint16_t));
+        machineCodeCopy<repatch>(writeTarget - 2, instructions, 2 * sizeof(uint16_t));
     }
 
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkConditionalJumpT4(Condition cond, uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(        
@@ -3154,11 +3158,11 @@ private:
         ASSERT(!(reinterpret_cast<intptr_t>(target) & 1));
         
         uint16_t newInstruction = ifThenElse(cond) | OP_IT;
-        machineCodeCopy<copy>(writeTarget - 3, &newInstruction, sizeof(uint16_t));
-        linkJumpT4<copy>(writeTarget, instruction, target, BranchWithLink::No);
+        machineCodeCopy<repatch>(writeTarget - 3, &newInstruction, sizeof(uint16_t));
+        linkJumpT4<repatch>(writeTarget, instruction, target, BranchWithLink::No);
     }
 
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkBX(uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(
@@ -3176,21 +3180,21 @@ private:
         instructions[3] = twoWordOp5i6Imm4Reg4EncodedImmSecond(JUMP_TEMPORARY_REGISTER, hi16);
         instructions[4] = OP_BX | (JUMP_TEMPORARY_REGISTER << 3);
 
-        machineCodeCopy<copy>(writeTarget - 5, instructions, 5 * sizeof(uint16_t));
+        machineCodeCopy<repatch>(writeTarget - 5, instructions, 5 * sizeof(uint16_t));
     }
 
-    template<MachineCodeCopyMode copy = MachineCodeCopyMode::JITMemcpy>
+    template <RepatchingInfo repatch = jitMemcpyRepatch>
     static void linkConditionalBX(Condition cond, uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(        
         ASSERT(!(reinterpret_cast<intptr_t>(instruction) & 1));
         ASSERT(!(reinterpret_cast<intptr_t>(target) & 1));
         
-        linkBX<copy>(writeTarget, instruction, target);
+        linkBX<repatch>(writeTarget, instruction, target);
         uint16_t newInstruction = ifThenElse(cond, true, true) | OP_IT;
-        machineCodeCopy<copy>(writeTarget - 6, &newInstruction, sizeof(uint16_t));
+        machineCodeCopy<repatch>(writeTarget - 6, &newInstruction, sizeof(uint16_t));
     }
-    
+
     static void linkJumpAbsolute(uint16_t* writeTarget, const uint16_t* instruction, void* target)
     {
         // FIMXE: this should be up in the MacroAssembler layer. :-(
@@ -3210,7 +3214,7 @@ private:
             instructions[0] = OP_NOP_T1;
             instructions[1] = OP_NOP_T2a;
             instructions[2] = OP_NOP_T2b;
-            performJITMemcpy(writeTarget - 5, instructions, 3 * sizeof(uint16_t));
+            performJITMemcpy<jitMemcpyRepatch>(writeTarget - 5, instructions, 3 * sizeof(uint16_t));
             linkJumpT4(writeTarget, instruction, target, BranchWithLink::No);
         } else {
             const uint16_t JUMP_TEMPORARY_REGISTER = ARMRegisters::ip;
@@ -3223,7 +3227,7 @@ private:
             instructions[2] = twoWordOp5i6Imm4Reg4EncodedImmFirst(OP_MOVT, hi16);
             instructions[3] = twoWordOp5i6Imm4Reg4EncodedImmSecond(JUMP_TEMPORARY_REGISTER, hi16);
             instructions[4] = OP_BX | (JUMP_TEMPORARY_REGISTER << 3);
-            performJITMemcpy(writeTarget - 5, instructions, 5 * sizeof(uint16_t));
+            performJITMemcpy<jitMemcpyRepatch>(writeTarget - 5, instructions, 5 * sizeof(uint16_t));
         }
     }
 

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -1085,7 +1085,7 @@ public:
 
     void emitNops(size_t memoryToFillWithNopsInBytes)
     {
-#if CPU(ARM64)
+#if CPU(ARM64) || CPU(ARM)
         RELEASE_ASSERT(memoryToFillWithNopsInBytes % 4 == 0);
         for (unsigned i = 0; i < memoryToFillWithNopsInBytes / 4; ++i)
             m_assembler.nop();
@@ -1094,7 +1094,7 @@ public:
         size_t startCodeSize = buffer.codeSize();
         size_t targetCodeSize = startCodeSize + memoryToFillWithNopsInBytes;
         buffer.ensureSpace(memoryToFillWithNopsInBytes);
-        AssemblerType::template fillNops<MachineCodeCopyMode::Memcpy>(static_cast<char*>(buffer.data()) + startCodeSize, memoryToFillWithNopsInBytes);
+        AssemblerType::fillNops(static_cast<char*>(buffer.data()) + startCodeSize, memoryToFillWithNopsInBytes);
         buffer.setCodeSize(targetCodeSize);
 #endif
     }
@@ -1250,4 +1250,3 @@ void printInternal(PrintStream& out, JSC::AbstractMacroAssemblerBase::StatusCond
 } // namespace WTF
 
 #endif // ENABLE(ASSEMBLER)
-

--- a/Source/JavaScriptCore/assembler/AssemblerCommon.h
+++ b/Source/JavaScriptCore/assembler/AssemblerCommon.h
@@ -26,11 +26,33 @@
 #pragma once
 
 #include <JavaScriptCore/OSCheck.h>
+#include <JavaScriptCore/Options.h>
 #include <optional>
 #include <wtf/Atomics.h>
 #include <wtf/MathExtras.h>
+#include <wtf/OptionSet.h>
 
 namespace JSC {
+
+enum class RepatchingFlag : uint8_t {
+    Atomic = 1 << 0,
+    Memcpy = 1 << 1, // or JITMemcpy
+    Flush = 1 << 2,
+};
+
+using RepatchingInfo = WTF::ConstexprOptionSet<RepatchingFlag>;
+constexpr RepatchingInfo jitMemcpyRepatch = RepatchingInfo { };
+constexpr RepatchingInfo jitMemcpyRepatchAtomic = RepatchingInfo { RepatchingFlag::Atomic };
+constexpr RepatchingInfo jitMemcpyRepatchFlush = RepatchingInfo { RepatchingFlag::Flush };
+constexpr RepatchingInfo memcpyRepatchFlush = RepatchingInfo { RepatchingFlag::Memcpy, RepatchingFlag::Flush };
+constexpr RepatchingInfo memcpyRepatch = RepatchingInfo { RepatchingFlag::Memcpy };
+
+ALWAYS_INLINE constexpr RepatchingInfo noFlush(RepatchingInfo i)
+{
+    auto tmp = *i;
+    tmp.remove(RepatchingFlag::Flush);
+    return { tmp };
+}
 
 template<size_t bits, typename Type>
 ALWAYS_INLINE constexpr bool isInt(Type t)
@@ -352,17 +374,13 @@ ALWAYS_INLINE bool isValidARMThumb2Immediate(int64_t value)
     return false;
 }
 
-enum class MachineCodeCopyMode : uint8_t {
-    Memcpy,
-    JITMemcpy,
-};
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-static ALWAYS_INLINE void* memcpyAtomicIfPossible(void* dst, const void* src, size_t n)
+ALWAYS_INLINE void* memcpyAtomic(void* dst, const void* src, size_t n)
 {
-#if !CPU(NEEDS_ALIGNED_ACCESS)
-    // We would like to do atomic write here.
+    // This produces a much nicer error message for unaligned accesses.
+    if constexpr (is32Bit())
+        RELEASE_ASSERT(!(reinterpret_cast<uintptr_t>(dst) & static_cast<uintptr_t>(n - 1)));
     switch (n) {
     case 1:
         WTF::atomicStore(std::bit_cast<uint8_t*>(dst), *std::bit_cast<const uint8_t*>(src), std::memory_order_relaxed);
@@ -379,32 +397,50 @@ static ALWAYS_INLINE void* memcpyAtomicIfPossible(void* dst, const void* src, si
     default:
         break;
     }
-#endif
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+ALWAYS_INLINE void* memcpyTearing(void* dst, const void* src, size_t n)
+{
+    // We should expect these instructions to be torn, so let's verify that.
+    if (Options::fuzzAtomicJITMemcpy()) [[unlikely]] {
+        auto* d = reinterpret_cast<uint8_t*>(dst);
+        auto* s = reinterpret_cast<const uint8_t*>(src);
+        for (size_t i = 0; i < n; ++i, ++s, ++d) {
+            *d = *s;
+            WTF::storeLoadFence();
+        }
+    }
     return memcpy(dst, src, n);
 }
 
-static void* performJITMemcpy(void* dst, const void* src, size_t n);
+static ALWAYS_INLINE void* memcpyAtomicIfPossible(void* dst, const void* src, size_t n)
+{
+    if (isPowerOfTwo(n) && n <= sizeof(CPURegister))
+        return memcpyAtomic(dst, src, n);
+    return memcpyTearing(dst, src, n);
+}
 
-template<MachineCodeCopyMode copy>
+template<RepatchingInfo repatch>
+void* performJITMemcpy(void* dst, const void* src, size_t n);
+
+template<RepatchingInfo repatch>
 ALWAYS_INLINE void* machineCodeCopy(void* dst, const void* src, size_t n)
 {
-#if CPU(ARM_THUMB2)
-    // For thumb instructions, we want to avoid the case where we have
-    // to repatch a 32-bit instruction that crosses 2 words.
-    bool isAligned = (dst == WTF::roundUpToMultipleOf<4>(dst));
-    if (n == 2 * sizeof(int16_t) && isAligned) {
-        *static_cast<uint32_t*>(dst) = *static_cast<const uint32_t*>(src);
-        return dst;
+    static_assert(!(*repatch).contains(RepatchingFlag::Flush));
+    if constexpr (is32Bit()) {
+        // Avoid unaligned accesses.
+        if (WTF::isAligned(dst, n))
+            return memcpyAtomicIfPossible(dst, src, n);
+        return memcpyTearing(dst, src, n);
     }
-    if (n == 1 * sizeof(int16_t)) {
-        *static_cast<uint16_t*>(dst) = *static_cast<const uint16_t*>(src);
-        return dst;
-    }
-#endif
-    if constexpr (copy == MachineCodeCopyMode::Memcpy)
+    if constexpr ((*repatch).contains(RepatchingFlag::Memcpy) && (*repatch).contains(RepatchingFlag::Atomic))
+        return memcpyAtomic(dst, src, n);
+    else if constexpr ((*repatch).contains(RepatchingFlag::Memcpy))
         return memcpyAtomicIfPossible(dst, src, n);
     else
-        return performJITMemcpy(dst, src, n);
+        return performJITMemcpy<repatch>(dst, src, n);
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -302,8 +302,10 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
 #endif
 
     uint8_t* codeOutData = m_code.dataLocation<uint8_t*>();
+// It is important not to spill this to the stack, so we don't make a local.
+#define shouldCopyDirectlyToJITRegion (!m_shouldPerformBranchCompaction || g_jscConfig.useFastJITPermissions)
 
-    BranchCompactionLinkBuffer outBuffer(m_size, g_jscConfig.useFastJITPermissions ? codeOutData : 0);
+    BranchCompactionLinkBuffer outBuffer(m_size, shouldCopyDirectlyToJITRegion ? codeOutData : 0);
     uint8_t* outData = outBuffer.data();
 
 #if CPU(ARM64)
@@ -411,20 +413,20 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
             target = std::bit_cast<uint8_t*>(to);
         else
             target = codeOutData + to - executableOffsetFor(to);
-        if (g_jscConfig.useFastJITPermissions)
-            MacroAssembler::link<MachineCodeCopyMode::Memcpy>(linkRecord, outData + linkRecord.from(), location, target);
+        if (shouldCopyDirectlyToJITRegion)
+            MacroAssembler::link<memcpyRepatch>(linkRecord, outData + linkRecord.from(), location, target);
         else
-            MacroAssembler::link<MachineCodeCopyMode::JITMemcpy>(linkRecord, outData + linkRecord.from(), location, target);
+            MacroAssembler::link<jitMemcpyRepatch>(linkRecord, outData + linkRecord.from(), location, target);
     }
 
     size_t compactSize = writePtr + initialSize - readPtr;
     if (!m_executableMemory) {
         size_t nopSizeInBytes = initialSize - compactSize;
 
-        if (g_jscConfig.useFastJITPermissions)
-            Assembler::fillNops<MachineCodeCopyMode::Memcpy>(outData + compactSize, nopSizeInBytes);
+        if (shouldCopyDirectlyToJITRegion)
+            Assembler::fillNops<memcpyRepatch>(outData + compactSize, nopSizeInBytes);
         else
-            Assembler::fillNops<MachineCodeCopyMode::JITMemcpy>(outData + compactSize, nopSizeInBytes);
+            Assembler::fillNops<jitMemcpyRepatch>(outData + compactSize, nopSizeInBytes);
     }
     if (g_jscConfig.useFastJITPermissions)
         threadSelfRestrict<MemoryRestriction::kRwxToRx>();
@@ -434,6 +436,8 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
         m_executableMemory->shrink(m_size);
     }
 
+#undef shouldCopyDirectlyToJITRegion
+
 #if ENABLE(JIT)
     if (g_jscConfig.useFastJITPermissions) {
         ASSERT(codeOutData == outData);
@@ -441,11 +445,11 @@ void LinkBuffer::copyCompactAndLinkCode(MacroAssembler& macroAssembler, JITCompi
             dumpJITMemory(outData, outData, m_size);
     } else {
         ASSERT(codeOutData != outData);
-        performJITMemcpy(codeOutData, outData, m_size);
+        performJITMemcpy<jitMemcpyRepatch>(codeOutData, outData, m_size);
     }
 #else
     ASSERT(codeOutData != outData);
-    performJITMemcpy(codeOutData, outData, m_size);
+    performJITMemcpy<jitMemcpyRepatch>(codeOutData, outData, m_size);
 #endif
 
 #if ENABLE(MPROTECT_RX_TO_RWX)
@@ -483,7 +487,7 @@ void LinkBuffer::linkCode(MacroAssembler& macroAssembler, JITCompilationEffort e
 #if CPU(ARM64)
     RELEASE_ASSERT(roundUpToMultipleOf<Assembler::instructionSize>(code) == code);
 #endif
-    performJITMemcpy(code, buffer.data(), buffer.codeSize());
+    performJITMemcpy<jitMemcpyRepatch>(code, buffer.data(), buffer.codeSize());
 #elif CPU(ARM_THUMB2)
     copyCompactAndLinkCode<uint16_t>(macroAssembler, effort);
 #elif CPU(ARM64)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -97,8 +97,8 @@ public:
     static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to) { return Assembler::computeJumpType(record, from, to); }
     static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return Assembler::jumpSizeDelta(jumpType, jumpLinkType); }
 
-    template<MachineCodeCopyMode copy>
-    ALWAYS_INLINE static void link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction, uint8_t* to) { return Assembler::link<copy>(record, from, fromInstruction, to); }
+    template<RepatchingInfo repatch>
+    ALWAYS_INLINE static void link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction, uint8_t* to) { return Assembler::link<repatch>(record, from, fromInstruction, to); }
 
     static bool isCompactPtrAlignedAddressOffset(ptrdiff_t value)
     {
@@ -5211,7 +5211,7 @@ public:
 
     static void reemitInitialMoveWithPatch(void* address, void* value)
     {
-        Assembler::setPointer(static_cast<int*>(address), value, dataTempRegister, true);
+        Assembler::setPointer<jitMemcpyRepatchFlush>(static_cast<int*>(address), value, dataTempRegister);
     }
 
     // Miscellaneous operations:

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "AssemblerCommon.h"
 #include <wtf/Platform.h>
 
 #if ENABLE(ASSEMBLER) && CPU(ARM_THUMB2)
@@ -118,8 +119,8 @@ public:
     static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to) { return ARMv7Assembler::computeJumpType(record, from, to); }
     static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return ARMv7Assembler::jumpSizeDelta(jumpType, jumpLinkType); }
 
-    template<MachineCodeCopyMode copy>
-    ALWAYS_INLINE static void link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction, uint8_t* to) { return ARMv7Assembler::link<copy>(record, from, fromInstruction, to); }
+    template<RepatchingInfo repatch>
+    ALWAYS_INLINE static void link(LinkRecord& record, uint8_t* from, const uint8_t* fromInstruction, uint8_t* to) { return ARMv7Assembler::link<repatch>(record, from, fromInstruction, to); }
 
     struct ArmAddress {
         enum AddressType {

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1678,7 +1678,7 @@ public:
 
     static void replaceWithNops(void* from, size_t memoryToFillWithNopsInBytes)
     {
-        fillNops<MachineCodeCopyMode::Memcpy>(from, memoryToFillWithNopsInBytes);
+        fillNops(from, memoryToFillWithNopsInBytes);
         cacheFlush(from, memoryToFillWithNopsInBytes);
     }
 
@@ -1703,7 +1703,6 @@ public:
         __builtin___clear_cache(static_cast<char*>(code), reinterpret_cast<char*>(end));
     }
 
-    template<MachineCodeCopyMode copy>
     static void fillNops(void* base, size_t size)
     {
         uint32_t* ptr = static_cast<uint32_t*>(base);
@@ -1712,7 +1711,7 @@ public:
 
         uint32_t nop = RISCV64Instructions::ADDI::construct(RISCV64Registers::zero, RISCV64Registers::zero, IImmediate::v<IImmediate, 0>());
         for (size_t i = 0, n = size / sizeof(uint32_t); i < n; ++i)
-            machineCodeCopy<copy>(&ptr[i], &nop, sizeof(uint32_t));
+            machineCodeCopy<memcpyRepatch>(&ptr[i], &nop, sizeof(uint32_t));
     }
 
     typedef enum {

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -6244,7 +6244,7 @@ public:
     {
 #if ENABLE(MPROTECT_RX_TO_RWX)
         uint8_t op = OP_HLT;
-        performJITMemcpy(instructionStart, &op, 1);
+        performJITMemcpy<jitMemcpyRepatch>(instructionStart, &op, 1);
 #else
         WTF::unalignedStore<uint8_t>(instructionStart, static_cast<uint8_t>(OP_HLT));
 #endif
@@ -6259,7 +6259,7 @@ public:
         uint8_t buffer[5];
         buffer[0] = static_cast<uint8_t>(OP_JMP_rel32);
         WTF::unalignedStore<int32_t>(buffer + 1, static_cast<int32_t>(distance));
-        performJITMemcpy(ptr, buffer, 5);
+        performJITMemcpy<jitMemcpyRepatch>(ptr, buffer, 5);
 #else
         WTF::unalignedStore<uint8_t>(ptr, static_cast<uint8_t>(OP_JMP_rel32));
         WTF::unalignedStore<int32_t>(ptr + 1, static_cast<int32_t>(distance));
@@ -6268,11 +6268,7 @@ public:
 
     static void replaceWithNops(void* instructionStart, size_t memoryToFillWithNopsInBytes)
     {
-#if ENABLE(MPROTECT_RX_TO_RWX)
-        fillNops<MachineCodeCopyMode::JITMemcpy>(instructionStart, memoryToFillWithNopsInBytes);
-#else
-        fillNops<MachineCodeCopyMode::Memcpy>(instructionStart, memoryToFillWithNopsInBytes);
-#endif
+        fillNops(instructionStart, memoryToFillWithNopsInBytes);
     }
 
     static constexpr ptrdiff_t maxJumpReplacementSize()
@@ -6302,7 +6298,7 @@ public:
         buffer[0] = PRE_REX | (1 << 3) | (dst >> 3);
         buffer[1] = OP_MOV_EAXIv | (dst & 7);
         memcpy(buffer + rexBytes + opcodeBytes, u.asBytes, instructionSize - rexBytes - opcodeBytes);
-        performJITMemcpy(ptr, buffer, instructionSize);
+        performJITMemcpy<jitMemcpyRepatch>(ptr, buffer, instructionSize);
 #else
         ptr[0] = PRE_REX | (1 << 3) | (dst >> 3);
         ptr[1] = OP_MOV_EAXIv | (dst & 7);
@@ -6332,7 +6328,7 @@ public:
         buffer[0] = PRE_REX | (1 << 3) | (dst >> 3);
         buffer[1] = OP_MOV_EAXIv | (dst & 7);
         memcpy(buffer + rexBytes + opcodeBytes, u.asBytes, instructionSize - rexBytes - opcodeBytes);
-        performJITMemcpy(ptr, buffer, instructionSize);
+        performJITMemcpy<jitMemcpyRepatch>(ptr, buffer, instructionSize);
 #else
         ptr[0] = PRE_REX | (dst >> 3);
         ptr[1] = OP_MOV_EAXIv | (dst & 7);
@@ -6357,7 +6353,7 @@ public:
         buffer[0] = OP_GROUP1_EvIz;
         buffer[1] = (X86InstructionFormatter::ModRmRegister << 6) | (GROUP1_OP_CMP << 3) | dst;
         memcpy(buffer + 2, u.asBytes, maxJumpReplacementSize() - opcodeBytes - modRMBytes);
-        performJITMemcpy(ptr, buffer, maxJumpReplacementSize());
+        performJITMemcpy<jitMemcpyRepatch>(ptr, buffer, maxJumpReplacementSize());
 #else
         ptr[0] = OP_GROUP1_EvIz;
         ptr[1] = (X86InstructionFormatter::ModRmRegister << 6) | (GROUP1_OP_CMP << 3) | dst;
@@ -6383,7 +6379,7 @@ public:
         buffer[0] = OP_GROUP1_EvIz;
         buffer[1] = (X86InstructionFormatter::ModRmMemoryNoDisp << 6) | (GROUP1_OP_CMP << 3) | dst;
         memcpy(buffer + 2, u.asBytes, maxJumpReplacementSize() - opcodeBytes - modRMBytes);
-        performJITMemcpy(ptr, buffer, maxJumpReplacementSize());
+        performJITMemcpy<jitMemcpyRepatch>(ptr, buffer, maxJumpReplacementSize());
 #else
         ptr[0] = OP_GROUP1_EvIz;
         ptr[1] = (X86InstructionFormatter::ModRmMemoryNoDisp << 6) | (GROUP1_OP_CMP << 3) | dst;
@@ -6416,10 +6412,8 @@ public:
         m_formatter.oneByteOp(OP_NOP);
     }
 
-    template<MachineCodeCopyMode copy>
     static void fillNops(void* base, size_t size)
     {
-        UNUSED_PARAM(copy);
         static const uint8_t nops[10][10] = {
             // nop
             {0x90},
@@ -6457,10 +6451,11 @@ public:
                 *bufferWriter++ = nops[nopRest-1][i];
 
             ASSERT(nopSize == bufferWriter - buffer);
-            if constexpr (copy == MachineCodeCopyMode::JITMemcpy)
-                performJITMemcpy(where, buffer, nopSize);
-            else
-                memcpy(where, buffer, nopSize);
+#if ENABLE(MPROTECT_RX_TO_RWX)
+            machineCodeCopy<jitMemcpyRepatch>(where, buffer, nopSize);
+#else
+            machineCodeCopy<memcpyRepatch>(where, buffer, nopSize);
+#endif
             where += nopSize;
             size -= nopSize;
         }
@@ -6474,7 +6469,7 @@ private:
     static void setPointer(void* where, void* value)
     {
 #if ENABLE(MPROTECT_RX_TO_RWX)
-        performJITMemcpy(std::bit_cast<void**>(where) - 1, &value, sizeof(void*));
+        performJITMemcpy<jitMemcpyRepatch>(std::bit_cast<void**>(where) - 1, &value, sizeof(void*));
 #else
         WTF::unalignedStore<void*>(std::bit_cast<void**>(where) - 1, value);
 #endif
@@ -6483,7 +6478,7 @@ private:
     static void setInt32(void* where, int32_t value)
     {
 #if ENABLE(MPROTECT_RX_TO_RWX)
-        performJITMemcpy(std::bit_cast<int32_t*>(where) - 1, &value, sizeof(int32_t));
+        performJITMemcpy<jitMemcpyRepatch>(std::bit_cast<int32_t*>(where) - 1, &value, sizeof(int32_t));
 #else
         WTF::unalignedStore<int32_t>(std::bit_cast<int32_t*>(where) - 1, value);
 #endif
@@ -6492,7 +6487,7 @@ private:
     static void setInt8(void* where, int8_t value)
     {
 #if ENABLE(MPROTECT_RX_TO_RWX)
-        performJITMemcpy(std::bit_cast<int8_t*>(where) - 1, &value, sizeof(int8_t));
+        performJITMemcpy<jitMemcpyRepatch>(std::bit_cast<int8_t*>(where) - 1, &value, sizeof(int8_t));
 #else
         WTF::unalignedStore<int8_t>(std::bit_cast<int8_t*>(where) - 1, value);
 #endif

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -852,9 +852,9 @@ private:
             auto emitJumpTo = [&] (void* target) {
                 RELEASE_ASSERT(Assembler::canEmitJump(std::bit_cast<void*>(jumpLocation), target));
                 if (useMemcpy)
-                    Assembler::fillNearTailCall<MachineCodeCopyMode::Memcpy>(currentIsland, target);
+                    Assembler::fillNearTailCall<memcpyRepatchFlush>(currentIsland, target);
                 else
-                    Assembler::fillNearTailCall<MachineCodeCopyMode::JITMemcpy>(currentIsland, target);
+                    Assembler::fillNearTailCall<jitMemcpyRepatchFlush>(currentIsland, target);
             };
 
             if (Assembler::canEmitJump(std::bit_cast<void*>(jumpLocation), std::bit_cast<void*>(target))) {
@@ -1427,7 +1427,7 @@ ExecutableMemoryHandle::~ExecutableMemoryHandle()
         // We don't have a performJITMemset so just use a zeroed buffer.
         auto zeros = MallocSpan<uint8_t>::zeroedMalloc(sizeInBytes());
         auto span = zeros.span();
-        performJITMemcpy(start().untaggedPtr(), span.data(), span.size());
+        performJITMemcpy<jitMemcpyRepatch>(start().untaggedPtr(), span.data(), span.size());
     }
     jit_heap_deallocate(key());
 }

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.h
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.h
@@ -210,7 +210,54 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
+#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
+ALWAYS_INLINE void jitMemcpyCheckForZeros(void *dst, const void *src, size_t n)
+{
+    if (Options::zeroExecutableMemoryOnFree()) [[unlikely]]
+        return;
+    // On x86-64, the maximum immediate size is 8B, no opcodes/prefixes have 0x00
+    // On other architectures this could be smaller
+    constexpr size_t maxZeroByteRunLength = 16;
+    // This algorithm works because the number of 0-bytes which can fit into
+    // one qword (8) is smaller than the limit on which we assert.
+    constexpr size_t stride = sizeof(uint64_t);
+    static_assert(stride <= maxZeroByteRunLength);
+
+    const char* dstBuff = reinterpret_cast<const char*>(dst);
+    size_t runLength = 0;
+    size_t i = 0;
+    if (n > stride) {
+        for (; (reinterpret_cast<uintptr_t>(dstBuff) + i) % stride; i++) {
+            if (!(dstBuff[i]))
+                runLength++;
+            else
+                runLength = 0;
+        }
+        for (; i + stride <= n; i += stride) {
+            uint64_t chunk = *reinterpret_cast<const uint64_t*>(dstBuff + i);
+            if (!chunk) {
+                runLength += sizeof(chunk);
+                RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + stride);
+            } else {
+                runLength += (std::countr_zero(chunk) / 8);
+                RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + (std::countr_zero(chunk) / 8));
+                runLength = std::countl_zero(chunk) / 8;
+            }
+        }
+        for (; i < n; i++) {
+            if (!(dstBuff[i])) {
+                runLength++;
+                RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + 1);
+            }
+        }
+    }
+}
+#else
+ALWAYS_INLINE void jitMemcpyCheckForZeros(void *, const void *, size_t) { }
+
+#endif
+
+ALWAYS_INLINE void jitMemcpyChecks(void *dst, const void *src, size_t n)
 {
 #if CPU(ARM64)
     static constexpr size_t instructionSize = sizeof(unsigned);
@@ -221,67 +268,32 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
         RELEASE_ASSERT(!Gigacage::contains(src));
         RELEASE_ASSERT(static_cast<uint8_t*>(dst) + n <= endOfFixedExecutableMemoryPool());
 
-#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-        auto checkForZeroes = [dst, src, n] () {
-            if (Options::zeroExecutableMemoryOnFree()) [[unlikely]]
-                return;
-            // On x86-64, the maximum immediate size is 8B, no opcodes/prefixes have 0x00
-            // On other architectures this could be smaller
-            constexpr size_t maxZeroByteRunLength = 16;
-            // This algorithm works because the number of 0-bytes which can fit into
-            // one qword (8) is smaller than the limit on which we assert.
-            constexpr size_t stride = sizeof(uint64_t);
-            static_assert(stride <= maxZeroByteRunLength);
-
-            const char* dstBuff = reinterpret_cast<const char*>(dst);
-            size_t runLength = 0;
-            size_t i = 0;
-            if (n > stride) {
-                for (; (reinterpret_cast<uintptr_t>(dstBuff) + i) % stride; i++) {
-                    if (!(dstBuff[i]))
-                        runLength++;
-                    else
-                        runLength = 0;
-                }
-                for (; i + stride <= n; i += stride) {
-                    uint64_t chunk = *reinterpret_cast<const uint64_t*>(dstBuff + i);
-                    if (!chunk) {
-                        runLength += sizeof(chunk);
-                        RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + stride);
-                    } else {
-                        runLength += (std::countr_zero(chunk) / 8);
-                        RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + (std::countr_zero(chunk) / 8));
-                        runLength = std::countl_zero(chunk) / 8;
-                    }
-                }
-                for (; i < n; i++) {
-                    if (!(dstBuff[i])) {
-                        runLength++;
-                        RELEASE_ASSERT_ZERO_CHECK(runLength, dst, src, n, i + 1);
-                    }
-                }
-            }
-        };
-#endif
-
         if (Options::dumpJITMemoryPath()) [[unlikely]]
             dumpJITMemory(dst, src, n);
+    }
+}
 
+template<RepatchingInfo repatch>
+ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n)
+{
+    static_assert(!(*repatch).contains(RepatchingFlag::Memcpy));
+    static_assert(!(*repatch).contains(RepatchingFlag::Flush));
+    jitMemcpyChecks(dst, src, n);
+    if (isJITPC(dst)) {
 #if ENABLE(MPROTECT_RX_TO_RWX)
         auto ret = performJITMemcpyWithMProtect(dst, src, n);
-#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-        checkForZeroes();
-#endif
+        jitMemcpyCheckForZeros(dst, src, n);
         return ret;
 #endif
 
         if (g_jscConfig.useFastJITPermissions) {
             threadSelfRestrict<MemoryRestriction::kRwxToRw>();
-            memcpyAtomicIfPossible(dst, src, n);
+            if constexpr ((*repatch).contains(RepatchingFlag::Atomic))
+                memcpyAtomic(dst, src, n);
+            else
+                memcpyAtomicIfPossible(dst, src, n);
             threadSelfRestrict<MemoryRestriction::kRwxToRx>();
-#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-            checkForZeroes();
-#endif
+            jitMemcpyCheckForZeros(dst, src, n);
             return dst;
         }
 
@@ -292,18 +304,13 @@ static ALWAYS_INLINE void* performJITMemcpy(void *dst, const void *src, size_t n
             off_t offset = (off_t)((uintptr_t)dst - startOfFixedExecutableMemoryPool<uintptr_t>());
             retagCodePtr<JITThunkPtrTag, CFunctionPtrTag>(g_jscConfig.jitWriteSeparateHeaps)(offset, src, n);
             RELEASE_ASSERT(!Gigacage::contains(src));
-#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-            checkForZeroes();
-#endif
+            jitMemcpyCheckForZeros(dst, src, n);
             return dst;
         }
 #endif
-
-        auto ret = memcpyAtomicIfPossible(dst, src, n);
-#if ENABLE(JIT_SCAN_ASSEMBLER_BUFFER_FOR_ZEROES)
-        checkForZeroes();
-#endif
-        return ret;
+        memcpyAtomicIfPossible(dst, src, n);
+        jitMemcpyCheckForZeros(dst, src, n);
+        return dst;
     }
 
     return memcpyAtomicIfPossible(dst, src, n);
@@ -376,7 +383,7 @@ private:
     ~ExecutableAllocator() = default;
 };
 
-static inline void* performJITMemcpy(void *dst, const void *src, size_t n)
+inline void* performJITMemcpy(void *dst, const void *src, size_t n)
 {
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return memcpy(dst, src, n);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -443,6 +443,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, exitOnResourceExhaustion, false, Normal, nullptr) \
     v(Bool, useExceptionFuzz, false, Normal, nullptr) \
     v(Unsigned, fireExceptionFuzzAt, 0, Normal, nullptr) \
+    v(Bool, fuzzAtomicJITMemcpy, false, Normal, nullptr) \
     v(Bool, validateDFGExceptionHandling, ASSERT_ENABLED, Normal, "Causes the DFG to emit code validating exception handling for each node that can exit"_s) \
     v(Bool, dumpSimulatedThrows, false, Normal, "Dumps the call stack of the last simulated throw if exception scope verification fails"_s) \
     v(Bool, validateExceptionChecks, false, Normal, "Verifies that needed exception checks are performed."_s) \

--- a/Source/WTF/wtf/OptionSet.h
+++ b/Source/WTF/wtf/OptionSet.h
@@ -38,6 +38,7 @@
 namespace WTF {
 
 template<typename E> class OptionSet;
+template<typename E> struct ConstexprOptionSet;
 
 // OptionSet is a class that represents a set of enumerators in a space-efficient manner. The enumerators
 // must be powers of two greater than 0. This class is useful as a replacement for passing a bitmask of
@@ -195,6 +196,8 @@ private:
     {
     }
     StorageType m_storage { 0 };
+
+    friend struct ConstexprOptionSet<E>;
 };
 
 namespace IsValidOptionSetHelper {
@@ -216,6 +219,25 @@ WARN_UNUSED_RETURN constexpr bool isValidOptionSet(OptionSet<E> optionSet)
     auto allValidBitsValue = IsValidOptionSetHelper::OptionSetValueChecker<std::make_unsigned_t<std::underlying_type_t<E>>, typename EnumTraits<E>::values>::allValidBits();
     return (optionSet.toRaw() | allValidBitsValue) == allValidBitsValue;
 }
+
+// A structural type requires all base classes and non-static data members are public and non-mutable.
+// This helper lets you use OptionSet in template parameters.
+template<typename E>
+struct ConstexprOptionSet {
+    ALWAYS_INLINE constexpr ConstexprOptionSet(OptionSet<E> o)
+        : storage(o.m_storage)
+    {
+    }
+
+    ALWAYS_INLINE constexpr ConstexprOptionSet(std::initializer_list<E> initializerList)
+        : ConstexprOptionSet<E>(OptionSet<E>(WTFMove(initializerList)))
+    {
+    }
+
+    ALWAYS_INLINE constexpr OptionSet<E> operator*() const { return OptionSet<E>::fromRaw(storage); }
+
+    const OptionSet<E>::StorageType storage;
+};
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -159,6 +159,25 @@ inline bool is8ByteAligned(void* p)
     return !((uintptr_t)(p) & (sizeof(double) - 1));
 }
 
+inline bool isAligned(void* ptr, int alignment = sizeof(void*))
+{
+    return reinterpret_cast<uintptr_t>(ptr) % alignment == 0;
+}
+
+template <typename T>
+inline bool isAligned(T* ptr, int alignment = sizeof(void*))
+{
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(alignment >= alignof(T));
+    return reinterpret_cast<uintptr_t>(ptr) % alignment == 0;
+}
+
+template <typename T, int alignment = sizeof(void*)>
+inline bool isAligned(T* ptr)
+{
+    static_assert(alignment >= alignof(T));
+    return isAligned<T>(ptr, alignment);
+}
+
 inline std::byte* alignedBytes(std::byte* pointer, size_t alignment)
 {
     return reinterpret_cast<std::byte*>((reinterpret_cast<uintptr_t>(pointer) - 1u + alignment) & -alignment);


### PR DESCRIPTION
#### ebda8e26827a74360113aa00e52763aac48c9b58
<pre>
Add performJITMemcpyAtomic and simplify jit copying code [2].
<a href="https://bugs.webkit.org/show_bug.cgi?id=297235">https://bugs.webkit.org/show_bug.cgi?id=297235</a>

Reviewed by Keith Miller.

The eventual goal of this series of patches is to make clear, explicit and separate
entrypoints into code that eventually copies to the jit region or an assembler buffer,
to clearly separate patching that must be atomic and patching that does not.

This is important to ensure that every place relying on atomic copying behaviour
is explicitly documented, so that ARMv7 can ensure the correct alignment of these regions.

To start, we carefuly thread through a new atomic flag, but we avoid changing behavior yet.

The only change this patch should make is that sometimes we can avoid a buffer allocation
when linking.

Canonical link: <a href="https://commits.webkit.org/298849@main">https://commits.webkit.org/298849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f437e61233c7b6b3badd109114032b09887d560e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116624 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67196 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43006 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, fast/css/vertical-align-rem-on-root.html, http/tests/permissions/storage-access-permissions-query.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dom/string-prototype-properties.html, storage/indexeddb/cursor-value-private.html, storage/indexeddb/intversion-pending-version-changes-ascending-private.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-rgb16f-rgb-half_float.html, webgl/2.0.0/conformance2/textures/image/tex-2d-rgba4-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-3d-rgb8-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image_data/tex-3d-rgba4-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html, webgl/2.0.y/conformance/ogles/GL/degrees/degrees_001_to_006.html, webgl/2.0.y/conformance2/query/occlusion-query.html, webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66365 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108738 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125834 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115152 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97244 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97037 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24754 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20286 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39485 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49004 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143850 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42875 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37032 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->