### PR TITLE
[AX]: check-webkit-style: DRT/WKTR - resolve all `whitespace/end_of_line` warnings

### DIFF
--- a/Tools/DumpRenderTree/AccessibilityController.cpp
+++ b/Tools/DumpRenderTree/AccessibilityController.cpp
@@ -96,7 +96,7 @@ static JSValueRef getElementAtPointCallback(JSContextRef context, JSObjectRef fu
         x = JSValueToNumber(context, arguments[0], exception);
         y = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     AccessibilityController* controller = static_cast<AccessibilityController*>(JSObjectGetPrivate(thisObject));
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, controller->elementAtPoint(x, y));
 }
@@ -105,7 +105,7 @@ static JSValueRef getAccessibleElementByIdCallback(JSContextRef context, JSObjec
 {
     JSStringRef idAttribute = 0;
     if (argumentCount == 1)
-        idAttribute = JSValueToStringCopy(context, arguments[0], exception);    
+        idAttribute = JSValueToStringCopy(context, arguments[0], exception);
     AccessibilityController* controller = static_cast<AccessibilityController*>(JSObjectGetPrivate(thisObject));
     JSValueRef result = AccessibilityUIElement::makeJSAccessibilityUIElement(context, controller->accessibleElementById(idAttribute));
     if (idAttribute)
@@ -117,7 +117,7 @@ static JSValueRef addNotificationListenerCallback(JSContextRef context, JSObject
 {
     if (argumentCount != 1)
         return JSValueMakeBoolean(context, false);
-    
+
     AccessibilityController* controller = static_cast<AccessibilityController*>(JSObjectGetPrivate(thisObject));
     JSObjectRef callback = JSValueToObject(context, arguments[0], exception);
     bool succeeded = controller->addNotificationListener(callback);

--- a/Tools/DumpRenderTree/AccessibilityTextMarker.cpp
+++ b/Tools/DumpRenderTree/AccessibilityTextMarker.cpp
@@ -65,17 +65,17 @@ JSClassRef AccessibilityTextMarker::getJSClass()
     static const JSStaticValue staticValues[] = {
         { 0, 0, 0, 0 }
     };
-    
+
     static const JSStaticFunction staticFunctions[] = {
         { "isEqual", isMarkerEqualCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { 0, 0, 0 }
     };
-    
+
     static const JSClassDefinition classDefinition = {
         0, kJSClassAttributeNone, "AccessibilityTextMarker", 0, staticValues, staticFunctions,
         0, markerFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
-    
+
     static JSClassRef accessibilityTextMarkerClass = JSClassCreate(&classDefinition);
     return accessibilityTextMarkerClass;
 }
@@ -93,7 +93,7 @@ static JSValueRef isMarkerRangeEqualCallback(JSContextRef context, JSObjectRef f
 {
     if (argumentCount != 1)
         return JSValueMakeBoolean(context, false);
-    
+
     JSObjectRef otherMarker = JSValueToObject(context, arguments[0], exception);
     return JSValueMakeBoolean(context, toTextMarkerRange(thisObject)->isEqual(toTextMarkerRange(otherMarker)));
 }
@@ -117,17 +117,17 @@ JSClassRef AccessibilityTextMarkerRange::getJSClass()
     static const JSStaticValue staticValues[] = {
         { 0, 0, 0, 0 }
     };
-    
+
     static const JSStaticFunction staticFunctions[] = {
         { "isEqual", isMarkerRangeEqualCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { 0, 0, 0 }
     };
-    
+
     static const JSClassDefinition classDefinition = {
         0, kJSClassAttributeNone, "AccessibilityTextMarkerRange", 0, staticValues, staticFunctions,
         0, markerRangeFinalize, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
-    
+
     static JSClassRef accessibilityTextMarkerRangeClass = JSClassCreate(&classDefinition);
     return accessibilityTextMarkerRangeClass;
 }

--- a/Tools/DumpRenderTree/AccessibilityTextMarker.h
+++ b/Tools/DumpRenderTree/AccessibilityTextMarker.h
@@ -47,12 +47,12 @@ public:
     AccessibilityTextMarker(PlatformTextMarker);
     AccessibilityTextMarker(const AccessibilityTextMarker&);
     ~AccessibilityTextMarker();
-    
+
     PlatformTextMarker platformTextMarker() const;
-    
+
     static JSObjectRef makeJSAccessibilityTextMarker(JSContextRef, const AccessibilityTextMarker&);
     bool isEqual(AccessibilityTextMarker*);
-    
+
 private:
     static JSClassRef getJSClass();
 #if PLATFORM(MAC)
@@ -67,9 +67,9 @@ public:
     AccessibilityTextMarkerRange(PlatformTextMarkerRange);
     AccessibilityTextMarkerRange(const AccessibilityTextMarkerRange&);
     ~AccessibilityTextMarkerRange();
-    
+
     PlatformTextMarkerRange platformTextMarkerRange() const;
-    
+
     static JSObjectRef makeJSAccessibilityTextMarkerRange(JSContextRef, const AccessibilityTextMarkerRange&);
     bool isEqual(AccessibilityTextMarkerRange*);
 

--- a/Tools/DumpRenderTree/AccessibilityUIElement.cpp
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.cpp
@@ -126,7 +126,7 @@ static JSValueRef lineForIndexCallback(JSContextRef context, JSObjectRef functio
     int indexNumber = -1;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return JSValueMakeNumber(context, toAXElement(thisObject)->lineForIndex(indexNumber));
 }
 
@@ -135,7 +135,7 @@ static JSValueRef rangeForLineCallback(JSContextRef context, JSObjectRef functio
     int indexNumber = -1;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     auto rangeLine = toAXElement(thisObject)->rangeForLine(indexNumber);
     return JSValueMakeString(context, rangeLine.get());
 }
@@ -149,7 +149,7 @@ static JSValueRef boundsForRangeCallback(JSContextRef context, JSObjectRef funct
     }
 
     auto boundsDescription = toAXElement(thisObject)->boundsForRange(location, length);
-    return JSValueMakeString(context, boundsDescription.get());    
+    return JSValueMakeString(context, boundsDescription.get());
 }
 
 static JSValueRef rangeForPositionCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -159,9 +159,9 @@ static JSValueRef rangeForPositionCallback(JSContextRef context, JSObjectRef fun
         x = JSValueToNumber(context, arguments[0], exception);
         y = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     auto rangeDescription = toAXElement(thisObject)->rangeForPosition(x, y);
-    return JSValueMakeString(context, rangeDescription.get());    
+    return JSValueMakeString(context, rangeDescription.get());
 }
 
 static JSValueRef stringForRangeCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -171,9 +171,9 @@ static JSValueRef stringForRangeCallback(JSContextRef context, JSObjectRef funct
         location = JSValueToNumber(context, arguments[0], exception);
         length = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     auto stringDescription = toAXElement(thisObject)->stringForRange(location, length);
-    return JSValueMakeString(context, stringDescription.get());    
+    return JSValueMakeString(context, stringDescription.get());
 }
 
 static JSValueRef attributedStringForRangeCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -183,9 +183,9 @@ static JSValueRef attributedStringForRangeCallback(JSContextRef context, JSObjec
         location = JSValueToNumber(context, arguments[0], exception);
         length = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     auto stringDescription = toAXElement(thisObject)->attributedStringForRange(location, length);
-    return JSValueMakeString(context, stringDescription.get());    
+    return JSValueMakeString(context, stringDescription.get());
 }
 
 static JSValueRef attributedStringRangeIsMisspelledCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -195,7 +195,7 @@ static JSValueRef attributedStringRangeIsMisspelledCallback(JSContextRef context
         location = JSValueToNumber(context, arguments[0], exception);
         length = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     return JSValueMakeBoolean(context, toAXElement(thisObject)->attributedStringRangeIsMisspelled(location, length));
 }
 
@@ -210,20 +210,20 @@ static JSValueRef uiElementCountForSearchPredicateCallback(JSContextRef context,
     if (argumentCount >= 5 && argumentCount <= 6) {
         if (JSValueIsObject(context, arguments[0]))
             startElement = toAXElement(JSValueToObject(context, arguments[0], exception));
-        
+
         isDirectionNext = JSValueToBoolean(context, arguments[1]);
-        
+
         searchKey = arguments[2];
-        
+
         if (JSValueIsString(context, arguments[3]))
             searchText = adopt(JSValueToStringCopy(context, arguments[3], exception));
-        
+
         visibleOnly = JSValueToBoolean(context, arguments[4]);
-        
+
         if (argumentCount == 6)
             immediateDescendantsOnly = JSValueToBoolean(context, arguments[5]);
     }
-    
+
     return JSValueMakeNumber(context, toAXElement(thisObject)->uiElementCountForSearchPredicate(context, startElement, isDirectionNext, searchKey, searchText.get(), visibleOnly, immediateDescendantsOnly));
 }
 
@@ -238,20 +238,20 @@ static JSValueRef uiElementForSearchPredicateCallback(JSContextRef context, JSOb
     if (argumentCount >= 5 && argumentCount <= 6) {
         if (JSValueIsObject(context, arguments[0]))
             startElement = toAXElement(JSValueToObject(context, arguments[0], exception));
-        
+
         isDirectionNext = JSValueToBoolean(context, arguments[1]);
-        
+
         searchKey = arguments[2];
-        
+
         if (JSValueIsString(context, arguments[3]))
             searchText = adopt(JSValueToStringCopy(context, arguments[3], exception));
-        
+
         visibleOnly = JSValueToBoolean(context, arguments[4]);
-        
+
         if (argumentCount == 6)
             immediateDescendantsOnly = JSValueToBoolean(context, arguments[5]);
     }
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->uiElementForSearchPredicate(context, startElement, isDirectionNext, searchKey, searchText.get(), visibleOnly, immediateDescendantsOnly));
 }
 
@@ -259,7 +259,7 @@ static JSValueRef selectTextWithCriteriaCallback(JSContextRef context, JSObjectR
 {
     if (argumentCount < 2 || argumentCount > 4)
         return JSValueMakeUndefined(context);
-    
+
     auto ambiguityResolution = adopt(JSValueToStringCopy(context, arguments[0], exception));
     JSValueRef searchStrings = arguments[1];
     JSStringRef replacementString = nullptr;
@@ -268,7 +268,7 @@ static JSValueRef selectTextWithCriteriaCallback(JSContextRef context, JSObjectR
     JSStringRef activityString = nullptr;
     if (argumentCount == 4)
         activityString = JSValueToStringCopy(context, arguments[3], exception);
-    
+
     auto result = toAXElement(thisObject)->selectTextWithCriteria(context, ambiguityResolution.get(), searchStrings, replacementString, activityString);
     if (replacementString)
         JSStringRelease(replacementString);
@@ -299,7 +299,7 @@ static JSValueRef indexOfChildCallback(JSContextRef context, JSObjectRef functio
 {
     if (argumentCount != 1)
         return 0;
-    
+
     JSObjectRef otherElement = JSValueToObject(context, arguments[0], exception);
     AccessibilityUIElement* childElement = toAXElement(otherElement);
     return JSValueMakeNumber(context, (double)toAXElement(thisObject)->indexOfChild(childElement));
@@ -320,7 +320,7 @@ static JSValueRef headerElementAtIndexCallback(JSContextRef context, JSObjectRef
 {
     if (argumentCount != 1)
         return 0;
-    
+
     unsigned index = JSValueToNumber(context, arguments[0], exception);
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->headerElementAtIndex(index));
 }
@@ -386,7 +386,7 @@ static JSValueRef childAtIndexCallback(JSContextRef context, JSObjectRef functio
     int indexNumber = -1;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->getChildAtIndex(indexNumber));
 }
 
@@ -395,7 +395,7 @@ static JSValueRef selectedChildAtIndexCallback(JSContextRef context, JSObjectRef
     int indexNumber = -1;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->selectedChildAtIndex(indexNumber));
 }
 
@@ -404,7 +404,7 @@ static JSValueRef linkedUIElementAtIndexCallback(JSContextRef context, JSObjectR
     int indexNumber = -1;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->linkedUIElementAtIndex(indexNumber));
 }
 
@@ -413,7 +413,7 @@ static JSValueRef disclosedRowAtIndexCallback(JSContextRef context, JSObjectRef 
     int indexNumber = 0;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->disclosedRowAtIndex(indexNumber));
 }
 
@@ -422,7 +422,7 @@ static JSValueRef ariaOwnsElementAtIndexCallback(JSContextRef context, JSObjectR
     int indexNumber = 0;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->ariaOwnsElementAtIndex(indexNumber));
 }
 
@@ -431,7 +431,7 @@ static JSValueRef ariaFlowToElementAtIndexCallback(JSContextRef context, JSObjec
     int indexNumber = 0;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->ariaFlowToElementAtIndex(indexNumber));
 }
 
@@ -449,7 +449,7 @@ static JSValueRef selectedRowAtIndexCallback(JSContextRef context, JSObjectRef f
     int indexNumber = 0;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->selectedRowAtIndex(indexNumber));
 }
 
@@ -458,7 +458,7 @@ static JSValueRef rowAtIndexCallback(JSContextRef context, JSObjectRef function,
     int indexNumber = 0;
     if (argumentCount == 1)
         indexNumber = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->rowAtIndex(indexNumber));
 }
 
@@ -469,7 +469,7 @@ static JSValueRef isEqualCallback(JSContextRef context, JSObjectRef function, JS
         otherElement = JSValueToObject(context, arguments[0], exception);
     else
         return JSValueMakeBoolean(context, false);
-    
+
     return JSValueMakeBoolean(context, toAXElement(thisObject)->isEqual(toAXElement(otherElement)));
 }
 
@@ -480,9 +480,9 @@ static JSValueRef setValueCallback(JSContextRef context, JSObjectRef function, J
         if (JSValueIsString(context, arguments[0]))
             valueText = adopt(JSValueToStringCopy(context, arguments[0], exception));
     }
-    
+
     toAXElement(thisObject)->setValue(valueText.get());
-    
+
     return JSValueMakeUndefined(context);
 }
 
@@ -523,7 +523,7 @@ static JSValueRef elementAtPointCallback(JSContextRef context, JSObjectRef funct
         x = JSValueToNumber(context, arguments[0], exception);
         y = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->elementAtPoint(x, y));
 }
 
