### PR TITLE
Use API::Error instead of NSError on WebExtensionController and WebExtensionContext

### DIFF
--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -50,9 +50,11 @@ public:
     WEBCORE_EXPORT ResourceError(CFErrorRef error);
 
     WEBCORE_EXPORT CFErrorRef cfError() const;
+    WEBCORE_EXPORT CFErrorRef cfError(CFErrorRef) const;
     WEBCORE_EXPORT operator CFErrorRef() const;
     WEBCORE_EXPORT ResourceError(NSError *);
     WEBCORE_EXPORT NSError *nsError() const;
+    WEBCORE_EXPORT NSError *nsError(NSError *) const;
     WEBCORE_EXPORT operator NSError *() const;
 
 

--- a/Source/WebKit/Shared/API/APIError.h
+++ b/Source/WebKit/Shared/API/APIError.h
@@ -42,6 +42,11 @@ public:
         return adoptRef(*new Error(error));
     }
 
+    static Ref<Error> create(const WebCore::ResourceError& error, const RefPtr<API::Error>& underlyingError)
+    {
+        return adoptRef(*new Error(error, underlyingError));
+    }
+
     enum General {
         Internal = 300
     };
@@ -100,6 +105,7 @@ public:
     const WTF::String& localizedDescription() const { return m_platformError.localizedDescription(); }
 
     const WebCore::ResourceError& platformError() const { return m_platformError; }
+    const RefPtr<Error> underlyingError() const { return m_underlyingError; }
 
 private:
     Error()
@@ -111,7 +117,14 @@ private:
     {
     }
 
+    Error(const WebCore::ResourceError& error, const RefPtr<Error>& underlyingError)
+        : m_platformError(error)
+        , m_underlyingError(underlyingError)
+    {
+    }
+
     WebCore::ResourceError m_platformError;
+    RefPtr<Error> m_underlyingError;
 };
 
 } // namespace API

--- a/Source/WebKit/Shared/Cocoa/WKNSError.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSError.mm
@@ -32,6 +32,9 @@
 
 - (NSObject *)_web_createTarget
 {
+    RefPtr underlyingError = downcast<API::Error>(&self._apiObject)->underlyingError();
+    if (underlyingError)
+        return [(__bridge NSError *)downcast<API::Error>(&self._apiObject)->platformError().cfError((__bridge CFErrorRef)wrapper(*underlyingError)) copy];
     return [(__bridge NSError *)downcast<API::Error>(&self._apiObject)->platformError().cfError() copy];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
@@ -30,6 +30,7 @@
 #import "config.h"
 #import "WKWebExtensionControllerInternal.h"
 
+#import "WKNSError.h"
 #import "WKWebExtensionContextInternal.h"
 #import "WKWebExtensionControllerConfigurationInternal.h"
 #import "WKWebExtensionDataRecordInternal.h"
@@ -79,14 +80,36 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionCont
 {
     NSParameterAssert([extensionContext isKindOfClass:WKWebExtensionContext.class]);
 
-    return Ref { *_webExtensionController }->load(Ref { extensionContext._webExtensionContext }, outError);
+    if (outError)
+        *outError = nil;
+
+    auto loadResult = Ref { *_webExtensionController }->load(Ref { extensionContext._webExtensionContext });
+
+    if (!loadResult) {
+        if (outError)
+            *outError = wrapper(loadResult.error());
+        return false;
+    }
+
+    return loadResult.value();
 }
 
 - (BOOL)unloadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
     NSParameterAssert([extensionContext isKindOfClass:WKWebExtensionContext.class]);
 
-    return Ref { *_webExtensionController }->unload(Ref { extensionContext._webExtensionContext }, outError);
+    if (outError)
+        *outError = nil;
+
+    auto unloadResult = Ref { *_webExtensionController }->unload(Ref { extensionContext._webExtensionContext });
+
+    if (!unloadResult) {
+        if (outError)
+            *outError = wrapper(unloadResult.error());
+        return false;
+    }
+
+    return unloadResult.value();
 }
 
 - (WKWebExtensionContext *)extensionContextForExtension:(WKWebExtension *)extension

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -369,7 +369,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         for (NSString *scriptPath in scriptPaths) {
             RefPtr<API::Error> error;
             if (!extension->resourceStringForPath(scriptPath, error)) {
-                recordError(::WebKit::wrapper(*error));
+                recordError(*error);
                 *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", scriptPath).createNSString().autorelease();
                 return false;
             }
@@ -384,7 +384,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         for (NSString *styleSheetPath in styleSheetPaths) {
             RefPtr<API::Error> error;
             if (!extension->resourceStringForPath(styleSheetPath, error)) {
-                recordError(::WebKit::wrapper(*error));
+                recordError(*error);
                 *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", styleSheetPath).createNSString().autorelease();
                 return false;
             }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -750,13 +750,13 @@ RefPtr<WebCore::Icon> WebExtensionAction::icon(WebCore::FloatSize idealSize)
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
         if (m_customIconVariants) {
             result = extensionContext->protectedExtension()->bestIconVariant(m_customIconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
-                extensionContext->recordError(::WebKit::wrapper(error));
+                extensionContext->recordError(error);
             });
         } else
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
         if (m_customIcons) {
             result = extensionContext->protectedExtension()->bestIcon(m_customIcons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
-                extensionContext->recordError(::WebKit::wrapper(error));
+                extensionContext->recordError(error);
             });
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -93,7 +93,7 @@ std::optional<SourcePair> sourcePairForResource(const String& path, WebExtension
     Ref extension = extensionContext.extension();
     auto scriptString = extension->resourceStringForPath(path, error, WebExtension::CacheResult::Yes);
     if (!scriptString || error) {
-        extensionContext.recordError(wrapper(error));
+        extensionContext.recordErrorIfNeeded(error);
         return std::nullopt;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -373,13 +373,13 @@ RefPtr<WebCore::Icon> WebExtensionMenuItem::icon(WebCore::FloatSize idealSize) c
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_iconVariants) {
         result = extensionContext->protectedExtension()->bestIconVariant(m_iconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
-            extensionContext->recordError(wrapper(error.get()));
+            extensionContext->recordError(error);
         });
     } else
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_icons) {
         result = extensionContext->protectedExtension()->bestIcon(m_icons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
-            extensionContext->recordError(wrapper(error.get()));
+            extensionContext->recordError(error);
         });
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -120,7 +120,7 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         RefPtr<API::Error> error;
         RefPtr resourceData = extension->resourceDataForPath(requestURL.path().toString(), error);
         if (!resourceData || error) {
-            extensionContext->recordErrorIfNeeded(wrapper(error));
+            extensionContext->recordErrorIfNeeded(error);
             task->didComplete([NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil]);
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -260,6 +260,16 @@ public:
         BackgroundContentFailedToLoad,
     };
 
