### PR TITLE
Rename LegacyRenderSVGTransformableContainer::m_lastTranslation

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -60,9 +60,9 @@ bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
     if (useElement) {
         SVGLengthContext lengthContext(element.ptr());
         FloatSize translation(useElement->x().value(lengthContext), useElement->y().value(lengthContext));
-        if (translation != m_lastTranslation)
+        if (translation != m_additionalTranslation)
             m_needsTransformUpdate = true;
-        m_lastTranslation = translation;
+        m_additionalTranslation = translation;
     }
 
     auto referenceBoxRect = transformReferenceBoxRect();
@@ -76,7 +76,7 @@ bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
         return false;
 
     m_localTransform = element->animatedLocalTransform();
-    m_localTransform.translate(m_lastTranslation);
+    m_localTransform.translate(m_additionalTranslation);
     m_needsTransformUpdate = false;
     return true;
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -47,7 +47,7 @@ private:
     bool m_needsTransformUpdate : 1;
     bool m_didTransformToRootUpdate : 1;
     AffineTransform m_localTransform;
-    FloatSize m_lastTranslation;
+    FloatSize m_additionalTranslation;
     FloatRect m_lastTransformReferenceBoxRect;
 };
 


### PR DESCRIPTION
#### 65811fd53c5cc3784a71c0da86330ce950823517
<pre>
Rename LegacyRenderSVGTransformableContainer::m_lastTranslation
<a href="https://bugs.webkit.org/show_bug.cgi?id=297256">https://bugs.webkit.org/show_bug.cgi?id=297256</a>
<a href="https://rdar.apple.com/problem/158091618">rdar://problem/158091618</a>

Reviewed by Simon Fraser.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/d08d007eb06c09515e72c2ec5fe4659ad7082443">https://chromium.googlesource.com/chromium/src.git/+/d08d007eb06c09515e72c2ec5fe4659ad7082443</a>

To m_additionalTranslation, since &apos;last&apos; is ambiguous. The &apos;additional&apos;
is from spec wording: &quot;An additional transformation translate(x,y) ...&quot;.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::calculateLocalTransform):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:

Canonical link: <a href="https://commits.webkit.org/298628@main">https://commits.webkit.org/298628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a7c5ebdda62eb6b7074b7d4e7711dee0209f7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66601 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88017 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68428 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48244 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->