@@ -531,7 +531,7 @@ static JSValueRef isAttributeSupportedCallback(JSContextRef context, JSObjectRef
 {
     JSStringRef attribute = 0;
     if (argumentCount == 1)
-        attribute = JSValueToStringCopy(context, arguments[0], exception);    
+        attribute = JSValueToStringCopy(context, arguments[0], exception);
     JSValueRef result = JSValueMakeBoolean(context, toAXElement(thisObject)->isAttributeSupported(attribute));
     if (attribute)
         JSStringRelease(attribute);
@@ -542,7 +542,7 @@ static JSValueRef isAttributeSettableCallback(JSContextRef context, JSObjectRef 
 {
     JSStringRef attribute = 0;
     if (argumentCount == 1)
-        attribute = JSValueToStringCopy(context, arguments[0], exception);    
+        attribute = JSValueToStringCopy(context, arguments[0], exception);
     JSValueRef result = JSValueMakeBoolean(context, toAXElement(thisObject)->isAttributeSettable(attribute));
     if (attribute)
         JSStringRelease(attribute);
@@ -629,9 +629,9 @@ static JSValueRef uiElementArrayAttributeValueCallback(JSContextRef context, JSO
 {
     if (argumentCount != 1)
         return JSValueMakeUndefined(context);
-    
+
     auto attribute = adopt(JSValueToStringCopy(context, arguments[0], exception));
-    
+
     Vector<AccessibilityUIElement> elements;
     toAXElement(thisObject)->uiElementArrayAttributeValue(attribute.get(), elements);
     return convertElementsToObjectArray(context, elements);
@@ -642,7 +642,7 @@ static JSValueRef uiElementAttributeValueCallback(JSContextRef context, JSObject
     JSRetainPtr<JSStringRef> attribute;
     if (argumentCount == 1)
         attribute = adopt(JSValueToStringCopy(context, arguments[0], exception));
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->uiElementAttributeValue(attribute.get()));
 }
 
@@ -665,7 +665,7 @@ static JSValueRef cellForColumnAndRowCallback(JSContextRef context, JSObjectRef 
         column = JSValueToNumber(context, arguments[0], exception);
         row = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->cellForColumnAndRow(column, row));
 }
 
@@ -691,7 +691,7 @@ static JSValueRef setSelectedTextRangeCallback(JSContextRef context, JSObjectRef
         location = JSValueToNumber(context, arguments[0], exception);
         length = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     toAXElement(thisObject)->setSelectedTextRange(location, length);
     return JSValueMakeUndefined(context);
 }
@@ -812,7 +812,7 @@ static JSValueRef textMarkerRangeForElementCallback(JSContextRef context, JSObje
     AccessibilityUIElement* uiElement = 0;
     if (argumentCount == 1)
         uiElement = toAXElement(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->textMarkerRangeForElement(uiElement));
 }
 
@@ -861,12 +861,12 @@ static JSValueRef attributedStringForTextMarkerRangeContainsAttributeCallback(JS
         attribute = JSValueToStringCopy(context, arguments[0], exception);
         markerRange = toTextMarkerRange(JSValueToObject(context, arguments[1], exception));
     }
-    
+
     JSValueRef result = JSValueMakeBoolean(context, toAXElement(thisObject)->attributedStringForTextMarkerRangeContainsAttribute(attribute, markerRange));
     if (attribute)
         JSStringRelease(attribute);
-    
-    return result;    
+
+    return result;
 }
 
 static JSValueRef indexForTextMarkerCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -874,7 +874,7 @@ static JSValueRef indexForTextMarkerCallback(JSContextRef context, JSObjectRef f
     AccessibilityTextMarker* marker = 0;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return JSValueMakeNumber(context, toAXElement(thisObject)->indexForTextMarker(marker));
 }
 
@@ -901,7 +901,7 @@ static JSValueRef textMarkerForIndexCallback(JSContextRef context, JSObjectRef f
     int textIndex = 0;
     if (argumentCount == 1)
         textIndex = JSValueToNumber(context, arguments[0], exception);
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->textMarkerForIndex(textIndex));
 }
 
@@ -910,7 +910,7 @@ static JSValueRef textMarkerRangeLengthCallback(JSContextRef context, JSObjectRe
     AccessibilityTextMarkerRange* range = 0;
     if (argumentCount == 1)
         range = toTextMarkerRange(JSValueToObject(context, arguments[0], exception));
-    
+
     return JSValueMakeNumber(context, (int)toAXElement(thisObject)->textMarkerRangeLength(range));
 }
 
@@ -919,7 +919,7 @@ static JSValueRef nextTextMarkerCallback(JSContextRef context, JSObjectRef funct
     AccessibilityTextMarker* marker = 0;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->nextTextMarker(marker));
 }
 
@@ -928,7 +928,7 @@ static JSValueRef previousTextMarkerCallback(JSContextRef context, JSObjectRef f
     AccessibilityTextMarker* marker = 0;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->previousTextMarker(marker));
 }
 
@@ -937,9 +937,9 @@ static JSValueRef stringForTextMarkerRangeCallback(JSContextRef context, JSObjec
     AccessibilityTextMarkerRange* markerRange = 0;
     if (argumentCount == 1)
         markerRange = toTextMarkerRange(JSValueToObject(context, arguments[0], exception));
-    
+
     auto markerRangeString = toAXElement(thisObject)->stringForTextMarkerRange(markerRange);
-    return JSValueMakeString(context, markerRangeString.get());    
+    return JSValueMakeString(context, markerRangeString.get());
 }
 
 static JSValueRef attributedStringForTextMarkerRangeCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -977,7 +977,7 @@ static JSValueRef endTextMarkerForBoundsCallback(JSContextRef context, JSObjectR
         width = JSValueToNumber(context, arguments[2], exception);
         height = JSValueToNumber(context, arguments[3], exception);
     }
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->endTextMarkerForBounds(x, y, width, height));
 }
 
@@ -993,7 +993,7 @@ static JSValueRef startTextMarkerForBoundsCallback(JSContextRef context, JSObjec
         width = JSValueToNumber(context, arguments[2], exception);
         height = JSValueToNumber(context, arguments[3], exception);
     }
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->startTextMarkerForBounds(x, y, width, height));
 }
 
@@ -1005,7 +1005,7 @@ static JSValueRef textMarkerForPointCallback(JSContextRef context, JSObjectRef f
         x = JSValueToNumber(context, arguments[0], exception);
         y = JSValueToNumber(context, arguments[1], exception);
     }
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->textMarkerForPoint(x, y));
 }
 
@@ -1017,7 +1017,7 @@ static JSValueRef textMarkerRangeForMarkersCallback(JSContextRef context, JSObje
         startMarker = toTextMarker(JSValueToObject(context, arguments[0], exception));
         endMarker = toTextMarker(JSValueToObject(context, arguments[1], exception));
     }
-    
+
     return AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->textMarkerRangeForMarkers(startMarker, endMarker));
 }
 
@@ -1026,7 +1026,7 @@ static JSValueRef startTextMarkerForTextMarkerRangeCallback(JSContextRef context
     AccessibilityTextMarkerRange* markerRange = 0;
     if (argumentCount == 1)
         markerRange = toTextMarkerRange(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->startTextMarkerForTextMarkerRange(markerRange));
 }
 
@@ -1035,7 +1035,7 @@ static JSValueRef endTextMarkerForTextMarkerRangeCallback(JSContextRef context, 
     AccessibilityTextMarkerRange* markerRange = 0;
     if (argumentCount == 1)
         markerRange = toTextMarkerRange(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->endTextMarkerForTextMarkerRange(markerRange));
 }
 
@@ -1044,7 +1044,7 @@ static JSValueRef accessibilityElementForTextMarkerCallback(JSContextRef context
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityUIElement::makeJSAccessibilityUIElement(context, toAXElement(thisObject)->accessibilityElementForTextMarker(marker));
 }
 
@@ -1063,7 +1063,7 @@ static JSValueRef leftWordTextMarkerRangeForTextMarkerCallback(JSContextRef cont
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->leftWordTextMarkerRangeForTextMarker(marker));
 }
 
@@ -1072,7 +1072,7 @@ static JSValueRef rightWordTextMarkerRangeForTextMarkerCallback(JSContextRef con
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->rightWordTextMarkerRangeForTextMarker(marker));
 }
 
@@ -1081,7 +1081,7 @@ static JSValueRef previousWordStartTextMarkerForTextMarkerCallback(JSContextRef 
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->previousWordStartTextMarkerForTextMarker(marker));
 }
 
@@ -1090,7 +1090,7 @@ static JSValueRef nextWordEndTextMarkerForTextMarkerCallback(JSContextRef contex
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->nextWordEndTextMarkerForTextMarker(marker));
 }
 
@@ -1099,7 +1099,7 @@ static JSValueRef paragraphTextMarkerRangeForTextMarkerCallback(JSContextRef con
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->paragraphTextMarkerRangeForTextMarker(marker));
 }
 
@@ -1108,7 +1108,7 @@ static JSValueRef previousParagraphStartTextMarkerForTextMarkerCallback(JSContex
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->previousParagraphStartTextMarkerForTextMarker(marker));
 }
 
@@ -1117,7 +1117,7 @@ static JSValueRef nextParagraphEndTextMarkerForTextMarkerCallback(JSContextRef c
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->nextParagraphEndTextMarkerForTextMarker(marker));
 }
 
@@ -1126,7 +1126,7 @@ static JSValueRef sentenceTextMarkerRangeForTextMarkerCallback(JSContextRef cont
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->sentenceTextMarkerRangeForTextMarker(marker));
 }
 
@@ -1135,7 +1135,7 @@ static JSValueRef previousSentenceStartTextMarkerForTextMarkerCallback(JSContext
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->previousSentenceStartTextMarkerForTextMarker(marker));
 }
 
@@ -1144,7 +1144,7 @@ static JSValueRef nextSentenceEndTextMarkerForTextMarkerCallback(JSContextRef co
     AccessibilityTextMarker* marker = nullptr;
     if (argumentCount == 1)
         marker = toTextMarker(JSValueToObject(context, arguments[0], exception));
-    
+
     return AccessibilityTextMarker::makeJSAccessibilityTextMarker(context, toAXElement(thisObject)->nextSentenceEndTextMarkerForTextMarker(marker));
 }
 
@@ -1211,9 +1211,9 @@ static JSValueRef getIsValidCallback(JSContextRef context, JSObjectRef thisObjec
     AccessibilityUIElement* uiElement = toAXElement(thisObject);
     if (!uiElement->hasPlatformUIElement())
         return JSValueMakeBoolean(context, false);
-    
+
     // There might be other platform logic that one could check here...
-    
+
     return JSValueMakeBoolean(context, true);
 }
 
