### PR TITLE
AX: AXProperty::{SupportsExpandedTextValue, ExpandedTextValue} are never updated after dynamic page changes, resulting in stale values being served to assistive technologies

### DIFF
--- a/LayoutTests/accessibility/dynamic-expanded-text-expected.txt
+++ b/LayoutTests/accessibility/dynamic-expanded-text-expected.txt
@@ -1,0 +1,10 @@
+This test ensures the expanded-text value of an abbreviation is updated after dynamic page changes.
+
+PASS: text.stringAttributeValue('AXExpandedTextValue') === 'Laughing out loud'
+PASS: text.isAttributeSupported('AXExpandedTextValue') === true
+PASS: text.stringAttributeValue('AXExpandedTextValue') === 'Lots of luck'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+LOL

--- a/LayoutTests/accessibility/dynamic-expanded-text.html
+++ b/LayoutTests/accessibility/dynamic-expanded-text.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<abbr id="abbr" title="Laughing out loud">LOL</abbr>
+
+<script>
+var output = "This test ensures the expanded-text value of an abbreviation is updated after dynamic page changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webarea = accessibilityController.rootElement.childAtIndex(0);
+    var text = webarea.childAtIndex(0);
+    output += expect("text.stringAttributeValue('AXExpandedTextValue')", "'Laughing out loud'");
+    if (accessibilityController.platformName === "mac")
+        output += expect("text.isAttributeSupported('AXExpandedTextValue')", "true");
+
+    document.getElementById("abbr").setAttribute("title", "Lots of luck");
+    setTimeout(async function() {
+        output += await expectAsync("text.stringAttributeValue('AXExpandedTextValue')", "'Lots of luck'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/mac/abbr-acronym-tags-expected.txt
+++ b/LayoutTests/accessibility/mac/abbr-acronym-tags-expected.txt
@@ -1,18 +1,16 @@
+This tests that 'alternate text' for certain tags works correctly, including abbr tag, acronym tag and abbr attribute.
+
+PASS: abbr.stringAttributeValue('AXExpandedTextValue') === 'World Wide Web'
+PASS: content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange) === true
+PASS: acronym.stringAttributeValue('AXExpandedTextValue') === 'WebKit2'
+PASS: content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange) === true
+PASS: headerCell.stringAttributeValue('AXExpandedTextValue') === 'Test'
+PASS: headerCell.stringAttributeValue('AXExpandedTextValue') === 'foo'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
 WWW
 WK2
 Longer Test
 test
-This tests that 'alternate text' for certain tags works correctly, including abbr tag, acronym tag and abbr attribute.
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS abbr.stringAttributeValue('AXExpandedTextValue') is 'World Wide Web'
-PASS content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange) is true
-PASS acronym.stringAttributeValue('AXExpandedTextValue') is 'WebKit2'
-PASS content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange) is true
-PASS headerCell.stringAttributeValue('AXExpandedTextValue') is 'Test'
-PASS successfullyParsed is true
-
-TEST COMPLETE
-

--- a/LayoutTests/accessibility/mac/abbr-acronym-tags.html
+++ b/LayoutTests/accessibility/mac/abbr-acronym-tags.html
@@ -1,15 +1,16 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
-<body id="body">
+<body>
 
-<div id="content1">
-<abbr title="World Wide Web">WWW</abbr>
+<div id="content1" role="group">
+    <abbr title="World Wide Web">WWW</abbr>
 </div>
 
-<div id="content2">
+<div id="content2" role="group">
 <acronym title="WebKit2">WK2</acronym>
 </div>
 
@@ -18,36 +19,36 @@
 <tr><td>test</td></tr>
 </table>
 
-
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that 'alternate text' for certain tags works correctly, including abbr tag, acronym tag and abbr attribute.\n\n";
 
