### PR TITLE
Implement EventTarget#when

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window-expected.txt
@@ -2,5 +2,5 @@
 PASS No observer handlers can be invoked in detached document
 PASS Subscriber.error() does not "report the exception" even when an `error()` handler is not present, when it is invoked in a detached document
 PASS Cannot subscribe to an Observable in a detached document
-FAIL Observable from EventTarget does not get notified for events in detached documents promise_test: Unhandled rejection with value: object "TypeError: event_target.when is not a function. (In 'event_target.when('customevent')', 'event_target.when' is undefined)"
+PASS Observable from EventTarget does not get notified for events in detached documents
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL EventTarget.when() returns an Observable assert_implements: The EventTarget interface has an `when` method undefined
-FAIL Aborting the subscription should stop the emission of events target.when is not a function. (In 'target.when("test")', 'target.when' is undefined)
-FAIL EventTarget Observables can multicast subscriptions for event handling target.when is not a function. (In 'target.when("test")', 'target.when' is undefined)
+PASS EventTarget.when() returns an Observable
+PASS Aborting the subscription should stop the emission of events
+PASS EventTarget Observables can multicast subscriptions for event handling
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL EventTarget.when() returns an Observable assert_implements: The EventTarget interface has an `when` method undefined
-FAIL Aborting the subscription should stop the emission of events target.when is not a function. (In 'target.when("test")', 'target.when' is undefined)
-FAIL EventTarget Observables can multicast subscriptions for event handling target.when is not a function. (In 'target.when("test")', 'target.when' is undefined)
+PASS EventTarget.when() returns an Observable
+PASS Aborting the subscription should stop the emission of events
+PASS EventTarget Observables can multicast subscriptions for event handling
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL EventTarget Observables can listen for events in the capturing or bubbling phase body.when is not a function. (In 'body.when('click', {capture: true})', 'body.when' is undefined)
-FAIL EventTarget Observables can be 'passive' target.when is not a function. (In 'target.when('event', {passive: true})', 'target.when' is undefined)
+PASS EventTarget Observables can listen for events in the capturing or bubbling phase
+PASS EventTarget Observables can be 'passive'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.worker-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL from(): Observable.from() is a function assert_equals: Observable.from() is a function expected "function" but got "undefined"
 PASS from(): Failed conversions
-FAIL from(): Given an observable, it returns that exact observable target.when is not a function. (In 'target.when('custom')', 'target.when' is undefined)
+FAIL from(): Given an observable, it returns that exact observable Observable.from is not a function. (In 'Observable.from(observable)', 'Observable.from' is undefined)
 FAIL from(): Given an array Observable.from is not a function. (In 'Observable.from(array)', 'Observable.from' is undefined)
 FAIL from(): Iterable converts to Observable Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): [Symbol.iterator] side-effects (one observable) Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt
@@ -1,4 +1,5 @@
 CONSOLE MESSAGE: Error: error from source
+CONSOLE MESSAGE: Error: error from inspect() subscribe handler
 
 PASS inspect(): Provides a pre-subscription subscribe callback
 PASS inspect(): Provides a way to tap into the values and completions of the source observable using an observer
@@ -12,5 +13,5 @@ PASS inspect(): Throwing an error in the next handler function in do should be c
 PASS inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback
 PASS inspect(): Provides a way to tap into the moment a source observable is unsubscribed from
 PASS inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from
-FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when("error")', 'self.when' is undefined)
+PASS inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt
@@ -11,5 +11,5 @@ PASS inspect(): Throwing an error in the next handler function in do should be c
 PASS inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback
 PASS inspect(): Provides a way to tap into the moment a source observable is unsubscribed from
 PASS inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from
-FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when("error")', 'self.when' is undefined)
+PASS inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs
 

--- a/LayoutTests/inspector/model/remote-object-get-properties-expected.txt
+++ b/LayoutTests/inspector/model/remote-object-get-properties-expected.txt
@@ -655,6 +655,7 @@ ALL PROPERTIES:
     addEventListener
     removeEventListener
     dispatchEvent
+    when
     Symbol(Symbol.toStringTag)
     toString
     toLocaleString

--- a/LayoutTests/inspector/runtime/getPreview-expected.txt
+++ b/LayoutTests/inspector/runtime/getPreview-expected.txt
@@ -49,7 +49,7 @@ PASS: RemoteObject.updatePreview should return null for a null RemoteObject.
 {"type":"object","description":"Foo","lossless":false,"properties":[{"name":"#value","type":"number","value":"42","isPrivate":true}]}
 
 -- Running test case: Runtime.getPreview.Internal