@@ -1551,7 +1551,7 @@ static JSValueRef addNotificationListenerCallback(JSContextRef context, JSObject
 {
     if (argumentCount != 1)
         return JSValueMakeBoolean(context, false);
-    
+
     JSObjectRef callback = JSValueToObject(context, arguments[0], exception);
     bool succeeded = toAXElement(thisObject)->addNotificationListener(callback);
     return JSValueMakeBoolean(context, succeeded);
@@ -1660,7 +1660,7 @@ static JSValueRef textMarkerRangeMatchesTextNearMarkersCallback(JSContextRef con
         startMarker = toTextMarker(JSValueToObject(context, arguments[1], exception));
         endMarker = toTextMarker(JSValueToObject(context, arguments[2], exception));
     }
-    
+
     JSValueRef result = AccessibilityTextMarkerRange::makeJSAccessibilityTextMarkerRange(context, toAXElement(thisObject)->textMarkerRangeMatchesTextNearMarkers(searchText, startMarker, endMarker));
     if (searchText)
         JSStringRelease(searchText);
@@ -1807,7 +1807,7 @@ AccessibilityTextMarker AccessibilityUIElement::startTextMarkerForTextMarkerRang
 
 AccessibilityTextMarker AccessibilityUIElement::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
 {
-    return 0;   
+    return 0;
 }
 
 AccessibilityUIElement AccessibilityUIElement::accessibilityElementForTextMarker(AccessibilityTextMarker*)
@@ -1832,7 +1832,7 @@ AccessibilityTextMarker AccessibilityUIElement::textMarkerForPoint(int x, int y)
 
 AccessibilityTextMarker AccessibilityUIElement::previousTextMarker(AccessibilityTextMarker*)
 {
-    return 0;    
+    return 0;
 }
 
 AccessibilityTextMarker AccessibilityUIElement::nextTextMarker(AccessibilityTextMarker*)

--- a/Tools/DumpRenderTree/AccessibilityUIElement.h
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.h
@@ -80,7 +80,7 @@ public:
     bool isInDescriptionListDetail() const;
     bool isInDescriptionListTerm() const;
     bool isInCell() const;
-    
+
     AccessibilityUIElement elementAtPoint(int x, int y);
     AccessibilityUIElement getChildAtIndex(unsigned);
     unsigned indexOfChild(AccessibilityUIElement*);
@@ -97,7 +97,7 @@ public:
     JSRetainPtr<JSStringRef> allAttributes();
     JSRetainPtr<JSStringRef> attributesOfLinkedUIElements();
     AccessibilityUIElement linkedUIElementAtIndex(unsigned);
-    
+
     JSRetainPtr<JSStringRef> attributesOfDocumentLinks();
     JSRetainPtr<JSStringRef> attributesOfChildren();
     JSRetainPtr<JSStringRef> parameterizedAttributeNames();
@@ -156,7 +156,7 @@ public:
     bool isBusy() const;
     bool isEnabled();
     bool isRequired() const;
-    
+
     bool isFocused() const;
     bool isFocusable() const;
     bool isSelected() const;
@@ -169,7 +169,7 @@ public:
     void setSelectedChildAtIndex(unsigned) const;
     void removeSelectionAtIndex(unsigned) const;
     void clearSelectedChildren() const;
-    
+
     bool isExpanded() const;
     bool isChecked() const;
     bool isVisible() const;
@@ -191,7 +191,7 @@ public:
 
     // CSS3-speech properties.
     JSRetainPtr<JSStringRef> speakAs();
-    
+
     // Table-specific attributes
     JSRetainPtr<JSStringRef> attributesOfColumnHeaders();
     JSRetainPtr<JSStringRef> attributesOfRowHeaders();
@@ -227,7 +227,7 @@ public:
     bool isGrabbed() const;
     // A space concatentated string of all the drop effects.
     JSRetainPtr<JSStringRef> ariaDropEffects() const;
-    
+
     // Parameterized attributes
     int lineForIndex(int);
     JSRetainPtr<JSStringRef> rangeForLine(int);
@@ -249,16 +249,16 @@ public:
     void increaseTextSelection();
     void decreaseTextSelection();
     AccessibilityUIElement linkedElement();
-    
+
     bool scrollPageUp();
     bool scrollPageDown();
     bool scrollPageLeft();
     bool scrollPageRight();
-    
+
     bool hasTextEntryTrait();
     AccessibilityUIElement fieldsetAncestorElement();
     JSRetainPtr<JSStringRef> attributedStringForElement();
-    
+
     bool isDeletion();
     bool isInsertion();
     bool isFirstItemInSuggestion();
@@ -325,7 +325,7 @@ public:
     bool addNotificationListener(JSObjectRef functionCallback);
     // Make sure you call remove, because you can't rely on objects being deallocated in a timely fashion.
     void removeNotificationListener();
-    
+
 #if PLATFORM(IOS_FAMILY)
     JSRetainPtr<JSStringRef> traits();
     JSRetainPtr<JSStringRef> identifier();
@@ -334,10 +334,10 @@ public:
     AccessibilityUIElement headerElementAtIndex(unsigned);
     // This will simulate the accessibilityDidBecomeFocused API in UIKit.
     void assistiveTechnologySimulatedFocus();
-    
+
     bool isTextArea() const;
     bool isSearchField() const;
-    
+
     bool isMarkAnnotation() const;
 
     AccessibilityTextMarkerRange textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*);
@@ -346,11 +346,11 @@ public:
 #if PLATFORM(COCOA)
     JSRetainPtr<JSStringRef> embeddedImageDescription() const;
 #endif
-    
+
 #if PLATFORM(MAC)
     // Returns an ordered list of supported actions for an element.
     JSRetainPtr<JSStringRef> supportedActions();
-    
+
     // A general description of the elements making up multiscript pre/post objects.
     JSRetainPtr<JSStringRef> mathPostscriptsDescription() const;
     JSRetainPtr<JSStringRef> mathPrescriptsDescription() const;
@@ -363,7 +363,7 @@ private:
 #if !PLATFORM(COCOA)
     PlatformUIElement m_element;
 #endif
-    
+
 #if PLATFORM(COCOA)
     RetainPtr<id> m_element;
     RetainPtr<id> m_notificationHandler;

--- a/Tools/DumpRenderTree/ios/AccessibilityControllerIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityControllerIOS.mm
@@ -76,14 +76,14 @@ static id findAccessibleObjectById(id obj, NSString *idAttribute)
     id objIdAttribute = [obj accessibilityIdentifier];
     if ([objIdAttribute isKindOfClass:[NSString class]] && [objIdAttribute isEqualToString:idAttribute])
         return obj;
-    
+
     NSUInteger childrenCount = [obj accessibilityElementCount];
     for (NSUInteger i = 0; i < childrenCount; ++i) {
         id result = findAccessibleObjectById([obj accessibilityElementAtIndex:i], idAttribute);
         if (result)
             return result;
     }
-    
+
     return 0;
 }
 
@@ -92,13 +92,13 @@ AccessibilityUIElement AccessibilityController::accessibleElementById(JSStringRe
     id webDocumentView = [[mainFrame frameView] documentView];
     if (![webDocumentView isKindOfClass:[WebHTMLView class]])
         return 0;
-    
+
     id root = [(WebHTMLView *)webDocumentView accessibilityRootElement];
     NSString *idAttribute = [NSString stringWithJSStringRef:idAttributeRef];
     id result = findAccessibleObjectById(root, idAttribute);
     if (result)
         return AccessibilityUIElement(result);
-    
+
     return 0;
 }
 
@@ -122,7 +122,7 @@ bool AccessibilityController::addNotificationListener(JSObjectRef functionCallba
 {
     if (!functionCallback)
         return false;
-    
+
     // Mac programmers should not be adding more than one global notification listener.
     // Other platforms may be different.
     if (m_globalNotificationHandler)
@@ -130,7 +130,7 @@ bool AccessibilityController::addNotificationListener(JSObjectRef functionCallba
     m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] init]);
     [m_globalNotificationHandler setCallback:functionCallback];
     [m_globalNotificationHandler startObserving];
-    
+
     return true;
 }
 

--- a/Tools/DumpRenderTree/ios/AccessibilityTextMarkerIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityTextMarkerIOS.mm
@@ -51,8 +51,8 @@ bool AccessibilityTextMarker::isEqual(AccessibilityTextMarker* other)
     return [platformTextMarker() isEqual:other->platformTextMarker()];
 }
 
-PlatformTextMarker AccessibilityTextMarker::platformTextMarker() const 
-{ 
+PlatformTextMarker AccessibilityTextMarker::platformTextMarker() const
+{
     return m_textMarker;
 }
 

--- a/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
@@ -142,7 +142,7 @@ static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString *attribute
     [attribute getCharacters:buffer.mutableSpan().data()];
     buffer.append(':');
     buffer.append(' ');
-    
+
     Vector<UniChar> valueBuffer([value length]);
     [value getCharacters:valueBuffer.mutableSpan().data()];
     buffer.appendVector(valueBuffer);
@@ -188,7 +188,7 @@ int AccessibilityUIElement::elementTextPosition()
 int AccessibilityUIElement::elementTextLength()
 {
     NSRange range = [[m_element valueForKey:@"elementTextRange"] rangeValue];
-    return range.length;    
+    return range.length;
 }
 
 bool AccessibilityUIElement::hasTextEntryTrait()
@@ -202,7 +202,7 @@ AccessibilityUIElement AccessibilityUIElement::fieldsetAncestorElement()
     id ancestorElement = [m_element _accessibilityFieldsetAncestor];
     if (ancestorElement)
         return AccessibilityUIElement(ancestorElement);
-    
+
     return nullptr;
 }
 
@@ -273,14 +273,14 @@ void AccessibilityUIElement::getChildrenWithRange(Vector<AccessibilityUIElement>
     // We want to preserve that in order to test against invalid indexes being input.
     NSInteger maxValue = static_cast<NSInteger>(location + length);
     for (NSInteger k = location; k < maxValue; ++k)
-        elementVector.append(AccessibilityUIElement([m_element accessibilityElementAtIndex:k]));    
+        elementVector.append(AccessibilityUIElement([m_element accessibilityElementAtIndex:k]));
 }
 
 int AccessibilityUIElement::childrenCount()
 {
     Vector<AccessibilityUIElement> children;
     getChildren(children);
-    
+
     return children.size();
 }
 
@@ -289,8 +289,8 @@ AccessibilityUIElement AccessibilityUIElement::elementAtPoint(int x, int y)
     id element = [m_element accessibilityHitTest:NSMakePoint(x, y)];
     if (!element)
         return nil;
-    
-    return AccessibilityUIElement(element); 
+
+    return AccessibilityUIElement(element);
 }
 
 unsigned AccessibilityUIElement::indexOfChild(AccessibilityUIElement* element)
@@ -302,7 +302,7 @@ AccessibilityUIElement AccessibilityUIElement::getChildAtIndex(unsigned index)
 {
     Vector<AccessibilityUIElement> children;
     getChildrenWithRange(children, index, 1);
-    
+
     if (children.size() == 1)
         return children[0];
     return nil;
@@ -313,7 +313,7 @@ AccessibilityUIElement AccessibilityUIElement::headerElementAtIndex(unsigned ind
     NSArray *headers = [m_element accessibilityHeaderElements];
     if (index < [headers count])
         return [headers objectAtIndex:index];
-    
+
     return 0;
 }
 
@@ -322,7 +322,7 @@ AccessibilityUIElement AccessibilityUIElement::linkedElement()
     id linkedElement = [m_element accessibilityLinkedElement];
     if (linkedElement)
         return AccessibilityUIElement(linkedElement);
-    
+
     return 0;
 }
 
@@ -376,7 +376,7 @@ AccessibilityUIElement AccessibilityUIElement::parentElement()
     id accessibilityObject = [m_element accessibilityContainer];
     if (accessibilityObject)
         return AccessibilityUIElement(accessibilityObject);
-    
+
     return nil;
 }
 