-    description("This tests that 'alternate text' for certain tags works correctly, including abbr tag, acronym tag and abbr attribute.");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-    if (window.accessibilityController) {
+    var content = accessibilityController.accessibleElementById("content1");
+    var abbr = content.childAtIndex(0);
+    output += expect("abbr.stringAttributeValue('AXExpandedTextValue')", "'World Wide Web'");
+    var markerRange = content.textMarkerRangeForElement(content);
+    output += expect("content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange)", "true");
 
-        var content = accessibilityController.accessibleElementById("content1");
-        var abbr = content.childAtIndex(0);
-        shouldBe("abbr.stringAttributeValue('AXExpandedTextValue')", "'World Wide Web'");
-        var markerRange = content.textMarkerRangeForElement(content);
-        shouldBeTrue("content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange)");
+    content = accessibilityController.accessibleElementById("content2");
+    var acronym = content.childAtIndex(0);
+    output += expect("acronym.stringAttributeValue('AXExpandedTextValue')", "'WebKit2'");
+    markerRange = content.textMarkerRangeForElement(content);
+    output += expect("content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange)", "true");
 
-        content = accessibilityController.accessibleElementById("content2");
-        var acronym = content.childAtIndex(0);
-        shouldBe("acronym.stringAttributeValue('AXExpandedTextValue')", "'WebKit2'");
-        markerRange = content.textMarkerRangeForElement(content);
-        shouldBeTrue("content.attributedStringForTextMarkerRangeContainsAttribute('AXExpandedTextValue', markerRange)");
+    var headerCell = accessibilityController.accessibleElementById("cell");
+    output += expect("headerCell.stringAttributeValue('AXExpandedTextValue')", "'Test'");
 
-        var headerCell = accessibilityController.accessibleElementById("cell");
-        shouldBe("headerCell.stringAttributeValue('AXExpandedTextValue')", "'Test'");
+    document.getElementById("cell").setAttribute("abbr", "foo");
+    setTimeout(async function() {
+        output += await expectAsync("headerCell.stringAttributeValue('AXExpandedTextValue')", "'foo'");
 
-
-    }
-
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -760,6 +760,8 @@ imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-005.html [ Pass
 accessibility/opacity-0-bounding-box.html [ Skip ]
 accessibility/clip-path-bounding-box.html [ Skip ]
 
+accessibility/dynamic-expanded-text.html [ Skip ]
+
 accessibility/dynamic-content-visibility.html [ Skip ]
 accessibility/password-notifications-timing.html [ Skip ]
 

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1525,6 +1525,29 @@ AXCoreObject* AXCoreObject::titleUIElement() const
 #endif
 }
 
+String AXCoreObject::expandedTextValue() const
+{
+    if (isStaticText()) {
+        if (RefPtr parent = parentObject()) {
+            auto parentName = parent->elementName();
+            if (parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym)
+                return parent->titleAttribute();
+        }
+    }
+    return hasCellRole() ? abbreviation() : String();
+}
+
+bool AXCoreObject::supportsExpandedTextValue() const
+{
+    if (isStaticText()) {
+        if (RefPtr parent = parentObject()) {
+            auto parentName = parent->elementName();
+            return parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym;
+        }
+    }
+    return hasCellRole() && !abbreviation().isEmpty();
+}
+
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::linkedObjects() const
 {
     auto linkedObjects = flowToObjects();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1196,7 +1196,11 @@ public:
     // This should be the visible text that's actually on the screen if possible.
     // If there's alternative text (e.g. provided by description()), that can override the title.
     virtual String title() const;
+    // This is the value of the title HTML / SVG attribute, differing from the above function which refers to
+    // the notion of "title" accessibility text, a composite of many different attributes and page text.
+    virtual String titleAttribute() const = 0;
     virtual String webAreaTitle() const { return emptyString(); }
+
     virtual String description() const = 0;
 
     virtual std::optional<String> textContent() const = 0;
@@ -1230,8 +1234,9 @@ public:
     virtual const String placeholderValue() const = 0;
 
     // Abbreviations
-    virtual String expandedTextValue() const = 0;
-    virtual bool supportsExpandedTextValue() const = 0;
+    virtual String abbreviation() const = 0;
+    String expandedTextValue() const;
+    bool supportsExpandedTextValue() const;
 
     // Only if isColorWell()
     virtual SRGBA<uint8_t> colorValue() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -651,6 +651,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::AXRowIndexText:
         stream << "AXRowIndexText";
         break;
+    case AXProperty::Abbreviation:
+        stream << "Abbreviation";
+        break;
     case AXProperty::AccessKey:
         stream << "AccessKey";
         break;
@@ -754,9 +757,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::EmbeddedImageDescription:
         stream << "EmbeddedImageDescription";
-        break;
-    case AXProperty::ExpandedTextValue:
-        stream << "ExpandedTextValue";
         break;
     case AXProperty::ExplicitAutoCompleteValue:
         stream << "ExplicitAutoCompleteValue";
@@ -1159,9 +1159,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::SupportsExpanded:
         stream << "SupportsExpanded";
         break;
-    case AXProperty::SupportsExpandedTextValue:
-        stream << "SupportsExpandedTextValue";
-        break;
     case AXProperty::SupportsKeyShortcuts:
         stream << "SupportsKeyShortcuts";
         break;
@@ -1190,6 +1187,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         stream << "TextRuns";
         break;
 #endif
+    case AXProperty::TitleAttribute:
+        stream << "TitleAttribute";
+        break;
     case AXProperty::URL:
         stream << "URL";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3180,6 +3180,8 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         postNotification(element, AXNotification::CellScopeChanged);
     else if (attrName == datetimeAttr)
         postNotification(element, AXNotification::DatetimeChanged);
+    else if (attrName == abbrAttr)
+        postNotification(element, AXNotification::AbbreviationChanged);
 
     if (!attrName.localName().string().startsWith("aria-"_s))
         return;
@@ -5022,6 +5024,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             continue;
 
         switch (notification.second) {
+        case AXNotification::AbbreviationChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::Abbreviation });
+            break;
         case AXNotification::AccessKeyChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::AccessKey });
             break;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -171,6 +171,7 @@ protected:
 };
 
 #define WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro) \
