### PR TITLE
[bmalloc] Return to manually re-zeroing wasm memory

### DIFF
--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -47,7 +47,7 @@
 #endif
 
 #if defined(MADV_ZERO) && BOS(DARWIN)
-#define BMALLOC_USE_MADV_ZERO 1
+#define BMALLOC_USE_MADV_ZERO 0
 #else
 #define BMALLOC_USE_MADV_ZERO 0
 #endif

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -71,13 +71,11 @@ void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSi
     RELEASE_BASSERT(size >= requestedSize);
 
     void* result;
-    if (auto* systemHeap = SystemHeap::tryGet()) {
+    if (auto* systemHeap = SystemHeap::tryGet())
         result = systemHeap->memalignLarge(alignment, size);
-        if (result)
-            vmZeroAndPurge(result, size);
-    } else {
+    else {
 #if BUSE(LIBPAS)
-        result = tryZeroedMemalign(alignment, size, mode, kind);
+        result = tryMemalign(alignment, size, mode, kind);
 #else
         BUNUSED(mode);
         kind = mapToActiveHeapKind(kind);
@@ -91,10 +89,12 @@ void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSi
             // pages they dirty:
             // https://bugs.webkit.org/show_bug.cgi?id=184207
             heap.externalDecommit(lock, result, size);
-            vmZeroAndPurge(result, size);
         }
 #endif
     }
+
+    if (result)
+        vmZeroAndPurge(result, size);
 
     return result;
 }


### PR DESCRIPTION
#### ea798e7c558574fe9060ebbfdbb6bb7284423272
<pre>
[bmalloc] Return to manually re-zeroing wasm memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=297292">https://bugs.webkit.org/show_bug.cgi?id=297292</a>
<a href="https://rdar.apple.com/158164635">rdar://158164635</a>

Reviewed by Yusuke Suzuki.

Surprisingly, this patch still causes a performance regression on JS3,
albeit smaller than before. Revert for the time being, as this
will require a novel strategy.

* Source/bmalloc/bmalloc/VMAllocate.h: Also turn off MADV_ZERO usage,
  revert to using mmap to zero the range.
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::tryLargeZeroedMemalignVirtual): Return to using
  tryMemalign and then zeroing ourselves.

Canonical link: <a href="https://commits.webkit.org/298632@main">https://commits.webkit.org/298632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48a68de276454d49fb18f3c29024b9d2b2c2bd6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66541 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/980b7bb0-fa97-4713-bcce-99b2ef565a13) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f84a31e-ea57-42b2-946c-60b4dc090d3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68523 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22193 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65714 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108104 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125197 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114523 "Found 1 new JSC stress test failure: stress/catch-from-function-inlining-simd-function.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38834 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42778 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143207 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42242 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36919 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->