### PR TITLE
[JSC] Inline WasmGC object allocations in OMG

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -830,13 +830,23 @@ private:
     Value* emitAtomicCompareExchange(ExtAtomicOpType, Type, Value* pointer, Value* expected, Value*, uint32_t offset);
 
     Value* decodeNonNullStructure(Value* structureID);
+    Value* encodeStructureID(Value* structure);
+
+    Value* allocatorForWasmGCHeapCellSize(Value* size, BasicBlock* slowPath);
+    Value* allocateWasmGCHeapCell(Value* allocator, BasicBlock* slowPath);
+    Value* allocateWasmGCObject(Value* allocator, Value* structure, Value* typeInfo, BasicBlock* slowPath);
+    Value* allocateWasmGCArrayUninitialized(uint32_t typeIndex, Value* size);
+    Value* allocateWasmGCStructUninitialized(uint32_t typeIndex);
+
+    void mutatorFence();
 
     Value* emitGetArrayPayloadBase(Wasm::StorageType, Value*);
     void emitArrayNullCheck(Value*, ExceptionType);
     void emitArraySetUnchecked(uint32_t, Value*, Value*, Value*);
+    void emitArraySetUncheckedWithoutWriteBarrier(uint32_t, Value*, Value*, Value*);
     // Returns true if a writeBarrier/mutatorFence is needed.
     bool WARN_UNUSED_RETURN emitStructSet(Value*, uint32_t, const StructType&, Value*);
-    ExpressionType WARN_UNUSED_RETURN pushArrayNew(uint32_t typeIndex, Value* initValue, ExpressionType size);
+    Value* WARN_UNUSED_RETURN allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size);
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
     ExpressionType WARN_UNUSED_RETURN pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
     void emitRefTestOrCast(CastKind, ExpressionType, bool, int32_t, bool, ExpressionType&);
@@ -3051,36 +3061,60 @@ auto OMGIRGenerator::addI31GetU(ExpressionType ref, ExpressionType& result) -> P
     return { };
 }
 
-Variable* OMGIRGenerator::pushArrayNew(uint32_t typeIndex, Value* initValue, ExpressionType size)
+Value* OMGIRGenerator::allocateWasmGCArray(uint32_t typeIndex, Value* initValue, Value* size)
 {
     StorageType elementType;
     getArrayElementType(typeIndex, elementType);
 
-    // FIXME: Emit this inline.
-    // https://bugs.webkit.org/show_bug.cgi?id=245405
-    Value* resultValue;
-    if (!elementType.unpacked().isV128()) {
-        resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::Arrayref), operationWasmArrayNew,
-            instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
-            get(size), initValue);
-    } else {
-        Value* lane0 = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, B3::Int64, SIMDLane::i64x2, SIMDSignMode::None, uint8_t { 0 }, initValue);
-        Value* lane1 = m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, B3::Int64, SIMDLane::i64x2, SIMDSignMode::None, uint8_t { 1 }, initValue);
-        resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::Arrayref), operationWasmArrayNewVector,
-            instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
-            get(size), lane0, lane1);
-    }
+    auto* object = allocateWasmGCArrayUninitialized(typeIndex, size);
 
+    auto* loopHeader = m_proc.addBlock();
+    auto* loopBody = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    auto* payload = emitGetArrayPayloadBase(elementType, object);
+    auto* remainingUpsilon = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), size));
+
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), loopHeader);
+    loopHeader->addPredecessor(m_currentBlock);
+    m_currentBlock = loopHeader;
+
+    Value* remaining = m_currentBlock->appendNew<Value>(m_proc, Phi, pointerType(), origin());
+    remainingUpsilon->setPhi(remaining);
     {
-        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), resultValue, m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()))));
-
-        check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-            this->emitExceptionCheck(jit, origin, ExceptionType::BadArrayNew);
-        });
+        Value* condition = m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), remaining, constant(pointerType(), 0));
+        m_currentBlock->appendNewControlValue(m_proc, Branch, origin(), condition, FrequentedBlock(continuation), FrequentedBlock(loopBody));
+        continuation->addPredecessor(m_currentBlock);
+        loopBody->addPredecessor(m_currentBlock);
     }
 