@@ -392,7 +392,7 @@ void AccessibilityUIElement::increaseTextSelection()
 
 void AccessibilityUIElement::decreaseTextSelection()
 {
-    [m_element accessibilityModifySelection:WebCore::TextGranularity::CharacterGranularity increase:NO];    
+    [m_element accessibilityModifySelection:WebCore::TextGranularity::CharacterGranularity increase:NO];
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
@@ -401,13 +401,13 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForSelection()
-{ 
+{
     NSString *stringForRange = [m_element selectionRangeString];
     return [stringForRange createJSStringRef];
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned location, unsigned length)
-{ 
+{
     NSString *stringForRange = [m_element stringForRange:NSMakeRange(location, length)];
     return [stringForRange createJSStringRef];
 }
@@ -418,7 +418,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsign
     NSAttributedString* string = [m_element attributedStringForRange:range];
     if (![string isKindOfClass:[NSAttributedString class]])
         return 0;
-    
+
     NSString* stringWithAttrs = [string description];
     return [stringWithAttrs createJSStringRef];
 }
@@ -428,7 +428,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForElement()
     NSAttributedString *string = [m_element attributedStringForElement];
     if (![string isKindOfClass:[NSAttributedString class]])
         return nullptr;
-    
+
     return [[string description] createJSStringRef];
 }
 
@@ -445,19 +445,19 @@ static void _CGPathEnumerationIteration(void *info, const CGPathElement *element
     case kCGPathElementMoveToPoint:
         [result appendString:@"\tMove to point\n"];
         break;
-        
+
     case kCGPathElementAddLineToPoint:
         [result appendString:@"\tLine to\n"];
         break;
-        
+
     case kCGPathElementAddQuadCurveToPoint:
         [result appendString:@"\tQuad curve to\n"];
         break;
-        
+
     case kCGPathElementAddCurveToPoint:
         [result appendString:@"\tCurve to\n"];
         break;
-        
+
     case kCGPathElementCloseSubpath:
         [result appendString:@"\tClose\n"];
         break;
@@ -468,9 +468,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
 {
     NSMutableString *result = [NSMutableString stringWithString:@"\nStart Path\n"];
     CGPathRef pathRef = [m_element _accessibilityPath];
-    
+
     CGPathApply(pathRef, result, _CGPathEnumerationIteration);
-    
+
     return [result createJSStringRef];
 }
 
@@ -483,7 +483,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::lineTextMarkerRangeForTextM
     id startTextMarker = [m_element lineStartMarkerForMarker:textMarker->platformTextMarker()];
     id endTextMarker = [m_element lineEndMarkerForMarker:textMarker->platformTextMarker()];
     NSArray *textMarkers = @[startTextMarker, endTextMarker];
-    
+
     id textMarkerRange = [m_element textMarkerRangeForMarkers:textMarkers];
     return AccessibilityTextMarkerRange(textMarkerRange);
 }
@@ -743,19 +743,19 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(JSStringRe
 {
     if (JSStringIsEqualToUTF8CString(attribute, "AXPlaceholderValue"))
         return [[m_element accessibilityPlaceholderValue] createJSStringRef];
-    
+
     if (JSStringIsEqualToUTF8CString(attribute, "AXARIACurrent"))
         return [[m_element accessibilityARIACurrentStatus] createJSStringRef];
 
     if (JSStringIsEqualToUTF8CString(attribute, "AXExpandedTextValue"))
         return [[m_element accessibilityExpandedTextValue] createJSStringRef];
-    
+
     if (JSStringIsEqualToUTF8CString(attribute, "AXSortDirection"))
         return [[m_element accessibilitySortDirection] createJSStringRef];
-    
+
     if (JSStringIsEqualToUTF8CString(attribute, "AXTextualContext"))
         return [[m_element accessibilityTextualContext] createJSStringRef];
-    
+
     if (JSStringIsEqualToUTF8CString(attribute, "AXRowIndexDescription"))
         return [[m_element accessibilityRowIndexDescription] createJSStringRef];
 
@@ -1129,7 +1129,7 @@ bool AccessibilityUIElement::addNotificationListener(JSObjectRef functionCallbac
 {
     if (!functionCallback)
         return false;
-    
+
     // iOS programmers should not be adding more than one notification listener per element.
     // Other platforms may be different.
     if (m_notificationHandler)
@@ -1139,7 +1139,7 @@ bool AccessibilityUIElement::addNotificationListener(JSObjectRef functionCallbac
     [m_notificationHandler setPlatformElement:platformUIElement()];
     [m_notificationHandler setCallback:functionCallback];
     [m_notificationHandler startObserving];
-    
+
     return true;
 }
 
@@ -1147,7 +1147,7 @@ void AccessibilityUIElement::removeNotificationListener()
 {
     // iOS programmers should not be trying to remove a listener that's already removed.
     ASSERT(m_notificationHandler);
-    
+
     [m_notificationHandler stopObserving];
     m_notificationHandler = nil;
 }
@@ -1280,7 +1280,7 @@ double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
         return [m_element accessibilityARIARowIndex];
     if (JSStringIsEqualToUTF8CString(attribute, "AXBlockquoteLevel"))
         return [m_element accessibilityBlockquoteLevel];
-    
+
     return 0;
 }
 

--- a/Tools/DumpRenderTree/mac/AccessibilityCommonMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityCommonMac.mm
@@ -52,7 +52,7 @@
 NSDictionary *searchPredicateParameterizedAttributeForSearchCriteria(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, unsigned resultsLimit, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     NSMutableDictionary *parameterizedAttribute = [NSMutableDictionary dictionary];
-    
+
     if (startElement && startElement->platformUIElement())
         [parameterizedAttribute setObject:startElement->platformUIElement() forKey:@"AXStartElement"];
 
@@ -88,7 +88,7 @@ NSDictionary *searchPredicateParameterizedAttributeForSearchCriteria(JSContextRe
 
     [parameterizedAttribute setObject:@(visibleOnly) forKey:@"AXVisibleOnly"];
     [parameterizedAttribute setObject:@(immediateDescendantsOnly) forKey:@"AXImmediateDescendantsOnly"];
-    
+
     return parameterizedAttribute;
 }
 

--- a/Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm
@@ -56,7 +56,7 @@ AccessibilityController::~AccessibilityController()
 AccessibilityUIElement AccessibilityController::elementAtPoint(int x, int y)
 {
     id accessibilityObject = [[[mainFrame frameView] documentView] accessibilityHitTest:NSMakePoint(x, y)];
-    return AccessibilityUIElement(accessibilityObject);    
+    return AccessibilityUIElement(accessibilityObject);
 }
 
 AccessibilityUIElement AccessibilityController::focusedElement()
@@ -68,10 +68,10 @@ AccessibilityUIElement AccessibilityController::focusedElement()
 AccessibilityUIElement AccessibilityController::rootElement()
 {
     // FIXME: we could do some caching here.
-    
+
     // Layout tests expect that the root element will be the scroll area
     // containing the web area object. That will be the parent of the accessibilityRoot on WK1.
-    
+
     id accessibilityObject = [[mainFrame accessibilityRoot] accessibilityAttributeValue:NSAccessibilityParentAttribute];
     return AccessibilityUIElement(accessibilityObject);
 }
@@ -139,7 +139,7 @@ bool AccessibilityController::addNotificationListener(JSObjectRef functionCallba
 {
     if (!functionCallback)
         return false;
- 
+
     // Mac programmers should not be adding more than one global notification listener.
     // Other platforms may be different.
     if (m_globalNotificationHandler)

--- a/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
@@ -65,7 +65,7 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     JSValueUnprotect([mainFrame globalContext], m_notificationFunctionCallback);
     m_notificationFunctionCallback = 0;
-    
+
     [super dealloc];
 }
 
@@ -73,10 +73,10 @@
 {
     if (!callback)
         return;
- 
-    if (m_notificationFunctionCallback) 
+
+    if (m_notificationFunctionCallback)
         JSValueUnprotect([mainFrame globalContext], m_notificationFunctionCallback);
-    
+
     m_notificationFunctionCallback = callback;
     JSValueProtect([mainFrame globalContext], m_notificationFunctionCallback);
 }

--- a/Tools/DumpRenderTree/mac/AccessibilityTextMarkerMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityTextMarkerMac.mm
@@ -52,7 +52,7 @@ bool AccessibilityTextMarker::isEqual(AccessibilityTextMarker* other)
 }
 
 id AccessibilityTextMarker::platformTextMarker() const
-{ 
+{
     return m_textMarker.get();
 }
 

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -149,7 +149,7 @@ static NSString* descriptionOfValue(id valueObject, id focusedAccessibilityObjec
             return [NSString stringWithFormat:@"<%@: '%@'>", role, title];
         return [NSString stringWithFormat:@"<%@>", role];
     }
-    
+
     return [valueObject description];
 }
 
@@ -160,12 +160,12 @@ static NSString* attributesOfElement(id accessibilityObject)
     NSMutableString* attributesString = [NSMutableString string];
     for (NSUInteger i = 0; i < [supportedAttributes count]; ++i) {
         NSString* attribute = [supportedAttributes objectAtIndex:i];
-        
+
         // Right now, position provides useless and screen-specific information, so we do not
         // want to include it for the sake of universally passing tests.
         if ([attribute isEqualToString:@"AXPosition"])
             continue;
-        
+
         // Skip screen-specific information.
         if ([attribute isEqualToString:@"_AXPrimaryScreenHeight"] || [attribute isEqualToString:@"AXRelativeFrame"])
             continue;
@@ -196,7 +196,7 @@ static NSString* attributesOfElement(id accessibilityObject)
         [attributesString appendFormat:@"%@: %@\n", attribute, value];
         END_AX_OBJC_EXCEPTIONS
     }
-    
+
     return attributesString;
 }
 
@@ -222,7 +222,7 @@ static JSRetainPtr<JSStringRef> descriptionOfElements(Vector<AccessibilityUIElem
         NSString* attributes = attributesOfElement(elementVector[i].platformUIElement());
         [allElementString appendFormat:@"%@\n------------\n", attributes];
     }
-    
+
     return [allElementString createJSStringRef];
 }
 
@@ -238,10 +238,10 @@ template<typename T> static JSObjectRef convertVectorToObjectArray(JSContextRef 
 static NSDictionary *selectTextParameterizedAttributeForCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     NSMutableDictionary *parameterizedAttribute = [NSMutableDictionary dictionary];
-    
+
     if (ambiguityResolution)
         [parameterizedAttribute setObject:[NSString stringWithJSStringRef:ambiguityResolution] forKey:@"AXSelectTextAmbiguityResolution"];
-    
+
     if (searchStrings) {
         NSMutableArray *searchStringsParameter = [NSMutableArray array];
         if (JSValueIsString(context, searchStrings)) {
@@ -260,16 +260,16 @@ static NSDictionary *selectTextParameterizedAttributeForCriteria(JSContextRef co
         }
         [parameterizedAttribute setObject:searchStringsParameter forKey:@"AXSelectTextSearchStrings"];
     }
-    
+
     if (replacementString) {
         [parameterizedAttribute setObject:@"AXSelectTextActivityFindAndReplace" forKey:@"AXSelectTextActivity"];
         [parameterizedAttribute setObject:[NSString stringWithJSStringRef:replacementString] forKey:@"AXSelectTextReplacementString"];
     } else
         [parameterizedAttribute setObject:@"AXSelectTextActivityFindAndSelect" forKey:@"AXSelectTextActivity"];
-    
+
     if (activity)
         [parameterizedAttribute setObject:[NSString stringWithJSStringRef:activity] forKey:@"AXSelectTextActivity"];
-    
+
     return parameterizedAttribute;
 }
 
@@ -349,7 +349,7 @@ int AccessibilityUIElement::childrenCount()
 {
     Vector<AccessibilityUIElement> children;
     getChildren(children);
-    
+
     return children.size();
 }
 
@@ -358,8 +358,8 @@ AccessibilityUIElement AccessibilityUIElement::elementAtPoint(int x, int y)
     id element = [m_element accessibilityHitTest:NSMakePoint(x, y)];
     if (!element)
         return nil;
-    
-    return AccessibilityUIElement(element); 
+
+    return AccessibilityUIElement(element);
 }
 
 unsigned AccessibilityUIElement::indexOfChild(AccessibilityUIElement* element)
@@ -384,7 +384,7 @@ AccessibilityUIElement AccessibilityUIElement::linkedUIElementAtIndex(unsigned i
     if (index < [objects count])
         return [objects objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -395,7 +395,7 @@ AccessibilityUIElement AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned i
     if (index < [objects count])
         return [objects objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -406,7 +406,7 @@ AccessibilityUIElement AccessibilityUIElement::ariaFlowToElementAtIndex(unsigned
     if (index < [objects count])
         return [objects objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -436,7 +436,7 @@ AccessibilityUIElement AccessibilityUIElement::selectedChildAtIndex(unsigned ind
     if (index < [array count])
         return [array objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -456,7 +456,7 @@ AccessibilityUIElement AccessibilityUIElement::selectedRowAtIndex(unsigned index
     if (index < [rows count])
         return [rows objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -467,7 +467,7 @@ AccessibilityUIElement AccessibilityUIElement::rowAtIndex(unsigned index)
     if (index < [rows count])
         return [rows objectAtIndex:index];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -478,7 +478,7 @@ AccessibilityUIElement AccessibilityUIElement::titleUIElement()
     if (accessibilityObject)
         return AccessibilityUIElement(accessibilityObject);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -489,7 +489,7 @@ AccessibilityUIElement AccessibilityUIElement::parentElement()
     if (accessibilityObject)
         return AccessibilityUIElement(accessibilityObject);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -500,7 +500,7 @@ AccessibilityUIElement AccessibilityUIElement::disclosedByRow()
     if (accessibilityObject)
         return AccessibilityUIElement(accessibilityObject);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -590,7 +590,7 @@ AccessibilityUIElement AccessibilityUIElement::uiElementAttributeValue(JSStringR
     id uiElement = [m_element accessibilityAttributeValue:[NSString stringWithJSStringRef:attribute]];
     return AccessibilityUIElement(uiElement);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -607,7 +607,7 @@ double AccessibilityUIElement::numberAttributeValue(NSString *attribute) const
     if ([value isKindOfClass:[NSNumber class]])
         return [value doubleValue];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0;
 }
 
@@ -618,7 +618,7 @@ bool AccessibilityUIElement::boolAttributeValue(NSString *attribute) const
     if ([value isKindOfClass:[NSNumber class]])
         return [value boolValue];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -639,7 +639,7 @@ bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
     BEGIN_AX_OBJC_EXCEPTIONS
     return [m_element accessibilityIsAttributeSettable:[NSString stringWithJSStringRef:attribute]];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -648,19 +648,19 @@ bool AccessibilityUIElement::isAttributeSupported(JSStringRef attribute)
     BEGIN_AX_OBJC_EXCEPTIONS
     return [[m_element accessibilityAttributeNames] containsObject:[NSString stringWithJSStringRef:attribute]];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::parameterizedAttributeNames()
 {
     NSArray* supportedParameterizedAttributes = [m_element accessibilityParameterizedAttributeNames];
-    
+
     NSMutableString* attributesString = [NSMutableString string];
     for (NSUInteger i = 0; i < [supportedParameterizedAttributes count]; ++i) {
         [attributesString appendFormat:@"%@\n", [supportedParameterizedAttributes objectAtIndex:i]];
     }
-    
+
     return [attributesString createJSStringRef];
 }
 
@@ -670,7 +670,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
     NSString *role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityRoleAttribute], m_element.get());
     return concatenateAttributeAndValue(@"AXRole", role);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -690,7 +690,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
     NSString* role = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityRoleDescriptionAttribute], m_element.get());
     return concatenateAttributeAndValue(@"AXRoleDescription", role);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -700,7 +700,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
     NSString *computedRoleString = descriptionOfValue([m_element accessibilityAttributeValue:@"AXARIARole"], m_element.get());
     return [computedRoleString createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -776,7 +776,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
     id description = descriptionOfValue([m_element accessibilityAttributeValue:NSAccessibilityHelpAttribute], m_element.get());
     return concatenateAttributeAndValue(@"AXHelp", description);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -816,9 +816,9 @@ double AccessibilityUIElement::x()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     NSValue* positionValue = [m_element accessibilityAttributeValue:NSAccessibilityPositionAttribute];
-    return static_cast<double>([positionValue pointValue].x);    
+    return static_cast<double>([positionValue pointValue].x);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0.0f;
 }
 
@@ -826,9 +826,9 @@ double AccessibilityUIElement::y()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     NSValue* positionValue = [m_element accessibilityAttributeValue:NSAccessibilityPositionAttribute];
-    return static_cast<double>([positionValue pointValue].y);    
+    return static_cast<double>([positionValue pointValue].y);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0.0f;
 }
 
@@ -838,7 +838,7 @@ double AccessibilityUIElement::width()
     NSValue* sizeValue = [m_element accessibilityAttributeValue:NSAccessibilitySizeAttribute];
     return static_cast<double>([sizeValue sizeValue].width);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0.0f;
 }
 
@@ -848,7 +848,7 @@ double AccessibilityUIElement::height()
     NSValue* sizeValue = [m_element accessibilityAttributeValue:NSAccessibilitySizeAttribute];
     return static_cast<double>([sizeValue sizeValue].height);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0.0f;
 }
 
@@ -856,9 +856,9 @@ double AccessibilityUIElement::clickPointX()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     NSValue* positionValue = [m_element accessibilityAttributeValue:@"AXClickPoint"];
-    return static_cast<double>([positionValue pointValue].x);        
+    return static_cast<double>([positionValue pointValue].x);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0.0f;
 }
 
@@ -868,7 +868,7 @@ double AccessibilityUIElement::clickPointY()
     NSValue* positionValue = [m_element accessibilityAttributeValue:@"AXClickPoint"];
     return static_cast<double>([positionValue pointValue].y);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0.0f;
 }
 
@@ -894,7 +894,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
     if ([valueDescription isKindOfClass:[NSString class]])
         return concatenateAttributeAndValue(@"AXValueDescription", valueDescription);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -903,9 +903,9 @@ int AccessibilityUIElement::insertionPointLineNumber()
     BEGIN_AX_OBJC_EXCEPTIONS
     id value = [m_element accessibilityAttributeValue:NSAccessibilityInsertionPointLineNumberAttribute];
     if ([value isKindOfClass:[NSNumber class]])
-        return [(NSNumber *)value intValue]; 
+        return [(NSNumber *)value intValue];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return -1;
 }
 
@@ -915,7 +915,7 @@ bool AccessibilityUIElement::isPressActionSupported()
     NSArray* actions = [m_element accessibilityActionNames];
     return [actions containsObject:NSAccessibilityPressAction];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -925,7 +925,7 @@ bool AccessibilityUIElement::isIncrementActionSupported()
     NSArray* actions = [m_element accessibilityActionNames];
     return [actions containsObject:NSAccessibilityIncrementAction];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -935,7 +935,7 @@ bool AccessibilityUIElement::isDecrementActionSupported()
     NSArray* actions = [m_element accessibilityActionNames];
     return [actions containsObject:NSAccessibilityDecrementAction];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -998,7 +998,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
     if ([value isKindOfClass:[NSArray class]])
         return [[value componentsJoinedByString:@", "] createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-        
+
     return nullptr;
 }
 
@@ -1008,7 +1008,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
     id value = [m_element accessibilityAttributeValue:@"AXDOMClassList"];
     if (![value isKindOfClass:[NSArray class]])
         return nullptr;
-    
+
     NSMutableString* classList = [NSMutableString string];
     NSInteger length = [value count];
     for (NSInteger k = 0; k < length; ++k) {
@@ -1016,10 +1016,10 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
         if (k < length - 1)
             [classList appendString:@", "];
     }
-    
+
     return [classList createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1050,10 +1050,10 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
         if (k < length - 1)
             [dropEffects appendString:@","];
     }
-    
+
     return [dropEffects createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1063,7 +1063,7 @@ int AccessibilityUIElement::lineForIndex(int index)
     BEGIN_AX_OBJC_EXCEPTIONS
     id value = [m_element accessibilityAttributeValue:NSAccessibilityLineForIndexParameterizedAttribute forParameter:@(index)];
     if ([value isKindOfClass:[NSNumber class]])
-        return [(NSNumber *)value intValue]; 
+        return [(NSNumber *)value intValue];
     END_AX_OBJC_EXCEPTIONS
 
     return -1;
@@ -1076,7 +1076,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForLine(int line)
     if ([value isKindOfClass:[NSValue class]])
         return [NSStringFromRange([value rangeValue]) createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1087,7 +1087,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForPosition(int x, int y)
     if ([value isKindOfClass:[NSValue class]])
         return [NSStringFromRange([value rangeValue]) createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1099,13 +1099,13 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned locatio
     id value = [m_element accessibilityAttributeValue:NSAccessibilityBoundsForRangeParameterizedAttribute forParameter:[NSValue valueWithRange:range]];
     NSRect rect = NSMakeRect(0,0,0,0);
     if ([value isKindOfClass:[NSValue class]])
-        rect = [value rectValue]; 
-    
+        rect = [value rectValue];
+
     // don't return position information because it is platform dependent
     NSMutableString* boundsDescription = [NSMutableString stringWithFormat:@"{{%f, %f}, {%f, %f}}",-1.0f,-1.0f,rect.size.width,rect.size.height];
     return [boundsDescription createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1116,10 +1116,10 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned locatio
     id string = [m_element accessibilityAttributeValue:NSAccessibilityStringForRangeParameterizedAttribute forParameter:[NSValue valueWithRange:range]];
     if (![string isKindOfClass:[NSString class]])
         return 0;
-    
+
     return [string createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1130,11 +1130,11 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsign
     NSAttributedString* string = [m_element accessibilityAttributeValue:NSAccessibilityAttributedStringForRangeParameterizedAttribute forParameter:[NSValue valueWithRange:range]];
     if (![string isKindOfClass:[NSAttributedString class]])
         return 0;
-    
+
     NSString* stringWithAttrs = [string description];
     return [stringWithAttrs createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1154,7 +1154,7 @@ bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned location
 #endif
     return misspelled;
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -1166,7 +1166,7 @@ unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef c
     if ([value isKindOfClass:[NSArray class]])
         return [value count];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0;
 }
 
@@ -1197,7 +1197,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContex
     if ([result isKindOfClass:[NSString class]])
         return [result createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1222,7 +1222,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
     auto columnHeadersVector = makeVector<AccessibilityUIElement>(columnHeadersArray);
     return descriptionOfElements(columnHeadersVector);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1233,7 +1233,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
     auto rowHeadersVector = makeVector<AccessibilityUIElement>(rowHeadersArray);
     return descriptionOfElements(rowHeadersVector);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1244,7 +1244,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
     auto columnsVector = makeVector<AccessibilityUIElement>(columnsArray);
     return descriptionOfElements(columnsVector);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1255,7 +1255,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
     auto rowsVector = makeVector<AccessibilityUIElement>(rowsArray);
     return descriptionOfElements(rowsVector);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1266,7 +1266,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
     auto cellsVector = makeVector<AccessibilityUIElement>(cellsArray);
     return descriptionOfElements(cellsVector);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1276,12 +1276,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfHeader()
     id headerObject = [m_element accessibilityAttributeValue:NSAccessibilityHeaderAttribute];
     if (!headerObject)
         return [@"" createJSStringRef];
-    
+
     Vector<AccessibilityUIElement> headerVector;
     headerVector.append(headerObject);
     return descriptionOfElements(headerVector);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1290,7 +1290,7 @@ int AccessibilityUIElement::rowCount()
     BEGIN_AX_OBJC_EXCEPTIONS
     return [m_element accessibilityArrayAttributeCount:NSAccessibilityRowsAttribute];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0;
 }
 
@@ -1299,7 +1299,7 @@ int AccessibilityUIElement::columnCount()
     BEGIN_AX_OBJC_EXCEPTIONS
     return [m_element accessibilityArrayAttributeCount:NSAccessibilityColumnsAttribute];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0;
 }
 
@@ -1324,7 +1324,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::rowIndexRange()
     NSMutableString* rangeDescription = [NSMutableString stringWithFormat:@"{%lu, %lu}", static_cast<unsigned long>(range.location), static_cast<unsigned long>(range.length)];
     return [rangeDescription createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1338,7 +1338,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::columnIndexRange()
     NSMutableString* rangeDescription = [NSMutableString stringWithFormat:@"{%lu, %lu}",static_cast<unsigned long>(range.location), static_cast<unsigned long>(range.length)];
     return [rangeDescription createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1347,7 +1347,7 @@ AccessibilityUIElement AccessibilityUIElement::cellForColumnAndRow(unsigned col,
     NSArray *colRowArray = @[@(col), @(row)];
     BEGIN_AX_OBJC_EXCEPTIONS
     return [m_element accessibilityAttributeValue:@"AXCellForColumnAndRow" forParameter:colRowArray];
-    END_AX_OBJC_EXCEPTIONS    
+    END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
 }
@@ -1356,11 +1356,11 @@ AccessibilityUIElement AccessibilityUIElement::horizontalScrollbar() const
 {
     if (!m_element)
         return nullptr;
-    
+
     BEGIN_AX_OBJC_EXCEPTIONS
     return AccessibilityUIElement([m_element accessibilityAttributeValue:NSAccessibilityHorizontalScrollBarAttribute]);
-    END_AX_OBJC_EXCEPTIONS    
-    
+    END_AX_OBJC_EXCEPTIONS
+
     return nullptr;
 }
 
@@ -1371,7 +1371,7 @@ AccessibilityUIElement AccessibilityUIElement::verticalScrollbar() const
 
     BEGIN_AX_OBJC_EXCEPTIONS
     return AccessibilityUIElement([m_element accessibilityAttributeValue:NSAccessibilityVerticalScrollBarAttribute]);
-    END_AX_OBJC_EXCEPTIONS        
+    END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
 }
@@ -1381,7 +1381,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
     BEGIN_AX_OBJC_EXCEPTIONS
     NSMutableString *result = [NSMutableString stringWithString:@"\nStart Path\n"];
     NSBezierPath *bezierPath = [m_element accessibilityAttributeValue:NSAccessibilityPathAttribute];
-    
+
     NSUInteger elementCount = [bezierPath elementCount];
     for (NSUInteger i = 0; i < elementCount; i++) {
         switch ([bezierPath elementAtIndex:i]) {
@@ -1418,7 +1418,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
     NSMutableString *rangeDescription = [NSMutableString stringWithFormat:@"{%lu, %lu}", static_cast<unsigned long>(range.location), static_cast<unsigned long>(range.length)];
     return [rangeDescription createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1488,7 +1488,7 @@ void AccessibilityUIElement::setSelectedChild(AccessibilityUIElement* element) c
     BEGIN_AX_OBJC_EXCEPTIONS
     NSArray* array = @[element->platformUIElement()];
     [m_element accessibilitySetValue:array forAttribute:NSAccessibilitySelectedChildrenAttribute];
-    END_AX_OBJC_EXCEPTIONS    
+    END_AX_OBJC_EXCEPTIONS
 }
 
 void AccessibilityUIElement::setSelectedChildAtIndex(unsigned index) const
@@ -1535,7 +1535,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     NSURL *url = [m_element accessibilityAttributeValue:NSAccessibilityURLAttribute];
     return [[url absoluteString] createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1543,7 +1543,7 @@ bool AccessibilityUIElement::addNotificationListener(JSObjectRef functionCallbac
 {
     if (!functionCallback)
         return false;
- 
+
     // Mac programmers should not be adding more than one notification listener per element.
     // Other platforms may be different.
     if (m_notificationHandler)
@@ -1572,7 +1572,7 @@ bool AccessibilityUIElement::isFocusable() const
     BEGIN_AX_OBJC_EXCEPTIONS
     result = [m_element accessibilityIsAttributeSettable:NSAccessibilityFocusedAttribute];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return result;
 }
 
@@ -1716,7 +1716,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::lineTextMarkerRangeForTextM
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXLineTextMarkerRangeForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1742,7 +1742,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::textMarkerRangeForElement(A
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXTextMarkerRangeForUIElement" forParameter:element->platformUIElement()];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1752,7 +1752,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::selectedTextMarkerRange()
     id textMarkerRange = [m_element accessibilityAttributeValue:NSAccessibilitySelectedTextMarkerRangeAttribute];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1761,12 +1761,12 @@ void AccessibilityUIElement::resetSelectedTextMarkerRange()
     id start = [m_element accessibilityAttributeValue:@"AXStartTextMarker"];
     if (!start)
         return;
-    
+
     NSArray* textMarkers = @[start, start];
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXTextMarkerRangeForUnorderedTextMarkers" forParameter:textMarkers];
     if (!textMarkerRange)
         return;
-    
+
     BEGIN_AX_OBJC_EXCEPTIONS
     [m_element _accessibilitySetValue:textMarkerRange forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute];
     END_AX_OBJC_EXCEPTIONS
@@ -1804,7 +1804,7 @@ int AccessibilityUIElement::textMarkerRangeLength(AccessibilityTextMarkerRange* 
     NSNumber* lengthValue = [m_element accessibilityAttributeValue:@"AXLengthForTextMarkerRange" forParameter:range->platformTextMarkerRange()];
     return [lengthValue intValue];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return 0;
 }
 
@@ -1814,12 +1814,12 @@ bool AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute
     NSAttributedString* string = [m_element accessibilityAttributeValue:@"AXAttributedStringForTextMarkerRange" forParameter:range->platformTextMarkerRange()];
     if (![string isKindOfClass:[NSAttributedString class]])
         return false;
-    
+
     NSDictionary* attrs = [string attributesAtIndex:0 effectiveRange:nil];
     if ([attrs objectForKey:[NSString stringWithJSStringRef:attribute]])
-        return true;    
+        return true;
     END_AX_OBJC_EXCEPTIONS
-    
+
     return false;
 }
 
@@ -1829,7 +1829,7 @@ int AccessibilityUIElement::indexForTextMarker(AccessibilityTextMarker* marker)
     NSNumber* indexNumber = [m_element accessibilityAttributeValue:@"AXIndexForTextMarker" forParameter:marker->platformTextMarker()];
     return [indexNumber intValue];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return -1;
 }
 
@@ -1839,7 +1839,7 @@ AccessibilityTextMarker AccessibilityUIElement::textMarkerForIndex(int textIndex
     id textMarker = [m_element accessibilityAttributeValue:@"AXTextMarkerForIndex" forParameter:[NSNumber numberWithInteger:textIndex]];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1873,7 +1873,7 @@ AccessibilityTextMarker AccessibilityUIElement::previousTextMarker(Accessibility
     id previousMarker = [m_element accessibilityAttributeValue:@"AXPreviousTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(previousMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1883,7 +1883,7 @@ AccessibilityTextMarker AccessibilityUIElement::nextTextMarker(AccessibilityText
     id nextMarker = [m_element accessibilityAttributeValue:@"AXNextTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(nextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1893,7 +1893,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForTextMarkerRange(Access
     id textString = [m_element accessibilityAttributeValue:@"AXStringForTextMarkerRange" forParameter:markerRange->platformTextMarkerRange()];
     return [textString createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2003,7 +2003,7 @@ AccessibilityTextMarker AccessibilityUIElement::startTextMarkerForTextMarkerRang
     id textMarker = [m_element accessibilityAttributeValue:@"_AXStartTextMarkerForTextMarkerRange" forParameter:range->platformTextMarkerRange()];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2013,7 +2013,7 @@ AccessibilityTextMarker AccessibilityUIElement::endTextMarkerForTextMarkerRange(
     id textMarker = [m_element accessibilityAttributeValue:@"_AXEndTextMarkerForTextMarkerRange" forParameter:range->platformTextMarkerRange()];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2023,7 +2023,7 @@ AccessibilityTextMarker AccessibilityUIElement::endTextMarkerForBounds(int x, in
     id textMarker = [m_element accessibilityAttributeValue:NSAccessibilityEndTextMarkerForBoundsParameterizedAttribute forParameter:[NSValue valueWithRect:NSMakeRect(x, y, width, height)]];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2033,7 +2033,7 @@ AccessibilityTextMarker AccessibilityUIElement::startTextMarkerForBounds(int x, 
     id textMarker = [m_element accessibilityAttributeValue:NSAccessibilityStartTextMarkerForBoundsParameterizedAttribute forParameter:[NSValue valueWithRect:NSMakeRect(x, y, width, height)]];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2043,7 +2043,7 @@ AccessibilityTextMarker AccessibilityUIElement::textMarkerForPoint(int x, int y)
     id textMarker = [m_element accessibilityAttributeValue:@"AXTextMarkerForPosition" forParameter:[NSValue valueWithPoint:NSMakePoint(x, y)]];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2053,7 +2053,7 @@ AccessibilityUIElement AccessibilityUIElement::accessibilityElementForTextMarker
     id uiElement = [m_element accessibilityAttributeValue:@"AXUIElementForTextMarker" forParameter:marker->platformTextMarker()];
     return AccessibilityUIElement(uiElement);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2063,7 +2063,7 @@ AccessibilityTextMarker AccessibilityUIElement::startTextMarker()
     id textMarker = [m_element accessibilityAttributeValue:@"AXStartTextMarker"];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2073,7 +2073,7 @@ AccessibilityTextMarker AccessibilityUIElement::endTextMarker()
     id textMarker = [m_element accessibilityAttributeValue:@"AXEndTextMarker"];
     return AccessibilityTextMarker(textMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2082,7 +2082,7 @@ bool AccessibilityUIElement::setSelectedTextMarkerRange(AccessibilityTextMarkerR
     BEGIN_AX_OBJC_EXCEPTIONS
     [m_element accessibilitySetValue:markerRange->platformTextMarkerRange() forAttribute:NSAccessibilitySelectedTextMarkerRangeAttribute];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return true;
 }
 
@@ -2092,7 +2092,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::leftWordTextMarkerRangeForT
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXLeftWordTextMarkerRangeForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2102,7 +2102,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::rightWordTextMarkerRangeFor
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXRightWordTextMarkerRangeForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2112,7 +2112,7 @@ AccessibilityTextMarker AccessibilityUIElement::previousWordStartTextMarkerForTe
     id previousTextMarker = [m_element accessibilityAttributeValue:@"AXPreviousWordStartTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(previousTextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2122,7 +2122,7 @@ AccessibilityTextMarker AccessibilityUIElement::nextWordEndTextMarkerForTextMark
     id nextTextMarker = [m_element accessibilityAttributeValue:@"AXNextWordEndTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(nextTextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2132,7 +2132,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::paragraphTextMarkerRangeFor
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXParagraphTextMarkerRangeForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2142,7 +2142,7 @@ AccessibilityTextMarker AccessibilityUIElement::previousParagraphStartTextMarker
     id previousTextMarker = [m_element accessibilityAttributeValue:@"AXPreviousParagraphStartTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(previousTextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2152,7 +2152,7 @@ AccessibilityTextMarker AccessibilityUIElement::nextParagraphEndTextMarkerForTex
     id nextTextMarker = [m_element accessibilityAttributeValue:@"AXNextParagraphEndTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(nextTextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2162,7 +2162,7 @@ AccessibilityTextMarkerRange AccessibilityUIElement::sentenceTextMarkerRangeForT
     id textMarkerRange = [m_element accessibilityAttributeValue:@"AXSentenceTextMarkerRangeForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarkerRange(textMarkerRange);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2172,7 +2172,7 @@ AccessibilityTextMarker AccessibilityUIElement::previousSentenceStartTextMarkerF
     id previousTextMarker = [m_element accessibilityAttributeValue:@"AXPreviousSentenceStartTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(previousTextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2182,7 +2182,7 @@ AccessibilityTextMarker AccessibilityUIElement::nextSentenceEndTextMarkerForText
     id nextTextMarker = [m_element accessibilityAttributeValue:@"AXNextSentenceEndTextMarkerForTextMarker" forParameter:textMarker->platformTextMarker()];
     return AccessibilityTextMarker(nextTextMarker);
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2231,7 +2231,7 @@ static NSString *convertMathMultiscriptPairsToString(NSArray *pairs)
         for (NSString *key in pair)
             [result appendFormat:@"\t%lu. %@ = %@\n", (unsigned long)index, key, [[pair objectForKey:key] accessibilityAttributeValue:NSAccessibilitySubroleAttribute]];
     }];
-    
+
     return result;
 }
 
@@ -2241,7 +2241,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPostscriptsDescription() co
     NSArray *pairs = [m_element accessibilityAttributeValue:@"AXMathPostscripts"];
     return [convertMathMultiscriptPairsToString(pairs) createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -2251,7 +2251,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPrescriptsDescription() con
     NSArray *pairs = [m_element accessibilityAttributeValue:@"AXMathPrescripts"];
     return [convertMathMultiscriptPairsToString(pairs) createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -109,7 +109,7 @@ public:
     JSRetainPtr<JSStringRef> allAttributes();
     JSRetainPtr<JSStringRef> attributesOfLinkedUIElements();
     RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned);
-    
+
     JSRetainPtr<JSStringRef> attributesOfDocumentLinks();
     JSRetainPtr<JSStringRef> attributesOfChildren();
     JSRetainPtr<JSStringRef> parameterizedAttributeNames();
@@ -244,7 +244,7 @@ public:
 
     // CSS3-speech properties.
     JSRetainPtr<JSStringRef> speakAs();
-    
+
     // Table-specific attributes
     JSRetainPtr<JSStringRef> attributesOfColumnHeaders();
     JSRetainPtr<JSStringRef> attributesOfRowHeaders();
@@ -296,7 +296,7 @@ public:
     bool isGrabbed() const;
     // A space concatentated string of all the drop effects.
     JSRetainPtr<JSStringRef> ariaDropEffects() const;
-    
+
     // Parameterized attributes
     int lineForIndex(int);
     JSRetainPtr<JSStringRef> rangeForLine(int);
@@ -324,7 +324,7 @@ public:
     JSRetainPtr<JSStringRef> wordAtOffset(int offset);
     JSRetainPtr<JSStringRef> lineAtOffset(int offset);
     JSRetainPtr<JSStringRef> sentenceAtOffset(int offset);
-    
+
     // Table-specific
     RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row);
 
@@ -400,13 +400,13 @@ public:
     JSValueRef mathRootRadicand(JSContextRef);
 
     JSRetainPtr<JSStringRef> pathDescription() const;
-    
+
     // Notifications
     // Function callback should take one argument, the name of the notification.
     bool addNotificationListener(JSContextRef, JSValueRef functionCallback);
     // Make sure you call remove, because you can't rely on objects being deallocated in a timely fashion.
     bool removeNotificationListener();
-    
+
     JSRetainPtr<JSStringRef> identifier();
     JSRetainPtr<JSStringRef> traits();
     int elementTextPosition();
@@ -425,7 +425,7 @@ public:
     bool scrollPageDown();
     bool scrollPageLeft();
     bool scrollPageRight();
-    
+
     bool isInDescriptionListDetail() const;
     bool isInDescriptionListTerm() const;
 
@@ -439,7 +439,7 @@ public:
     bool isFirstItemInSuggestion() const;
     bool isLastItemInSuggestion() const;
     bool isRemoteFrame() const;
-    
+
     bool isMarkAnnotation() const;
 private:
     AccessibilityUIElement(PlatformUIElement);

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
@@ -50,7 +50,7 @@ bool AccessibilityController::addNotificationListener(JSContextRef context, JSVa
 {
     if (!functionCallback)
         return false;
-    
+
     // Mac programmers should not be adding more than one global notification listener.
     // Other platforms may be different.
     if (m_globalNotificationHandler)
@@ -59,7 +59,7 @@ bool AccessibilityController::addNotificationListener(JSContextRef context, JSVa
     m_globalNotificationHandler = adoptNS([[AccessibilityNotificationHandler alloc] initWithContext:context]);
     [m_globalNotificationHandler setCallback:functionCallback];
     [m_globalNotificationHandler startObserving];
-    
+
     return true;
 }
 
@@ -84,14 +84,14 @@ static id findAccessibleObjectById(id obj, NSString *idAttribute)
     id objIdAttribute = [obj accessibilityIdentifier];
     if ([objIdAttribute isKindOfClass:[NSString class]] && [objIdAttribute isEqualToString:idAttribute])
         return obj;
-    
+
     NSUInteger childrenCount = [obj accessibilityElementCount];
     for (NSUInteger i = 0; i < childrenCount; ++i) {
         id result = findAccessibleObjectById([obj accessibilityElementAtIndex:i], idAttribute);
         if (result)
             return result;
     }
-    
+
     return nil;
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -176,7 +176,7 @@ static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString *attribute
 
     return adopt(JSStringCreateWithCharacters(buffer.span().data(), buffer.size()));
 }
-    
+
 AccessibilityUIElement::AccessibilityUIElement(PlatformUIElement element)
     : m_element(element)
 {
@@ -212,7 +212,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::headerElementAtIndex(unsi
     NSArray *headers = [m_element accessibilityHeaderElements];
     if (index < [headers count])
         return AccessibilityUIElement::create([headers objectAtIndex:index]);
-    
+
     return nullptr;
 }
 
@@ -221,7 +221,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedElement()
     id linkedElement = [m_element accessibilityLinkedElement];
     if (linkedElement)
         return AccessibilityUIElement::create(linkedElement);
-    
+
     return nullptr;
 }
 
@@ -259,7 +259,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPoint(int x, int
     id element = [m_element accessibilityHitTest:CGPointMake(x, y)];
     if (!element)
         return nil;
-    
+
     return AccessibilityUIElement::create(element);
 }
 
@@ -448,7 +448,7 @@ double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
         return [m_element accessibilityARIARowIndex];
     if (JSStringIsEqualToUTF8CString(attribute, "AXBlockquoteLevel"))
         return [m_element accessibilityBlockquoteLevel];
-    
+
     return 0;
 }
 
@@ -821,7 +821,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForElement()
     NSAttributedString *string = [m_element attributedStringForElement];
     if (![string isKindOfClass:[NSAttributedString class]])
         return nullptr;
-    
+
     return [[string description] createJSStringRef];
 }
 
@@ -920,7 +920,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::fieldsetAncestorElement()
     id ancestorElement = [m_element _accessibilityFieldsetAncestor];
     if (ancestorElement)
         return AccessibilityUIElement::create(ancestorElement);
-    
+
     return nullptr;
 }
 
@@ -1006,11 +1006,11 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
 void AccessibilityUIElement::scrollToMakeVisible()
 {
 }
-    
+
 void AccessibilityUIElement::scrollToGlobalPoint(int x, int y)
 {
 }
-    
+
 void AccessibilityUIElement::scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height)
 {
 }
@@ -1061,7 +1061,7 @@ void AccessibilityUIElement::press()
 {
     [m_element _accessibilityActivate];
 }
-    
+
 bool AccessibilityUIElement::dismiss()
 {
     return [m_element accessibilityPerformEscape];
@@ -1097,7 +1097,7 @@ void AccessibilityUIElement::assistiveTechnologySimulatedFocus()
 {
     [m_element accessibilityElementDidBecomeFocused];
 }
-    
+
 bool AccessibilityUIElement::scrollPageUp()
 {
     return [m_element accessibilityScroll:UIAccessibilityScrollDirectionUp];
@@ -1132,7 +1132,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForSelection()
     NSString *stringForRange = [m_element selectionRangeString];
     return [stringForRange createJSStringRef];
 }
-    
+
 int AccessibilityUIElement::elementTextPosition()
 {
     NSRange range = [[m_element valueForKey:@"elementTextRange"] rangeValue];
@@ -1142,9 +1142,9 @@ int AccessibilityUIElement::elementTextPosition()
 int AccessibilityUIElement::elementTextLength()
 {
     NSRange range = [[m_element valueForKey:@"elementTextRange"] rangeValue];
-    return range.length;    
+    return range.length;
 }
-    
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
 {
     NSURL *url = [m_element accessibilityURL];
@@ -1155,7 +1155,7 @@ bool AccessibilityUIElement::addNotificationListener(JSContextRef context, JSVal
 {
     if (!functionCallback)
         return false;
-    
+
     // iOS programmers should not be adding more than one notification listener per element.
     // Other platforms may be different.
     if (m_notificationHandler)
@@ -1165,7 +1165,7 @@ bool AccessibilityUIElement::addNotificationListener(JSContextRef context, JSVal
     [m_notificationHandler setPlatformElement:platformUIElement()];
     [m_notificationHandler setCallback:functionCallback];
     [m_notificationHandler startObserving];
-    
+
     return true;
 }
 
@@ -1173,10 +1173,10 @@ bool AccessibilityUIElement::removeNotificationListener()
 {
     // iOS programmers should not be trying to remove a listener that's already removed.
     ASSERT(m_notificationHandler);
-    
+
     [m_notificationHandler stopObserving];
     m_notificationHandler = nil;
-    
+
     return true;
 }
 
@@ -1281,7 +1281,7 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::lineTextMarkerRange
     id startTextMarker = [m_element lineStartMarkerForMarker:textMarker->platformTextMarker()];
     id endTextMarker = [m_element lineEndMarkerForMarker:textMarker->platformTextMarker()];
     NSArray *textMarkers = @[startTextMarker, endTextMarker];
-    
+
     id textMarkerRange = [m_element textMarkerRangeForMarkers:textMarkers];
     return AccessibilityTextMarkerRange::create(textMarkerRange);
 }
@@ -1370,7 +1370,7 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForBounds
 {
     return nullptr;
 }
-    
+
 bool AccessibilityUIElement::replaceTextInRange(JSStringRef string, int location, int length)
 {
     return [m_element accessibilityReplaceRange:NSMakeRange(location, length) withText:[NSString stringWithJSStringRef:string]];
@@ -1488,7 +1488,7 @@ RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousSentenceStartTex
 {
     return nullptr;
 }
-    
+
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeMatchesTextNearMarkers(JSStringRef text, AccessibilityTextMarker* startMarker, AccessibilityTextMarker* endMarker)
 {
     NSArray *textMarkers = nil;
@@ -1534,9 +1534,9 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
 {
     NSMutableString *result = [NSMutableString stringWithString:@"\nStart Path\n"];
     CGPathRef pathRef = [m_element _accessibilityPath];
-    
+
     CGPathApply(pathRef, result, _CGPathEnumerationIteration);
-    
+
     return [result createJSStringRef];
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -89,7 +89,7 @@ bool AccessibilityController::addNotificationListener(JSContextRef context, JSVa
 bool AccessibilityController::removeNotificationListener()
 {
     ASSERT(m_globalNotificationHandler);
-    
+
     [m_globalNotificationHandler.get() stopObserving];
     m_globalNotificationHandler.clear();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -294,10 +294,10 @@ static JSRetainPtr<JSStringRef> descriptionOfElements(const Vector<RefPtr<Access
 static NSDictionary *selectTextParameterizedAttributeForCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     NSMutableDictionary *parameterizedAttribute = [NSMutableDictionary dictionary];
-    
+
     if (ambiguityResolution)
         [parameterizedAttribute setObject:[NSString stringWithJSStringRef:ambiguityResolution] forKey:@"AXSelectTextAmbiguityResolution"];
-    
+
     if (searchStrings) {
         NSMutableArray *searchStringsParameter = [NSMutableArray array];
         if (JSValueIsString(context, searchStrings))
@@ -310,16 +310,16 @@ static NSDictionary *selectTextParameterizedAttributeForCriteria(JSContextRef co
         }
         [parameterizedAttribute setObject:searchStringsParameter forKey:@"AXSelectTextSearchStrings"];
     }
-    
+
     if (replacementString) {
         [parameterizedAttribute setObject:@"AXSelectTextActivityFindAndReplace" forKey:@"AXSelectTextActivity"];
         [parameterizedAttribute setObject:[NSString stringWithJSStringRef:replacementString] forKey:@"AXSelectTextReplacementString"];
     } else
         [parameterizedAttribute setObject:@"AXSelectTextActivityFindAndSelect" forKey:@"AXSelectTextActivity"];
-    
+
     if (activity)
         [parameterizedAttribute setObject:[NSString stringWithJSStringRef:activity] forKey:@"AXSelectTextActivity"];
-    
+
     return parameterizedAttribute;
 }
 
@@ -1120,7 +1120,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
     auto description = descriptionOfValue(attributeValue(NSAccessibilityHelpAttribute).get());
     return concatenateAttributeAndValue(@"AXHelp", description.get());
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1148,7 +1148,7 @@ double AccessibilityUIElement::x()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     auto positionValue = attributeValue(NSAccessibilityPositionAttribute);
-    return static_cast<double>([positionValue pointValue].x);    
+    return static_cast<double>([positionValue pointValue].x);
     END_AX_OBJC_EXCEPTIONS
 
     return 0.0f;
@@ -1158,7 +1158,7 @@ double AccessibilityUIElement::y()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     auto positionValue = attributeValue(NSAccessibilityPositionAttribute);
-    return static_cast<double>([positionValue pointValue].y);    
+    return static_cast<double>([positionValue pointValue].y);
     END_AX_OBJC_EXCEPTIONS
 
     return 0.0f;
@@ -1188,7 +1188,7 @@ double AccessibilityUIElement::clickPointX()
 {
     BEGIN_AX_OBJC_EXCEPTIONS
     auto positionValue = attributeValue(@"AXClickPoint");
-    return static_cast<double>([positionValue pointValue].x);        
+    return static_cast<double>([positionValue pointValue].x);
     END_AX_OBJC_EXCEPTIONS
 
     return 0.0f;
@@ -1257,7 +1257,7 @@ int AccessibilityUIElement::insertionPointLineNumber()
     BEGIN_AX_OBJC_EXCEPTIONS
     auto value = attributeValue(NSAccessibilityInsertionPointLineNumberAttribute);
     if ([value isKindOfClass:[NSNumber class]])
-        return [(NSNumber *)value intValue]; 
+        return [(NSNumber *)value intValue];
     END_AX_OBJC_EXCEPTIONS
 
     return -1;
@@ -1374,7 +1374,7 @@ int AccessibilityUIElement::hierarchicalLevel() const
 
     return 0;
 }
-    
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
@@ -1439,7 +1439,7 @@ int AccessibilityUIElement::lineForIndex(int index)
     BEGIN_AX_OBJC_EXCEPTIONS
     auto value = attributeValueForParameter(NSAccessibilityLineForIndexParameterizedAttribute, @(index));
     if ([value isKindOfClass:[NSNumber class]])
-        return [(NSNumber *)value intValue]; 
+        return [(NSNumber *)value intValue];
     END_AX_OBJC_EXCEPTIONS
 
     return -1;
@@ -1479,7 +1479,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned locatio
     auto value = attributeValueForParameter(NSAccessibilityBoundsForRangeParameterizedAttribute, [NSValue valueWithRange:range]);
     NSRect rect = NSMakeRect(0,0,0,0);
     if ([value isKindOfClass:[NSValue class]])
-        rect = [value rectValue]; 
+        rect = [value rectValue];
 
     // don't return position information because it is platform dependent
     NSMutableString* boundsDescription = makeBoundsDescription(rect, false /* exposePosition */);
@@ -1515,7 +1515,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned locatio
 
     return [string createJSStringRef];
     END_AX_OBJC_EXCEPTIONS
-    
+
     return nullptr;
 }
 
@@ -1756,7 +1756,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::cellForColumnAndRow(unsig
     BEGIN_AX_OBJC_EXCEPTIONS
     if (auto cell = attributeValueForParameter(@"AXCellForColumnAndRow", colRowArray))
         return AccessibilityUIElement::create(cell.get());
-    END_AX_OBJC_EXCEPTIONS    
+    END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
 }
@@ -1769,7 +1769,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() con
     BEGIN_AX_OBJC_EXCEPTIONS
     if (id scrollbar = attributeValue(NSAccessibilityHorizontalScrollBarAttribute).get())
         return AccessibilityUIElement::create(scrollbar);
-    END_AX_OBJC_EXCEPTIONS    
+    END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
 }
@@ -1782,7 +1782,7 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
     BEGIN_AX_OBJC_EXCEPTIONS
     if (id scrollbar = attributeValue(NSAccessibilityVerticalScrollBarAttribute).get())
         return AccessibilityUIElement::create(scrollbar);
-    END_AX_OBJC_EXCEPTIONS        
+    END_AX_OBJC_EXCEPTIONS
 
     return nullptr;
 }
@@ -1979,7 +1979,7 @@ bool AccessibilityUIElement::addNotificationListener(JSContextRef context, JSVal
 {
     if (!functionCallback)
         return false;
- 
+
     // Mac programmers should not be adding more than one notification listener per element.
     // Other platforms may be different.
     if (m_notificationHandler)
@@ -2000,7 +2000,7 @@ bool AccessibilityUIElement::removeNotificationListener()
 
     [m_notificationHandler stopObserving];
     m_notificationHandler = nil;
-    
+
     return true;
 }
 
@@ -2675,12 +2675,12 @@ bool AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute
 
     NSDictionary* attrs = [string attributesAtIndex:0 effectiveRange:nil];
     if ([attrs objectForKey:[NSString stringWithJSStringRef:attribute]])
-        return true;    
+        return true;
     END_AX_OBJC_EXCEPTIONS
 
     return false;
 }
-    
+
 int AccessibilityUIElement::indexForTextMarker(AccessibilityTextMarker* marker)
 {
     if (!marker)


### PR DESCRIPTION
#### b559d3d6ec26a12188a6855c86938030690086f1
<pre>
[AX]: check-webkit-style: DRT/WKTR - resolve all `whitespace/end_of_line` warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=297280">https://bugs.webkit.org/show_bug.cgi?id=297280</a>

Reviewed by Tyler Wilcock.

This reduces warnings reported for DRT/WKTR accessibility code from ~270 to 22.

* Tools/DumpRenderTree/AccessibilityController.cpp:
(getElementAtPointCallback):
(getAccessibleElementByIdCallback):
(addNotificationListenerCallback):
* Tools/DumpRenderTree/AccessibilityTextMarker.cpp:
(AccessibilityTextMarker::getJSClass):
(isMarkerRangeEqualCallback):
(AccessibilityTextMarkerRange::getJSClass):
* Tools/DumpRenderTree/AccessibilityTextMarker.h:
* Tools/DumpRenderTree/AccessibilityUIElement.cpp:
(lineForIndexCallback):
(rangeForLineCallback):
(boundsForRangeCallback):
(rangeForPositionCallback):
(stringForRangeCallback):
(attributedStringForRangeCallback):
(attributedStringRangeIsMisspelledCallback):
(uiElementCountForSearchPredicateCallback):
(uiElementForSearchPredicateCallback):
(selectTextWithCriteriaCallback):
(indexOfChildCallback):
(headerElementAtIndexCallback):
(childAtIndexCallback):
(selectedChildAtIndexCallback):
(linkedUIElementAtIndexCallback):
(disclosedRowAtIndexCallback):
(ariaOwnsElementAtIndexCallback):
(ariaFlowToElementAtIndexCallback):
(selectedRowAtIndexCallback):
(rowAtIndexCallback):
(isEqualCallback):
(setValueCallback):
(elementAtPointCallback):
(isAttributeSupportedCallback):
(isAttributeSettableCallback):
(uiElementArrayAttributeValueCallback):
(uiElementAttributeValueCallback):
(cellForColumnAndRowCallback):
(setSelectedTextRangeCallback):
(textMarkerRangeForElementCallback):
(attributedStringForTextMarkerRangeContainsAttributeCallback):
(indexForTextMarkerCallback):
(textMarkerForIndexCallback):
(textMarkerRangeLengthCallback):
(nextTextMarkerCallback):
(previousTextMarkerCallback):
(stringForTextMarkerRangeCallback):
(endTextMarkerForBoundsCallback):
(startTextMarkerForBoundsCallback):
(textMarkerForPointCallback):
(textMarkerRangeForMarkersCallback):
(startTextMarkerForTextMarkerRangeCallback):
(endTextMarkerForTextMarkerRangeCallback):
(accessibilityElementForTextMarkerCallback):
(leftWordTextMarkerRangeForTextMarkerCallback):
(rightWordTextMarkerRangeForTextMarkerCallback):
(previousWordStartTextMarkerForTextMarkerCallback):
(nextWordEndTextMarkerForTextMarkerCallback):
(paragraphTextMarkerRangeForTextMarkerCallback):
(previousParagraphStartTextMarkerForTextMarkerCallback):
(nextParagraphEndTextMarkerForTextMarkerCallback):
(sentenceTextMarkerRangeForTextMarkerCallback):
(previousSentenceStartTextMarkerForTextMarkerCallback):
(nextSentenceEndTextMarkerForTextMarkerCallback):
(getIsValidCallback):
(addNotificationListenerCallback):
(textMarkerRangeMatchesTextNearMarkersCallback):
(AccessibilityUIElement::endTextMarkerForTextMarkerRange):
(AccessibilityUIElement::previousTextMarker):
* Tools/DumpRenderTree/AccessibilityUIElement.h:
* Tools/DumpRenderTree/ios/AccessibilityControllerIOS.mm:
(findAccessibleObjectById):
(AccessibilityController::accessibleElementById):
(AccessibilityController::addNotificationListener):
* Tools/DumpRenderTree/ios/AccessibilityTextMarkerIOS.mm:
(AccessibilityTextMarker::platformTextMarker const):
* Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm:
(concatenateAttributeAndValue):
(AccessibilityUIElement::elementTextLength):
(AccessibilityUIElement::fieldsetAncestorElement):
(AccessibilityUIElement::getChildrenWithRange):
(AccessibilityUIElement::childrenCount):
(AccessibilityUIElement::elementAtPoint):
(AccessibilityUIElement::getChildAtIndex):
(AccessibilityUIElement::headerElementAtIndex):
(AccessibilityUIElement::linkedElement):
(AccessibilityUIElement::parentElement):
(AccessibilityUIElement::decreaseTextSelection):
(AccessibilityUIElement::stringForSelection):
(AccessibilityUIElement::stringForRange):
(AccessibilityUIElement::attributedStringForRange):
(AccessibilityUIElement::attributedStringForElement):
(_CGPathEnumerationIteration):
(AccessibilityUIElement::pathDescription const):
(AccessibilityUIElement::lineTextMarkerRangeForTextMarker):
(AccessibilityUIElement::stringAttributeValue):
(AccessibilityUIElement::addNotificationListener):
(AccessibilityUIElement::removeNotificationListener):
(AccessibilityUIElement::numberAttributeValue):
* Tools/DumpRenderTree/mac/AccessibilityCommonMac.mm:
(searchPredicateParameterizedAttributeForSearchCriteria):
* Tools/DumpRenderTree/mac/AccessibilityControllerMac.mm:
(AccessibilityController::elementAtPoint):
(AccessibilityController::rootElement):
(AccessibilityController::addNotificationListener):
* Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm:
(-[AccessibilityNotificationHandler dealloc]):
(-[AccessibilityNotificationHandler setCallback:]):
* Tools/DumpRenderTree/mac/AccessibilityTextMarkerMac.mm:
(AccessibilityTextMarker::platformTextMarker const):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(descriptionOfValue):
(attributesOfElement):
(descriptionOfElements):
(selectTextParameterizedAttributeForCriteria):
(AccessibilityUIElement::childrenCount):
(AccessibilityUIElement::elementAtPoint):
(AccessibilityUIElement::linkedUIElementAtIndex):
(AccessibilityUIElement::ariaOwnsElementAtIndex):
(AccessibilityUIElement::ariaFlowToElementAtIndex):
(AccessibilityUIElement::selectedChildAtIndex const):
(AccessibilityUIElement::selectedRowAtIndex):
(AccessibilityUIElement::rowAtIndex):
(AccessibilityUIElement::titleUIElement):
(AccessibilityUIElement::parentElement):
(AccessibilityUIElement::disclosedByRow):
(AccessibilityUIElement::uiElementAttributeValue const):
(AccessibilityUIElement::numberAttributeValue const):
(AccessibilityUIElement::boolAttributeValue const):
(AccessibilityUIElement::isAttributeSettable):
(AccessibilityUIElement::isAttributeSupported):
(AccessibilityUIElement::parameterizedAttributeNames):
(AccessibilityUIElement::role):
(AccessibilityUIElement::roleDescription):
(AccessibilityUIElement::computedRoleString):
(AccessibilityUIElement::helpText const):
(AccessibilityUIElement::x):
(AccessibilityUIElement::y):
(AccessibilityUIElement::width):
(AccessibilityUIElement::height):
(AccessibilityUIElement::clickPointX):
(AccessibilityUIElement::clickPointY):
(AccessibilityUIElement::valueDescription):
(AccessibilityUIElement::insertionPointLineNumber):
(AccessibilityUIElement::isPressActionSupported):
(AccessibilityUIElement::isIncrementActionSupported):
(AccessibilityUIElement::isDecrementActionSupported):
(AccessibilityUIElement::speakAs):
(AccessibilityUIElement::classList const):
(AccessibilityUIElement::ariaDropEffects const):
(AccessibilityUIElement::lineForIndex):
(AccessibilityUIElement::rangeForLine):
(AccessibilityUIElement::rangeForPosition):
(AccessibilityUIElement::boundsForRange):
(AccessibilityUIElement::stringForRange):
(AccessibilityUIElement::attributedStringForRange):
(AccessibilityUIElement::attributedStringRangeIsMisspelled):
(AccessibilityUIElement::uiElementCountForSearchPredicate):
(AccessibilityUIElement::selectTextWithCriteria):
(AccessibilityUIElement::attributesOfColumnHeaders):
(AccessibilityUIElement::attributesOfRowHeaders):
(AccessibilityUIElement::attributesOfColumns):
(AccessibilityUIElement::attributesOfRows):
(AccessibilityUIElement::attributesOfVisibleCells):
(AccessibilityUIElement::attributesOfHeader):
(AccessibilityUIElement::rowCount):
(AccessibilityUIElement::columnCount):
(AccessibilityUIElement::rowIndexRange):
(AccessibilityUIElement::columnIndexRange):
(AccessibilityUIElement::cellForColumnAndRow):
(AccessibilityUIElement::horizontalScrollbar const):
(AccessibilityUIElement::verticalScrollbar const):
(AccessibilityUIElement::pathDescription const):
(AccessibilityUIElement::selectedTextRange):
(AccessibilityUIElement::setSelectedChild const):
(AccessibilityUIElement::url):
(AccessibilityUIElement::addNotificationListener):
(AccessibilityUIElement::isFocusable const):
(AccessibilityUIElement::lineTextMarkerRangeForTextMarker):
(AccessibilityUIElement::textMarkerRangeForElement):
(AccessibilityUIElement::selectedTextMarkerRange):
(AccessibilityUIElement::resetSelectedTextMarkerRange):
(AccessibilityUIElement::textMarkerRangeLength):
(AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute):
(AccessibilityUIElement::indexForTextMarker):
(AccessibilityUIElement::textMarkerForIndex):
(AccessibilityUIElement::previousTextMarker):
(AccessibilityUIElement::nextTextMarker):
(AccessibilityUIElement::stringForTextMarkerRange):
(AccessibilityUIElement::startTextMarkerForTextMarkerRange):
(AccessibilityUIElement::endTextMarkerForTextMarkerRange):
(AccessibilityUIElement::endTextMarkerForBounds):
(AccessibilityUIElement::startTextMarkerForBounds):
(AccessibilityUIElement::textMarkerForPoint):
(AccessibilityUIElement::accessibilityElementForTextMarker):
(AccessibilityUIElement::startTextMarker):
(AccessibilityUIElement::endTextMarker):
(AccessibilityUIElement::setSelectedTextMarkerRange):
(AccessibilityUIElement::leftWordTextMarkerRangeForTextMarker):
(AccessibilityUIElement::rightWordTextMarkerRangeForTextMarker):
(AccessibilityUIElement::previousWordStartTextMarkerForTextMarker):
(AccessibilityUIElement::nextWordEndTextMarkerForTextMarker):
(AccessibilityUIElement::paragraphTextMarkerRangeForTextMarker):
(AccessibilityUIElement::previousParagraphStartTextMarkerForTextMarker):
(AccessibilityUIElement::nextParagraphEndTextMarkerForTextMarker):
(AccessibilityUIElement::sentenceTextMarkerRangeForTextMarker):
(AccessibilityUIElement::previousSentenceStartTextMarkerForTextMarker):
(AccessibilityUIElement::nextSentenceEndTextMarkerForTextMarker):
(convertMathMultiscriptPairsToString):
(AccessibilityUIElement::mathPostscriptsDescription const):
(AccessibilityUIElement::mathPrescriptsDescription const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm:
(WTR::AccessibilityController::addNotificationListener):
(WTR::findAccessibleObjectById):
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::headerElementAtIndex):
(WTR::AccessibilityUIElement::linkedElement):
(WTR::AccessibilityUIElement::elementAtPoint):
(WTR::AccessibilityUIElement::numberAttributeValue):
(WTR::AccessibilityUIElement::attributedStringForElement):
(WTR::AccessibilityUIElement::fieldsetAncestorElement):
(WTR::AccessibilityUIElement::elementTextLength):
(WTR::AccessibilityUIElement::addNotificationListener):
(WTR::AccessibilityUIElement::removeNotificationListener):
(WTR::AccessibilityUIElement::lineTextMarkerRangeForTextMarker):
(WTR::AccessibilityUIElement::pathDescription const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::removeNotificationListener):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::selectTextParameterizedAttributeForCriteria):
(WTR::AccessibilityUIElement::helpText const):
(WTR::AccessibilityUIElement::x):
(WTR::AccessibilityUIElement::y):
(WTR::AccessibilityUIElement::clickPointX):
(WTR::AccessibilityUIElement::insertionPointLineNumber):
(WTR::AccessibilityUIElement::lineForIndex):
(WTR::AccessibilityUIElement::boundsForRange):
(WTR::AccessibilityUIElement::stringForRange):
(WTR::AccessibilityUIElement::cellForColumnAndRow):
(WTR::AccessibilityUIElement::horizontalScrollbar const):
(WTR::AccessibilityUIElement::verticalScrollbar const):
(WTR::AccessibilityUIElement::addNotificationListener):
(WTR::AccessibilityUIElement::removeNotificationListener):
(WTR::AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute):

Canonical link: <a href="https://commits.webkit.org/298590@main">https://commits.webkit.org/298590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03e090f079c714921f4540b4bbe7051cd162b53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65690 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125172 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42858 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32171 "Found 1 new test failure: http/tests/push-api/permissions-ephemeral.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96847 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96630 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24590 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41891 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19768 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38787 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42747 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->