### PR TITLE
[WPE] <dialog> does not close if Escape is pressed inside a contenteditable element

### DIFF
--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-input-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-input-expected.txt
@@ -1,8 +1,0 @@
-Test dialog modal is closed by escape key with input focused
-
-
-
-Harness Error (TIMEOUT), message = null
-
-NOTRUN Test dialog modal is closed by escape key with input focused
-

--- a/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
@@ -105,7 +105,6 @@ static const KeyDownEntry keyDownEntries[] = {
     { 'B',         CtrlKey,          "ToggleBold"                              },
     { 'I',         CtrlKey,          "ToggleItalic"                            },
     { 'U',         CtrlKey,          "ToggleUnderline"                         },
-    { VK_ESCAPE, 0,                  "Cancel"                                  },
     { VK_OEM_PERIOD, CtrlKey,        "Cancel"                                  },
     { VK_TAB,    0,                  "InsertTab"                               },
     { VK_TAB,    ShiftKey,           "InsertBacktab"                           },

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -239,7 +239,7 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
 
     if (keyval == WPE_KEY_Escape) {
         webkit_web_view_end_immersive_session(webView);
-        return TRUE;
+        return FALSE;
     }
 
     return FALSE;


### PR DESCRIPTION
#### 68ee5059655db26efab6e4c26b69f08d2d0bec3e
<pre>
[WPE] &lt;dialog&gt; does not close if Escape is pressed inside a contenteditable element
<a href="https://bugs.webkit.org/show_bug.cgi?id=297091">https://bugs.webkit.org/show_bug.cgi?id=297091</a>

Reviewed by Carlos Garcia Campos.

This commit fixes two issues related to handling of &apos;Escape&apos; character
in WPEWebKit.

First one, when WPE&apos;s MiniBrowser handles the &apos;Escape&apos; character it
should return FALSE, so the keypress also reaches the UIProcess.

Then, &apos;WebEditorClientWPE&apos; should not capture &apos;Escape&apos; to emit a &apos;Cancel&apos;
command. In addition, &apos;Cancel&apos; is not a command in &apos;EditorCommand.cpp&apos;.

* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-with-input-expected.txt: Removed.
* Source/WebKit/WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp:
* Tools/MiniBrowser/wpe/main.cpp:

Canonical link: <a href="https://commits.webkit.org/298562@main">https://commits.webkit.org/298562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2aaedf260f2854500ecb81c05d6123d038b29fdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68473 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115298 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28053 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65643 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108033 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125125 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114452 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/115359 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100211 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96600 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38734 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18525 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48289 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->