### PR TITLE
[iOS] PointerLockOptions.unadjustedMovement is supported when a pointing device is available

### DIFF
--- a/LayoutTests/http/tests/resources/pointer-lock/pointer-lock-test-harness.js
+++ b/LayoutTests/http/tests/resources/pointer-lock/pointer-lock-test-harness.js
@@ -9,16 +9,11 @@ if (!window.testRunner) {
     }, 0);
 }
 
-function runOnKeyPress(fn)
+function runWithUserGesture(fn)
 {
-    function keypressHandler() {
-        document.removeEventListener('keypress', keypressHandler, false);
-        fn();
+    if (window.testRunner) {
+        internals.withUserGesture(() => setTimeout(fn, 0) );
     }
-    document.addEventListener('keypress', keypressHandler, false);
-
-    if (window.testRunner)
-        eventSender.keyDown(" ", []);
 }
 
 function doNextStep(args)
@@ -34,7 +29,7 @@ function doNextStep(args)
         var thisStep = currentStep++;
         if (thisStep < todo.length)
             if (args.withUserGesture)
-                runOnKeyPress(todo[thisStep]);
+                runWithUserGesture(todo[thisStep]);
             else
                 todo[thisStep]();
         else if (thisStep == todo.length)

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -345,6 +345,8 @@ fast/shadow-dom/pointerlockelement-in-slot.html
 fast/js-promise/js-promise-invalid-context-access.html [ Skip ]
 imported/w3c/web-platform-tests/pointerlock [ Skip ]
 
+pointer-lock/pointer-lock-option-unadjusted-movement.html [ Pass ]
+
 # FIXME: Media tests not supported on iOS
 http/tests/media
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements

--- a/LayoutTests/platform/ios/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
+++ b/LayoutTests/platform/ios/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt
@@ -14,9 +14,10 @@ PASS [object Promise] is non-null.
 PASS onpointerlockchange received after: Unlock
      Lock with PointerLockOptionsEnabled = false
 PASS undefined is undefined.
-FAIL onpointerlockerror received after: Lock with PointerLockOptionsEnabled = false
+PASS onpointerlockchange received after: Lock with PointerLockOptionsEnabled = false
+     Unlock
+PASS onpointerlockchange received after: Unlock
 PASS successfullyParsed is true
-Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/pointer-lock/lock-lost-on-alert-expected.txt
+++ b/LayoutTests/pointer-lock/lock-lost-on-alert-expected.txt
@@ -9,8 +9,8 @@ PASS window.testRunner is defined.
 PASS onpointerlockchange received after: Lock targetDiv1.
 PASS document.pointerLockElement is targetDiv1
      Alert cancel targetDiv1 lock.
-PASS document.pointerLockElement is null
 PASS onpointerlockchange received after: Alert cancel targetDiv1 lock.
+PASS document.pointerLockElement is null
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/pointer-lock/lock-lost-on-alert.html
+++ b/LayoutTests/pointer-lock/lock-lost-on-alert.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -28,12 +28,14 @@
         function () {
             expectOnlyChangeEvent("Alert cancel targetDiv1 lock.");
             alert('Alert text');
+            setTimeout(doNextStep, 0);
+        },
+        function () {
             shouldBe("document.pointerLockElement", "null");
         },
     ];
     doNextStepWithUserGesture();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>
 

--- a/LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement.html
+++ b/LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement.html
@@ -1,7 +1,8 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +13,7 @@
     description("Test pointer lock unadjustedMovement option.")
     window.jsTestIsAsync = true;
     shouldBeDefined("window.testRunner");
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
 
@@ -68,9 +70,12 @@
             document.exitPointerLock();
         },
     ];
