### PR TITLE
[EWS] Add initial WPT export builder

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/test
+++ b/LayoutTests/imported/w3c/web-platform-tests/test
@@ -1,0 +1,1 @@
+hello test 1 2 3

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -215,7 +215,7 @@
     {
       "name": "Style-EWS", "shortname": "style", "icon": "testOnly",
       "factory": "StyleFactory", "platform": "*",
-      "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
+      "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
       "name": "Apply-WatchList-EWS", "shortname": "watchlist",
@@ -434,17 +434,17 @@
     {
       "name": "Bindings-Tests-EWS", "shortname": "bindings", "icon": "testOnly",
       "factory": "BindingsFactory", "platform": "*",
-      "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
+      "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
       "name": "WebKitPy-Tests-EWS", "shortname": "webkitpy", "icon": "testOnly",
       "factory": "WebKitPyFactory", "platform": "*",
-      "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
+      "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
       "name": "WebKitPerl-Tests-EWS", "shortname": "webkitperl", "icon": "testOnly",
       "factory": "WebKitPerlFactory", "platform": "*",
-      "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
+      "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
       "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly",
@@ -475,7 +475,7 @@
     {
       "name": "Services-EWS", "shortname": "services", "icon": "testOnly",
       "factory": "ServicesFactory", "platform": "*",
-      "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
+      "workernames": ["ews151", "ews253", "webkit-misc"]
     },
     {
       "name": "Commit-Queue", "shortname": "commit", "icon": "buildAndTest",
@@ -499,6 +499,11 @@
       "name": "Safe-Merge-Queue", "shortname": "safe-merge", "icon": "buildAndTest",
       "factory": "SafeMergeQueueFactory", "platform": "*",
       "workernames": ["webkit-cq-01", "webkit-cq-02", "webkit-cq-03", "webkit-cq-04", "webkit-cq-05"]
+    },
+    {
+      "name": "WPT-Export-EWS", "shortname": "wpt-export", "icon": "testOnly",
+      "factory": "WPTExportFactory", "platform": "*",
+      "workernames": ["ews2000", "ews151", "ews253", "webkit-misc"]
     }
   ],
   "schedulers": [
@@ -525,7 +530,7 @@
             "macOS-Sequoia-Debug-Build-EWS", "macOS-Sonoma-Release-Build-EWS", "macOS-Safer-CPP-Checks-EWS",
             "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-18-Build-EWS", "tvOS-18-Simulator-Build-EWS", "visionOS-2-Build-EWS", "visionOS-2-Simulator-Build-EWS",
             "watchOS-11-Build-EWS", "watchOS-11-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "PlayStation-Build-EWS", "Win-Build-EWS",
-            "WPE-Cairo-Build-EWS"
+            "WPE-Cairo-Build-EWS", "WPT-Export-EWS"
       ]
     },
     {

--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -534,10 +534,10 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
             log.msg(f"PR #{pr_number} ({head_sha}) was updated by '{sender}', ignoring it")
             return defer.returnValue(([], 'git'))
 
-        if custom_suffix != '' and pr_number % 10 != 0:
-            # To trigger testing environment on every PR, please comment out this if block and restart buildbot
-            log.msg(f'Ignoring PR {pr_number} ({head_sha}) on testing environment.')
-            return defer.returnValue(([], 'git'))
+        # if custom_suffix != '' and pr_number % 10 != 0:
+        #     # To trigger testing environment on every PR, please comment out this if block and restart buildbot
+        #     log.msg(f'Ignoring PR {pr_number} ({head_sha}) on testing environment.')
+        #     return defer.returnValue(([], 'git'))
 
         if action == 'labeled' and GitHub.UNSAFE_MERGE_QUEUE_LABEL in labels:
             log.msg(f'PR #{pr_number} ({head_sha}) was labeled for unsafe-merge-queue')

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -438,3 +438,23 @@ class SafeMergeQueueFactory(factory.BuildFactory):
         super().__init__()
         for project in GITHUB_PROJECTS:
             self.addStep(RetrievePRDataFromLabel(project, label=GitHub.SAFE_MERGE_QUEUE_LABEL))
+
+
+class WPTExportFactory(factory.BuildFactory):
+    findModifiedLayoutTests = False
+
+    def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, **kwargs):
+        factory.BuildFactory.__init__(self)
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=buildOnly, triggers=triggers, triggered_by=triggered_by, remotes=remotes, additionalArguments=additionalArguments))
+        self.addStep(CheckChangeRelevance())
+        self.addStep(ValidateChange())
+        self.addStep(PrintConfiguration())
+        self.addStep(CleanGitRepo())
+        self.addStep(SetCredentialHelper())
+        self.addStep(CheckOutSource())
+        self.addStep(FetchBranches())
+        self.addStep(ShowIdentifier())
+        self.addStep(CheckOutPullRequest())
+        self.addStep(KillOldProcesses())
+        self.addStep(ValidateChange(addURLs=False))
+        self.addStep(ExportWPTChanges())

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -711,6 +711,21 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'webkitperl-tests'
         ],
