### PR TITLE
Adopt _WKJSHandle in WebKitTestRunner

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips.html
@@ -14,7 +14,7 @@ function tooltipDidChangeCallback(tooltip)
 async function runTest() {
 
     if (window.testRunner) {
-        testRunner.installTooltipDidChangeCallback('tooltipDidChangeCallback');
+        testRunner.installTooltipDidChangeCallback(tooltipDidChangeCallback);
 
         await eventSender.asyncMouseMoveTo(30, 30);
         await eventSender.asyncMouseMoveTo(100, 100);

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -30,6 +30,7 @@
 #include "APIDictionary.h"
 #include "APIJSHandle.h"
 #include "APINumber.h"
+#include "APISerializedNode.h"
 #include "APISerializedScriptValue.h"
 #include "APIString.h"
 #include "WKSharedAPICast.h"
@@ -67,11 +68,109 @@ RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Value&& root)
         Ref dictionary = API::Dictionary::create();
         m_dictionaries.append({ WTFMove(map), dictionary });
         return { WTFMove(dictionary) };
-    }, [] (JSHandleInfo&&) -> RefPtr<API::Object> {
-        return nullptr;
-    }, [] (UniqueRef<WebCore::SerializedNode>&&) -> RefPtr<API::Object> {
-        return nullptr;
+    }, [] (JSHandleInfo&& info) -> RefPtr<API::Object> {
+        return API::JSHandle::create(WTFMove(info));
+    }, [] (UniqueRef<WebCore::SerializedNode>&& node) -> RefPtr<API::Object> {
+        return API::SerializedNode::create(WTFMove(node.get()));
     });
+}
+
+static bool isSerializable(API::Object* object)
+{
+    if (!object)
+        return false;
+
+    switch (object->type()) {
+    case API::Object::Type::String:
+    case API::Object::Type::Boolean:
+    case API::Object::Type::Double:
+    case API::Object::Type::UInt64:
+    case API::Object::Type::Int64:
+    case API::Object::Type::JSHandle:
+    case API::Object::Type::SerializedNode:
+        return true;
+    case API::Object::Type::Array:
+        return std::ranges::all_of(downcast<API::Array>(object)->elements(), [] (const RefPtr<API::Object>& element) {
+            return isSerializable(element.get());
+        });
+    case API::Object::Type::Dictionary:
+        return std::ranges::all_of(downcast<API::Dictionary>(object)->map(), [] (const KeyValuePair<String, RefPtr<API::Object>>& pair) {
+            return isSerializable(pair.value.get());
+        });
+    default:
+        return false;
+    }
+}
+
+auto JavaScriptEvaluationResult::toValue(API::Object* object) -> Value
+{
+    if (!object)
+        return EmptyType::Undefined;
+
+    switch (object->type()) {
+    case API::Object::Type::String:
+        return downcast<API::String>(object)->string();
+    case API::Object::Type::Boolean:
+        return downcast<API::Boolean>(object)->value();
+    case API::Object::Type::Double:
+        return downcast<API::Double>(object)->value();
+    case API::Object::Type::UInt64:
+        return static_cast<double>(downcast<API::UInt64>(object)->value());
+    case API::Object::Type::Int64:
+        return static_cast<double>(downcast<API::Int64>(object)->value());
+    case API::Object::Type::JSHandle:
+        return downcast<API::JSHandle>(object)->info();
+    case API::Object::Type::SerializedNode:
+        return makeUniqueRef<WebCore::SerializedNode>(downcast<API::SerializedNode>(object)->coreSerializedNode());
+    case API::Object::Type::Array: {
+        Vector<JSObjectID> vector;
+        for (auto& element : downcast<API::Array>(object)->elements())
+            vector.append(addObjectToMap(element.get()));
+        return { WTFMove(vector) };
+    }
+    case API::Object::Type::Dictionary: {
+        HashMap<JSObjectID, JSObjectID> map;
+        for (auto& [key, value] : downcast<API::Dictionary>(object)->map())
+            map.set(addObjectToMap(API::String::create(key).ptr()), addObjectToMap(value.get()));
+        return { WTFMove(map) };
+    }
+    default:
+        // This object has been null checked and went through isSerializable which only supports these types.
+        ASSERT_NOT_REACHED();
+        return EmptyType::Undefined;
+    }
+}
+
+std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(API::Object* object)
+{
+    if (!isSerializable(object))
+        return std::nullopt;
+    return JavaScriptEvaluationResult(object);
+}
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(API::Object* object)
+    : m_root(addObjectToMap(object))
+{
+}
+
+JSObjectID JavaScriptEvaluationResult::addObjectToMap(API::Object* object)
+{
+    if (!object) {
+        if (!m_nullObjectID) {
+            m_nullObjectID = JSObjectID::generate();
+            m_map.add(*m_nullObjectID, Value { EmptyType::Undefined });
+        }
+        return *m_nullObjectID;
+    }
+
+    auto it = m_apiObjectsInMap.find(object);
+    if (it != m_apiObjectsInMap.end())
+        return it->value;
+
+    auto identifier = JSObjectID::generate();
+    m_apiObjectsInMap.set(object, identifier);
+    m_map.add(identifier, toValue(object));
+    return identifier;
 }
 
 RefPtr<API::Object> JavaScriptEvaluationResult::toAPI()

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.h
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.h
@@ -85,6 +85,8 @@ public:
     GRefPtr<JSCValue> toJSC();
 #endif
 