-    return push(resultValue);
+    m_currentBlock = loopBody;
+    auto* updatedRemaining = m_currentBlock->appendNew<Value>(m_proc, Sub, pointerType(), origin(), remaining, constant(pointerType(), 1));
+    auto* updatedRemainingUpsilon = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), updatedRemaining);
+    updatedRemainingUpsilon->setPhi(remaining);
+
+    Value* indexedAddress = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), payload, m_currentBlock->appendNew<Value>(m_proc, Mul, pointerType(), origin(), updatedRemaining, constant(pointerType(), elementType.elementSize())));
+
+    if (elementType.is<PackedType>()) {
+        switch (elementType.as<PackedType>()) {
+        case PackedType::I8:
+            m_currentBlock->appendNew<MemoryValue>(m_proc, Store8, origin(), initValue, indexedAddress);
+            break;
+        case PackedType::I16:
+            m_currentBlock->appendNew<MemoryValue>(m_proc, Store16, origin(), initValue, indexedAddress);
+            break;
+        }
+    } else {
+        ASSERT(elementType.is<Type>());
+        m_currentBlock->appendNew<MemoryValue>(m_proc, Store, origin(), initValue, indexedAddress);
+    }
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), FrequentedBlock(loopHeader));
+    loopHeader->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
+    mutatorFence();
+
+    return object;
 }
 
 // Given a type index, verify that it's an array type and return its expansion
@@ -3116,16 +3150,9 @@ auto OMGIRGenerator::addArrayNew(uint32_t typeIndex, ExpressionType size, Expres
 #endif
 
     Value* initValue = get(value);
-    if (value->type() == B3::Float || value->type() == B3::Double) {
-        initValue = m_currentBlock->appendNew<Value>(m_proc, BitwiseCast, origin(), initValue);
-        if (initValue->type() == B3::Int32)
-            initValue = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), initValue);
-    }
-
-    result = pushArrayNew(typeIndex, initValue, size);
-
-    emitArrayNullCheck(get(result), ExceptionType::BadArrayNew);
-
+    Value* sizeValue = get(size);
+    Value* array = allocateWasmGCArray(typeIndex, initValue, sizeValue);
+    result = push(array);
     return { };
 }
 
@@ -3144,14 +3171,22 @@ Variable* OMGIRGenerator::pushArrayNewFromSegment(ArraySegmentOperation operatio
 
 auto OMGIRGenerator::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result) -> PartialResult
 {
-    Type resultType;
-    getArrayRefType(typeIndex, resultType);
+    StorageType elementType;
+    getArrayElementType(typeIndex, elementType);
 
-    result = push(callWasmOperation(m_currentBlock, toB3Type(resultType), operationWasmArrayNewEmpty,
-        instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex), get(size)));
+    Value* initValue = nullptr;
+    if (isRefType(elementType.unpacked()))
+        initValue = m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()));
+    else if (elementType.elementSize() == 16)
+        initValue = m_currentBlock->appendNew<Const128Value>(m_proc, origin(), v128_t { });
+    else if (elementType.elementSize() <= 4)
+        initValue = m_currentBlock->appendNew<Const32Value>(m_proc, origin(), 0);
+    else
+        initValue = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), 0);
 
-    emitArrayNullCheck(get(result), ExceptionType::BadArrayNew);
-
+    Value* sizeValue = get(size);
+    Value* array = allocateWasmGCArray(typeIndex, initValue, sizeValue);
+    result = push(array);
     return { };
 }
 
