### PR TITLE
Implement Observable#toArray

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any-expected.txt
@@ -1,8 +1,10 @@
+CONSOLE MESSAGE: Error: custom error
+CONSOLE MESSAGE: Error: custom error
 
-FAIL toArray(): basic next/complete promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): first error() rejects promise; subsequent error()s report the exceptions assert_equals: expected object "Error: custom error" but got object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): complete() resolves promise; subsequent error()s report the exceptions promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): Subscribing with an aborted signal returns an immediately rejected promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: AbortSignal.abort()})', 'observable.toArray' is undefined)"
-FAIL toArray(): Aborting the passed-in signal rejects the returned promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
-FAIL Operator Promise abort ordering promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
+PASS toArray(): basic next/complete
+PASS toArray(): first error() rejects promise; subsequent error()s report the exceptions
+PASS toArray(): complete() resolves promise; subsequent error()s report the exceptions
+PASS toArray(): Subscribing with an aborted signal returns an immediately rejected promise
+PASS toArray(): Aborting the passed-in signal rejects the returned promise
+PASS Operator Promise abort ordering
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL toArray(): basic next/complete promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): first error() rejects promise; subsequent error()s report the exceptions assert_equals: expected object "Error: custom error" but got object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): complete() resolves promise; subsequent error()s report the exceptions promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray()', 'observable.toArray' is undefined)"
-FAIL toArray(): Subscribing with an aborted signal returns an immediately rejected promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: AbortSignal.abort()})', 'observable.toArray' is undefined)"
-FAIL toArray(): Aborting the passed-in signal rejects the returned promise promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
-FAIL Operator Promise abort ordering promise_test: Unhandled rejection with value: object "TypeError: observable.toArray is not a function. (In 'observable.toArray({signal: controller.signal})', 'observable.toArray' is undefined)"
+PASS toArray(): basic next/complete
+PASS toArray(): first error() rejects promise; subsequent error()s report the exceptions
+PASS toArray(): complete() resolves promise; subsequent error()s report the exceptions
+PASS toArray(): Subscribing with an aborted signal returns an immediately rejected promise
+PASS toArray(): Aborting the passed-in signal rejects the returned promise
+PASS Operator Promise abort ordering
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1278,6 +1278,7 @@ dom/InternalObserverDrop.cpp
 dom/InternalObserverEvery.cpp
 dom/InternalObserverFilter.cpp
 dom/InternalObserverFind.cpp
+dom/InternalObserverToArray.cpp
 dom/InternalObserverFirst.cpp
 dom/InternalObserverForEach.cpp
 dom/InternalObserverFromScript.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -16987,6 +16987,8 @@
 		A871DFDF0A15376B00B12A68 /* RenderReplaced.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderReplaced.h; sourceTree = "<group>"; };
 		A871DFE00A15376B00B12A68 /* RenderWidget.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderWidget.h; sourceTree = "<group>"; };
 		A871DFE10A15376B00B12A68 /* RenderWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = RenderWidget.cpp; sourceTree = "<group>"; };
+		A873715F2E263331006211CB /* InternalObserverToArray.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InternalObserverToArray.h; sourceTree = "<group>"; };
+		A87371602E263331006211CB /* InternalObserverToArray.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InternalObserverToArray.cpp; sourceTree = "<group>"; };
 		A8748BDF12CBF2DC001FBA41 /* HashTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HashTools.h; sourceTree = "<group>"; };
 		A8748D6612CC3763001FBA41 /* ImageOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageOrientation.h; sourceTree = "<group>"; };
 		A8805AF116C96AEA000E9D98 /* InputStreamPreprocessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InputStreamPreprocessor.h; sourceTree = "<group>"; };
@@ -39681,6 +39683,8 @@
 				A88FE6802CCF6FF30070D898 /* InternalObserverSome.h */,
 				33839EF92C5CB39E00F1E4FA /* InternalObserverTake.cpp */,
 				33839EFA2C5CB3A600F1E4FA /* InternalObserverTake.h */,
+				A87371602E263331006211CB /* InternalObserverToArray.cpp */,
+				A873715F2E263331006211CB /* InternalObserverToArray.h */,
 				FFEFAB2D183BCC6F00514553 /* JSSubscriberCustom.cpp */,
 				85031B2D0A44EFC700F992E0 /* KeyboardEvent.cpp */,
 				85031B2E0A44EFC700F992E0 /* KeyboardEvent.h */,