+    static std::optional<JavaScriptEvaluationResult> extract(API::Object*);
+
     WKRetainPtr<WKTypeRef> toWK();
     RefPtr<API::Object> toAPI();
 
@@ -92,6 +94,10 @@ public:
 
 private:
     JavaScriptEvaluationResult(JSGlobalContextRef, JSValueRef);
+    JavaScriptEvaluationResult(API::Object*);
+
+    JSObjectID addObjectToMap(API::Object*);
+    Value toValue(API::Object*);
 
 #if USE(GLIB)
     explicit JavaScriptEvaluationResult(GVariant*);
@@ -128,6 +134,7 @@ private:
 
     // Used for serializing to IPC
     HashMap<Protected<JSValueRef>, JSObjectID> m_jsObjectsInMap;
+    HashMap<RefPtr<API::Object>, JSObjectID> m_apiObjectsInMap;
     std::optional<JSObjectID> m_nullObjectID;
 
     // Used for deserializing from IPC to JS

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -184,6 +184,7 @@ struct WebPageCreationParameters {
 
     bool useDarkAppearance { false };
     bool useElevatedUserInterfaceLevel { false };
+    bool allowJSHandleInPageContentWorld { false };
 
 #if PLATFORM(MAC)
     std::optional<WebCore::DestinationColorSpace> colorSpace { };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -106,6 +106,7 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
     bool useDarkAppearance;
     bool useElevatedUserInterfaceLevel;
+    bool allowJSHandleInPageContentWorld;
 
 #if PLATFORM(MAC)
     std::optional<WebCore::DestinationColorSpace> colorSpace;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -367,6 +367,16 @@ bool PageConfiguration::lockdownModeEnabled() const
     return lockdownModeEnabledBySystem();
 }
 
+void PageConfiguration::setAllowJSHandleInPageContentWorld(bool allow)
+{
+    m_data.allowJSHandleInPageContentWorld = allow;
+}
+
+bool PageConfiguration::allowJSHandleInPageContentWorld() const
+{
+    return m_data.allowJSHandleInPageContentWorld;
+}
+
 void PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebProcessLaunchUntilFirstLoad)
 {
     RELEASE_LOG(Process, "%p - PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(%d)", this, delaysWebProcessLaunchUntilFirstLoad);

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -453,6 +453,9 @@ public:
     void setDelaysWebProcessLaunchUntilFirstLoad(bool);
     bool delaysWebProcessLaunchUntilFirstLoad() const;
 
+    void setAllowJSHandleInPageContentWorld(bool);
+    bool allowJSHandleInPageContentWorld() const;
+
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_data.contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_data.contentSecurityPolicyModeForExtension; }
 
@@ -636,6 +639,8 @@ private:
         bool scrollToTextFragmentMarkingEnabled { true };
         bool showsSystemScreenTimeBlockingView { true };
         bool shouldSendConsoleLogsToUIProcessForTesting { false };