-{"type":"object","description":"EventTarget","lossless":false,"properties":[{"name":"listeners","type":"object","value":"Object","internal":true},{"name":"addEventListener","type":"function","value":""},{"name":"removeEventListener","type":"function","value":""},{"name":"dispatchEvent","type":"function","value":""}]}
+{"type":"object","description":"EventTarget","lossless":false,"properties":[{"name":"listeners","type":"object","value":"Object","internal":true},{"name":"addEventListener","type":"function","value":""},{"name":"removeEventListener","type":"function","value":""},{"name":"dispatchEvent","type":"function","value":""},{"name":"when","type":"function","value":""}]}
 
 -- Running test case: Runtime.getPreview.InvalidObjectId
 PASS: Should produce an error.

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1170,6 +1170,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/EventInit.idl
     dom/EventListenerOptions.idl
     dom/EventModifierInit.idl
+    dom/EventTarget+Observable.idl
     dom/EventTarget.idl
     dom/FocusEvent.idl
     dom/FocusOptions.idl
@@ -1206,6 +1207,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/NonDocumentTypeChildNode.idl
     dom/NonElementParentNode.idl
     dom/Observable.idl
+    dom/ObservableEventListenerOptions.idl
     dom/ObservableInspector.idl
     dom/ObservableInspectorAbortCallback.idl
     dom/OverflowEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1462,6 +1462,7 @@ $(PROJECT_DIR)/dom/EventListener.idl
 $(PROJECT_DIR)/dom/EventListenerOptions.idl
 $(PROJECT_DIR)/dom/EventModifierInit.idl
 $(PROJECT_DIR)/dom/EventNames.json
+$(PROJECT_DIR)/dom/EventTarget+Observable.idl
 $(PROJECT_DIR)/dom/EventTarget.idl
 $(PROJECT_DIR)/dom/EventTargetFactory.in
 $(PROJECT_DIR)/dom/FocusEvent.idl
@@ -1499,6 +1500,7 @@ $(PROJECT_DIR)/dom/NodeList.idl
 $(PROJECT_DIR)/dom/NonDocumentTypeChildNode.idl
 $(PROJECT_DIR)/dom/NonElementParentNode.idl
 $(PROJECT_DIR)/dom/Observable.idl
+$(PROJECT_DIR)/dom/ObservableEventListenerOptions.idl
 $(PROJECT_DIR)/dom/ObservableInspector.idl
 $(PROJECT_DIR)/dom/ObservableInspectorAbortCallback.idl
 $(PROJECT_DIR)/dom/OverflowEvent.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1158,6 +1158,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/EventListenerOptions.idl \
     $(WebCore)/dom/EventModifierInit.idl \
     $(WebCore)/dom/EventTarget.idl \
+    $(WebCore)/dom/EventTarget+Observable.idl \
     $(WebCore)/dom/FocusEvent.idl \
     $(WebCore)/dom/FocusOptions.idl \
     $(WebCore)/dom/FormDataEvent.idl \
@@ -1194,6 +1195,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/NonElementParentNode.idl \
     $(WebCore)/dom/OverflowEvent.idl \
     $(WebCore)/dom/Observable.idl \
+    $(WebCore)/dom/ObservableEventListenerOptions.idl \
     $(WebCore)/dom/ObservableInspector.idl \
     $(WebCore)/dom/ObservableInspectorAbortCallback.idl \
     $(WebCore)/dom/PageRevealEvent.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1319,6 +1319,7 @@ dom/NodeRareData.cpp
 dom/NodeTraversal.cpp
 dom/Observable.cpp
 dom/OverflowEvent.cpp
+dom/ObservableEventTarget.cpp
 dom/PageRevealEvent.cpp
 dom/PageSwapEvent.cpp
 dom/PageTransitionEvent.cpp
@@ -4317,6 +4318,7 @@ JSOESTextureHalfFloat.cpp
 JSOESTextureHalfFloatLinear.cpp
 JSOESVertexArrayObject.cpp
 JSObservable.cpp
+JSObservableEventListenerOptions.cpp
 JSObservableInspector.cpp
 JSObservableInspectorAbortCallback.cpp
 JSOfflineAudioCompletionEvent.cpp

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.h
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.h
@@ -48,6 +48,8 @@ public:
 
     operator JSC::JSObject&() { ASSERT(m_wrapper); return *m_wrapper; }
 
