### PR TITLE
Split out media element subtests for `document.caretPositionFromPoint`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS document.caretPositionFromPoint() should return a CaretPosition over audio elements
+PASS document.caretPositionFromPoint() should return a CaretPosition over video elements
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>document.caretPositionFromPoint()</title>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-document-caretpositionfrompoint">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="container"></div>
+<script>
+  test(() => {
+    container.setHTMLUnsafe(`<audio controls></audio>`);
+    const audio = document.querySelector("audio");
+    const caretPosition = document.caretPositionFromPoint(audio.offsetLeft + audio.offsetWidth / 2, audio.offsetTop + audio.offsetHeight / 2);
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 0);
+  }, "document.caretPositionFromPoint() should return a CaretPosition over audio elements");
+
+  test(() => {
+    container.setHTMLUnsafe(`<video controls></video>`);
+    const video = document.querySelector("video");
+    const caretPosition = document.caretPositionFromPoint(video.offsetLeft + video.offsetWidth / 2, video.offsetTop + video.offsetHeight / 2);
+    assert_equals(caretPosition.offsetNode, container);
+    assert_equals(caretPosition.offset, 0);
+  }, "document.caretPositionFromPoint() should return a CaretPosition over video elements");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt
@@ -5,8 +5,6 @@ PASS document.caretPositionFromPoint() should return null for a document with no
 PASS document.caretPositionFromPoint() should return null if given coordinates outside of the viewport
 PASS document.caretPositionFromPoint() should return a CaretPosition at the specified location
 PASS document.caretPositionFromPoint() should return a CaretPosition over elements with `user-select: none`
-PASS document.caretPositionFromPoint() should return a CaretPosition over video elements
-PASS document.caretPositionFromPoint() should return a CaretPosition over audio elements
 PASS document.caretPositionFromPoint() should return a CaretPosition over SVG elements
 PASS CaretRange.getClientRect() should return a DOMRect that matches one obtained from a manually constructed Range
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html
@@ -70,22 +70,6 @@
   }, "document.caretPositionFromPoint() should return a CaretPosition over elements with `user-select: none`");
 
   test(() => {
-    container.setHTMLUnsafe(`<video controls></video>`);
-    const video = document.querySelector("video");
-    const caretPosition = document.caretPositionFromPoint(video.offsetLeft + video.offsetWidth / 2, video.offsetTop + video.offsetHeight / 2);
-    assert_equals(caretPosition.offsetNode, container);
-    assert_equals(caretPosition.offset, 0);
-  }, "document.caretPositionFromPoint() should return a CaretPosition over video elements");
-
-  test(() => {
-    container.setHTMLUnsafe(`<audio controls></audio>`);
-    const audio = document.querySelector("audio");
-    const caretPosition = document.caretPositionFromPoint(audio.offsetLeft + audio.offsetWidth / 2, audio.offsetTop + audio.offsetHeight / 2);
-    assert_equals(caretPosition.offsetNode, container);
-    assert_equals(caretPosition.offset, 0);
-  }, "document.caretPositionFromPoint() should return a CaretPosition over audio elements");
-
-  test(() => {
     container.setHTMLUnsafe(`<svg width=100 height=100><circle cx=50 cy=50 r=50 /></svg>`);
     const circle = document.querySelector("circle");
     const caretPosition = document.caretPositionFromPoint(50, 50);


### PR DESCRIPTION
#### 1d685fdfd363ca437a24ed6b36b0403756b18574
<pre>
Split out media element subtests for `document.caretPositionFromPoint`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297306">https://bugs.webkit.org/show_bug.cgi?id=297306</a>
<a href="https://rdar.apple.com/158184707">rdar://158184707</a>

Reviewed by Aditya Keerthi.

See <a href="https://github.com/web-platform-tests/wpt/pull/54176#issuecomment-3180486900">https://github.com/web-platform-tests/wpt/pull/54176#issuecomment-3180486900</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html:

Canonical link: <a href="https://commits.webkit.org/298600@main">https://commits.webkit.org/298600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df117b31e8aed767f6dafff00bf0f0307d24533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122088 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/780ae0ab-71e0-4946-9658-8d08247e8635) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebfb996c-a97d-4df3-828a-84e9cd5cbede) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68557 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65770 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22360 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100305 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24597 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41936 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19819 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42813 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/43984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->