@@ -3170,27 +3205,19 @@ auto OMGIRGenerator::addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentInd
 
 auto OMGIRGenerator::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result) -> PartialResult
 {
-    // Get the result type for the array.new_fixed operation
-    Type resultType;
-    getArrayRefType(typeIndex, resultType);
+    StorageType elementType;
+    getArrayElementType(typeIndex, elementType);
 
-    // Allocate an uninitialized array whose length matches the argument count
-
-    // FIXME: inline the allocation.
-    // https://bugs.webkit.org/show_bug.cgi?id=244388
-    Value* arrayValue = callWasmOperation(m_currentBlock, toB3Type(resultType), operationWasmArrayNewEmpty,
-        instanceValue(), m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex),
-        m_currentBlock->appendNew<Const32Value>(m_proc, origin(), args.size()));
-
-    emitArrayNullCheck(arrayValue, ExceptionType::BadArrayNew);
+    auto* size = constant(Int32, args.size());
+    auto* object = allocateWasmGCArrayUninitialized(typeIndex, size);
 
     for (uint32_t i = 0; i < args.size(); ++i) {
         // Emit the array set code -- note that this omits the bounds check, since
         // if operationWasmArrayNewEmpty() returned a non-null value, it's an array of the right size
-        emitArraySetUnchecked(typeIndex, arrayValue, m_currentBlock->appendNew<Const32Value>(m_proc, origin(), i), get(args[i]));
+        emitArraySetUncheckedWithoutWriteBarrier(typeIndex, object, m_currentBlock->appendNew<Const32Value>(m_proc, origin(), i), get(args[i]));
     }
-    result = push(arrayValue);
-
+    mutatorFence();
+    result = push(object);
     return { };
 }
 
@@ -3284,7 +3311,7 @@ Value* OMGIRGenerator::emitGetArrayPayloadBase(Wasm::StorageType fieldType, Valu
 
 // Does the array set without null check and bounds checks -- can be
 // called directly by addArrayNewFixed()
-void OMGIRGenerator::emitArraySetUnchecked(uint32_t typeIndex, Value* arrayref, Value* index, Value* setValue)
+void OMGIRGenerator::emitArraySetUncheckedWithoutWriteBarrier(uint32_t typeIndex, Value* arrayref, Value* index, Value* setValue)
 {
     StorageType elementType;
     getArrayElementType(typeIndex, elementType);
@@ -3308,11 +3335,17 @@ void OMGIRGenerator::emitArraySetUnchecked(uint32_t typeIndex, Value* arrayref, 
 
     ASSERT(elementType.is<Type>());
     m_currentBlock->appendNew<MemoryValue>(m_proc, memoryKind(Store), origin(), setValue, indexedAddress);
+}
 
+void OMGIRGenerator::emitArraySetUnchecked(uint32_t typeIndex, Value* arrayref, Value* index, Value* setValue)
+{
+    emitArraySetUncheckedWithoutWriteBarrier(typeIndex, arrayref, index, setValue);
+    StorageType elementType;
+    getArrayElementType(typeIndex, elementType);
     if (isRefType(elementType.unpacked()))
         emitWriteBarrier(arrayref, instanceValue());
-    return;
 }
+
 
 auto OMGIRGenerator::addArraySet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType value) -> PartialResult
 {
@@ -3458,54 +3491,20 @@ auto OMGIRGenerator::addArrayInitData(uint32_t, ExpressionType dst, ExpressionTy
 
 auto OMGIRGenerator::addStructNew(uint32_t typeIndex, ArgumentList& args, ExpressionType& result) -> PartialResult
 {
-    const auto type = Type { TypeKind::Ref, m_info.typeSignatures[typeIndex]->index() };
-
-    // FIXME: inline the allocation.
-    // https://bugs.webkit.org/show_bug.cgi?id=244388
-    Value* structValue = callWasmOperation(m_currentBlock, toB3Type(type), operationWasmStructNewEmpty,
-        instanceValue(),
-        m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex));
-
-    {
-        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), structValue, m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()))));
-        check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-            this->emitExceptionCheck(jit, origin, ExceptionType::BadStructNew);
-        });
-    }
-
+    Value* structValue = allocateWasmGCStructUninitialized(typeIndex);
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
-    bool needsWriteBarrier = false;
-    for (uint32_t i = 0; i < args.size(); ++i)
-        needsWriteBarrier |= emitStructSet(structValue, i, structType, get(args[i]));
-
-    // FIXME: This just needs to be a mutator fence.
-    if (needsWriteBarrier)
-        emitWriteBarrier(structValue, instanceValue());
-
+    for (uint32_t i = 0; i < args.size(); ++i) {
+        bool needsWriteBarrier = emitStructSet(structValue, i, structType, get(args[i]));
+        UNUSED_VARIABLE(needsWriteBarrier);
+    }
+    mutatorFence();
     result = push(structValue);
