### PR TITLE
Upload WPT Local-Network Access Tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6401,7 +6401,6 @@ imported/w3c/web-platform-tests/fetch/corb/script-html-correctly-labeled.tentati
 imported/w3c/web-platform-tests/fetch/corb/script-html-js-polyglot.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/script-html-via-cross-origin-blob-url.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/script-resource-with-json-parser-breaker.tentative.sub.html [ Skip ]
-imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/appcache-manifest.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/css-images.sub.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/element-a.https.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md
@@ -5,7 +5,7 @@ the Fetch specification.
 
 See also:
 
-* [Explainer](https://github.com/explainers-by-googlers/local-network-access)
+* [Spec](https://wicg.github.io/local-network-access/)
 
 Local Network Access replaced [Private Network
-Access](https://wicg.github.io/local-network-access/).
+Access](https://wicg.github.io/private-network-access/).

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window-expected.txt
@@ -1,0 +1,10 @@
+
+Harness Error (FAIL), message = ReferenceError: Can't find variable: Server
+
+FAIL loopback to loopback: no permission required. Can't find variable: iframeTest
+FAIL loopback to local: no permission required. Can't find variable: iframeTest
+FAIL loopback to public: no permission required. Can't find variable: iframeTest
+FAIL local to loopback: no permission required. Can't find variable: iframeTest
+FAIL local to local: no permission required. Can't find variable: iframeTest
+FAIL local to public: no permission required. Can't find variable: iframeTest
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.js
@@ -1,0 +1,199 @@
+// META: script=/common/subset-tests-by-key.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/utils.js
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// META: script=resources/support.sub.js
+// META: timeout=long
+// META: variant=?include=from-loopback
+// META: variant=?include=from-local
+// META: variant=?include=from-public
+// META: variant=?include=from-treat-as-public
+//
+// Spec: https://wicg.github.io/local-network-access/#integration-fetch
+//
+// These tests verify that secure contexts can navigate iframes to less-public
+// address spaces iff the initiating document has been granted the LNA
+// permission.
+//
+// This file covers only those tests that must execute in a secure context.
+
+setup(() => {
+  assert_true(window.isSecureContext);
+});
+
+// Source: secure loopback context.
+//
+// All iframe navigations unaffected by Local Network Access.
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => iframeTest(t, {
+                                     source: Server.HTTP_LOOPBACK,
+                                     target: Server.HTTPS_LOOPBACK,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => iframeTest(t, {
+                                     source: Server.HTTP_LOOPBACK,
+                                     target: Server.HTTPS_LOCAL,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to local: no permission required.');
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => iframeTest(t, {
+                                     source: Server.HTTP_LOOPBACK,
+                                     target: Server.HTTPS_PUBLIC,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to public: no permission required.');
+
+// Source: local secure context.
+//
+// All iframe navigations unaffected by Local Network Access.
+
+// Requests from the `local` address space to the `loopback` address space
+// are not yet restricted by LNA.
+subsetTestByKey(
+    'from-local', promise_test, t => iframeTest(t, {
+                                  source: Server.HTTP_LOCAL,
+                                  target: Server.HTTPS_LOOPBACK,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-local', promise_test, t => iframeTest(t, {
+                                  source: Server.HTTP_LOCAL,
+                                  target: Server.HTTPS_LOCAL,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to local: no permission required.');
+
+subsetTestByKey(
+    'from-local', promise_test, t => iframeTest(t, {
+                                  source: Server.HTTP_LOCAL,
+                                  target: Server.HTTPS_PUBLIC,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to public: no permission required.');
+
+
+// Generates tests of permission behavior for a single (source, target) pair.
+//
+// Scenarios:
+//
+// - parent (source) navigates child (target):
+//   - parent has been denied the LNA permission (failure)
+//   - parent has been granted the LNA permission (success)
+//
+function makePermissionTests({
+  key,
+  sourceName,
+  sourceServer,
+  sourceTreatAsPublic,
+  targetName,
+  targetServer,
+}) {
+  const prefix = `${sourceName} to ${targetName}: `;
+
+  const source = {
+    server: sourceServer,
+    treatAsPublic: sourceTreatAsPublic,
+  };
+
+  promise_test(
+      t => iframeTest(t, {
+        source,
+        target: {
+          server: targetServer,
+        },
+        expected: NavigationTestResult.FAILURE,
+        permission: 'denied',
+      }),
+      prefix + 'permission denied.');
+
+  promise_test(
+      t => iframeTest(t, {
+        source,
+        target: {
+          server: targetServer,
+        },
+        expected: NavigationTestResult.SUCCESS,
+        permission: 'granted',
+      }),
+      prefix + 'success.');
+}
+
+
+// Source: public secure context.
+//
+// iframe navigations to the loopback and local address spaces require the LNA
+// permission.
+
+subsetTestByKey('from-public', makePermissionTests, {
+  sourceServer: Server.HTTPS_PUBLIC,
+  sourceName: 'public',
+  targetServer: Server.HTTPS_LOOPBACK,
+  targetName: 'loopback',
+});
+
+subsetTestByKey('from-public', makePermissionTests, {
+  sourceServer: Server.HTTPS_PUBLIC,
+  sourceName: 'public',
+  targetServer: Server.HTTPS_LOCAL,
+  targetName: 'local',
+});
+
+subsetTestByKey(
+    'from-public', promise_test, t => iframeTest(t, {
+                                   source: Server.HTTPS_PUBLIC,
+                                   target: Server.HTTPS_PUBLIC,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to public: no permission required.');
+
+// The following tests verify that `CSP: treat-as-public-address` makes
+// documents behave as if they had been served from a public IP address.
+
+subsetTestByKey('from-treat-as-public', makePermissionTests, {
+  sourceServer: Server.HTTPS_LOOPBACK,
+  sourceTreatAsPublic: true,
+  sourceName: 'treat-as-public-address',
+  targetServer: Server.OTHER_HTTPS_LOOPBACK,
+  targetName: 'loopback',
+});
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => iframeTest(t, {
+      source: {
+        server: Server.HTTPS_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTPS_LOOPBACK,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to local (same-origin): no permission required.');
+
+subsetTestByKey('from-treat-as-public', makePermissionTests, {
+  sourceServer: Server.HTTPS_LOOPBACK,
+  sourceTreatAsPublic: true,
+  sourceName: 'treat-as-public-address',
+  targetServer: Server.HTTPS_LOCAL,
+  targetName: 'local',
+});
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => iframeTest(t, {
+      source: {
+        server: Server.HTTPS_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTPS_PUBLIC,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to public: no permission required.');

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window-expected.txt
@@ -1,0 +1,15 @@
+
+FAIL loopback to loopback: no permission required. Can't find variable: navigateTest
+FAIL loopback to local: no permission required. Can't find variable: navigateTest
+FAIL loopback to public: no preflight required. Can't find variable: navigateTest
+FAIL local to loopback: no permission required. Can't find variable: navigateTest
+FAIL local to local: no permission required. Can't find variable: navigateTest
+FAIL local to public: no permission required. Can't find variable: navigateTest
+FAIL public to loopback: no permission required. Can't find variable: navigateTest
+FAIL public to local: no permission required. Can't find variable: navigateTest
+FAIL public to public: no permission required. Can't find variable: navigateTest
+FAIL treat-as-public-address to loopback: no permission required. Can't find variable: navigateTest
+FAIL treat-as-public-address to loopback (same-origin): no permission required. Can't find variable: navigateTest
+FAIL treat-as-public-address to local: no permission required. Can't find variable: navigateTest
+FAIL treat-as-public-address to public: no permission required. Can't find variable: navigateTest
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.js
@@ -1,0 +1,151 @@
+// META: script=/common/subset-tests-by-key.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/utils.js
+// META: script=resources/support.sub.js
+// META: timeout=long
+// META: variant=?include=from-loopback
+// META: variant=?include=from-local
+// META: variant=?include=from-public
+// META: variant=?include=from-treat-as-public
+//
+// These tests verify that secure contexts can make top-level navigations
+// to less-public address spaces. These are not restricted under LNA.
+
+setup(() => {
+  assert_true(window.isSecureContext);
+});
+
+// Source: secure loopback context.
+//
+// All top-level navigations unaffected by Local Network Access.
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => navigateTest(t, {
+                                     source: Server.HTTPS_LOOPBACK,
+                                     target: Server.HTTPS_LOOPBACK,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => navigateTest(t, {
+                                     source: Server.HTTPS_LOOPBACK,
+                                     target: Server.HTTPS_LOCAL,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to local: no permission required.');
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => navigateTest(t, {
+                                     source: Server.HTTPS_LOOPBACK,
+                                     target: Server.HTTPS_PUBLIC,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to public: no preflight required.');
+
+// Source: secure local context.
+//
+// All top-level navigations unaffected by Local Network Access.
+
+subsetTestByKey(
+    'from-local', promise_test, t => navigateTest(t, {
+                                  source: Server.HTTPS_LOCAL,
+                                  target: Server.HTTPS_LOOPBACK,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-local', promise_test, t => navigateTest(t, {
+                                  source: Server.HTTPS_LOCAL,
+                                  target: Server.HTTPS_LOCAL,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to local: no permission required.');
+
+subsetTestByKey(
+    'from-local', promise_test, t => navigateTest(t, {
+                                  source: Server.HTTPS_LOCAL,
+                                  target: Server.HTTPS_PUBLIC,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to public: no permission required.');
+
+// Source: secure public context.
+//
+// All top-level navigations unaffected by Local Network Access
+
+subsetTestByKey(
+    'from-public', promise_test, t => navigateTest(t, {
+                                   source: Server.HTTPS_PUBLIC,
+                                   target: Server.HTTPS_LOOPBACK,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-public', promise_test, t => navigateTest(t, {
+                                   source: Server.HTTPS_PUBLIC,
+                                   target: Server.HTTPS_LOCAL,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to local: no permission required.');
+
+subsetTestByKey(
+    'from-public', promise_test, t => navigateTest(t, {
+                                   source: Server.HTTPS_PUBLIC,
+                                   target: Server.HTTPS_PUBLIC,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to public: no permission required.');
+
+// The following tests verify that `CSP: treat-as-public-address` makes
+// documents behave as if they had been served from a public IP address.
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTPS_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.OTHER_HTTPS_LOOPBACK,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTPS_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTPS_LOOPBACK,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to loopback (same-origin): no permission required.');
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTPS_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTPS_LOCAL,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to local: no permission required.');
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTPS_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTPS_PUBLIC,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to public: no permission required.');

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_false: expected false got true
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.js
@@ -1,0 +1,154 @@
+// META: script=/common/subset-tests-by-key.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/utils.js
+// META: script=resources/support.sub.js
+// META: timeout=long
+// META: variant=?include=from-loopback
+// META: variant=?include=from-local
+// META: variant=?include=from-public
+// META: variant=?include=from-treat-as-public
+//
+// These tests verify that nonsecure contexts can make top-level navigations
+// to less-public address spaces. These are not restricted under LNA.
+//
+// This file covers only those tests that must execute in a non secure context.
+// Other tests are defined in: navigate.tentative.https.window.js
+
+setup(() => {
+  assert_false(window.isSecureContext);
+});
+
+// Source: nonsecure loopback context.
+//
+// All top-level navigations unaffected by Local Network Access.
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => navigateTest(t, {
+                                     source: Server.HTTP_LOOPBACK,
+                                     target: Server.HTTP_LOOPBACK,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => navigateTest(t, {
+                                     source: Server.HTTP_LOOPBACK,
+                                     target: Server.HTTP_LOCAL,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to local: no permission required.');
+
+subsetTestByKey(
+    'from-loopback', promise_test, t => navigateTest(t, {
+                                     source: Server.HTTP_LOOPBACK,
+                                     target: Server.HTTP_PUBLIC,
+                                     expected: NavigationTestResult.SUCCESS,
+                                   }),
+    'loopback to public: no preflight required.');
+
+// Source: secure local context.
+//
+// All top-level navigations unaffected by Local Network Access.
+
+subsetTestByKey(
+    'from-local', promise_test, t => navigateTest(t, {
+                                  source: Server.HTTP_LOCAL,
+                                  target: Server.HTTP_LOOPBACK,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-local', promise_test, t => navigateTest(t, {
+                                  source: Server.HTTP_LOCAL,
+                                  target: Server.HTTP_LOCAL,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to local: no permission required.');
+
+subsetTestByKey(
+    'from-local', promise_test, t => navigateTest(t, {
+                                  source: Server.HTTP_LOCAL,
+                                  target: Server.HTTP_PUBLIC,
+                                  expected: NavigationTestResult.SUCCESS,
+                                }),
+    'local to public: no permission required.');
+
+// Source: secure public context.
+//
+// All top-level navigations unaffected by Local Network Access
+
+subsetTestByKey(
+    'from-public', promise_test, t => navigateTest(t, {
+                                   source: Server.HTTP_PUBLIC,
+                                   target: Server.HTTP_LOOPBACK,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-public', promise_test, t => navigateTest(t, {
+                                   source: Server.HTTP_PUBLIC,
+                                   target: Server.HTTP_LOCAL,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to local: no permission required.');
+
+subsetTestByKey(
+    'from-public', promise_test, t => navigateTest(t, {
+                                   source: Server.HTTP_PUBLIC,
+                                   target: Server.HTTP_PUBLIC,
+                                   expected: NavigationTestResult.SUCCESS,
+                                 }),
+    'public to public: no permission required.');
+
+// The following tests verify that `CSP: treat-as-public-address` makes
+// documents behave as if they had been served from a public IP address.
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTP_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.OTHER_HTTP_LOOPBACK,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to loopback: no permission required.');
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTP_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTP_LOOPBACK,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to loopback (same-origin): no permission required.');
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTP_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTP_LOCAL,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to local: no permission required.');
+
+subsetTestByKey(
+    'from-treat-as-public', promise_test,
+    t => navigateTest(t, {
+      source: {
+        server: Server.HTTP_LOOPBACK,
+        treatAsPublic: true,
+      },
+      target: Server.HTTP_PUBLIC,
+      expected: NavigationTestResult.SUCCESS,
+    }),
+    'treat-as-public-address to public: no permission required.');

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/iframer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/iframer.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Iframer</title>
+
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="support.sub.js"></script>
+<script>
+"use strict";
+
+// Set the 'local-network-access' permission then attempt to iframe a resource
+// in the local address space.
+//
+// By default, 'local-network-access' permission is set to 'granted'. This can
+// be changed by passing in a different value via the 'permission' URL parameter.
+// Valid values:
+//
+//    * granted
+//    * denied
+//    * prompt
+Promise.resolve().then(async () => {
+    const window_url = new URL(window.location.href);
+    let permission_value = 'granted';
+    if (window_url.searchParams.has('permission')) {
+        permission_value = window_url.searchParams.get('permission');
+    }
+
+    test_driver.set_test_context(opener);
+    await test_driver.set_permission({ name: 'local-network-access' }, permission_value);
+
+    const child = document.createElement('iframe');
+    child.src = new URL(window.location).searchParams.get('url');
+    document.body.appendChild(child);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/navigate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/navigate.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigate</title>
+<body></body>
+<script>
+  const window_url = new URL(window.location.href);
+  targetUrl = window_url.searchParams.get('url');
+  window.location.href = targetUrl;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/openee.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/openee.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Openee</title>
+<script>
+  // Message back to whatever caused this page to load that it was successful.
+  top.opener.postMessage({ message: "loaded" }, "*");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/w3c-import.log
@@ -17,5 +17,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local-http.html
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-local.html
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/fetch-public-http-wrong-address-space.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/iframer.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/navigate.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/openee.html
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/support.sub.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/target.py

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/w3c-import.log
@@ -17,3 +17,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md
 /LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/fetch.tentative.https.html
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.js

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2110,6 +2110,8 @@ imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-constr
 imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-importscripts.https.sub.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-importscripts.sub.html [ DumpJSConsoleLogInStdErr ]
 
+imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.html [ Failure ]
+
 imported/w3c/web-platform-tests/fetch/private-network-access/service-worker-fetch.https.window.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.window.html [ DumpJSConsoleLogInStdErr ]
 


### PR DESCRIPTION
#### c1266359aee03e8061ea3e661f49fa4119424bad
<pre>
Upload WPT Local-Network Access Tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=295049">https://bugs.webkit.org/show_bug.cgi?id=295049</a>
<a href="https://rdar.apple.com/154416306">rdar://154416306</a>

Reviewed by Alex Christensen.

Uploaded LNA tests, runtime flag is enabled in resources/support.sub.js

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/README.md:
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/iframe.tentative.https.window.js: Added.
(setup):
(makePermissionTests):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.https.window.js: Added.
(setup):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/navigate.tentative.window.js: Added.
(setup):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/iframer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/navigate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/openee.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/support.sub.js:
(Server):
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/fetch/local-network-access/w3c-import.log:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298608@main">https://commits.webkit.org/298608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ade39999fac203ab1546f602d7265678d5e6b94a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122047 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88115 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125150 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41908 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19791 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42725 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->