### PR TITLE
AX: WebAccessibilityObjectWrapperBase::_identifier isn't a very useful field and causes every wrapper to be 8 bytes larger than necessary

### DIFF
--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -181,7 +181,7 @@ bool AXIsolatedObject::isDetached() const
 
 void AXIsolatedObject::attachPlatformWrapper(AccessibilityObjectWrapper* wrapper)
 {
-    [wrapper attachIsolatedObject:this];
+    [wrapper attachIsolatedObject:*this];
     setWrapper(wrapper);
 }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -69,13 +69,11 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const Si
     // or invalid IDs)? https://bugs.webkit.org/show_bug.cgi?id=293262
     std::atomic<bool> m_isolatedObjectInitialized;
 #endif
-
-    Markable<WebCore::AXID> _identifier;
 }
 
 - (id)initWithAccessibilityObject:(WebCore::AccessibilityObject&)axObject;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-- (void)attachIsolatedObject:(WebCore::AXIsolatedObject*)isolatedObject;
+- (void)attachIsolatedObject:(WebCore::AXIsolatedObject&)isolatedObject;
 - (BOOL)hasIsolatedObject;
 #endif
 
@@ -83,8 +81,6 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node&, StringView, const Si
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 - (void)detachIsolatedObject:(WebCore::AccessibilityDetachmentType)detachmentType;
 #endif
-
-@property (nonatomic, assign) Markable<WebCore::AXID> identifier;
 
 // FIXME: unified these two methods into one.
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 4f518cd6ec326624d90cf96840d963f23d543e85
<pre>
AX: WebAccessibilityObjectWrapperBase::_identifier isn&apos;t a very useful field and causes every wrapper to be 8 bytes larger than necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=297253">https://bugs.webkit.org/show_bug.cgi?id=297253</a>
<a href="https://rdar.apple.com/158085042">rdar://158085042</a>

Reviewed by Joshua Hoffman.

Remove this unnecessary field. The limited utility it had can be expressed in terms of the other member variables.

This reduces the size of every iOS and macOS wrapper from 48 bytes to 40 bytes.

* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::attachPlatformWrapper):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase attachAXObject:]):
(-[WebAccessibilityObjectWrapperBase attachIsolatedObject:]):
(-[WebAccessibilityObjectWrapperBase detach]):

Canonical link: <a href="https://commits.webkit.org/298566@main">https://commits.webkit.org/298566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d31aba6972b604df8760361d3ac5ffe9499c322a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66383 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88005 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68412 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22076 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65579 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125061 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96760 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24570 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19679 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38669 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42103 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->