+    JSDOMGlobalObject* globalObject() const { ASSERT(m_wrapper); return static_cast<JSDOMGlobalObject*>(m_wrapper->globalObject()); }
+
 private:
     EventTarget* m_wrapped { nullptr };
     JSC::JSObject* m_wrapper { nullptr };

--- a/Source/WebCore/dom/EventTarget+Observable.idl
+++ b/Source/WebCore/dom/EventTarget+Observable.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+// https://wicg.github.io/observable/#event-target-integration
+
+[
+  ImplementedBy=Observable
+]
+partial interface EventTarget {
+  [CallWith=CurrentScriptExecutionContext, Exposed=(Window,Worker), EnabledBySetting=ObservableEnabled] Observable when([AtomString] DOMString eventType, optional ObservableEventListenerOptions options = {});
+};

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -28,6 +28,7 @@
 #include "AbortSignal.h"
 #include "CallbackResult.h"
 #include "Document.h"
+#include "EventTarget.h"
 #include "Exception.h"
 #include "ExceptionCode.h"
 #include "InternalObserverDrop.h"
@@ -46,6 +47,8 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSSubscriptionObserverCallback.h"
 #include "MapperCallback.h"
+#include "ObservableEventListenerOptions.h"
+#include "ObservableEventTarget.h"
 #include "ObservableInspector.h"
 #include "PredicateCallback.h"
 #include "ReducerCallback.h"