+    macro(AbbreviationChanged) \
     macro(AccessKeyChanged) \
     macro(ActiveDescendantChanged) \
     macro(AnnouncementRequested) \

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2608,11 +2608,6 @@ String AccessibilityObject::getAttributeTrimmed(const QualifiedName& attribute) 
     return value.trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
-String AccessibilityObject::nameAttribute() const
-{
-    return getAttribute(nameAttr);
-}
-
 int AccessibilityObject::integralAttribute(const QualifiedName& attributeName) const
 {
     return parseHTMLInteger(getAttribute(attributeName)).value_or(0);

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -419,8 +419,7 @@ public:
     String extendedDescription() const final;
 
     // Abbreviations
-    String expandedTextValue() const override { return String(); }
-    bool supportsExpandedTextValue() const override { return false; }
+    String abbreviation() const final { return getAttribute(HTMLNames::abbrAttr); }
 
     Vector<Ref<Element>> elementsFromAttribute(const QualifiedName&) const;
 
@@ -561,7 +560,8 @@ public:
     const AtomString& getAttribute(const QualifiedName&) const;
     String getAttributeTrimmed(const QualifiedName&) const;
 
-    String nameAttribute() const final;
+    String nameAttribute() const final { return getAttribute(HTMLNames::nameAttr); }
+    String titleAttribute() const final { return getAttribute(HTMLNames::titleAttr); }
     int integralAttribute(const QualifiedName&) const;
     bool hasElementName(const ElementName) const final;
     bool hasAttachmentTag() const final { return hasElementName(ElementName::HTML_attachment); }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2217,29 +2217,6 @@ AccessibilityObject* AccessibilityRenderObject::observableObject() const
     return nullptr;
 }
 