-    doNextStepWithUserGesture();
+    (async () => {
+        window.testRunner?.focusWebView();
+        await UIHelper.setWindowIsKey(true);
+        doNextStepWithUserGesture();
+    })();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2067,6 +2067,10 @@ window.UIHelper = class UIHelper {
 
     static setWindowIsKey(isKey)
     {
+        if (!this.isWebKit2()) {
+            testRunner.setWindowIsKey(isKey);
+            return Promise.resolve();
+        }
         const script = `uiController.windowIsKey = ${isKey}`;
         return new Promise(resolve => testRunner.runUIScript(script, resolve));
     }

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -108,6 +108,7 @@ class EmptyChromeClient : public ChromeClient {
 
     KeyboardUIMode keyboardUIMode() final { return KeyboardAccessDefault; }
 
+    bool hasAccessoryMousePointingDevice() const final { return false; }
     bool hoverSupportedByPrimaryPointingDevice() const final { return false; };
     bool hoverSupportedByAnyAvailablePointingDevice() const final { return false; }
     std::optional<PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const final { return std::nullopt; };

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -261,6 +261,7 @@ public:
     virtual bool runJavaScriptPrompt(LocalFrame&, const String& message, const String& defaultValue, String& result) = 0;
     virtual KeyboardUIMode keyboardUIMode() = 0;
 
+    virtual bool hasAccessoryMousePointingDevice() const = 0;
     virtual bool hoverSupportedByPrimaryPointingDevice() const = 0;
     virtual bool hoverSupportedByAnyAvailablePointingDevice() const = 0;
     virtual std::optional<PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const = 0;

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -331,10 +331,10 @@ void PointerLockController::rejectPromises(ExceptionCode code, const String& rea
         promise->reject(code, reason);
 }
 
-bool PointerLockController::supportsUnadjustedMovement()
+bool PointerLockController::supportsUnadjustedMovement() const
 {
-#if HAVE(MOUSE_UNACCELERATED_MOVEMENT)
-    return true;
+#if HAVE(MOUSE_UNACCELERATED_MOVEMENT) || PLATFORM(IOS_FAMILY)
+    return m_page.chrome().client().hasAccessoryMousePointingDevice();
 #else
     return false;
 #endif

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -79,8 +79,6 @@ public:
     void dispatchLockedMouseEvent(const PlatformMouseEvent&, const AtomString& eventType);
     void dispatchLockedWheelEvent(const PlatformWheelEvent&);
 
-    static bool supportsUnadjustedMovement();
-
 private:
     void clearElement();
     void enqueueEvent(const AtomString& type, Element*);
@@ -88,6 +86,8 @@ private:
     void resolvePromises();
     void rejectPromises(ExceptionCode, const String&);
     void elementWasRemovedInternal();
+
+    bool supportsUnadjustedMovement() const;
 
     Page& m_page;
     bool m_lockPending { false };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -709,6 +709,12 @@ KeyboardUIMode WebChromeClient::keyboardUIMode()
     return page ? page->keyboardUIMode() : KeyboardAccessDefault;
 }
 
+bool WebChromeClient::hasAccessoryMousePointingDevice() const
+{
+    RefPtr page = m_page.get();
+    return page && page->hasAccessoryMousePointingDevice();
+}
+
 bool WebChromeClient::hoverSupportedByPrimaryPointingDevice() const
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -129,6 +129,7 @@ private:
 
     WebCore::KeyboardUIMode keyboardUIMode() final;
 
+    bool hasAccessoryMousePointingDevice() const final;
     bool hoverSupportedByPrimaryPointingDevice() const final;
     bool hoverSupportedByAnyAvailablePointingDevice() const final;
     std::optional<WebCore::PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10584,6 +10584,13 @@ std::unique_ptr<FrameInfoData> WebPage::takeMainFrameNavigationInitiator()
     return std::exchange(m_mainFrameNavigationInitiator, nullptr);
 }
 
+#if !PLATFORM(IOS_FAMILY)
+bool WebPage::hasAccessoryMousePointingDevice() const
+{
+    return true;
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -714,6 +714,7 @@ public:
 
     void setMainFrameDocumentVisualUpdatesAllowed(bool);
 
+    bool hasAccessoryMousePointingDevice() const;
     bool hoverSupportedByPrimaryPointingDevice() const;
     bool hoverSupportedByAnyAvailablePointingDevice() const;
     std::optional<WebCore::PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5499,7 +5499,7 @@ static bool isMousePrimaryPointingDevice()
 #endif
 }
 
-static bool hasAccessoryMousePointingDevice()
+bool WebPage::hasAccessoryMousePointingDevice() const
 {
     if (isMousePrimaryPointingDevice())
         return true;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h
@@ -50,6 +50,7 @@ private:
     void runOpenPanel(WebCore::LocalFrame&, WebCore::FileChooser&) final;
     void showShareSheet(WebCore::ShareDataWithParsedURL&&, CompletionHandler<void(bool)>&&) final;
 
+    bool hasAccessoryMousePointingDevice() const final { return false; }
     bool hoverSupportedByPrimaryPointingDevice() const final { return false; }
     bool hoverSupportedByAnyAvailablePointingDevice() const final { return false; }
     std::optional<WebCore::PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const final { return WebCore::PointerCharacteristics::Coarse; }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -157,6 +157,7 @@ private:
 
     WebCore::KeyboardUIMode keyboardUIMode() final;
 
+    bool hasAccessoryMousePointingDevice() const override { return true; }
     bool hoverSupportedByPrimaryPointingDevice() const override { return true; }
     bool hoverSupportedByAnyAvailablePointingDevice() const override { return true; }
     std::optional<WebCore::PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const override { return WebCore::PointerCharacteristics::Fine; }

--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -1785,6 +1785,11 @@ static JSValueRef setObscuredContentInsetsCallback(JSContextRef context, JSObjec
     return TestRunner::alwaysResolvePromise(context);
 }
 
+static JSValueRef setHasMouseDeviceForTestingCallback(JSContextRef context, JSObjectRef, JSObjectRef, size_t, const JSValueRef[], JSValueRef*)
+{
+    return JSValueMakeUndefined(context);
+}
+
 static JSValueRef failNextNewCodeBlock(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     if (argumentCount < 1)
@@ -2105,6 +2110,7 @@ const JSStaticFunction* TestRunner::staticFunctions()
         { "stopLoading", stopLoadingCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "forceImmediateCompletion", forceImmediateCompletionCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setObscuredContentInsets", setObscuredContentInsetsCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "setHasMouseDeviceForTesting", setHasMouseDeviceForTestingCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "setPageScaleFactor", setPageScaleFactorCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
 #if PLATFORM(IOS_FAMILY)
         { "setPagePaused", setPagePausedCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -397,6 +397,8 @@ public:
     void setPageScaleFactor(double scaleFactor, long x, long y);
     static JSValueRef alwaysResolvePromise(JSContextRef);
 
+    void setHasMouseDeviceForTesting(bool);
+
 private:
     TestRunner(const std::string& testURL, const std::string& expectedPixelHash);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -472,4 +472,6 @@ interface TestRunner {
     // ResourceMonitor
     readonly attribute boolean canModifyResourceMonitorList;
     Promise<undefined> setResourceMonitorList(DOMString rulesText);
+
+    undefined setHasMouseDeviceForTesting(boolean hasMouseDevice);
 };

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2189,6 +2189,11 @@ bool TestRunner::shouldDumpAllFrameScrollPositions() const
     return postSynchronousPageMessageReturningBoolean("ShouldDumpAllFrameScrollPositions");
 }
 
+void TestRunner::setHasMouseDeviceForTesting(bool hasMouseDevice)
+{
+    postSynchronousPageMessage("SetHasMouseDeviceForTesting", hasMouseDevice);
+}
+
 ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -588,6 +588,8 @@ public:
     }
     void setResourceMonitorList(JSContextRef, JSStringRef rulesText, JSValueRef callback);
 
+    void setHasMouseDeviceForTesting(bool);
+
 private:
     TestRunner();
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4684,4 +4684,10 @@ void TestController::setResourceMonitorList(WKStringRef rulesText, CompletionHan
     WKContextSetResourceMonitorURLsForTesting(m_context.get(), rulesText, completionHandler.leak(), adoptAndCallCompletionHandler);
 }
 
+#if !PLATFORM(IOS_FAMILY)
+void TestController::setHasMouseDeviceForTesting(bool)
+{
+}
+#endif
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -50,6 +50,7 @@ OBJC_CLASS NSColor;
 OBJC_CLASS NSString;
 OBJC_CLASS UIKeyboardInputMode;
 OBJC_CLASS UIPasteboardConsistencyEnforcer;
+OBJC_CLASS WKMouseDeviceObserver;
 OBJC_CLASS WKWebViewConfiguration;
 
 namespace WTR {
@@ -465,6 +466,8 @@ public:
     bool useWorkQueue() const { return m_useWorkQueue; }
 
     void listenForTooltipChanges(WKFrameInfoRef, WKTypeRef);
+
+    void setHasMouseDeviceForTesting(bool);
 
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1470,6 +1470,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     if (WKStringIsEqualToUTF8CString(messageName, "ShouldDumpAllFrameScrollPositions"))
         return adoptWK(WKBooleanCreate(m_shouldDumpAllFrameScrollPositions));
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetHasMouseDeviceForTesting")) {
+        TestController::singleton().setHasMouseDeviceForTesting((booleanValue(messageBody)));
+        return nullptr;
+    }
+
     ASSERT_NOT_REACHED();
     return nullptr;
 }

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -66,6 +66,15 @@ static unsigned globalKeyboardUpdateForChangedSelectionCount = 0;
 
 @end
 
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+
+@interface WKMouseDeviceObserver
++ (WKMouseDeviceObserver *)sharedInstance;
+- (void)_setHasMouseDeviceForTesting:(BOOL)hasMouseDevice;
+@end
+
+#endif
+
 #if HAVE(UI_WINDOW_SCENE_GEOMETRY_PREFERENCES)
 
 @interface WindowDidRotateObserver : NSObject
@@ -616,6 +625,17 @@ void TestController::unlockScreenOrientation()
     [UIView performWithoutAnimation:^{
         [webView.window.rootViewController setNeedsUpdateOfSupportedInterfaceOrientations];
     }];
+}
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+void TestController::setHasMouseDeviceForTesting(bool hasMouseDevice)
+{
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+    [[NSClassFromString(@"WKMouseDeviceObserver") sharedInstance] _setHasMouseDeviceForTesting:hasMouseDevice];
+#else
+    UNUSED_PARAM(hasMouseDevice);
+#endif
 }
 #endif
 


### PR DESCRIPTION
#### a515900071861d7aebe336fddcae0ee204b5e5e8
<pre>
[iOS] PointerLockOptions.unadjustedMovement is supported when a pointing device is available
<a href="https://bugs.webkit.org/show_bug.cgi?id=297304">https://bugs.webkit.org/show_bug.cgi?id=297304</a>
<a href="https://rdar.apple.com/158184340">rdar://158184340</a>

Reviewed by Aditya Keerthi.

Given we will be generating pointermove deltas from unaccelerated data
(c.f. webkit.org/b/297305) to begin with, this option is unconditionally
supported on iOS family whenever a pointing device is available.

This patch exposes WebPage::hasAccessoryMousePointingDevice(), which
keys off of the WebProcess singleton, allowing PointerLockController to
evaluate whether the `unadjustedMovement` option can be respected. Note
that this only meaningfully changes the iOS behavior because we
unconditionally report that a mouse pointing device is present on other
platforms.

Moreover, this patch improves some iOS test coverage of the pointer lock
feature through pointer-lock-option-unadjusted-movement.html. To get
this test running, we need to force toggle the PointerLockEnabled
preference. We also need to mock the web process into thinking a mouse
pointing device is available, which we accomplish through new TestRunner
interface.

* LayoutTests/http/tests/resources/pointer-lock/pointer-lock-test-harness.js:
(runWithUserGesture):
(runOnKeyPress.keypressHandler): Deleted.
(runOnKeyPress): Deleted.
(doNextStep): Deleted.

Instead of emulating the act of obtaining user gesture with a keypress,
let us just run the test steps with user gesture granted (through our
Internals testing interface).

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/pointer-lock/pointer-lock-option-unadjusted-movement-expected.txt: Added.
* LayoutTests/pointer-lock/pointer-lock-option-unadjusted-movement.html:

Altered the test slightly to obtain keyWindow/FR status before running
the test steps, since this is a prerequisite for pointer lock
activation.

* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/PointerLockController.cpp:
(WebCore::PointerLockController::rejectPromises):
(WebCore::PointerLockController::supportsUnadjustedMovement): Deleted.
* Source/WebCore/page/PointerLockController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::hasAccessoryMousePointingDevice const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::mediaSessionManager const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::isMousePrimaryPointingDevice):
(WebKit::hasAccessoryMousePointingDevice): Deleted.
* Source/WebKitLegacy/ios/WebCoreSupport/WebChromeClientIOS.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setHasMouseDeviceForTesting):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setHasMouseDeviceForTesting):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):
(WTR::TestController::setHasMouseDeviceForTesting):

Keep hold of the shared WKMouseDeviceObserver instance and start/stop as
appropriate.

Canonical link: <a href="https://commits.webkit.org/298635@main">https://commits.webkit.org/298635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fad3cf73bc0bebadf5e629f702f94970fab7990

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66638 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fbbe79e4-1c15-4e59-8715-8b50cdbf3f6a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88192 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6071fd4a-f30f-4a6a-a124-bcad0cd90b68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68603 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22271 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65825 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125293 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96926 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96710 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19868 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38927 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48460 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->