-
     return { };
 }
 
 auto OMGIRGenerator::addStructNewDefault(uint32_t typeIndex, ExpressionType& result) -> PartialResult
 {
-    const auto type = Type { TypeKind::Ref, m_info.typeSignatures[typeIndex]->index() };
-
-    // FIXME: inline the allocation.
-    // https://bugs.webkit.org/show_bug.cgi?id=244388
-    Value* structValue = callWasmOperation(m_currentBlock, toB3Type(type), operationWasmStructNewEmpty,
-        instanceValue(),
-        m_currentBlock->appendNew<Const32Value>(m_proc, origin(), typeIndex));
-
-    {
-        CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(),
-            m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), structValue, m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()))));
-        check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
-            this->emitExceptionCheck(jit, origin, ExceptionType::BadStructNew);
-        });
-    }
-
+    Value* structValue = allocateWasmGCStructUninitialized(typeIndex);
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
     for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
         Value* initValue;
@@ -3519,9 +3518,8 @@ auto OMGIRGenerator::addStructNewDefault(uint32_t typeIndex, ExpressionType& res
         bool needsWriteBarrier = emitStructSet(structValue, i, structType, initValue);
         UNUSED_VARIABLE(needsWriteBarrier);
     }
-
+    mutatorFence();
     result = push(structValue);
-
     return { };
 }
 
@@ -3811,6 +3809,202 @@ Value* OMGIRGenerator::decodeNonNullStructure(Value* structureID)
         m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), structureID),
         constant(pointerType(), startOfStructureHeap()));
 #endif