-String AccessibilityRenderObject::expandedTextValue() const
-{
-    if (RefPtr parent = parentObject()) {
-        auto parentName = parent->elementName();
-        if (parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym)
-            return parent->getAttribute(titleAttr);
-    }
-
-    return String();
-}
-
-bool AccessibilityRenderObject::supportsExpandedTextValue() const
-{
-    if (role() == AccessibilityRole::StaticText) {
-        if (RefPtr parent = parentObject()) {
-            auto parentName = parent->elementName();
-            return parentName == ElementName::HTML_abbr || parentName == ElementName::HTML_acronym;
-        }
-    }
-
-    return false;
-}
-
 bool AccessibilityRenderObject::shouldIgnoreAttributeRole() const
 {
     return m_ariaRole == AccessibilityRole::Document && hasContentEditableAttributeSet();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -199,8 +199,6 @@ private:
 #if PLATFORM(MAC)
     void updateAttachmentViewParents();
 #endif
-    String expandedTextValue() const override;
-    bool supportsExpandedTextValue() const override;
     virtual void updateRoleAfterChildrenCreation();
 
     bool inheritsPresentationalRole() const override;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -261,16 +261,6 @@ bool AccessibilityTableCell::isRowHeader() const
     return false;
 }
 
-String AccessibilityTableCell::expandedTextValue() const
-{
-    return getAttribute(abbrAttr);
-}
-
-bool AccessibilityTableCell::supportsExpandedTextValue() const
-{
-    return isTableHeaderCell() && hasAttribute(abbrAttr);
-}
-
 AXCoreObject::AccessibilityChildrenVector AccessibilityTableCell::rowHeaders()
 {
     AccessibilityChildrenVector headers;

--- a/Source/WebCore/accessibility/AccessibilityTableCell.h
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.h
@@ -87,8 +87,6 @@ private:
     // If a table cell is not exposed as a table cell, a TH element can serve as its title UI element.
     AccessibilityObject* titleUIElement() const final;
     bool computeIsIgnored() const final;
-    String expandedTextValue() const final;
-    bool supportsExpandedTextValue() const final;
     void ensureIndexesUpToDate() const;
 
     unsigned m_rowIndex { 0 };

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -324,8 +324,7 @@ private:
     AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::RadioButtonGroup)); }
     AXIsolatedObject* scrollBar(AccessibilityOrientation) final;
     const String placeholderValue() const final { return stringAttributeValue(AXProperty::PlaceholderValue); }
-    String expandedTextValue() const final { return stringAttributeValue(AXProperty::ExpandedTextValue); }
-    bool supportsExpandedTextValue() const final { return boolAttributeValue(AXProperty::SupportsExpandedTextValue); }
+    String abbreviation() const final { return stringAttributeValue(AXProperty::Abbreviation); }
     SRGBA<uint8_t> colorValue() const final;
     String subrolePlatformString() const final { return stringAttributeValue(AXProperty::SubrolePlatformString); }
     String ariaRoleDescription() const final { return stringAttributeValue(AXProperty::ARIARoleDescription); };
@@ -530,6 +529,7 @@ private:
 
     String textContentPrefixFromListMarker() const final;
     String webAreaTitle() const final { return stringAttributeValue(AXProperty::WebAreaTitle); }
