### PR TITLE
Unreviewed, reverting 298582@main (947090ddf062)

### DIFF
--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <array>
-#include <type_traits>
 #include <wtf/Assertions.h>
 #include <wtf/text/LChar.h>
 
@@ -40,59 +39,57 @@
 // characters if the intent is to do processing only if the character is ASCII.
 
 namespace WTF {
-template<typename T>
-concept Character = std::convertible_to<std::remove_cv_t<T>, char>;
 
-template<Character CharacterType> constexpr bool isASCII(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIAlpha(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIDigit(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIHexDigit(CharacterType);
-template<Character CharacterType> constexpr bool isASCIILower(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIOctalDigit(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIPrintable(CharacterType);
-template<Character CharacterType> constexpr bool isTabOrSpace(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIWhitespace(CharacterType);
-template<Character CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType);
-template<Character CharacterType> constexpr bool isASCIIUpper(CharacterType);
+template<typename CharacterType> constexpr bool isASCII(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIAlpha(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIDigit(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIHexDigit(CharacterType);
+template<typename CharacterType> constexpr bool isASCIILower(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType);
+template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType);
+template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType);
+template<typename CharacterType> constexpr bool isASCIIUpper(CharacterType);
 
 // Inverse of isASCIIWhitespace for predicates
-template<Character CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType);
+template<typename CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType);
 
-template<Character CharacterType> CharacterType toASCIILower(CharacterType);
-template<Character CharacterType> CharacterType toASCIIUpper(CharacterType);
+template<typename CharacterType> CharacterType toASCIILower(CharacterType);
+template<typename CharacterType> CharacterType toASCIIUpper(CharacterType);
 
-template<Character CharacterType> uint8_t toASCIIHexValue(CharacterType);
-template<Character CharacterType> uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter);
+template<typename CharacterType> uint8_t toASCIIHexValue(CharacterType);
+template<typename CharacterType> uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter);
 
 constexpr char lowerNibbleToASCIIHexDigit(uint8_t);
 constexpr char upperNibbleToASCIIHexDigit(uint8_t);
 constexpr char lowerNibbleToLowercaseASCIIHexDigit(uint8_t);
 constexpr char upperNibbleToLowercaseASCIIHexDigit(uint8_t);
 
-template<Character CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType, char expectedASCIILowercaseLetter);
+template<typename CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType, char expectedASCIILowercaseLetter);
 
 // The toASCIILowerUnchecked function can be used for comparing any input character
 // to a lowercase English character. The isASCIIAlphaCaselessEqual function should
 // be used for regular comparison of ASCII alpha characters, but switch statements
 // in the CSS tokenizer, for example, instead make direct use toASCIILowerUnchecked.
-template<Character CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType);
+template<typename CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType);
 
 extern WTF_EXPORT_PRIVATE const std::array<uint8_t, 256> asciiCaseFoldTable;
 
-template<Character CharacterType> constexpr bool isASCII(CharacterType character)
+template<typename CharacterType> constexpr bool isASCII(CharacterType character)
 {
     return !(character & ~0x7F);
 }
 
-template<Character CharacterType> constexpr bool isASCIILower(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIILower(CharacterType character)
 {
     return character >= 'a' && character <= 'z';
 }
 
-template<Character CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType character)
+template<typename CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType character)
 {
     // This function can be used for comparing any input character
     // to a lowercase English character. The isASCIIAlphaCaselessEqual
@@ -102,53 +99,53 @@ template<Character CharacterType> constexpr CharacterType toASCIILowerUnchecked(
     return character | 0x20;
 }
 
-template<Character CharacterType> constexpr bool isASCIIAlpha(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIAlpha(CharacterType character)
 {
     return isASCIILower(toASCIILowerUnchecked(character));
 }
 
-template<Character CharacterType> constexpr bool isASCIIDigit(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIDigit(CharacterType character)
 {
     return character >= '0' && character <= '9';
 }
 
-template<Character CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType character)
 {
     return isASCIIDigit(character) || isASCIIAlpha(character);
 }
 
-template<Character CharacterType> constexpr bool isASCIIHexDigit(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIHexDigit(CharacterType character)
 {
     return isASCIIDigit(character) || (toASCIILowerUnchecked(character) >= 'a' && toASCIILowerUnchecked(character) <= 'f');
 }
 
-template<Character CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType character)
 {
     return character == '0' || character == '1';
 }
 
-template<Character CharacterType> constexpr bool isASCIIOctalDigit(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType character)
 {
     return character >= '0' && character <= '7';
 }
 
-template<Character CharacterType> constexpr bool isASCIIPrintable(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType character)
 {
     return character >= ' ' && character <= '~';
 }
 
-template<Character CharacterType> constexpr bool isTabOrSpace(CharacterType character)
+template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType character)
 {
     return character == ' ' || character == '\t';
 }
 
 // Infra's "ASCII whitespace" <https://infra.spec.whatwg.org/#ascii-whitespace>
-template<Character CharacterType> constexpr bool isASCIIWhitespace(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType character)
 {
     return character == ' ' || character == '\n' || character == '\t' || character == '\r' || character == '\f';
 }
 
-template<Character CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(CharacterType character)
 {
     // This is different from isASCIIWhitespace: JSON/HTTP/XML do not accept \f as a whitespace.
     // ECMA-404 specifies the following:
@@ -163,22 +160,22 @@ template<Character CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(Char
     return character == ' ' || character == '\n' || character == '\t' || character == '\r';
 }
 
-template<Character CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType character)
+template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType character)
 {
     return isASCIIWhitespace(character) || character == '\v';
 }
 
