### PR TITLE
REGRESSION(298121@main): [ iOS, macOS wk2 ] 4x imported/w3c/web-platform-tests/navigation-api/ (layout-tests) tests are constant text failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS navigation.forward() goes to the nearest forward entry
+FAIL navigation.forward() goes to the nearest forward entry assert_equals: expected 0 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS navigation.traverseTo() goes to the nearest entry when going forward
+FAIL navigation.traverseTo() goes to the nearest entry when going forward assert_equals: expected 0 but got 2
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4852,12 +4852,6 @@ imported/w3c/web-platform-tests/cookiestore/encoding.https.any.html [ Skip ]
 imported/w3c/web-platform-tests/cookiestore/encoding.https.any.serviceworker.html [ Skip ]
 imported/w3c/web-platform-tests/cookiestore/httponly_cookies.https.window.html [ Skip ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=296820 REGRESSION(298121@main): [ iOS, macOS wk2 ] 4x imported/w3c/web-platform-tests/navigation-api/ (layout-tests) tests are constant text failures
-imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child.html [ Failure ]
-
 fast/text/emphasis-overlap.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.sharedworker.html [ Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8215,12 +8215,6 @@ webkit.org/b/296824 [ Release ] http/tests/webcodecs/audio-encoder-callbacks-do-
 
 webkit.org/b/296833 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-096.html [ Pass ImageOnlyFailure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=296820 REGRESSION(298121@main): [ iOS, macOS wk2 ] 4x imported/w3c/web-platform-tests/navigation-api/ (layout-tests) tests are constant text failures
-imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child.html [ Failure ]
-
 webkit.org/b/296910 http/tests/app-privacy-report/app-attribution-beacon-isnotappinitiated.html [ Pass Failure ]
 
 webkit.org/b/296964 [ Release ] imported/w3c/web-platform-tests/webrtc/RTCDataChannel-GC.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2363,12 +2363,6 @@ webkit.org/b/296816 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/s
 
 webkit.org/b/296814 [ arm64 ] imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ Pass ImageOnlyFailure ]
 
-# https://bugs.webkit.org/show_bug.cgi?id=296820 REGRESSION(298121@main): [ iOS, macOS wk2 ] 4x imported/w3c/web-platform-tests/navigation-api/ (layout-tests) tests are constant text failures
-imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-methods/traverseTo-navigates-multiple-iframes.html [ Failure ]
-imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-for-navigation-in-child.html [ Failure ]
-
 webkit.org/b/293808 [ Sequoia Debug arm64 ] http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atan2.html [ Failure ]
 webkit.org/b/293808 [ Sequoia Debug arm64 ] http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/bitcast.html [ Timeout ]
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -404,10 +404,9 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
             return;
 
         Vector<FrameToNavigate> framesToNavigate;
-
-        if (auto targetItemFrameID = targetItem->frameID()) {
-            if (RefPtr fromItem = page->backForward().currentItem(*targetItemFrameID))
-                recursiveGatherFramesToNavigate(frame, framesToNavigate, targetItem, fromItem.get());
+        if (RefPtr fromItem = page->backForward().currentItem()) {
+            if (RefPtr localMainFrame = page->localMainFrame())
+                recursiveGatherFramesToNavigate(*localMainFrame, framesToNavigate, targetItem, fromItem.get());
         }
 
         page->setIsInSwipeAnimation(isInSwipeAnimation);

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -341,7 +341,27 @@ public:
         if (!entry)
             return std::nullopt;
 
-        return entry->associatedHistoryItem();
+        Ref historyItem = entry->associatedHistoryItem();
+
+        if (localFrame.isMainFrame())
+            return historyItem;
+
+        // FIXME: heuristic to fix disambigaute-* tests, we should find something more exact.
+        bool backwards = entry->index() < localFrame.window()->navigation().currentEntry()->index();
+
+        RefPtr page { localFrame.page() };
+        auto items = page->checkedBackForward()->allItems();
+        for (size_t i = 0 ; i < items.size(); i++) {
+            Ref item = items[backwards ? items.size() - 1 - i: i];
+            auto index = item->children().findIf([&historyItem](const auto& child) {
+                return child->itemSequenceNumber() == historyItem->itemSequenceNumber();
+            });
+            if (index != notFound) {
+                historyItem = item;
+                break;
+            }
+        }
+        return historyItem;
     }
 
     void fire(Frame& frame) override
@@ -369,8 +389,9 @@ public:
 
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
 
+        Ref rootFrame = localFrame->rootFrame();
         RefPtr upcomingTraverseMethodTracker = localFrame->window()->navigation().upcomingTraverseMethodTracker(m_key);
-        page->goToItemForNavigationAPI(*localFrame, *historyItem, FrameLoadType::IndexedBackForward, *localFrame, upcomingTraverseMethodTracker.get());
+        page->goToItemForNavigationAPI(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, *localFrame, upcomingTraverseMethodTracker.get());
 
         completionHandler(ScheduleHistoryNavigationResult::Completed);
     }


### PR DESCRIPTION
#### 7ae0ae5ad9ee40cddb49dfbff57a8e304840472b
<pre>
REGRESSION(298121@main): [ iOS, macOS wk2 ] 4x imported/w3c/web-platform-tests/navigation-api/ (layout-tests) tests are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=296820">https://bugs.webkit.org/show_bug.cgi?id=296820</a>
<a href="https://rdar.apple.com/157317021">rdar://157317021</a>

Reviewed by Charlie Wolfe.

298121@main contained two fixes. The second fix was changing
Page::goToItemForNavigationAPI to be called with the triggering frame
(sometimes an iframe) instead of always the main frame.

This change is causing these four failures. It seems like given the
design of the Navigation API, this change doesn&apos;t work. This API
expects navigation.back() and navigation.forward() to be able to
navigate over multiple frames, and check properties of those frames
(such as preventDefault). So in order to correctly collect these frames,
our recursive collection of frames must always begin at the main frame.

This patch reverts this second fix from 298121@main.

This does mean that the disambiguate* tests that 298121@main fixed will
again be failing. But that fix broke more tests than it fixed, and seems
wrong given the design of the Navigation API. We&apos;ll have to figure out
some other fix for the disambiguate* tests.

It&apos;s unusual that the bots didn&apos;t find these failures on 298121@main,
the bots were totally green. I&apos;m not sure why, but regardless, this
patch should fix those tests.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItemForNavigationAPI):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey):

Canonical link: <a href="https://commits.webkit.org/298616@main">https://commits.webkit.org/298616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef635326f9cc696625f144092c12de22d49d29b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66589 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88154 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68564 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22233 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65779 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125247 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96897 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96681 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19828 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18549 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48414 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42289 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->