### PR TITLE
Add cookie name prefix checks to Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any-expected.txt
@@ -15,25 +15,25 @@ PASS cookieStore.set with __Host- prefix and a domain option
 PASS cookieStore.set with __Host- prefix a path option
 PASS cookieStore.set with __host- prefix and a domain option
 PASS cookieStore.set with __host- prefix a path option
-FAIL cookieStore.set with __HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __hosthttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with   __Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with 	__Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with   __HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with 	__HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set with __Host-Http- prefix rejects
+PASS cookieStore.set with __host-http- prefix rejects
+PASS cookieStore.set with __Http- prefix rejects
+PASS cookieStore.set with __http- prefix rejects
+PASS cookieStore.set with   __Http- prefix rejects
+PASS cookieStore.set with 	__Http- prefix rejects
+PASS cookieStore.set with   __Host-Http- prefix rejects
+PASS cookieStore.set with 	__Host-Http- prefix rejects
 PASS cookieStore.set with malformed name.
 FAIL cookieStore.set a nameless cookie cannot have __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have __Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
-FAIL cookieStore.set a nameless cookie cannot have __HostHttp- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have __Host-Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have  __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have 	__Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have  __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have 	__Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have  __Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have 	__Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
-FAIL cookieStore.set a nameless cookie cannot have  __HostHttp- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
-FAIL cookieStore.set a nameless cookie cannot have 	__HostHttp- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have  __Host-Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have 	__Host-Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any.js
@@ -56,8 +56,8 @@
   }, `cookieStore.set with ${prefix} prefix a path option`);
 });
 
