### PR TITLE
[Safer CPP] Address issues in RenderBundleEncoder and ComputePassEncoder

### DIFF
--- a/Source/WebGPU/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,2 +1,1 @@
-ComputePassEncoder.mm
 Device.mm

--- a/Source/WebGPU/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,1 +1,0 @@
-RenderBundleEncoder.mm

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -280,8 +280,8 @@ id<MTLBuffer> ComputePassEncoder::runPredispatchIndirectCallValidation(const Buf
     static id<MTLFunction> function = nil;
     id<MTLDevice> mtlDevice = m_device->device();
     static std::once_flag onceFlag;
-    std::call_once(onceFlag, [&] {
-        auto dimensionMax = m_device->limits().maxComputeWorkgroupsPerDimension;
+    std::call_once(onceFlag, [protectedThis = Ref { *this }, &mtlDevice] {
+        auto dimensionMax = protectedThis->m_device->limits().maxComputeWorkgroupsPerDimension;
         MTLCompileOptions* options = [MTLCompileOptions new];
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         options.fastMathEnabled = YES;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -358,7 +358,7 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
         if (!group)
             continue;
 
-        auto pipelineOptionalBindGroupLayout = pipelineLayout->optionalBindGroupLayout(groupIndex);
+        auto pipelineOptionalBindGroupLayout = pipelineLayout->protectedOptionalBindGroupLayout(groupIndex);
         const Vector<uint32_t>* dynamicOffsets = nullptr;
         if (m_bindGroupDynamicOffsets) {
             if (auto it = m_bindGroupDynamicOffsets->find(groupIndex); it != m_bindGroupDynamicOffsets->end())
@@ -369,7 +369,7 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
             return false;
         }
 
-        if (protectedGroup && (protectedGroup->makeSubmitInvalid(ShaderStage::Vertex, pipelineOptionalBindGroupLayout) || protectedGroup->makeSubmitInvalid(ShaderStage::Fragment, pipelineOptionalBindGroupLayout)))
+        if (protectedGroup && (protectedGroup->makeSubmitInvalid(ShaderStage::Vertex, pipelineOptionalBindGroupLayout.get()) || protectedGroup->makeSubmitInvalid(ShaderStage::Fragment, pipelineOptionalBindGroupLayout.get())))
             m_makeSubmitInvalid = true;
     }
 


### PR DESCRIPTION
#### 3ee3965ab69139757abd968f53fb2b23517a2dd5
<pre>
[Safer CPP] Address issues in RenderBundleEncoder and ComputePassEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=297237">https://bugs.webkit.org/show_bug.cgi?id=297237</a>
<a href="https://rdar.apple.com/158068940">rdar://158068940</a>

Reviewed by Mike Wyrzykowski.

Address SaferCPP issues in RenderBundleEncoder and ComputePassEncoder.

* Source/WebGPU/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebGPU/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::runPredispatchIndirectCallValidation):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):

Canonical link: <a href="https://commits.webkit.org/298575@main">https://commits.webkit.org/298575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/174f173604e23a6da484b98406986f30d98c8878

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66397 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98b658c2-8dce-4270-869d-51dc79c8e9de) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88014 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/85389ccf-13d3-411a-9829-c55552ada860) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68424 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28018 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65592 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125074 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96767 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96553 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19684 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38682 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42649 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48238 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42116 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45450 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->