+}
+
+Value* OMGIRGenerator::encodeStructureID(Value* structure)
+{
+#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
+    return m_currentBlock->appendNew<B3::Value>(m_proc, B3::Trunc, origin(), m_currentBlock->appendNew<Value>(m_proc, ZShr, origin(), structure, m_currentBlock->appendNew<Const32Value>(m_proc, origin(), StructureID::encodeShiftAmount)));
+#else
+    return m_currentBlock->appendNew<B3::Value>(m_proc, B3::Trunc, origin(), m_currentBlock->appendNew<Value>(m_proc, B3::BitAnd, origin(), structure, constant(pointerType(), StructureID::structureIDMask)));
+#endif
+}
+
+Value* OMGIRGenerator::allocatorForWasmGCHeapCellSize(Value* sizeInBytes, BasicBlock* slowPath)
+{
+    static_assert(!(MarkedSpace::sizeStep & (MarkedSpace::sizeStep - 1)), "MarkedSpace::sizeStep must be a power of two.");
+
+    ptrdiff_t allocatorBufferBaseOffset = JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info.importFunctionCount(), m_info.tableCount(), m_info.globalCount(), m_info.typeCount(), 0);
+
+    unsigned stepShift = getLSBSet(MarkedSpace::sizeStep);
+
+    auto* continuation = m_proc.addBlock();
+
+    auto* sizeClassIndex = m_currentBlock->appendNew<Value>(m_proc, ZShr, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, B3::Add, origin(), sizeInBytes, constant(pointerType(), MarkedSpace::sizeStep - 1)),
+        m_currentBlock->appendNew<Const32Value>(m_proc, origin(), stepShift));
+
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, Above, origin(), sizeClassIndex, constant(pointerType(), MarkedSpace::largeCutoff >> stepShift)),
+        FrequentedBlock(slowPath, FrequencyClass::Rare), FrequentedBlock(continuation));
+    m_currentBlock->setSuccessors(FrequentedBlock(slowPath, FrequencyClass::Rare), FrequentedBlock(continuation));
+    slowPath->addPredecessor(m_currentBlock);
+    continuation->addPredecessor(m_currentBlock);
+    m_currentBlock = continuation;
+
+    Value* address = m_currentBlock->appendNew<Value>(m_proc, Add, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, B3::Add, origin(), instanceValue(), constant(pointerType(), allocatorBufferBaseOffset)),
+        m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), sizeClassIndex, constant(pointerType(), sizeof(Allocator))));
+    return m_currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), origin(), address);
+}
+
+Value* OMGIRGenerator::allocateWasmGCHeapCell(Value* allocator, BasicBlock* slowPath)
+{
+    auto* continuation = m_proc.addBlock();
+    auto* patchpoint = m_currentBlock->appendNew<B3::PatchpointValue>(m_proc, pointerType(), origin());
+    if (isARM64()) {
+        // emitAllocateWithNonNullAllocator uses the scratch registers on ARM.
+        patchpoint->clobber(RegisterSetBuilder::macroClobberedGPRs());
+    }
+    patchpoint->effects.terminal = true;
+    patchpoint->appendSomeRegisterWithClobber(allocator);
+    patchpoint->numGPScratchRegisters++;
+    patchpoint->resultConstraints = { ValueRep::SomeEarlyRegister };
+
+    patchpoint->setGenerator(
+        [=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+            AllowMacroScratchRegisterUsageIf allowScratchIf(jit, isARM64());
+            CCallHelpers::JumpList jumpToSlowPath;
+
+            GPRReg allocatorGPR = params[1].gpr();
+
+            // We use a patchpoint to emit the allocation path because whenever we mess with
+            // allocation paths, we already reason about them at the machine code level. We know
+            // exactly what instruction sequence we want. We're confident that no compiler
+            // optimization could make this code better. So, it's best to have the code in
+            // AssemblyHelpers::emitAllocate(). That way, the same optimized path is shared by
+            // all of the compiler tiers.
+            jit.emitAllocateWithNonNullAllocator(
+                params[0].gpr(), JITAllocator::variable(), allocatorGPR, params.gpScratch(0),
+                jumpToSlowPath, CCallHelpers::SlowAllocationResult::UndefinedBehavior);
+
+            CCallHelpers::Jump jumpToSuccess;
+            if (!params.fallsThroughToSuccessor(0))
+                jumpToSuccess = jit.jump();
+
+            Vector<Box<CCallHelpers::Label>> labels = params.successorLabels();
+
+            params.addLatePath(
+                [=] (CCallHelpers& jit) {
+                    jumpToSlowPath.linkTo(*labels[1], &jit);
+                    if (jumpToSuccess.isSet())
+                        jumpToSuccess.linkTo(*labels[0], &jit);
+                });
+        });
+
+    m_currentBlock->appendSuccessor({ continuation, FrequencyClass::Normal });
+    m_currentBlock->appendSuccessor({ slowPath, FrequencyClass::Rare });
+
+    m_currentBlock = continuation;
+    return patchpoint;
+}
+
+Value* OMGIRGenerator::allocateWasmGCObject(Value* allocator, Value* structure, Value* typeInfo, BasicBlock* slowPath)
+{
+    auto* cell = allocateWasmGCHeapCell(allocator, slowPath);
+    auto* structureID = encodeStructureID(structure);
+    m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), structureID, cell, safeCast<int32_t>(JSCell::structureIDOffset()));
+    m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), typeInfo, cell, safeCast<int32_t>(JSCell::indexingTypeAndMiscOffset()));
+    m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), constant(pointerType(), 0), cell, safeCast<int32_t>(JSObject::butterflyOffset()));
+    return cell;
+}
+
+Value* OMGIRGenerator::allocateWasmGCArrayUninitialized(uint32_t typeIndex, Value* size)
+{
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    auto* structure = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfGCObjectStructure(m_info.importFunctionCount(), m_info.tableCount(), m_info.globalCount(), typeIndex)));
+    const ArrayType* typeDefinition = m_info.typeSignatures[typeIndex]->expand().template as<ArrayType>();
+    size_t elementSize = typeDefinition->elementType().type.elementSize();
+    auto* extended = m_currentBlock->appendNew<Value>(m_proc, ZExt32, origin(), size);
+    auto* shifted = m_currentBlock->appendNew<Value>(m_proc, Shl, origin(), extended, constant(Int32, getLSBSet(elementSize)));
+    auto* sizeInBytes = m_currentBlock->appendNew<Value>(m_proc, Add, pointerType(), origin(), shifted, constant(pointerType(), sizeof(JSWebAssemblyArray)));
+    auto* allocator = allocatorForWasmGCHeapCellSize(sizeInBytes, slowPath);
+    auto* typeInfo = constant(Int32, JSWebAssemblyArray::typeInfoBlob().blob());
+    auto* cell = allocateWasmGCObject(allocator, structure, typeInfo, slowPath);
+    auto* fastValue = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), cell);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    auto* slowResult = callWasmOperation(m_currentBlock, toB3Type(Types::Arrayref), operationWasmArrayNewEmpty,
+        instanceValue(), constant(Int32, typeIndex), size);
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), slowResult, m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()))));
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, ExceptionType::BadArrayNew);
+    });
+    auto* slowValue = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), slowResult);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
+    auto* result = m_currentBlock->appendNew<Value>(m_proc, Phi, pointerType(), origin());
+    fastValue->setPhi(result);
+    slowValue->setPhi(result);
+
+    m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), size, result, safeCast<int32_t>(JSWebAssemblyArray::offsetOfSize()));
+    return result;
+}
+
+Value* OMGIRGenerator::allocateWasmGCStructUninitialized(uint32_t typeIndex)
+{
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    auto* structure = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfGCObjectStructure(m_info.importFunctionCount(), m_info.tableCount(), m_info.globalCount(), typeIndex)));
+    const StructType* typeDefinition = m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
+    Value* sizeInBytes = constant(pointerType(), JSWebAssemblyStruct::allocationSize(typeDefinition->instancePayloadSize()));
+    auto* allocator = allocatorForWasmGCHeapCellSize(sizeInBytes, slowPath);
+    auto* typeInfo = constant(Int32, JSWebAssemblyStruct::typeInfoBlob().blob());
+    auto* cell = allocateWasmGCObject(allocator, structure, typeInfo, slowPath);
+    auto* fastValue = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), cell);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    const auto type = Type { TypeKind::Ref, m_info.typeSignatures[typeIndex]->index() };
+    auto* slowResult = callWasmOperation(m_currentBlock, toB3Type(type), operationWasmStructNewEmpty,
+        instanceValue(), constant(Int32, typeIndex));
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), slowResult, m_currentBlock->appendNew<WasmConstRefValue>(m_proc, origin(), JSValue::encode(jsNull()))));
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, ExceptionType::BadStructNew);
+    });
+    auto* slowValue = m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), slowResult);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
+    auto* result = m_currentBlock->appendNew<Value>(m_proc, Phi, pointerType(), origin());
+    fastValue->setPhi(result);
+    slowValue->setPhi(result);
+
+    m_currentBlock->appendNew<B3::MemoryValue>(m_proc, B3::Store, origin(), constant(Int32, typeDefinition->instancePayloadSize()), result, safeCast<int32_t>(JSWebAssemblyStruct::offsetOfSize()));
+    return result;
+}
+
+void OMGIRGenerator::mutatorFence()
+{
+    if (isX86()) {
+        m_currentBlock->appendNew<FenceValue>(m_proc, origin());
+        return;
+    }
+
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+
+    Value* vm = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfVM()));
+    Value* shouldFence = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), vm, safeCast<int32_t>(VM::offsetOfHeapMutatorShouldBeFenced()));
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), shouldFence, FrequentedBlock(slowPath, FrequencyClass::Rare), FrequentedBlock(continuation));
+    slowPath->addPredecessor(m_currentBlock);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    m_currentBlock->appendNew<FenceValue>(m_proc, origin());
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
 }
 
 Value* OMGIRGenerator::emitLoadRTTFromObject(Value* reference)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -52,6 +52,7 @@ public:
 
     DECLARE_INFO;
 