+    String titleAttribute() const final { return stringAttributeValue(AXProperty::TitleAttribute); }
     String description() const final { return stringAttributeValue(AXProperty::Description); }
 
     std::optional<String> textContent() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -601,6 +601,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
     for (const auto& property : propertySet) {
         AXLOG(makeString("Property: "_s, property));
         switch (property) {
+        case AXProperty::Abbreviation:
+            properties.append({ AXProperty::Abbreviation, axObject.abbreviation().isolatedCopy() });
+            break;
         case AXProperty::AccessKey:
             properties.append({ AXProperty::AccessKey, axObject.accessKey().isolatedCopy() });
             break;
@@ -1703,6 +1706,8 @@ static bool shouldCacheElementName(ElementName name)
 {
     switch (name) {
     case ElementName::HTML_area:
+    case ElementName::HTML_abbr:
+    case ElementName::HTML_acronym:
     case ElementName::HTML_body:
     case ElementName::HTML_del:
     case ElementName::HTML_h1:
@@ -1786,6 +1791,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         auto elementName = object.elementName();
         if (shouldCacheElementName(elementName))
             setProperty(AXProperty::ElementName, elementName);
+        setProperty(AXProperty::TitleAttribute, object.titleAttribute().isolatedCopy());
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
         setProperty(AXProperty::TextRuns, std::make_shared<AXTextRuns>(object.textRuns()));
@@ -1955,11 +1961,6 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::PosInSet, object.posInSet());
         }
 
-        if (object.supportsExpandedTextValue()) {
-            setProperty(AXProperty::SupportsExpandedTextValue, true);
-            setProperty(AXProperty::ExpandedTextValue, object.expandedTextValue().isolatedCopy());
-        }
-
         if (object.supportsDatetimeAttribute())
             setProperty(AXProperty::DatetimeAttributeValue, object.datetimeAttributeValue().isolatedCopy());
 
@@ -1994,6 +1995,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::IsColumnHeader, object.isColumnHeader());
             setProperty(AXProperty::IsRowHeader, object.isRowHeader());
             setProperty(AXProperty::CellScope, object.cellScope().isolatedCopy());
+            setProperty(AXProperty::Abbreviation, object.abbreviation().isolatedCopy());
         }
 
         bool isTableRow = object.isTableRow();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -117,6 +117,7 @@ enum class AXProperty : uint16_t {
     SupportsSetSize = lastPropertyFlagIndex,
     // End bool attributes that are matched in order by AXPropertyFlag.
 
+    Abbreviation,
     ARIALevel,
     ARIARoleDescription,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
@@ -161,7 +162,6 @@ enum class AXProperty : uint16_t {
     DocumentURI,
     ElementName,
     EmbeddedImageDescription,
-    ExpandedTextValue,
     ExplicitAutoCompleteValue,
     ExplicitInvalidStatus,
     ExplicitLiveRegionRelevant,
@@ -282,7 +282,6 @@ enum class AXProperty : uint16_t {
     SupportsDropping,
     SupportsARIAOwns,
     SupportsCurrent,
-    SupportsExpandedTextValue,
     SupportsKeyShortcuts,
     TextContentPrefixFromListMarker,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
@@ -294,6 +293,7 @@ enum class AXProperty : uint16_t {
 #if ENABLE(AX_THREAD_TEXT_APIS)
     TextRuns,
 #endif
+    TitleAttribute,
     URL,
     UnderlineColor,
     ValueAutofillButtonType,


### PR DESCRIPTION
#### 701ef4b83ce6fb5b64a1469308f27b69ee13deea
<pre>
AX: AXProperty::{SupportsExpandedTextValue, ExpandedTextValue} are never updated after dynamic page changes, resulting in stale values being served to assistive technologies
<a href="https://bugs.webkit.org/show_bug.cgi?id=297225">https://bugs.webkit.org/show_bug.cgi?id=297225</a>
<a href="https://rdar.apple.com/158060676">rdar://158060676</a>

Reviewed by Joshua Hoffman.

Fix this by caching the components (the `title` and `abbr` attribute values) necessary to serve AXProperty::{SupportsExpandedTextValue, ExpandedTextValue}
rather than caching those as properties themselves. These component-style properties are much easier to keep up-to-date.

* LayoutTests/accessibility/dynamic-expanded-text-expected.txt: Added.
* LayoutTests/accessibility/dynamic-expanded-text.html: Added.
* LayoutTests/accessibility/mac/abbr-acronym-tags-expected.txt:
* LayoutTests/accessibility/mac/abbr-acronym-tags.html:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::expandedTextValue const):
(WebCore::AXCoreObject::supportsExpandedTextValue const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::nameAttribute const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::expandedTextValue const): Deleted.
(WebCore::AccessibilityRenderObject::supportsExpandedTextValue const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
(WebCore::AccessibilityTableCell::expandedTextValue const): Deleted.
(WebCore::AccessibilityTableCell::supportsExpandedTextValue const): Deleted.
* Source/WebCore/accessibility/AccessibilityTableCell.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::shouldCacheElementName):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/298617@main">https://commits.webkit.org/298617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c32b48095153902cf330c70c9a0e3d2f4036a14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66593 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88158 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68569 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65783 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125251 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96904 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96688 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24604 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19833 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48418 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42293 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45628 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->