### PR TITLE
[view-transitions] Add `document.activeViewTransition`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-active-view-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-active-view-transition-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL document.activeViewTransition returns the active transition assert_equals: activeViewTransition is null initially expected (object) null but got (undefined) undefined
+PASS document.activeViewTransition returns the active transition
 

--- a/Source/WebCore/dom/Document+ViewTransition.idl
+++ b/Source/WebCore/dom/Document+ViewTransition.idl
@@ -25,4 +25,5 @@
 
 partial interface Document {
     [EnabledBySetting=ViewTransitionsEnabled] ViewTransition startViewTransition(optional (ViewTransitionUpdateCallback or StartViewTransitionOptions) callbackOptions = {});
+    [EnabledBySetting=ViewTransitionsEnabled] readonly attribute ViewTransition? activeViewTransition;
 };


### PR DESCRIPTION
#### 6173a67d29d58b538dd59a45b85a365bc75ace08
<pre>
[view-transitions] Add `document.activeViewTransition`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297255">https://bugs.webkit.org/show_bug.cgi?id=297255</a>
<a href="https://rdar.apple.com/158089900">rdar://158089900</a>

Reviewed by Vitor Roriz.

As per resolution: <a href="https://github.com/w3c/csswg-drafts/issues/12407#issuecomment-3129024378">https://github.com/w3c/csswg-drafts/issues/12407#issuecomment-3129024378</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/document-active-view-transition-expected.txt:
* Source/WebCore/dom/Document+ViewTransition.idl:

Canonical link: <a href="https://commits.webkit.org/298550@main">https://commits.webkit.org/298550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05797a051242aad318b07e7e2fa0fbcec3d7895a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66399 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67926825-3d19-48ae-903f-ac981dd0a933) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88015 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a492bb4-ac8e-4b90-893e-7dd52cfdbd07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68425 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22086 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65594 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125076 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42762 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32083 "Found 1 new test failure: http/tests/referrer-policy-anchor/no-referrer/cross-origin-http-http.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96768 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96554 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41821 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19687 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38684 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18518 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48240 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43825 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->