+    static inline TypeInfoBlob typeInfoBlob();
     static inline WebAssemblyGCStructure* createStructure(VM&, JSGlobalObject*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
 
     static JSWebAssemblyArray* tryCreate(VM& vm, WebAssemblyGCStructure* structure, unsigned size);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
@@ -35,6 +35,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+
+TypeInfoBlob JSWebAssemblyArray::typeInfoBlob()
+{
+    return TypeInfoBlob(0, TypeInfo(WebAssemblyGCObjectType, StructureFlags));
+}
+
 WebAssemblyGCStructure* JSWebAssemblyArray::createStructure(VM& vm, JSGlobalObject* globalObject, Ref<const Wasm::TypeDefinition>&& type, Ref<const Wasm::RTT>&& rtt)
 {
     RELEASE_ASSERT(type->is<Wasm::ArrayType>());

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -52,6 +52,7 @@ public:
 
     DECLARE_INFO;
 
+    static inline TypeInfoBlob typeInfoBlob();
     static inline WebAssemblyGCStructure* createStructure(VM&, JSGlobalObject*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
     static JSWebAssemblyStruct* tryCreate(VM&, WebAssemblyGCStructure*);
     static JSWebAssemblyStruct* create(VM&, WebAssemblyGCStructure*);
@@ -76,6 +77,12 @@ protected:
     JSWebAssemblyStruct(VM&, WebAssemblyGCStructure*);
     DECLARE_DEFAULT_FINISH_CREATION;
 };
+
+
+TypeInfoBlob JSWebAssemblyStruct::typeInfoBlob()
+{
+    return TypeInfoBlob(0, TypeInfo(WebAssemblyGCObjectType, StructureFlags));
+}
 
 WebAssemblyGCStructure* JSWebAssemblyStruct::createStructure(VM& vm, JSGlobalObject* globalObject, Ref<const Wasm::TypeDefinition>&& type, Ref<const Wasm::RTT>&& rtt)
 {


### PR DESCRIPTION
#### 5c8bc53f18f94add32ef085f8a6799c74343e99a
<pre>
[JSC] Inline WasmGC object allocations in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=244388">https://bugs.webkit.org/show_bug.cgi?id=244388</a>
<a href="https://rdar.apple.com/99488201">rdar://99488201</a>

Reviewed by Keith Miller.

This patch adds inlined fast paths for WasmGC object allocations (WasmGC
array and struct) in OMG. We had this in BBQ, but not adding it into OMG
yet. Basically it is following to what FTL and BBQ are doing.

1. Getting allocators from Wasm Instnace, this is aligned to BBQ&apos;s fast
   path.
2. Doing some folding and optimizations similar to FTL&apos;s allocation
   path.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArray):
(JSC::Wasm::OMGIRGenerator::addArrayNew):
(JSC::Wasm::OMGIRGenerator::addArrayNewDefault):
(JSC::Wasm::OMGIRGenerator::addArrayNewFixed):
(JSC::Wasm::OMGIRGenerator::emitArraySetUncheckedWithoutWriteBarrier):
(JSC::Wasm::OMGIRGenerator::emitArraySetUnchecked):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):
(JSC::Wasm::OMGIRGenerator::encodeStructureID):
(JSC::Wasm::OMGIRGenerator::allocatorForWasmGCHeapCellSize):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCHeapCell):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCObject):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized):
(JSC::Wasm::OMGIRGenerator::mutatorFence):
(JSC::Wasm::OMGIRGenerator::pushArrayNew): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
(JSC::JSWebAssemblyArray::typeInfoBlob):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
(JSC::JSWebAssemblyStruct::typeInfoBlob):

Canonical link: <a href="https://commits.webkit.org/298551@main">https://commits.webkit.org/298551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fad01efcd848b95b5a3287384bd972f985307cd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66402 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2133f9a0-9612-497f-8e36-8d924c038fac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88018 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c63b4d8f-896b-472b-b0f2-fad38a698bd8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68429 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22087 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65597 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/107987 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125079 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114406 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96556 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19688 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38687 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48243 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/142736 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42121 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36896 "Found 7354 new JSC stress test failures: airjs-tests.yaml/stress-test.js.lockdown, basic-tests.yaml/stress-test.js.lockdown, cdjs-tests.yaml/main.js.lockdown, cdjs-tests.yaml/motion_test.js.lockdown, cdjs-tests.yaml/red_black_tree_test.js.lockdown, cdjs-tests.yaml/reduce_collision_set_test.js.lockdown, microbenchmarks/Float32Array-matrix-mult.js.lockdown, microbenchmarks/Int16Array-bubble-sort-with-byteLength.js.lockdown, microbenchmarks/Int16Array-bubble-sort.js.lockdown, microbenchmarks/Int16Array-load-int-mul.js.lockdown ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->