### PR TITLE
Cookie Store API: add branch for empty string path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS CookieListItem - cookieStore.set with empty string path defaults to current URL
+PASS CookieListItem - cookieStore.set with empty string path defaults to current URL with __host- prefix
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window.js
@@ -1,0 +1,23 @@
+// META: title=Cookie Store API: set()'s path option
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+
+promise_test(async testCase => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  const currentDirectory = currentPath.substr(0, currentPath.lastIndexOf('/'));
+
+  await cookieStore.set({ name: 'cookie-name', value: 'cookie-value', path: '' });
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete({ name: 'cookie-name', path: currentDirectory });
+  });
+
+  const internalCookie = await test_driver.get_named_cookie('cookie-name');
+  assert_equals(internalCookie.path, currentDirectory);
+}, 'CookieListItem - cookieStore.set with empty string path defaults to current URL');
+
+promise_test(async testCase => {
+  const currentUrl = new URL(self.location.href);
+  const currentPath = currentUrl.pathname;
+  return promise_rejects_js(testCase, TypeError, cookieStore.set({ name: '__host-cookie-name', value: 'cookie-value', path: '' }));
+}, 'CookieListItem - cookieStore.set with empty string path defaults to current URL with __host- prefix');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookiestore/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookiestore/w3c-import.log
@@ -53,6 +53,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_domain_parsing.tentative.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_limit.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_set_path.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_special_names.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscribe_arguments.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/cookiestore/cookieStore_subscriptions_empty.https.window.js

--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -137,7 +137,13 @@ struct CookieHash {
     static const bool safeToCompareToEmptyOrDeleted = false;
 };
 
-}
+namespace CookieUtil {
+
+WEBCORE_EXPORT String defaultPathForURL(const URL&);
+
+} // namespace CookieUtil
+
+} // namespace WebCore
 
 namespace WTF {
     template<typename T> struct DefaultHash;

--- a/Source/WebCore/platform/network/Cookie.cpp
+++ b/Source/WebCore/platform/network/Cookie.cpp
@@ -42,6 +42,25 @@ unsigned Cookie::hash() const
     return StringHash::hash(name) + StringHash::hash(domain) + StringHash::hash(path) + secure;
 }
 #endif
-    
+
+namespace CookieUtil {
+
+String defaultPathForURL(const URL& url)
+{
+    // Algorithm to generate the default path is outlined in https://tools.ietf.org/html/rfc6265#section-5.1.4
+
+    String path = url.path().toString();
+    if (path.isEmpty() || !path.startsWith('/'))
+        return "/"_s;
+
+    auto lastSlashPosition = path.reverseFind('/');
+    if (!lastSlashPosition)
+        return "/"_s;
+
+    return path.left(lastSlashPosition);
+}
+
+} // namespace CookieUtil
+
 } // namespace WebCore
 

--- a/Source/WebCore/platform/network/curl/CookieUtil.cpp
+++ b/Source/WebCore/platform/network/curl/CookieUtil.cpp
@@ -183,21 +183,6 @@ std::optional<Cookie> parseCookieHeader(const String& cookieLine)
     return cookie;
 }
 
-String defaultPathForURL(const URL& url)
-{
-    // Algorithm to generate the default path is outlined in https://tools.ietf.org/html/rfc6265#section-5.1.4
-
-    String path = url.path().toString();
-    if (path.isEmpty() || !path.startsWith('/'))
-        return "/"_s;
-
-    auto lastSlashPosition = path.reverseFind('/');
-    if (!lastSlashPosition)
-        return "/"_s;
-
-    return path.left(lastSlashPosition);
-}
-
 } // namespace CookieUtil
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/CookieUtil.h
+++ b/Source/WebCore/platform/network/curl/CookieUtil.h
@@ -40,8 +40,6 @@ bool isIPAddress(const String&);
 
 bool domainMatch(const String& cookieDomain, const String& host);
 
-WEBCORE_EXPORT String defaultPathForURL(const URL&);
-
 } // namespace CookieUtil
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2c5cf3d08ebf52730f55b3ff867213971049cb29
<pre>
Cookie Store API: add branch for empty string path
<a href="https://bugs.webkit.org/show_bug.cgi?id=297268">https://bugs.webkit.org/show_bug.cgi?id=297268</a>

Reviewed by Rupin Mittal.

Implement <a href="https://github.com/whatwg/cookiestore/pull/283">https://github.com/whatwg/cookiestore/pull/283</a> with tests
upstreamed at <a href="https://github.com/web-platform-tests/wpt/pull/54264">https://github.com/web-platform-tests/wpt/pull/54264</a>

Canonical link: <a href="https://commits.webkit.org/298681@main">https://commits.webkit.org/298681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91f4b2b3229d0b5ae08e1968b980062b2d9a64dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66874 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7e08405-b25a-421c-ad1c-5f8869ec1f96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88344 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/672d3b76-ee61-4a79-8201-b9416b4f7fe6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68773 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22455 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66051 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125519 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96848 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42140 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39157 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18577 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43094 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48686 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->