### PR TITLE
Move isRelativeGridTrackBreadthAsAuto off GridTrackSizingAlgorithm.

### DIFF
--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -361,6 +361,15 @@ void updateAutoMarginsInColumnAxisIfNeeded(RenderBox& gridItem, WritingMode writ
         gridItem.setMarginAfter(availableAlignmentSpace, writingMode);
 }
 
+bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength& length, std::optional<LayoutUnit> availableSpace)
+{
+    return length.isPercentOrCalculated() && !availableSpace;
+}
+bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth& length, std::optional<LayoutUnit> availableSpace)
+{
+    return length.isPercentOrCalculated() && !availableSpace;
+}
+
 } // namespace GridLayoutFunctions
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -32,6 +32,8 @@ namespace WebCore {
 
 namespace Style {
 enum class GridTrackSizingDirection : bool;
+class GridTrackBreadth;
+struct GridTrackFitContentLength;
 }
 
 class GridSpan;
@@ -93,6 +95,9 @@ LayoutUnit availableAlignmentSpaceForGridItemBeforeStretching(const RenderGrid&,
 void updateAutoMarginsIfNeeded(RenderBox&, WritingMode);
 void updateAutoMarginsInRowAxisIfNeeded(RenderBox&, WritingMode);
 void updateAutoMarginsInColumnAxisIfNeeded(RenderBox&, WritingMode);
+
+bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength&, std::optional<LayoutUnit> availableSpace);
+bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth&, std::optional<LayoutUnit> availableSpace);
 
 } // namespace GridLayoutFunctions
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -825,7 +825,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForG
         // or are running the track sizing algorithm in the opposite direction and haven't run it in the desired direction yet.
         const auto& trackSize = wasSetup() ? calculateGridTrackSize(direction, trackPosition) : rawGridTrackSize(direction, trackPosition);
         auto& maxTrackSize = trackSize.maxTrackBreadth();
-        if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || isRelativeGridTrackBreadthAsAuto(maxTrackSize, direction))
+        if (maxTrackSize.isContentSized() || maxTrackSize.isFlex() || GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(maxTrackSize, availableSpace(direction)))
             gridAreaIsIndefinite = true;
         else
             gridAreaSize += Style::evaluate(maxTrackSize.length(), availableSize.value_or(0_lu));
@@ -881,16 +881,6 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForGridItem(c
     return computeGridSpanSize(tracks(direction), span, addContentAlignmentOffset ? std::make_optional(m_renderGrid->gridItemOffset(direction)) : std::nullopt, m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSpace(direction)));
 }
 
-bool GridTrackSizingAlgorithm::isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength& length, Style::GridTrackSizingDirection direction) const
-{
-    return length.isPercentOrCalculated() && !availableSpace(direction);
-}
-
-bool GridTrackSizingAlgorithm::isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth& length, Style::GridTrackSizingDirection direction) const
-{
-    return length.isPercentOrCalculated() && !availableSpace(direction);
-}
-
 bool GridTrackSizingAlgorithm::isIntrinsicSizedGridArea(const RenderBox& gridItem, Style::GridTrackSizingDirection gridAreaDirection) const
 {
     ASSERT(wasSetup());
@@ -920,7 +910,7 @@ Style::GridTrackSize GridTrackSizingAlgorithm::calculateGridTrackSize(Style::Gri
 
     auto& trackSize = rawGridTrackSize(direction, translatedIndex);
     if (trackSize.isFitContent()) {
-        if (isRelativeGridTrackBreadthAsAuto(trackSize.fitContentTrackLength(), direction))
+        if (GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(trackSize.fitContentTrackLength(), availableSpace(direction)))
             return Style::GridTrackSize::MinMax { CSS::Keyword::Auto { }, CSS::Keyword::MaxContent { } };
         return trackSize;
     }
@@ -929,9 +919,9 @@ Style::GridTrackSize GridTrackSizingAlgorithm::calculateGridTrackSize(Style::Gri
     auto maxTrackBreadth = trackSize.maxTrackBreadth();
     // If the logical width/height of the grid container is indefinite, percentage
     // values are treated as <auto>.
-    if (isRelativeGridTrackBreadthAsAuto(trackSize.minTrackBreadth(), direction))
+    if (GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(trackSize.minTrackBreadth(), availableSpace(direction)))
         minTrackBreadth = CSS::Keyword::Auto { };
-    if (isRelativeGridTrackBreadthAsAuto(trackSize.maxTrackBreadth(), direction))
+    if (GridLayoutFunctions::isRelativeGridTrackBreadthAsAuto(trackSize.maxTrackBreadth(), availableSpace(direction)))
         maxTrackBreadth = CSS::Keyword::Auto { };
 
     // Flex sizes are invalid as a min sizing function. However we still can have a flexible |minTrackBreadth|

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -186,8 +186,6 @@ private:
     };
 
     std::optional<LayoutUnit> availableSpace() const;
-    bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength&, Style::GridTrackSizingDirection) const;
-    bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth&, Style::GridTrackSizingDirection) const;
     Style::GridTrackSize calculateGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
     const Style::GridTrackSize& rawGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
 


### PR DESCRIPTION
#### c70fe338b4dda60a8e5f95cb975704ff956af634
<pre>
Move isRelativeGridTrackBreadthAsAuto off GridTrackSizingAlgorithm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297245">https://bugs.webkit.org/show_bug.cgi?id=297245</a>
<a href="https://rdar.apple.com/problem/158074814">rdar://problem/158074814</a>

Reviewed by Brandon Stewart and Vitor Roriz.

This function currently lives on GridTrackSizingAlgorithm but there is
no need for that since it&apos;s used to determine some sort of
characteristic of a grid track&apos;s style. All that is required to make
this determination is the track itself and any available space. We can
instead move this over to GridLayoutFunctions and have it take in the
available space as an argument. This will make it a bit easier to move
some other functions off of GridTrackSizingAlgorithm which depend on
this one (calculateGridTrackSize and rawGridTrackSize). Since the logic
of those functions is a bit more involved, I don&apos;t want to include them
in this patch to keep the diffs for each patch focused.

Canonical link: <a href="https://commits.webkit.org/298554@main">https://commits.webkit.org/298554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3054742f39c4ac957cf1c3b9caa978fbf5a7f90c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121936 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66411 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f3b36c00-233d-448d-a8fd-f980f66f2356) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88024 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c48af3ea-5eab-458d-937f-08fae9bbafa4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68437 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65606 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125088 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96778 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24565 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38696 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42663 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48252 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->