+        'WPT-Export-EWS': [
+            'configure-build',
+            'check-change-relevance',
+            'validate-change',
+            'configuration',
+            'clean-up-git-repo',
+            'set-credential-helper',
+            'checkout-source',
+            'fetch-branch-references',
+            'show-identifier',
+            'checkout-pull-request',
+            'kill-old-processes',
+            'validate-change',
+            'export-wpt-changes'
+        ],
         'API-Tests-iOS-Simulator-EWS': [
             'configure-build',
             'validate-change',

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from twisted.internet import defer
 
 from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQueueFactory, Factory, GTKBuildFactory,
-                        GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
+                        GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory, WPTExportFactory,
                         StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory, PlayStationBuildFactory,
                         WinBuildFactory, WinTestsFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory,  visionOSBuildFactory, visionOSEmbeddedBuildFactory, visionOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
                         macOSWK1Factory, macOSWK2Factory, ServicesFactory, SaferCPPStaticAnalyzerFactory, UnsafeMergeQueueFactory, WatchListFactory, watchOSBuildFactory)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1324,6 +1324,10 @@ class CheckChangeRelevance(AnalyzeChange):
         re.compile(rb'Tools/CISupport/Shared/download-and-install-build-tools', re.IGNORECASE),
     ]
 
+    wpt_export_regexes = [
+        re.compile(rb'LayoutTests/imported/w3c/web-platform-tests', re.IGNORECASE),
+    ]
+
     group_to_paths_mapping = {
         'bindings': bindings_path_regexes,
         'monterey-release-build': monterey_builder_path_regexes,
@@ -1332,6 +1336,7 @@ class CheckChangeRelevance(AnalyzeChange):
         'webkitpy': webkitpy_path_regexes,
         'wk1-tests': wk1_path_regexes,
         'safer-cpp': safer_cpp_path_regexes,
+        'wpt-export': wpt_export_regexes,
     }
 
     def _patch_is_relevant(self, patch, builderName, timeout=30):
@@ -7803,3 +7808,41 @@ class ExtractStaticAnalyzerTestResults(ExtractTestResults):
 
     def addCustomURLs(self):
         pass
+
+
+class ExportWPTChanges(steps.ShellSequence):
+    name = 'export-wpt-changes'
+    descriptionDone = ['Exported WPT changes']
+    flunkOnFailure = True
+    haltOnFailure = True
+
+    def __init__(self, **kwargs):
+        super().__init__(logEnviron=False, **kwargs)
+
+    # def doStepIf(self, step):
+    #    return self.getProperty('owners')[0] in ('nt1m', 'briannafan')
+
+    # def hideStepIf(self, results, step):
+    #    return not self.doStepIf(step)
+
+    def buildCommandKwargs(self, warnings):
+        result = super().buildCommandKwargs(warnings)
+        if self.getProperty('sensitive', False):
+            result['stdioLogName'] = None
+        return result
+
+    def run(self):
+        self.commands = [
+            util.ShellArg(command=['git', 'config', '--global', 'credential.helper', '!echo_credentials() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; echo_credentials'], logname='stdio'),
+            util.ShellArg(command=['Tools/Scripts/export-w3c-test-changes', '-g', 'HEAD', '--dry-run', '--remote', 'webkit-ews-buildbot', '--remote-url', 'git@github.com:web-platform-tests/wpt.git'], logname='stdio')
+        ]
+
+        username, access_token = GitHub.credentials(user=GitHub.user_for_queue(self.getProperty('buildername', '')))
+        self.env = dict(
+            GIT_COMMITTER_NAME='EWS Buildbot',
+            GIT_COMMITTER_EMAIL='webkit-ews-buildbot@webkit.org',
+            GIT_USER=username,
+            GIT_PASSWORD=access_token,
+        )
+
+        return super().run()

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -9827,5 +9827,42 @@ class TestDisplaySaferCPPResults(BuildStepMixinAdditions, unittest.TestCase):
         self.assertEqual(self.getProperty('build_finish_summary'), 'Found 10 new failures in File1.cpp')
         self.assertEqual([LeaveComment(), SetBuildSummary()], next_steps)
 
