### PR TITLE
[Navigation API] Implement BFCache support for navigation.entries().

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN navigate event should fire when traversing to a bfcache hit Could have been BFCached but actually wasn't
+PASS navigate event should fire when traversing to a bfcache hit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Could have been BFCached but actually wasn't
+PASS entries() must contain the forward-history page after navigating back to a bfcached page
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt
@@ -1,3 +1,3 @@
 
-NOTRUN entries() must contain the forward-history page after navigating back to a bfcached page Could have been BFCached but actually wasn't
+PASS entries() must contain the forward-history page after navigating back to a bfcached page
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8267,6 +8267,8 @@ webkit.org/b/295751 [ Release ] http/tests/geolocation/geolocation-get-current-p
 
 webkit.org/b/297251 [ Release ] fast/mediastream/getUserMedia-echoCancellation.html [ Pass Failure ]
 
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html [ Timeout ]
+
 webkit.org/b/297346 workers/message-port-gc.html [ Crash ]
 
 webkit.org/b/297364 [ Debug ] imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-create.https.html [ Failure ]

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -197,6 +197,18 @@ Vector<Ref<HistoryItem>> BackForwardController::itemsForFrame(FrameIdentifier fr
     return historyItems;
 }
 
+Vector<Ref<HistoryItem>> BackForwardController::reachableItemsForFrame(FrameIdentifier frameID)
+{
+    // Returns only the frame items that correspond to the currently reachable session history.
+    // This is different from itemsForFrame() which returns all frame items across the frame's lifetime.
+    Vector<Ref<HistoryItem>> reachableFrameItems;
+    for (auto& item : allItems()) {
+        if (RefPtr childItem = item->childItemWithFrameID(frameID))
+            reachableFrameItems.append(childItem.releaseNonNull());
+    }
+    return reachableFrameItems;
+}
+
 void BackForwardController::close()
 {
     m_client->close();

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -76,6 +76,7 @@ public:
 
     Vector<Ref<HistoryItem>> allItems();
     Vector<Ref<HistoryItem>> itemsForFrame(FrameIdentifier);
+    Vector<Ref<HistoryItem>> reachableItemsForFrame(FrameIdentifier);
 
 private:
     Ref<Page> protectedPage() const;


### PR DESCRIPTION
#### 1623b8c4b1098bff857dff660fa99e750ec026f3
<pre>
[Navigation API] Implement BFCache support for navigation.entries().
<a href="https://bugs.webkit.org/show_bug.cgi?id=297291">https://bugs.webkit.org/show_bug.cgi?id=297291</a>
<a href="https://rdar.apple.com/158164248">rdar://158164248</a>

Reviewed by Alex Christensen.

Implement proper Back-Forward Cache (BFCache) support for the Navigation API&apos;s
navigation.entries() method. Previously, pages with Navigation API were unable
to enter BFCache, and iframe Navigation APIs were not updated during restoration.

This change enables Navigation API pages to be cached and ensures that
navigation.entries() is properly updated when restored from BFCache, including
correct disposal of unreachable forward history entries.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache-in-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-bfcache.html:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-after-bfcache.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::reachableItemsForFrame):
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):

Canonical link: <a href="https://commits.webkit.org/298691@main">https://commits.webkit.org/298691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eec4d5968165cd765b4f32ed0aee214260f9c359

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44618 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119318 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29287 "1 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68818 "Passed tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28370 "Exiting early after 10 failures. 43 tests run. 1 flakes") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66107 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125575 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43263 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100605 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24651 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/42176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20074 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48742 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42617 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->