-template<Character CharacterType> constexpr bool isASCIIUpper(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIUpper(CharacterType character)
 {
     return character >= 'A' && character <= 'Z';
 }
 
-template<Character CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType character)
+template<typename CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType character)
 {
     return !isASCIIWhitespace(character);
 }
 
-template<Character CharacterType> inline CharacterType toASCIILower(CharacterType character)
+template<typename CharacterType> inline CharacterType toASCIILower(CharacterType character)
 {
     return character | (isASCIIUpper(character) << 5);
 }
@@ -193,18 +190,18 @@ template<> inline LChar toASCIILower(LChar character)
     return asciiCaseFoldTable[character];
 }
 
-template<Character CharacterType> inline CharacterType toASCIIUpper(CharacterType character)
+template<typename CharacterType> inline CharacterType toASCIIUpper(CharacterType character)
 {
     return character & ~(isASCIILower(character) << 5);
 }
 
-template<Character CharacterType> inline uint8_t toASCIIHexValue(CharacterType character)
+template<typename CharacterType> inline uint8_t toASCIIHexValue(CharacterType character)
 {
     ASSERT(isASCIIHexDigit(character));
     return character < 'A' ? character - '0' : (character - 'A' + 10) & 0xF;
 }
 
-template<Character CharacterType> inline uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter)
+template<typename CharacterType> inline uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter)
 {
     return toASCIIHexValue(firstCharacter) << 4 | toASCIIHexValue(secondCharacter);
 }
@@ -233,7 +230,7 @@ constexpr char upperNibbleToLowercaseASCIIHexDigit(uint8_t value)
     return nibble + (nibble < 10 ? '0' : 'a' - 10);
 }
 
-template<Character CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType inputCharacter, char expectedASCIILowercaseLetter)
+template<typename CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType inputCharacter, char expectedASCIILowercaseLetter)
 {
     // Name of this argument says this must be a lowercase letter, but it can actually be:
     //   - a lowercase letter
@@ -252,7 +249,7 @@ template<Character CharacterType> constexpr bool isASCIIAlphaCaselessEqual(Chara
     return false;
 }
 
-template<Character CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType character)
 {
     return (character >= '!' && character <= '@') || (character >= '[' && character <= '`') || (character >= '{' && character <= '~');
 }
@@ -270,12 +267,12 @@ using WTF::isASCIIHexDigit;
 using WTF::isASCIILower;
 using WTF::isASCIIOctalDigit;
 using WTF::isASCIIPrintable;
-using WTF::isASCIIUpper;
+using WTF::isTabOrSpace;
 using WTF::isASCIIWhitespace;
 using WTF::isASCIIWhitespaceWithoutFF;
-using WTF::isNotASCIIWhitespace;
-using WTF::isTabOrSpace;
 using WTF::isUnicodeCompatibleASCIIWhitespace;
+using WTF::isASCIIUpper;
+using WTF::isNotASCIIWhitespace;
 using WTF::lowerNibbleToASCIIHexDigit;
 using WTF::lowerNibbleToLowercaseASCIIHexDigit;
 using WTF::toASCIIHexValue;


### PR DESCRIPTION
#### cef35303c750b6daed3afb11d7cc6ac77ae500df
<pre>
Unreviewed, reverting 298582@main (947090ddf062)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297309">https://bugs.webkit.org/show_bug.cgi?id=297309</a>
<a href="https://rdar.apple.com/158189609">rdar://158189609</a>

Broke Internal embedded builds

Reverted change:

    Add character concept to ASCIICType functions
    <a href="https://bugs.webkit.org/show_bug.cgi?id=297085">https://bugs.webkit.org/show_bug.cgi?id=297085</a>
    <a href="https://rdar.apple.com/157789937">rdar://157789937</a>
    298582@main (947090ddf062)

Canonical link: <a href="https://commits.webkit.org/298603@main">https://commits.webkit.org/298603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb763211fdeaa606253ca5d7c88c9e2b7963e42d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122104 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88ac389c-2570-406a-8b44-f4208f3d5bfb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44297 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f988c153-9730-42dd-9c66-6482dfb542de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118996 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/29038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/104133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/68575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65786 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108157 "Failed to checkout and rebase branch from PR 49308") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/22378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114576 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42942 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43307 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/100323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/41953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18541 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42829 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48421 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143260 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42296 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/36932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->