+
+class TestExportWPTChanges(BuildStepMixinAdditions, unittest.TestCase):
+    ENV = dict(GIT_USER='webkit-ews-buildbot', GIT_PASSWORD='password', GIT_COMMITTER_EMAIL='webkit-ews-buildbot@webkit.org', GIT_COMMITTER_NAME='EWS Buildbot')
+
+    def setUp(self):
+        GitHub.credentials = lambda user=None: ('webkit-ews-buildbot', 'password')
+        return self.setUpBuildStep()
+
+    def tearDown(self):
+        return self.tearDownBuildStep()
+
+    def configureStep(self):
+        self.setupStep(ExportWPTChanges())
+
+    def test_success(self):
+        self.configureStep()
+        self.setProperty('builddir', 'wkdir')
+        self.setProperty('buildnumber', 1234)
+        self.setProperty('owners', ['briannafan'])
+
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logEnviron=False,
+                        command=['git', 'config', '--global', 'credential.helper', '!echo_credentials() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; echo_credentials'],
+                        env=self.ENV)
+            + 0,
+            ExpectShell(workdir='wkdir',
+                        logEnviron=False,
+                        command=['Tools/Scripts/export-w3c-test-changes', '-g', 'HEAD', '--dry-run', '--remote', 'webkit-ews-buildbot', '--remote-url', 'git@github.com:web-platform-tests/wpt.git'],
+                        env=self.ENV)
+            + 0,
+        )
+
+        self.expectOutcome(result=SUCCESS, state_string='')
+        rc = self.runStep()
+        return rc
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### 7bcb1da9f8985a6f75c2c1d7a880eb2cfc4d4d80
<pre>
[EWS] Add initial WPT export builder
<a href="https://bugs.webkit.org/show_bug.cgi?id=297257">https://bugs.webkit.org/show_bug.cgi?id=297257</a>
<a href="https://rdar.apple.com/158098725">rdar://158098725</a>

Reviewed by NOBODY (OOPS!).

very much a WIP

- added unittests for factory and ExportWPTChanges step
- removing doStepIf so it runs on all PRs
- adding --dry-run argument so all changes are local for testing

* LayoutTests/imported/w3c/web-platform-tests/test: Added.
* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/events.py:
(GitHubEventHandlerNoEdits.handle_pull_request):
* Tools/CISupport/ews-build/factories.py:
(SafeMergeQueueFactory.__init__):
(WPTExportFactory):
(WPTExportFactory.__init__):
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/ews-build/loadConfig.py:
* Tools/CISupport/ews-build/steps.py:
(CheckChangeRelevance):
(ExtractStaticAnalyzerTestResults.addCustomURLs):
(ExportWPTChanges):
(ExportWPTChanges.__init__):
(ExportWPTChanges.buildCommandKwargs):
(ExportWPTChanges.run):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bcb1da9f8985a6f75c2c1d7a880eb2cfc4d4d80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70063 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86498a0c-f3ea-4689-830e-f34de29b2e3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89535 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59167 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9dffcc90-8e8c-42ef-b3d6-2fb88cd86d68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70028 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b8e0571c-2058-4778-8c8b-6e90964bc24f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67798 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127218 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98209 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/117407 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97997 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44762 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->