-['__HostHttp-', '__hosthttp-', '__Http-', '__http-', '  __Http-', '\t__Http-',
- '  __HostHttp-', '\t__HostHttp-'].forEach(prefix => {
+['__Host-Http-', '__host-http-', '__Http-', '__http-', '  __Http-', '\t__Http-',
+ '  __Host-Http-', '\t__Host-Http-'].forEach(prefix => {
   promise_test(async testCase => {
     await promise_rejects_js(testCase, TypeError,
         cookieStore.set({ name: `${prefix}cookie-name`, value: 'cookie-value'}));
@@ -75,8 +75,8 @@ promise_test(async testCase => {
     assert_true(exceptionThrown, "No exception thrown.");
 }, 'cookieStore.set with malformed name.');
 
-['__Host-', '__Secure-', '__Http-', '__HostHttp-', ' __Host-', '\t__Host-', ' __Secure-',
- '\t__Secure-', ' __Http-', '\t__Http-', ' __HostHttp-', '\t__HostHttp-'].forEach(prefix => {
+['__Host-', '__Secure-', '__Http-', '__Host-Http-', ' __Host-', '\t__Host-', ' __Secure-',
+ '\t__Secure-', ' __Http-', '\t__Http-', ' __Host-Http-', '\t__Host-Http-'].forEach(prefix => {
   promise_test(async testCase => {
     // Nameless cookies cannot have special prefixes
     await cookieStore.delete('');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any.serviceworker-expected.txt
@@ -15,25 +15,25 @@ PASS cookieStore.set with __Host- prefix and a domain option
 PASS cookieStore.set with __Host- prefix a path option
 PASS cookieStore.set with __host- prefix and a domain option
 PASS cookieStore.set with __host- prefix a path option
-FAIL cookieStore.set with __HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __hosthttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with   __Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with 	__Http- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with   __HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with 	__HostHttp- prefix rejects assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set with __Host-Http- prefix rejects
+PASS cookieStore.set with __host-http- prefix rejects
+PASS cookieStore.set with __Http- prefix rejects
+PASS cookieStore.set with __http- prefix rejects
+PASS cookieStore.set with   __Http- prefix rejects
+PASS cookieStore.set with 	__Http- prefix rejects
+PASS cookieStore.set with   __Host-Http- prefix rejects
+PASS cookieStore.set with 	__Host-Http- prefix rejects
 PASS cookieStore.set with malformed name.
 FAIL cookieStore.set a nameless cookie cannot have __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have __Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
-FAIL cookieStore.set a nameless cookie cannot have __HostHttp- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have __Host-Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have  __Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have 	__Host- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have  __Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have 	__Secure- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have  __Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 FAIL cookieStore.set a nameless cookie cannot have 	__Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
-FAIL cookieStore.set a nameless cookie cannot have  __HostHttp- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
-FAIL cookieStore.set a nameless cookie cannot have 	__HostHttp- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have  __Host-Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
+FAIL cookieStore.set a nameless cookie cannot have 	__Host-Http- prefix promise_test: Unhandled rejection with value: object "TypeError: The cookie name and value must not both be empty."
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -407,7 +407,9 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
         return;
     }
 
-    // The maximum attribute value size is specified at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
+    // https://cookiestore.spec.whatwg.org/#cookie-maximum-name-value-pair-size
+    static constexpr auto maximumNameValuePairSize = 4096;
+    // https://cookiestore.spec.whatwg.org/#cookie-maximum-attribute-value-size
     static constexpr auto maximumAttributeValueSize = 1024;
 
     auto url = context->cookieURL();
@@ -440,6 +442,26 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
             promise->reject(Exception { ExceptionCode::TypeError, "The cookie name and value must not both be empty."_s });
             return;
         }
+
+        if (cookie.value.startsWithIgnoringASCIICase("__Host-"_s)
+            || cookie.value.startsWithIgnoringASCIICase("__Host-Http-"_s)
+            || cookie.value.startsWithIgnoringASCIICase("__Http-"_s)
+            || cookie.value.startsWithIgnoringASCIICase("__Secure-"_s)) {
+            promise->reject(Exception { ExceptionCode::TypeError, "If the cookie name is empty, the value must not begin with \"__Host-\", \"__Host-Http-\", \"__Http-\", or \"__Secure-\""_s });
+            return;
+        }
+    }
+
+    if (cookie.name.startsWithIgnoringASCIICase("__Host-Http-"_s)
+        || cookie.name.startsWithIgnoringASCIICase("__Http-"_s)) {
+            promise->reject(Exception { ExceptionCode::TypeError, "The cookie name must not begin with \"__Host-Http-\" or \"__Http-\""_s });
+            return;
+    }
+
+    // FIXME: <rdar://85515842> Obtain the encoded length without allocating and encoding.
+    if (cookie.name.utf8().length() + cookie.value.utf8().length() > maximumNameValuePairSize) {
+        promise->reject(Exception { ExceptionCode::TypeError, makeString("The size of the cookie name and value must not be greater than "_s, maximumNameValuePairSize, " bytes"_s) });
+        return;
     }
 
     if (cookie.name.startsWithIgnoringASCIICase("__Host-"_s)) {


### PR DESCRIPTION
#### 62b02335fdf43aefbee467f6315dd6b52f749ed8
<pre>
Add cookie name prefix checks to Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=296267">https://bugs.webkit.org/show_bug.cgi?id=296267</a>
<a href="https://rdar.apple.com/156373016">rdar://156373016</a>

Reviewed by Alex Christensen.

Implement step 5.3 to 9, inclusive, of:
<a href="https://cookiestore.spec.whatwg.org/#set-a-cookie">https://cookiestore.spec.whatwg.org/#set-a-cookie</a>

Rename in test is upstreamed here:

<a href="https://github.com/web-platform-tests/wpt/pull/54226">https://github.com/web-platform-tests/wpt/pull/54226</a>
Canonical link: <a href="https://commits.webkit.org/298615@main">https://commits.webkit.org/298615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a13669815c2b2920b5e03acd81db5aa87b8a184

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66447 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/635eda86-a513-453c-95df-b11173c99329) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88053 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b0466a7-df09-4c11-8fd4-60e01bab19b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68466 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22131 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125118 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96807 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96594 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41854 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38727 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18548 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48282 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42160 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43867 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->