### PR TITLE
[Navigation API] Fix unhandled promise rejection in intercept handlers.

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt
@@ -1,7 +1,4 @@
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error
-
-Harness Error (FAIL), message = Unhandled rejection
 
 PASS NavigationTransition finished promise is fulfilled on success
 PASS NavigationTransition finished promise is rejected on error

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
-
-Harness Error (FAIL), message = Unhandled rejection
 
 PASS Invalid values for focusReset throw
 PASS Does not reset the focus when no navigate handler is present

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
-
-Harness Error (FAIL), message = Unhandled rejection
 
 PASS Focus should be reset before navigatesuccess
 PASS Focus should be reset before navigateerror

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for <a download> intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_no-currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for <a download> intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 FAIL event and promise ordering for same-document navigation.back() intercepted by passing a rejected promise to intercept() assert_array_equals: expected property 2 to be "currententrychange" but got "handler run" (expected array ["promise microtask", "navigate", "currententrychange", "handler run", "committed fulfilled", "navigateerror", "finished rejected", "transition.finished rejected"] got ["promise microtask", "navigate", "handler run", "currententrychange", "committed fulfilled", "navigateerror", "finished rejected", "transition.finished rejected"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_no-currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for same-document navigation.back() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for location.href setter intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_no-currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for location.href setter intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for same-document navigation.navigate() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_no-currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for same-document navigation.navigate() intercepted by passing a rejected promise to intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for navigation.reload() intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_no-currententrychange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_no-currententrychange-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: boo
-
-Harness Error (FAIL), message = Unhandled rejection: boo
 
 PASS event and promise ordering for navigation.reload() intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: oh no!
 
-Harness Error (FAIL), message = Unhandled rejection: oh no!
-
-FAIL navigation.transition.finished must not trigger unhandled rejections assert_unreached: unhandledrejection must not fire Reached unreachable code
+PASS navigation.transition.finished must not trigger unhandled rejections
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
-
-Harness Error (FAIL), message = Unhandled rejection
 
 PASS scroll: after-transition should not scroll when the intercept() handler rejects
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8248,8 +8248,6 @@ webkit.org/b/297144 fast/forms/state-restore-to-non-edited-controls.html [ Pass 
 
 webkit.org/b/297218 http/tests/in-app-browser-privacy/sub-frame-redirect-to-non-app-bound-domain-blocked.html [ Failure ]
 
-webkit.org/b/297222 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled.html [ Pass Failure ]
-
 webkit.org/b/297240 http/tests/site-isolation/edge-sampling-commit-root-frame-load.html [ Failure ]
 
 webkit.org/b/297131 [ Debug ] imported/w3c/web-platform-tests/web-locks/storage-buckets.tentative.https.any.worker.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2406,7 +2406,7 @@ webkit.org/b/297063 [ arm64 ] http/tests/xmlhttprequest/chunked-progress-event-e
 
 webkit.org/b/297078 [ Debug arm64 ] fast/parser/entity-comment-in-style.html [ Pass Timeout ]
 
-webkit.org/b/297222 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled.html [ Pass Failure ]
+webkit.org/b/297121 fast/page-color-sampling/color-sampling-fixed-ancestor-with-relative-container.html [ Failure ]
 
 webkit.org/b/297251 fast/mediastream/getUserMedia-echoCancellation.html [ Pass Failure ]
 

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -224,15 +224,16 @@ void JSPromise::markAsHandled(JSGlobalObject* lexicalGlobalObject)
 {
     VM& vm = lexicalGlobalObject->vm();
     uint32_t flags = this->flags();
-    if (!(flags & isFirstResolvingFunctionCalledFlag))
-        internalField(Field::Flags).set(vm, this, jsNumber(flags | isHandledFlag));
+    internalField(Field::Flags).set(vm, this, jsNumber(flags | isHandledFlag));
 }
 
 void JSPromise::rejectAsHandled(JSGlobalObject* lexicalGlobalObject, JSValue value)
 {
     // Setting isHandledFlag before calling reject since this removes round-trip between JSC and PromiseRejectionTracker, and it does not show an user-observable behavior.
-    markAsHandled(lexicalGlobalObject);
-    reject(lexicalGlobalObject, value);
+    if (!(flags() & isFirstResolvingFunctionCalledFlag)) {
+        markAsHandled(lexicalGlobalObject);
+        reject(lexicalGlobalObject, value);
+    }
 }
 
 void JSPromise::reject(JSGlobalObject* lexicalGlobalObject, Exception* reason)

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -95,4 +95,10 @@ DOMPromise::Status DOMPromise::status() const
     return Status::Rejected;
 }
 
+void DOMPromise::markAsHandled()
+{
+    ASSERT(!isSuspended());
+    promise()->markAsHandled(m_globalObject.get());
+}
+
 }

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -48,6 +48,8 @@ public:
     IsCallbackRegistered whenSettled(std::function<void()>&&);
     JSC::JSValue result() const;
 
+    void markAsHandled();
+
     enum class Status { Pending, Fulfilled, Rejected };
     Status status() const;
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1044,8 +1044,12 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
         for (auto& handler : event->handlers()) {
             auto callbackResult = handler->invoke();
-            if (callbackResult.type() != CallbackResultType::UnableToExecute)
-                promiseList.append(callbackResult.releaseReturnValue());
+            if (callbackResult.type() != CallbackResultType::UnableToExecute) {
+                auto promise = callbackResult.releaseReturnValue();
+                // Because rejection is reported as `navigateerror` event, we can mark this as handled.
+                promise->markAsHandled();
+                promiseList.append(WTFMove(promise));
+            }
         }
 
         if (promiseList.isEmpty()) {


### PR DESCRIPTION
#### 2eef61ccd0ff60ed893d67393c97a935fc9ff643
<pre>
[Navigation API] Fix unhandled promise rejection in intercept handlers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=296936">https://bugs.webkit.org/show_bug.cgi?id=296936</a>
<a href="https://rdar.apple.com/158138764">rdar://158138764</a>

Reviewed by Yusuke Suzuki.

Many of the tests in wpt/navigation-api/ produces &quot;Unhandled Promise Rejection: XXX&quot; errors in expected files.

For promises returned from handler() during intercept(), the errors are reported as navigateerror event. So we
can mark them as handled safely.

Also need to modify JSPromise to allow marking as handled for already resolved function to allow marking
Promise.reject() as handled for testing code.

* LayoutTests/http/wpt/navigation-api/transition-promises-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/focus-reset/focus-reset-timing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/back-same-document-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/location-href-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/navigate-same-document-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/reload-intercept-reject_no-currententrychange-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-finished-mark-as-handled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-reject-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::markAsHandled):
(JSC::JSPromise::rejectAsHandled):
* Source/WebCore/bindings/js/JSDOMPromise.cpp:
(WebCore::DOMPromise::markAsHandled):
* Source/WebCore/bindings/js/JSDOMPromise.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/298647@main">https://commits.webkit.org/298647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/182b2ff98c7bb5401707ab47341155aaf943e421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66674 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59dc9e16-35e6-4710-b3d8-de8d04599c1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88220 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd3d654f-31f9-46bc-94f1-7dd8cf3ac808) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68631 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65857 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108229 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125325 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114647 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96951 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24623 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42006 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38959 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48492 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143344 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42367 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36952 "Found 1 new JSC stress test failure: wasm.yaml/wasm/v8/import-function.js.wasm-eager-jettison (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44071 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->