### PR TITLE
Switch to TextIndicator for DragSourceState.

### DIFF
--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
@@ -40,7 +40,6 @@
 
 namespace WebCore {
 struct DragItem;
-struct TextIndicatorData;
 struct NodeIdentifierType;
 using NodeIdentifier = ObjectIdentifier<NodeIdentifierType>;
 }
@@ -52,7 +51,7 @@ struct DragSourceState {
     CGRect dragPreviewFrameInRootViewCoordinates { CGRectZero };
     using DragPreviewContentType = Variant<RetainPtr<UIImage>, RetainPtr<UIView>>;
     DragPreviewContentType dragPreviewContent;
-    std::optional<WebCore::TextIndicatorData> indicatorData;
+    RefPtr<WebCore::TextIndicator> textIndicator;
     std::optional<WebCore::Path> visiblePath;
     String linkTitle;
     URL linkURL;

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -130,7 +130,7 @@ static bool shouldUseVisiblePathToCreatePreviewForDragSource(const DragSourceSta
 
 static bool shouldUseTextIndicatorToCreatePreviewForDragSource(const DragSourceState& source)
 {
-    if (!source.indicatorData)
+    if (!source.textIndicator)
         return false;
 
     if (source.action.containsAny({ DragSourceAction::Link, DragSourceAction::Selection }))
@@ -314,9 +314,9 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
     }
 
     if (shouldUseTextIndicatorToCreatePreviewForDragSource(source)) {
-        auto indicatorData = source.indicatorData.value();
-        RetainPtr textIndicatorImage = uiImageForImage(indicatorData.contentImage.get());
-        return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicatorData.textBoundingRectInRootViewCoordinates, indicatorData.textRectsInBoundingRectCoordinates, cocoaColor(indicatorData.estimatedBackgroundColor).get(), nil, addPreviewViewToContainer).autorelease();
+        RefPtr textIndicator = source.textIndicator;
+        RetainPtr textIndicatorImage = uiImageForImage(textIndicator->contentImage());
+        return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, textIndicator->textBoundingRectInRootViewCoordinates(), textIndicator->textRectsInBoundingRectCoordinates(), cocoaColor(textIndicator->estimatedBackgroundColor()).get(), nil, addPreviewViewToContainer).autorelease();
     }
 
     return nil;
@@ -348,7 +348,7 @@ void DragDropInteractionState::stageDragItem(const DragItem& item, DragSourceSta
         item.sourceAction,
         item.dragPreviewFrameInRootViewCoordinates,
         dragPreviewContent,
-        item.image.textIndicator() ? std::optional { item.image.textIndicator()->data() } : std::nullopt,
+        item.image.textIndicator(),
         item.image.visiblePath(),
         item.title.isEmpty() ? nil : item.title.createNSString().get(),
         item.url.isEmpty() ? nil : item.url.createNSURL().get(),


### PR DESCRIPTION
#### 06911cdfc01853e50faacec1f52603f82b315c54
<pre>
Switch to TextIndicator for DragSourceState.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297288">https://bugs.webkit.org/show_bug.cgi?id=297288</a>
<a href="https://rdar.apple.com/158159818">rdar://158159818</a>

Reviewed by Aditya Keerthi.

Continuing the removal of TextIndicator Data.

* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::shouldUseTextIndicatorToCreatePreviewForDragSource):
(WebKit::DragDropInteractionState::createDragPreviewInternal const):
(WebKit::DragDropInteractionState::stageDragItem):

Canonical link: <a href="https://commits.webkit.org/298593@main">https://commits.webkit.org/298593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93993c54b2faf8fdc8c41eb65bd96d58eaf91c79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0f5c20d4-b814-4bd5-9be7-e760094e160f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a6de0c1-a448-4abb-b977-9ecd3012ef0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68517 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28108 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65705 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125188 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96860 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19774 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48359 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42229 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->