+    // Keep in sync with WKWebExtensionContextError values
+    enum class APIError : uint8_t {
+        Unknown = 1,
+        AlreadyLoaded,
+        NotLoaded,
+        BaseURLAlreadyInUse,
+        NoBackgroundContent,
+        BackgroundContentFailedToLoad
+    };
+
     enum class PermissionState : int8_t {
         DeniedExplicitly    = -3,
         DeniedImplicitly    = -2,
@@ -302,14 +312,17 @@ public:
 
     bool operator==(const WebExtensionContext& other) const { return (this == &other); }
 
-#if PLATFORM(COCOA)
-    NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
-    void recordErrorIfNeeded(NSError *error) { if (error) recordError(error); }
-    void recordError(NSError *);
+    Ref<API::Error> createError(Error, const String& customLocalizedDescription = nullString(), RefPtr<API::Error> underlyingError = nullptr);
+    void recordErrorIfNeeded(RefPtr<API::Error> error)
+    {
+        if (error)
+            recordError(*error);
+    }
+
+    void recordError(Ref<API::Error>);
     void clearError(Error);
 
-    NSArray *errors();
-#endif
+    Vector<Ref<API::Error>> errors();
 
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     const String& storageDirectory() const { return m_storageDirectory; }
@@ -318,9 +331,9 @@ public:
 
     Ref<WebExtensionStorageSQLiteStore> storageForType(WebExtensionDataType);
 
-    bool load(WebExtensionController&, String storageDirectory, NSError ** = nullptr);
-    bool unload(NSError ** = nullptr);
-    bool reload(NSError ** = nullptr);
+    Expected<bool, RefPtr<API::Error>> load(WebExtensionController&, String storageDirectory);
+    Expected<bool, RefPtr<API::Error>> unload();
+    Expected<bool, RefPtr<API::Error>> reload();
 
     bool isLoaded() const { return !!m_extensionController; }
 
@@ -543,16 +556,16 @@ public:
     URL backgroundContentURL();
     WKWebView *backgroundWebView() const { return m_backgroundWebView.get(); }
     bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
-
-    NSError *backgroundContentLoadError() const { return m_backgroundContentLoadError.get(); }
 #endif
+
+    RefPtr<API::Error> backgroundContentLoadError() const { return m_backgroundContentLoadError; }
 
     NSString *backgroundWebViewInspectionName();
     void setBackgroundWebViewInspectionName(const String&);
 
     bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);
     void didFinishDocumentLoad(WKWebView *, WKNavigation *);
-    void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
+    void didFailNavigation(WKWebView *, WKNavigation *, RefPtr<API::Error>);
     void webViewWebContentProcessDidTerminate(WKWebView *);
 
 #if PLATFORM(MAC)