--- a/Source/WebCore/dom/InternalObserverToArray.cpp
+++ b/Source/WebCore/dom/InternalObserverToArray.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InternalObserverToArray.h"
+
+#include "InternalObserver.h"
+#include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObject.h"
+#include "Observable.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class InternalObserverToArray final : public InternalObserver {
+public:
+    static Ref<InternalObserverToArray> create(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
+    {
+        Ref internalObserver = adoptRef(*new InternalObserverToArray(context, WTFMove(promise)));
+        internalObserver->suspendIfNeeded();
+        return internalObserver;
+    }
+
+private:
+    void next(JSC::JSValue value) final
+    {
+        m_list.append({ globalVM(), value });
+    }
+
+    void error(JSC::JSValue value) final
+    {
+        m_promise->reject<IDLAny>(value);
+    }
+
+    void complete() final
+    {
+        InternalObserver::complete();
+
+        m_promise->resolve<IDLSequence<IDLAny>>(m_list);
+    }
+
+    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final
+    {
+    }
+
+    InternalObserverToArray(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
+        : InternalObserver(context)
+        , m_promise(WTFMove(promise))
+    {
+    }
+
+    Vector<JSC::Strong<JSC::Unknown>> m_list;
+    const Ref<DeferredPromise> m_promise;
+};
+
+void createInternalObserverOperatorToArray(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    if (RefPtr signal = options.signal) {
+        if (signal->aborted())
+            return promise->reject<IDLAny>(signal->reason().getValue());
+
+        signal->addAlgorithm([promise](JSC::JSValue reason) {
+            promise->reject<IDLAny>(reason);
+        });
+    }
+
+    Ref observer = InternalObserverToArray::create(context, WTFMove(promise));
+    observable.subscribeInternal(context, WTFMove(observer), options);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverToArray.h
+++ b/Source/WebCore/dom/InternalObserverToArray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,54 +25,15 @@
 
 #pragma once
 
-#include "ActiveDOMObject.h"
-#include "ScriptExecutionContext.h"
-#include <JavaScriptCore/JSGlobalObject.h>
-#include <wtf/RefCounted.h>
-
-namespace JSC {
-class AbstractSlotVisitor;
-class JSValue;
-class VM;
-} // namespace JSC
+#include <wtf/Forward.h>
 
 namespace WebCore {
 
-class InternalObserver : public ActiveDOMObject, public RefCounted<InternalObserver> {
-public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+class DeferredPromise;
+class Observable;
+class ScriptExecutionContext;
+struct SubscribeOptions;
 
-    virtual ~InternalObserver() = default;
-
-    virtual void next(JSC::JSValue) = 0;
-    virtual void complete()
-    {
-        m_active = false;
-    }
-
-    virtual void error(JSC::JSValue);
-
-    virtual void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const = 0;
-
-protected:
-    JSC::VM& globalVM() const
-    {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
-        ASSERT(globalObject);
-        return globalObject->vm();
-    }
-
-    // ActiveDOMObject
-    void stop() override { }
-    bool virtualHasPendingActivity() const override { return m_active; }
-
-    InternalObserver(ScriptExecutionContext& context)
-        : ActiveDOMObject(&context)
-    {
-    }
-
-    bool m_active { true };
-};
+void createInternalObserverOperatorToArray(ScriptExecutionContext&, Observable&, const SubscribeOptions&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -43,6 +43,7 @@
 #include "InternalObserverReduce.h"
 #include "InternalObserverSome.h"
 #include "InternalObserverTake.h"
+#include "InternalObserverToArray.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSSubscriptionObserverCallback.h"
 #include "MapperCallback.h"
@@ -139,6 +140,11 @@ Ref<Observable> Observable::inspect(ScriptExecutionContext& context, std::option
             return create(createSubscriberCallbackInspect(context, *this, WTFMove(inspector)));
         }
     );
+}
+
+void Observable::toArray(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+{
+    return createInternalObserverOperatorToArray(context, *this, options, WTFMove(promise));
 }
 
 void Observable::first(ScriptExecutionContext& context, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -66,6 +66,7 @@ public:
 
     // Promise-returning operators.
 
+    void toArray(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void first(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/dom/Observable.idl
+++ b/Source/WebCore/dom/Observable.idl
@@ -45,6 +45,7 @@ interface Observable {
 
   // Promise-returning operators.
 
+  [CallWith=CurrentScriptExecutionContext] Promise<sequence<any>> toArray(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> first(optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<undefined> forEach(VisitorCallback callback, optional SubscribeOptions options = {});
   [CallWith=CurrentScriptExecutionContext] Promise<any> last(optional SubscribeOptions options = {});


### PR DESCRIPTION
#### a81f5a9146bbc3ef3290a4b7b9490259cbba3d3f
<pre>
Implement Observable#toArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=277514">https://bugs.webkit.org/show_bug.cgi?id=277514</a>

Reviewed by NOBODY (OOPS!).

This change introduces the `.toArray` promise-returning operator
for Observables, using the InternalObserver and subscribing immediately.

Spec: &lt;<a href="https://wicg.github.io/observable/#dom-observable-toarray">https://wicg.github.io/observable/#dom-observable-toarray</a>&gt;

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.worker-expected.txt: Rebaseline.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/InternalObserver.h:
(WebCore::InternalObserver::globalVM const): Added helper function, as
used often.
(WebCore::InternalObserver::InternalObserver):
* Source/WebCore/dom/InternalObserverToArray.cpp: Added.
(WebCore::createInternalObserverOperatorToArray):
* Source/WebCore/dom/InternalObserverToArray.h: Added.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::toArray):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/Observable.idl:
Exposes `Promise&lt;sequence&lt;any&gt;&gt; toArray(options)` as a promise-returning operator.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a81f5a9146bbc3ef3290a4b7b9490259cbba3d3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44302 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88167 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.html (failure)") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42717 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28160 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22244 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/observable/tentative/observable-toArray.any.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65791 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125259 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96686 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41958 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48426 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->