+        bool allowJSHandleInPageContentWorld { false };
+
 #if PLATFORM(VISION)
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -243,6 +243,7 @@ WK_EXPORT void WKPageSetPageStateClient(WKPageRef page, WKPageStateClientBase* c
 typedef void (*WKPageEvaluateJavaScriptFunction)(WKTypeRef, WKErrorRef, void*);
 WK_EXPORT void WKPageEvaluateJavaScriptInMainFrame(WKPageRef page, WKStringRef script, void* context, WKPageEvaluateJavaScriptFunction function);
 WK_EXPORT void WKPageEvaluateJavaScriptInFrame(WKPageRef page, WKFrameInfoRef frame, WKStringRef script, void* context, WKPageEvaluateJavaScriptFunction function);
+WK_EXPORT void WKPageCallAsyncJavaScript(WKPageRef page, WKStringRef script, WKDictionaryRef arguments, WKFrameInfoRef frame, void* context, WKPageEvaluateJavaScriptFunction callback);
 
 typedef void (*WKPageGetSourceForFrameFunction)(WKStringRef, WKErrorRef, void*);
 WK_EXPORT void WKPageGetSourceForFrame(WKPageRef page, WKFrameRef frame, void* context, WKPageGetSourceForFrameFunction function);

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -129,3 +129,13 @@ void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfi
 {
     toProtectedImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
 }
+
+void WKPageConfigurationSetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration, bool allow)
+{
+    toProtectedImpl(configuration)->setAllowJSHandleInPageContentWorld(allow);
+}
+
+bool WKPageConfigurationGetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration)
+{
+    return toProtectedImpl(configuration)->allowJSHandleInPageContentWorld();
+}

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
@@ -63,6 +63,9 @@ WK_EXPORT void WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(
 
 WK_EXPORT void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
 
+WK_EXPORT void WKPageConfigurationSetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration, bool allow);
+WK_EXPORT bool WKPageConfigurationGetAllowJSHandleInPageContentWorld(WKPageConfigurationRef configuration);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12076,6 +12076,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.canUseCredentialStorage = m_canUseCredentialStorage;
 
     parameters.httpsUpgradeEnabled = preferences->upgradeKnownHostsToHTTPSEnabled() ? m_configuration->httpsUpgradeEnabled() : false;
+    parameters.allowJSHandleInPageContentWorld = m_configuration->allowJSHandleInPageContentWorld();
     
 #if ENABLE(APP_HIGHLIGHTS)
     parameters.appHighlightsVisible = appHighlightsVisibility() ? HighlightVisibility::Visible : HighlightVisibility::Hidden;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1182,6 +1182,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         page->chrome().show();
         page->setOpenedByDOM();
     }
+
+    if (parameters.allowJSHandleInPageContentWorld)
+        InjectedBundleScriptWorld::normalWorldSingleton().setNodeInfoEnabled();
 }
 
 void WebPage::updateAfterDrawingAreaCreation(const WebPageCreationParameters& parameters)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -464,7 +464,7 @@ public:
     void setUseWorkQueue(bool useWorkQueue) { m_useWorkQueue = useWorkQueue; }
     bool useWorkQueue() const { return m_useWorkQueue; }
 
-    void listenForTooltipChanges(WKFrameInfoRef, WKStringRef);
+    void listenForTooltipChanges(WKFrameInfoRef, WKTypeRef);
 
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
@@ -801,7 +801,7 @@ private:
 
     struct TooltipChangeCallbackInfo {
         WKRetainPtr<WKFrameInfoRef> frame;
-        String callbackName;
+        WKRetainPtr<WKTypeRef> callbackHandle;
     };
     Vector<TooltipChangeCallbackInfo> m_framesListeningForTooltipChange;
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -191,6 +191,7 @@ void initializeWebViewConfiguration(const char* libraryPath, WKStringRef injecte
 #endif
         [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
         WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting((__bridge WKPageConfigurationRef)configuration.get(), true);
+        WKPageConfigurationSetAllowJSHandleInPageContentWorld((__bridge WKPageConfigurationRef)configuration.get(), true);
 
 #if USE(SYSTEM_PREVIEW)
         [configuration _setSystemPreviewEnabled:YES];


### PR DESCRIPTION
#### c03bf534de9a1c26c3da48a7cd4d08f355a306e7
<pre>
Adopt _WKJSHandle in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=297297">https://bugs.webkit.org/show_bug.cgi?id=297297</a>
<a href="https://rdar.apple.com/158171538">rdar://158171538</a>

Reviewed by Ryosuke Niwa.

This allows us to pass a JavaScript function to be called later to the UI process
instead of passing the name of that function and assembling a string to evaluate.

* LayoutTests/http/tests/site-isolation/mouse-events/iframes-with-tooltips.html:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::toAPI):
(WebKit::isSerializable):
(WebKit::JavaScriptEvaluationResult::toValue):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::setAllowJSHandleInPageContentWorld):
(API::PageConfiguration::allowJSHandleInPageContentWorld const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageCallAsyncJavaScript):
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationSetAllowJSHandleInPageContentWorld):
(WKPageConfigurationGetAllowJSHandleInPageContentWorld):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::tooltipDidChange):
(WTR::TestController::listenForTooltipChanges):
(WTR::TestController::installUserScript):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::initializeWebViewConfiguration):

Canonical link: <a href="https://commits.webkit.org/298606@main">https://commits.webkit.org/298606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10a52b95db10e957ab4683df2494436e1ee9ab97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122089 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c47bec5c-fe08-40df-9db0-3aa9872fb32a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88149 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47f3439f-a008-4ae2-9e96-1738b58982d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68559 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22226 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65771 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125239 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32220 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96675 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41940 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19821 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18542 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42280 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43985 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->