### PR TITLE
AX: Scrolled iframe content cannot be hit tested

### DIFF
--- a/LayoutTests/accessibility/mac/iframe-hit-testing-expected.txt
+++ b/LayoutTests/accessibility/mac/iframe-hit-testing-expected.txt
@@ -1,0 +1,9 @@
+This test verifies that hit testing returns the right element when an iframe is scrolled.
+
+PASS: accessibilityController.elementAtPoint(iframeCenterX + 100, iframeCenterY + 100).stringValue === 'AXValue: hello'
+PASS: accessibilityController.elementAtPoint(iframeCenterX + 100, iframeCenterY + 100).stringValue === 'AXValue: world'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/iframe-hit-testing.html
+++ b/LayoutTests/accessibility/mac/iframe-hit-testing.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<iframe onload="runTest()" id="iframe" width="200" height="200" srcdoc="<!DOCTYPE html>
+
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-size: 50px;
+        }
+        .page1 {
+            height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+        .page2 {
+            height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+    <div class='page1'>hello</div>
+    <div class='page2'>world</div>
+</body>
+</html>">
+</iframe>
+
+<script>
+var output = "This test verifies that hit testing returns the right element when an iframe is scrolled.\n\n";
+
+var iframeCenterx, iframeCenterY;
+
+function runTest() {
+    if (window.accessibilityController) {
+        window.jsTestIsAsync = true;
+
+        let iframe = document.getElementById('iframe');
+        iframeCenterX = iframe.getBoundingClientRect().left;
+        iframeCenterY = iframe.getBoundingClientRect().top;
+
+        setTimeout(async function () {
+            output += await expectAsync("accessibilityController.elementAtPoint(iframeCenterX + 100, iframeCenterY + 100).stringValue", "'AXValue: hello'");
+
+            // Scroll iframe to bottom.
+            iframe.contentWindow.scrollTo(0, iframe.contentDocument.body.scrollHeight);
+            output += await expectAsync("accessibilityController.elementAtPoint(iframeCenterX + 100, iframeCenterY + 100).stringValue", "'AXValue: world'");
+
+            debug(output);
+            finishJSTest();
+        }, 0);
+    }
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -991,6 +991,8 @@ accessibility/mac/bounds-for-range-centered.html [ Skip ]
 # Skipping because different hierarchy on WK1
 accessibility/youtube-embed-accessibility-hierarchy.html [ Skip ]
 
+accessibility/mac/iframe-hit-testing.html [ Skip ]
+
 # DOM paste access requests are not implemented in WebKit1.
 editing/async-clipboard/clipboard-change-data-while-reading.html [ Skip ]
 editing/async-clipboard/clipboard-do-not-read-text-from-platform-if-text-changes.html [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3153,11 +3153,14 @@ AccessibilityObject* AccessibilityObject::elementAccessibilityHitTest(const IntP
 {
     // Send the hit test back into the sub-frame if necessary.
     if (isAttachment()) {
-        Widget* widget = widgetForAttachmentView();
+        RefPtr widget = widgetForAttachmentView();
         // Normalize the point for the widget's bounds.
         if (widget && widget->isLocalFrameView()) {
-            if (CheckedPtr cache = axObjectCache())
-                return cache->getOrCreate(*widget)->accessibilityHitTest(IntPoint(point - widget->frameRect().location()));
+            RefPtr widgetScrollView = dynamicDowncast<ScrollView>(widget);
+            if (CheckedPtr cache = widgetScrollView ? axObjectCache() : nullptr) {
+                IntPoint adjustedPoint = IntPoint(point - widget->frameRect().location()) + widgetScrollView->scrollPosition();
+                return cache->getOrCreate(*widget)->accessibilityHitTest(adjustedPoint);
+            }
         }
 
         if (widget && widget->isRemoteFrameView()) {


### PR DESCRIPTION
#### 7f1653cda09d79f83de08cfc662fd4a0fa600f2e
<pre>
AX: Scrolled iframe content cannot be hit tested
<a href="https://bugs.webkit.org/show_bug.cgi?id=297296">https://bugs.webkit.org/show_bug.cgi?id=297296</a>
<a href="https://rdar.apple.com/155985059">rdar://155985059</a>

Reviewed by Tyler Wilcock.

When hit testing the main frame/page via WKAccessibilityWebPageObjectMac,
we account for the scroll position of that page. But, when an iframe is
hit tested, we are not adjusting for that frame&apos;s scroll position as
well. This fixes that issue, resolving several hit testing issues across ATs.

* LayoutTests/accessibility/mac/iframe-hit-testing-expected.txt: Added.
* LayoutTests/accessibility/mac/iframe-hit-testing.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::elementAccessibilityHitTest const):

Canonical link: <a href="https://commits.webkit.org/298627@main">https://commits.webkit.org/298627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/284b0ada52491a52f9495818fbb705e837388e62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66594 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/356f0587-fbf2-4d5c-9689-b7c13f68b79b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88159 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f989ae8-eee4-4e52-8f15-3f38f29d40d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68570 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22239 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65784 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125252 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96899 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38886 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48419 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42294 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45629 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->