### PR TITLE
dNR: send a message from the navigation client to the web extensions controllers when a content extension rule matches

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1014,7 +1014,7 @@
 #define ENABLE_WK_WEB_EXTENSIONS 1
 #endif
 
-// When this is enabled, CurrentContentRuleListFileVersion and currentDeclarativeNetRequestRuleTranslatorVersion need to be bumped.
+// When this is enabled, CurrentContentRuleListFileVersion, currentDeclarativeNetRequestRuleTranslatorVersion, and currentBackgroundContentListenerStateVersion need to be bumped.
 #if !defined(ENABLE_DNR_ON_RULE_MATCHED_DEBUG)
 #define ENABLE_DNR_ON_RULE_MATCHED_DEBUG 0
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -40,6 +40,9 @@ enum class WebExtensionEventListenerType : uint8_t {
     CommandsOnChanged,
     CommandsOnCommand,
     CookiesOnChanged,
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    DeclarativeNetRequestOnRuleMatchedDebug,
+#endif
     DevToolsElementsPanelOnSelectionChanged,
     DevToolsExtensionPanelOnHidden,
     DevToolsExtensionPanelOnSearch,
@@ -112,6 +115,10 @@ inline String toAPIString(WebExtensionEventListenerType eventType)
         return "onCommand"_s;
     case WebExtensionEventListenerType::CookiesOnChanged:
         return "onChanged"_s;
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    case WebExtensionEventListenerType::DeclarativeNetRequestOnRuleMatchedDebug:
+        return "onRuleMatchedDebug"_s;
+#endif
     case WebExtensionEventListenerType::DevToolsElementsPanelOnSelectionChanged:
         return "onSelectionChanged"_s;
     case WebExtensionEventListenerType::DevToolsExtensionPanelOnHidden:

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in
@@ -31,6 +31,9 @@ enum class WebKit::WebExtensionEventListenerType : uint8_t {
     CommandsOnChanged,
     CommandsOnCommand,
     CookiesOnChanged,
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    DeclarativeNetRequestOnRuleMatchedDebug,
+#endif
     DevToolsElementsPanelOnSelectionChanged,
     DevToolsExtensionPanelOnHidden,
     DevToolsExtensionPanelOnSearch,

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -769,7 +769,8 @@ void NavigationState::NavigationClient::contentRuleListMatchedRule(WebPageProxy&
     if (!m_navigationState)
         return;
 
-    // FIXME: rdar://157878200 (dNR: send a message from the navigation client to the web extensions controllers when a content extension rule matches)
+    if (RefPtr extensionController = page.webExtensionController())
+        extensionController->handleContentRuleListMatchedRule(page.identifier(), matchedRule);
 }
 #endif
     

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -877,6 +877,9 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
     NSDictionary<NSString *, id> *convertedRule = @{
         @"action": actionDictionary,
         @"trigger": triggerDictionary,
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+        @"_identifier": @(_ruleID),
+#endif
     };
 
     if ([chromeActionType isEqualToString:declarativeNetRequestRuleActionTypeAllowAllRequests]) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -140,6 +140,10 @@ struct WebExtensionCookieStoreParameters;
 struct WebExtensionMenuItemContextParameters;
 struct WebExtensionMessageTargetParameters;
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
+
 enum class WebExtensionContextInstallReason : uint8_t {
     None,
     ExtensionInstall,
@@ -564,6 +568,10 @@ public:
 
     bool handleContentRuleListNotificationForTab(WebExtensionTab&, const URL&, WebCore::ContentRuleListResults::Result);
     void incrementActionCountForTab(WebExtensionTab&, ssize_t incrementAmount);
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    void handleContentRuleListMatchedRule(WebExtensionTab&, WebCore::ContentRuleListMatchedRule&);
+#endif
 
     // Returns whether or not there are any matched rules after the purge.
     bool purgeMatchedRulesFromBefore(const WallTime&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -75,6 +75,10 @@ class WebsiteDataStore;
 struct WebExtensionControllerParameters;
 struct WebExtensionFrameParameters;
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+struct ContentRuleListMatchedRule;
+#endif
+
 #if ENABLE(INSPECTOR_EXTENSIONS)
 class WebInspectorUIProxy;
 #endif
@@ -170,6 +174,10 @@ public:
 #endif
 
     void handleContentRuleListNotification(WebPageProxyIdentifier, URL&, WebCore::ContentRuleListResults&);
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    void handleContentRuleListMatchedRule(WebPageProxyIdentifier, WebCore::ContentRuleListMatchedRule&);
+#endif
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     void inspectorWillOpen(WebInspectorUIProxy&, WebPageProxy&);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
@@ -31,6 +31,10 @@
 #include "WebExtensionAPIObject.h"
 #include "WebExtensionConstants.h"
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+#include "WebExtensionAPIEvent.h"
+#endif
+
 namespace WebKit {
 
 class WebPage;
@@ -57,7 +61,15 @@ public:
     double maxNumberOfStaticRulesets() const { return webExtensionDeclarativeNetRequestMaximumNumberOfStaticRulesets; }
     double maxNumberOfEnabledRulesets() const { return webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets; }
     double maxNumberOfDynamicAndSessionRules() const { return webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules; }
+
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
+    WebExtensionAPIEvent& onRuleMatchedDebug();
+
+private:
+    RefPtr<WebExtensionAPIEvent> m_onRuleMatchedDebug;
 #endif
+#endif // PLATFORM(COCOA)
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl
@@ -43,7 +43,7 @@
     [RaisesException] void isRegexSupported([NSDictionary] any regexOptions, [Optional, CallbackHandler] function callback);
     [RaisesException] void setExtensionActionOptions([NSDictionary] any options, [Optional, CallbackHandler] function callback);
 
-    // FIXME: <rdar://71867958> Implement onRuleMatchedDebug.
+    [Dynamic, Conditional=DNR_ON_RULE_MATCHED_DEBUG] readonly attribute WebExtensionAPIEvent onRuleMatchedDebug;
 
     [ImplementedAs=maxNumberOfStaticRulesets] readonly attribute double MAX_NUMBER_OF_STATIC_RULESETS;
     [ImplementedAs=maxNumberOfEnabledRulesets] readonly attribute double MAX_NUMBER_OF_ENABLED_STATIC_RULESETS;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -160,6 +160,11 @@ private:
     // Cookies
     void dispatchCookiesChangedEvent();
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    // DeclarativeNetRequest
+    void dispatchOnRuleMatchedDebugEvent(const WebCore::ContentRuleListMatchedRule&);
+#endif
+
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools
     void addInspectorPageIdentifier(WebCore::PageIdentifier, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -43,6 +43,11 @@ messages -> WebExtensionContextProxy {
     // Cookies
     DispatchCookiesChangedEvent()
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
+    // DeclarativeNetRequest
+    DispatchOnRuleMatchedDebugEvent(struct WebCore::ContentRuleListMatchedRule matchedRule)
+#endif
+
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools
     AddInspectorPageIdentifier(WebCore::PageIdentifier pageID, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier)


### PR DESCRIPTION
#### a7ebe0c9b14a28d8ed98580ba3b6412f1f259c57
<pre>
dNR: send a message from the navigation client to the web extensions controllers when a content extension rule matches
<a href="https://bugs.webkit.org/show_bug.cgi?id=297275">https://bugs.webkit.org/show_bug.cgi?id=297275</a>
<a href="https://rdar.apple.com/157878200">rdar://157878200</a>

Reviewed by Brian Weinstein.

This simple patch actually defines the onRuleMatchedDebug API on the declarativeNetRequest
namespace. We&apos;re just responding to the new notification (introduced in 2c0f6fd) that&apos;s published
from content blockers that indicate that a rule has matched. When it&apos;s published, we just find the
appropriate extension contexts to fire the onRuleMatchedDebug event listeners.

Wrote new tests to validate these changes.

* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h:
(WebKit::toAPIString):
* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.serialization.in:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::contentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::handleContentRuleListMatchedRule):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule _webKitRuleWithWebKitActionType:chromeActionType:condition:]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIDeclarativeNetRequest::isPropertyAllowed):
(WebKit::WebExtensionAPIDeclarativeNetRequest::onRuleMatchedDebug):
(WebKit::WebExtensionContextProxy::dispatchOnRuleMatchedDebugEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIDeclarativeNetRequest.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, OnRuleMatchedDebugWithoutPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, OnRuleMatchedDebug)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RegexRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, BasicRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, MainFrameResourceRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, SubFrameResourceRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RepeatedMainFrameResourceRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, CaseSensitiveConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ConvertingMultipleResourceTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ConvertingXHRWebSocketAndOtherTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, UpgradeSchemeForMainFrameRuleConversion)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithDomainType)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithNoSpecifiedResourceTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithUnsupportedExcludedResourceTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithEmptyExcludedResourceTypes)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithURLFilterAndRequestDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRequestDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithInitiatorDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedInitiatorDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedInitiatorDomainsAndInitiatorDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithEmptyExcludedDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRequestMethods)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithExcludedRequestMethods)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRequestMethodsAndExcludedRequestMethodsAndRequestDomainsAndExcludedRequestDomains)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, URLFilterSpecialCharacters)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithMainFrameAllowAllRequests)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithRedirect)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithModifyHeaders)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RuleConversionWithModifyHeadersWithBothResponseAndRequestHeaders)):

Canonical link: <a href="https://commits.webkit.org/298586@main">https://commits.webkit.org/298586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3640b42acacf6c6823f9d64529bb78ca123400b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115999 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/35654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/26196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1973239-2d3c-43b6-8f79-beb4fe248583) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117888 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/36350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed3b06dc-9b94-442b-a1eb-bb912ca64d9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118947 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/36350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/26196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/36350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/26196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/65720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/108108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/36350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114527 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/42887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/44242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/26196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18533 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/42780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/48372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/143211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/143211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->