@@ -601,7 +614,7 @@ public:
 
     void cookiesDidChange(API::HTTPCookieStore&);
 
-    void loadBackgroundContent(CompletionHandler<void(NSError *)>&&);
+    void loadBackgroundContent(CompletionHandler<void(RefPtr<API::Error>)>&&);
 
     void wakeUpBackgroundContentIfNecessary(Function<void()>&&);
     void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&&, Function<void()>&&);
@@ -641,6 +654,8 @@ private:
     friend class WebExtensionMessagePort;
 
     explicit WebExtensionContext();
+
+    int toAPIError(WebExtensionContext::Error);
 
     String stateFilePath() const;
     NSDictionary *currentState() const;
@@ -995,8 +1010,8 @@ private:
 
 #if PLATFORM(COCOA)
     RetainPtr<NSMutableDictionary> m_state;
-    RetainPtr<NSMutableArray> m_errors;
 #endif
+    Vector<Ref<API::Error>> m_errors;
 
     RefPtr<WebExtension> m_extension;
     WeakPtr<WebExtensionController> m_extensionController;
@@ -1044,9 +1059,9 @@ private:
 #if PLATFORM(COCOA)
     RetainPtr<WKWebView> m_backgroundWebView;
     RefPtr<ProcessThrottlerActivity> m_backgroundWebViewActivity;
-    RetainPtr<NSError> m_backgroundContentLoadError;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
 #endif
+    RefPtr<API::Error> m_backgroundContentLoadError;
 
     String m_backgroundWebViewInspectionName;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -50,7 +50,6 @@
 #include <wtf/URLHash.h>
 #include <wtf/WeakHashSet.h>
 
-OBJC_CLASS NSError;
 OBJC_CLASS NSMenu;
 OBJC_CLASS _WKWebExtensionControllerHelper;
 OBJC_PROTOCOL(WKWebExtensionControllerDelegatePrivate);
@@ -132,8 +131,8 @@ public:
     bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
     bool isFreshlyCreated() const { return m_freshlyCreated; }
 
-    bool load(WebExtensionContext&, NSError ** = nullptr);
-    bool unload(WebExtensionContext&, NSError ** = nullptr);
+    Expected<bool, RefPtr<API::Error>> load(WebExtensionContext&);
+    Expected<bool, RefPtr<API::Error>> unload(WebExtensionContext&);
 
     void unloadAll();
 


### PR DESCRIPTION
#### d348f170390f0ee57cafcfdb0a7040303992775c
<pre>
Use API::Error instead of NSError on WebExtensionController and WebExtensionContext
<a href="https://webkit.org/b/297301">https://webkit.org/b/297301</a>

Reviewed by Timothy Hatcher.

NSError is Cocoa-only. Using API::Error will allow for cross-platform support of WebExtensionController and WebExtensionContext.

* Source/WebCore/platform/network/cf/ResourceError.h:
* Source/WebCore/platform/network/mac/ResourceErrorMac.mm:
(WebCore::createNSErrorFromResourceErrorBase):
(WebCore::ResourceError::nsError const):
(WebCore::ResourceError::cfError const):
* Source/WebKit/Shared/API/APIError.h:
(API::Error::create):
(API::Error::underlyingError const):
(API::Error::Error):
* Source/WebKit/Shared/Cocoa/WKNSError.mm:
(-[WKNSError _web_createTarget]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext errors]):
(-[WKWebExtensionContext loadBackgroundContentWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm:
(-[WKWebExtensionController loadExtensionContext:error:]):
(-[WKWebExtensionController unloadExtensionContext:error:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::icon):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(-[_WKWebExtensionContextDelegate webView:didFailNavigation:withError:]):
(WebKit::WebExtensionContext::recordError):
(WebKit::WebExtensionContext::clearError):
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::unload):
(WebKit::WebExtensionContext::reload):
(WebKit::WebExtensionContext::loadBackgroundContent):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::didFailNavigation):
(WebKit::WebExtensionContext::addInjectedContent):
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRules):
(WebKit::toAPI): Deleted.
(WebKit::WebExtensionContext::createError): Deleted.
(WebKit::WebExtensionContext::errors): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::unloadAll):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::sourcePairForResource):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::icon const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::toAPIError):
(WebKit::WebExtensionContext::createError):
(WebKit::WebExtensionContext::errors):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::recordErrorIfNeeded):
(WebKit::WebExtensionContext::safeToLoadBackgroundContent const):
(WebKit::WebExtensionContext::backgroundContentLoadError const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:

Canonical link: <a href="https://commits.webkit.org/299009@main">https://commits.webkit.org/299009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9146dc3e036936a1e156d2d99dab268bf29db40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88938 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43624 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69422 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66886 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97611 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97397 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20668 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40427 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18750 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49632 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46760 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->