### PR TITLE
Fix Gamepad CoreIPC messages from being sent when flag is disabled

### DIFF
--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -233,20 +233,19 @@ void GamepadManager::registerDOMWindow(LocalDOMWindow& window)
     m_domWindows.add(window);
 
     // Anytime we register a LocalDOMWindow, we should make sure its NavigatorGamepad is constructed.
-    // Upon construction, it will register the navigator in m_navigators.
     Ref navigator = navigatorGamepadFromDOMWindow(window).navigator();
-    ASSERT(m_navigators.contains(navigator.get()));
-
-    // If this LocalDOMWindow's NavigatorGamepad was already registered but was still blind,
-    // then this LocalDOMWindow should be blind.
-    if (m_gamepadBlindNavigators.contains(navigator.get()))
-        m_gamepadBlindDOMWindows.add(window);
+    if (m_navigators.contains(navigator.get())) {
+        // If this LocalDOMWindow's NavigatorGamepad was already registered but was still blind,
+        // then this LocalDOMWindow should be blind.
+        if (m_gamepadBlindNavigators.contains(navigator.get()))
+            m_gamepadBlindDOMWindows.add(window);
 #if PLATFORM(VISION)
-    else if (m_gamepadQuarantinedNavigators.contains(navigator.get()))
-        m_gamepadQuarantinedDOMWindows.add(window);
+        else if (m_gamepadQuarantinedNavigators.contains(navigator.get()))
+            m_gamepadQuarantinedDOMWindows.add(window);
 #endif
 
-    maybeStartMonitoringGamepads();
+        maybeStartMonitoringGamepads();
+    }
 }
 
 void GamepadManager::unregisterDOMWindow(LocalDOMWindow& window)

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -49,7 +49,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigatorGamepad);
 NavigatorGamepad::NavigatorGamepad(Navigator& navigator)
     : m_navigator(navigator)
 {
-    GamepadManager::singleton().registerNavigator(navigator);
+    RefPtr document = navigator.document();
+    if (document && document->settingsValues().gamepadsEnabled)
+        GamepadManager::singleton().registerNavigator(navigator);
 }
 
 NavigatorGamepad::~NavigatorGamepad()


### PR DESCRIPTION
#### 5b287de62f0bc75d0746195b3ba818803c7273ce
<pre>
Fix Gamepad CoreIPC messages from being sent when flag is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=297277">https://bugs.webkit.org/show_bug.cgi?id=297277</a>
<a href="https://rdar.apple.com/problem/158142493">rdar://problem/158142493</a>

Reviewed by Sihui Liu.

Add sender side validation to prevent Gamepad related IPC to be sent when the feature flag is disabled. This prevents crashes not the CoreIPC endpoints are protected with the feature flag.

* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::registerDOMWindow):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::NavigatorGamepad):

Canonical link: <a href="https://commits.webkit.org/298680@main">https://commits.webkit.org/298680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1368f24aaa339e00b1e688179d169ecfec1b82da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66712 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6460604-7ae8-4da0-b5d9-f59506ae391e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f449c2ea-cd42-437a-b36d-392714ea93e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68659 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22329 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65893 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125361 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96979 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38996 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48528 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42403 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44107 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->