@@ -124,6 +127,11 @@ Ref<Observable> Observable::take(ScriptExecutionContext& context, uint64_t amoun
 Ref<Observable> Observable::drop(ScriptExecutionContext& context, uint64_t amount)
 {
     return create(createSubscriberCallbackDrop(context, *this, amount));
+}
+
+Ref<Observable> Observable::when(EventTarget& eventTarget, ScriptExecutionContext& context, const AtomString& eventType, const ObservableEventListenerOptions& options)
+{
+    return create(createSubscriberCallbackEventTarget(context, eventTarget, eventType, options));
 }
 
 Ref<Observable> Observable::inspect(ScriptExecutionContext& context, std::optional<InspectorUnion>&& inspectorUnion)

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -29,10 +29,12 @@
 #include "SubscriberCallback.h"
 #include "VoidCallback.h"
 #include <wtf/RefCounted.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class DeferredPromise;
+class EventTarget;
 class InternalObserver;
 class JSSubscriptionObserverCallback;
 class MapperCallback;
@@ -40,6 +42,7 @@ class PredicateCallback;
 class ReducerCallback;
 class ScriptExecutionContext;
 class VisitorCallback;
+struct ObservableEventListenerOptions;
 struct ObservableInspector;
 struct SubscribeOptions;
 struct SubscriptionObserver;
@@ -73,6 +76,10 @@ public:
     void every(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void some(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
     void reduce(ScriptExecutionContext&, Ref<ReducerCallback>&&, JSC::JSValue, const SubscribeOptions&, Ref<DeferredPromise>&&);
+
+    // EventTarget integration.
+
+    static Ref<Observable> when(EventTarget&, ScriptExecutionContext&, const AtomString&, const ObservableEventListenerOptions&);
 
 private:
     const Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/ObservableEventListenerOptions.h
+++ b/Source/WebCore/dom/ObservableEventListenerOptions.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct ObservableEventListenerOptions {
+    bool capture = { false };
+    std::optional<bool> passive;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ObservableEventListenerOptions.idl
+++ b/Source/WebCore/dom/ObservableEventListenerOptions.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary ObservableEventListenerOptions {
+  boolean capture = false;
+  boolean passive;
+};

--- a/Source/WebCore/dom/ObservableEventTarget.cpp
+++ b/Source/WebCore/dom/ObservableEventTarget.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+// https://wicg.github.io/observable/#event-target-integration
+
+#include "config.h"
+#include "ObservableEventTarget.h"
+
+#include "AddEventListenerOptions.h"
+#include "EventListener.h"
+#include "EventTarget.h"
+#include "JSEvent.h"
+#include "ObservableEventListenerOptions.h"
+#include "ScriptExecutionContext.h"
+#include "SubscribeOptions.h"
+#include "Subscriber.h"
+#include "SubscriberCallback.h"
+#include <wtf/WeakPtr.h>
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class ObservableEventListener final : public EventListener {
+public:
+    static Ref<ObservableEventListener> create(Ref<Subscriber>&& subscriber)
+    {
+        return adoptRef(*new ObservableEventListener(WTFMove(subscriber)));
+    }
+
+    void handleEvent(ScriptExecutionContext& context, Event& event) override
+    {
+        auto* globalObject = context.globalObject();
+        if (!globalObject)
+            return;
+
+        m_subscriber->next(toJS(globalObject, JSC::jsCast<JSDOMGlobalObject*>(globalObject), event));
+    }
+
+private:
+    ObservableEventListener(Ref<Subscriber>&& subscriber)
+        : EventListener(EventListener::CPPEventListenerType)
+        , m_subscriber(WTFMove(subscriber))
+    {
+    }
+
+    const Ref<Subscriber> m_subscriber;
+};
+
+class SubscriberCallbackEventTarget final : public SubscriberCallback {
+public:
+    static Ref<SubscriberCallbackEventTarget> create(ScriptExecutionContext& context, EventTarget& eventTarget, const AtomString& eventType, const ObservableEventListenerOptions& options)
+    {
+        return adoptRef(*new SubscriberCallbackEventTarget(context, eventTarget, eventType, options));
+    }
+
+    CallbackResult<void> invoke(Subscriber& subscriber) final
+    {
+        if (subscriber.signal().aborted())
+            return { };
+
+        if (RefPtr eventTarget = m_eventTarget.get()) {
+            AddEventListenerOptions addEventListenerOptions = { m_options.capture, m_options.passive, /* once */ false, subscriber.signal() };
+            eventTarget->addEventListener(m_eventType, ObservableEventListener::create(subscriber), WTFMove(addEventListenerOptions));
+        }
+
+        return { };
+    }
+
+    CallbackResult<void> invokeRethrowingException(Subscriber& subscriber) final { return invoke(subscriber); }
+
+private:
+    bool hasCallback() const final { return true; }
+
+    SubscriberCallbackEventTarget(ScriptExecutionContext& context, EventTarget& eventTarget, const AtomString& eventType, const ObservableEventListenerOptions& options)
+        : SubscriberCallback(&context)
+        , m_eventTarget(eventTarget)
+        , m_eventType(eventType)
+        , m_options(options)
+    {
+    }
+
+    WeakPtr<EventTarget, WeakPtrImplWithEventTargetData> m_eventTarget;
+    AtomString m_eventType;
+    ObservableEventListenerOptions m_options;
+};
+
+Ref<SubscriberCallback> createSubscriberCallbackEventTarget(ScriptExecutionContext& context, EventTarget& eventTarget, const AtomString& eventType, const ObservableEventListenerOptions& options)
+{
+    return SubscriberCallbackEventTarget::create(context, eventTarget, eventType, options);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ObservableEventTarget.h
+++ b/Source/WebCore/dom/ObservableEventTarget.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Marais Rossouw <me@marais.co>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/AtomString.h>
+
+namespace WebCore {
+
+class EventTarget;
+class ScriptExecutionContext;
+class SubscriberCallback;
+struct ObservableEventListenerOptions;
+
+Ref<SubscriberCallback> createSubscriberCallbackEventTarget(ScriptExecutionContext&, EventTarget&, const AtomString&, const ObservableEventListenerOptions&);
+
+} // namespace WebCore


### PR DESCRIPTION
#### 95dcb0e22a99b1709abd7db68af9863a52ae6ed5
<pre>
Implement EventTarget#when
<a href="https://bugs.webkit.org/show_bug.cgi?id=284432">https://bugs.webkit.org/show_bug.cgi?id=284432</a>

Reviewed by NOBODY (OOPS!).

This change extends the EventTarget interface with a new `when` method that
creates a new Observable. Once the user subscribes to this Observable, we add an
EventListener and forward events to its Subscriber&apos;s next handler.

Spec: &lt;<a href="https://wicg.github.io/observable/#event-target-integration">https://wicg.github.io/observable/#event-target-integration</a>&gt;

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.worker-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.js: Rebaseline.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt: Rebaseline.
* LayoutTests/inspector/model/remote-object-get-properties-expected.txt: Rebaseline.
* LayoutTests/inspector/runtime/getPreview-expected.txt: Rebaseline.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSEventTargetCustom.h:
(WebCore::JSEventTargetWrapper::globalObject const): The code generator
would like to call a `globalObject` on its `castedThis`, which does not
exist currently on our custom header.
* Source/WebCore/dom/EventTarget+Observable.idl:
Exposes a `Observable when(event, options)` IDL.
* Source/WebCore/dom/Observable.cpp:
(WebCore::Observable::when):
* Source/WebCore/dom/Observable.h:
* Source/WebCore/dom/ObservableEventListenerOptions.h: Added.
* Source/WebCore/dom/ObservableEventListenerOptions.idl: Added.
* Source/WebCore/dom/ObservableEventTarget.cpp: Added.
(WebCore::createSubscriberCallbackEventTarget):
* Source/WebCore/dom/ObservableEventTarget.h: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95dcb0e22a99b1709abd7db68af9863a52ae6ed5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26257 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122110 "Hash 95dcb0e2 for PR 49311 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66603 "Hash 95dcb0e2 for PR 49311 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44303 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/84986 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/35676 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119002 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29047 "Found 30 new test failures: http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/document-access.html http/tests/site-isolation/double-iframe.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/frame-index.html http/tests/site-isolation/history/add-iframe-while-changing-document-title.html http/tests/site-isolation/history/add-iframes-and-go-back.html http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104137 "Found 29 new API test failures: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SiteIsolation.PasteGIF, TestWebKitAPI.SiteIsolation.CompleteTextManipulation, TestWebKitAPI.SiteIsolation.CompleteTextManipulationFailsInSomeFrame, TestWebKitAPI.SiteIsolation.FocusOpenedWindow, TestWebKitAPI.SiteIsolation.PostMessageToIFrameWithOpaqueOrigin, TestWebKitAPI.SiteIsolation.ChildBeingNavigatedToNewDomainByParent, TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure, TestWebKitAPI.SiteIsolation.PostMessageWithNotAllowedTargetOrigin ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/65425 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28164 "Found 3 new test failures: imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html imported/w3c/web-platform-tests/fetch/security/dangling-markup-mitigation-data-url.tentative.sub.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22245 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65792 "Hash 95dcb0e2 for PR 49311 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98435 "Found 24 new API test failures: TestWebKitAPI.SiteIsolation.NavigationAfterWindowOpen, TestWebKitAPI.SiteIsolation.MainFrameRedirectBetweenExistingProcesses, TestWebKitAPI.SiteIsolation.CompleteTextManipulation, TestWebKitAPI.SiteIsolation.CompleteTextManipulationFailsInSomeFrame, TestWebKitAPI.SiteIsolation.FocusOpenedWindow, TestWebKitAPI.SiteIsolation.PostMessageToIFrameWithOpaqueOrigin, TestWebKitAPI.SiteIsolation.ChildBeingNavigatedToNewDomainByParent, TestWebKitAPI.SiteIsolation.NavigateOpenerToProvisionalNavigationFailure, TestWebKitAPI.SiteIsolation.PostMessageWithNotAllowedTargetOrigin, TestWebKitAPI.SiteIsolation.UserScript ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22382 "Found 48 new test failures: http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/document-access.html http/tests/site-isolation/double-iframe.html http/tests/site-isolation/draw-after-navigation.html http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html http/tests/site-isolation/edge-sampling-commit-root-frame-load.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/frame-index.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125260 "Hash 95dcb0e2 for PR 49311 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42948 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32239 "Found 46 new test failures: http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/document-access.html http/tests/site-isolation/double-iframe.html http/tests/site-isolation/draw-after-navigation.html http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html http/tests/site-isolation/edge-sampling-commit-root-frame-load.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/frame-index.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/93862 "Found 2 new test failures: imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/93686 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41959 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19841 "Found 48 new test failures: http/tests/site-isolation/basic-iframe-render-output.html http/tests/site-isolation/basic-iframe.html http/tests/site-isolation/basic-transparent-iframe.html http/tests/site-isolation/document-access.html http/tests/site-isolation/double-iframe.html http/tests/site-isolation/draw-after-navigation.html http/tests/site-isolation/draw-with-size-after-same-origin-navigation.html http/tests/site-isolation/edge-sampling-commit-root-frame-load.html http/tests/site-isolation/frame-access-after-window-open.html http/tests/site-isolation/frame-index.html ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38894 "Hash 95dcb0e2 for PR 49311 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42835 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48427 "Found 1 new failure in bindings/js/JSEventTargetCustom.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->