### PR TITLE
Correct encoding of cookies

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
@@ -2,8 +2,8 @@
 PASS HTTP set/overwrite/delete observed in CookieStore
 PASS HTTP set already-expired cookie should not be observed by CookieStore
 PASS HTTP duplicate cookie should not be observed by CookieStore
-FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies assert_equals: Cookie we wrote using HTTP in cookie jar expected "HTTP-🍪=🔵" but got "HTTP-ðª=ðµ"
+FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies assert_equals: Cookie we wrote using HTTP is observed: changed cookie name expected "HTTP-🍪" but got "HTTP-ðª"
 PASS CookieStore set/overwrite/delete observed in HTTP headers
-PASS HTTP headers agreed with CookieStore on encoding non-ASCII cookies
-FAIL Binary HTTP set/overwrite/delete observed in CookieStore assert_equals: Binary cookie we wrote using HTTP in cookie jar expected "HTTP-cookie=value\ufffd" but got "HTTP-cookie=valueï¿½"
+FAIL HTTP headers agreed with CookieStore on encoding non-ASCII cookies assert_equals: HTTP cookie jar contains only cookie we set expected "🍪=🔵" but got "ðª=ðµ"
+FAIL Binary HTTP set/overwrite/delete observed in CookieStore assert_equals: Binary cookie we wrote using HTTP in HTTP cookie jar expected "HTTP-cookie=value\ufffd" but got "HTTP-cookie=valueï¿½"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/encoding.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/encoding.https.any-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL BOM not stripped from name promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.name')"
-FAIL BOM not stripped from value assert_equals: expected "﻿value" but got "ï»¿value"
+PASS BOM not stripped from value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/encoding.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/encoding.https.any.serviceworker-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL BOM not stripped from name promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.name')"
-FAIL BOM not stripped from value assert_equals: expected "﻿value" but got "ï»¿value"
+PASS BOM not stripped from value
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -388,6 +388,14 @@ void CookieStore::set(String&& name, String&& value, Ref<DeferredPromise>&& prom
     set(CookieInit { WTFMove(name), WTFMove(value) }, WTFMove(promise));
 }
 
+static String cookieStringToLatin1(const String input)
+{
+    if (input.containsOnlyASCII())
+        return input;
+
+    return String::fromLatin1(input.utf8().data());
+}
+
 void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
 {
     RefPtr context = scriptExecutionContext();
@@ -453,6 +461,11 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
             return;
         }
     }
+
+    cookie.name = cookieStringToLatin1(cookie.name);
+    cookie.value = cookieStringToLatin1(cookie.value);
+
+    // FIXME: implement length check.
 
     cookie.domain = options.domain.isNull() ? domain : options.domain;
     if (!cookie.domain.isNull()) {

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -310,9 +310,9 @@ public:
 
 private:
 #if PLATFORM(COCOA)
-    enum IncludeHTTPOnlyOrNot { DoNotIncludeHTTPOnly, IncludeHTTPOnly };
-    std::pair<String, bool> cookiesForSession(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeHTTPOnlyOrNot, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;
-    std::optional<Vector<Cookie>> cookiesForSessionAsVector(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeHTTPOnlyOrNot, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&&) const;
+    enum class CookiesFor : bool { HTTP, DOM };
+    std::pair<String, bool> cookiesForSession(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, CookiesFor, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;
+    std::optional<Vector<Cookie>> cookiesForSessionAsVector(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, CookiesFor, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&&) const;
     RetainPtr<NSArray> httpCookies(CFHTTPCookieStorageRef) const;
     RetainPtr<NSArray> httpCookiesForURL(CFHTTPCookieStorageRef, NSURL *firstParty, const std::optional<SameSiteInfo>&, NSURL *, ThirdPartyCookieBlockingDecision) const;
     RetainPtr<NSArray> cookiesForURL(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;


### PR DESCRIPTION
#### b3be26c01a3b0abe3f68fd548bb8de388ee50d74
<pre>
Correct encoding of cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=297262">https://bugs.webkit.org/show_bug.cgi?id=297262</a>

Reviewed by NOBODY (OOPS!).

While cookies are (supposed to be) treated as byte sequences on the
network, we need to attempt to decode them as UTF-8 before exposing
them via JavaScript. And not return them at all when UTF-8 decode
fails.

This does not deal with cookie change subscriptions.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3be26c01a3b0abe3f68fd548bb8de388ee50d74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115908 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121957 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66644 "Failed to checkout and rebase branch from PR 49261") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f073f694-7c5b-412b-9202-1683bb5d55eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88045 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42645 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bec1d1ba-07f2-421f-a2b9-4dc92425cb3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68458 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125109 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96798 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96585 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41845 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19717 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38718 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42151 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45485 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->