### PR TITLE
Separate JSHandle and serialized node enabling SPIs

### DIFF
--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -55,8 +55,11 @@ public:
     void setAllowAutofill() { m_allowAutofill = true; }
     bool allowAutofill() const { return m_allowAutofill; }
 
-    void setNodeInfoEnabled() { m_nodeInfoEnabled = true; }
-    bool nodeInfoEnabled() const { return m_nodeInfoEnabled; }
+    bool allowJSHandleCreation() const { return m_allowJSHandleCreation; }
+    void setAllowJSHandleCreation() { m_allowJSHandleCreation = true; }
+
+    void setAllowNodeSerialization() { m_allowNodeSerialization = true; }
+    bool allowNodeSerialization() const { return m_allowNodeSerialization; }
 
     void setAllowElementUserInfo() { m_allowElementUserInfo = true; }
     bool allowElementUserInfo() const { return m_allowElementUserInfo; }
@@ -93,12 +96,13 @@ private:
     String m_name;
     Type m_type { Type::Internal };
 
-    bool m_allowAutofill { false };
-    bool m_allowElementUserInfo { false };
-    bool m_shadowRootIsAlwaysOpen { false };
-    bool m_closedShadowRootIsExposedForExtensions { false };
-    bool m_shouldDisableLegacyOverrideBuiltInsBehavior { false };
-    bool m_nodeInfoEnabled { false };
+    bool m_allowAutofill : 1 { false };
+    bool m_allowElementUserInfo : 1 { false };
+    bool m_shadowRootIsAlwaysOpen : 1 { false };
+    bool m_closedShadowRootIsExposedForExtensions : 1 { false };
+    bool m_shouldDisableLegacyOverrideBuiltInsBehavior : 1 { false };
+    bool m_allowJSHandleCreation : 1 { false };
+    bool m_allowNodeSerialization : 1 { false };
 };
 
 DOMWrapperWorld& normalWorld(JSC::VM&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -830,7 +830,7 @@ VisualViewport& LocalDOMWindow::visualViewport()
 
 bool LocalDOMWindow::shouldHaveWebKitNamespaceForWorld(DOMWrapperWorld& world)
 {
-    if (world.nodeInfoEnabled())
+    if (world.allowJSHandleCreation() || world.allowNodeSerialization())
         return true;
 
     RefPtr frame = this->frame();

--- a/Source/WebCore/page/WebKitJSHandle.idl
+++ b/Source/WebCore/page/WebKitJSHandle.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledForWorld=nodeInfoEnabled,
+    EnabledForWorld=allowJSHandleCreation,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT
 ] interface WebKitJSHandle {

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -31,8 +31,8 @@
     Exposed=Window
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace messageHandlers;
-    [EnabledForWorld=nodeInfoEnabled, CallWith=CurrentDocument] WebKitJSHandle createJSHandle(object object);
-    [EnabledForWorld=nodeInfoEnabled] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
+    [EnabledForWorld=allowJSHandleCreation, CallWith=CurrentDocument] WebKitJSHandle createJSHandle(object object);
+    [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
 };
 
 dictionary WebKitSerializedNodeInit {

--- a/Source/WebCore/page/WebKitSerializedNode.idl
+++ b/Source/WebCore/page/WebKitSerializedNode.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledForWorld=nodeInfoEnabled,
+    EnabledForWorld=allowNodeSerialization,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT
 ] interface WebKitSerializedNode {

--- a/Source/WebKit/Shared/ContentWorldData.serialization.in
+++ b/Source/WebKit/Shared/ContentWorldData.serialization.in
@@ -27,7 +27,8 @@ header: "ContentWorldData.h"
     AllowAutofill,
     AllowElementUserInfo,
     DisableLegacyBuiltinOverrides,
-    AllowNodeInfo,
+    AllowJSHandleCreation,
+    AllowNodeSerialization,
 };
 
 [DebugDecodingFailure] struct WebKit::ContentWorldData {

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -44,7 +44,8 @@ enum class ContentWorldOption : uint8_t {
     AllowAutofill = 1 << 1,
     AllowElementUserInfo = 1 << 2,
     DisableLegacyBuiltinOverrides = 1 << 3,
-    AllowNodeInfo = 1 << 4,
+    AllowJSHandleCreation = 1 << 4,
+    AllowNodeSerialization = 1 << 5,
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -62,8 +62,11 @@ public:
     bool disableLegacyBuiltinOverrides() const { return m_options.contains(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
     void setDisableLegacyBuiltinOverrides(bool value) { m_options.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides); }
 
-    bool allowNodeInfo() const { return m_options.contains(WebKit::ContentWorldOption::AllowNodeInfo); }
-    void setNodeInfoEnabled() { m_options.add(WebKit::ContentWorldOption::AllowNodeInfo); }
+    bool allowJSHandleCreation() const { return m_options.contains(WebKit::ContentWorldOption::AllowJSHandleCreation); }
+    void setAllowJSHandleCreation() { m_options.add(WebKit::ContentWorldOption::AllowJSHandleCreation); }
+
+    bool allowNodeSerialization() const { return m_options.contains(WebKit::ContentWorldOption::AllowNodeSerialization); }
+    void setAllowNodeSerialization() { m_options.add(WebKit::ContentWorldOption::AllowNodeSerialization); }
 
     void addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy&);
     void userContentControllerProxyDestroyed(WebKit::WebUserContentControllerProxy&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm
@@ -109,8 +109,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         optionSet.add(WebKit::ContentWorldOption::AllowElementUserInfo);
     if (configuration.disableLegacyBuiltinOverrides)
         optionSet.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides);
-    if (configuration.allowNodeInfo)
-        optionSet.add(WebKit::ContentWorldOption::AllowNodeInfo);
+    if (configuration.allowJSHandleCreation)
+        optionSet.add(WebKit::ContentWorldOption::AllowJSHandleCreation);
+    if (configuration.allowNodeSerialization)
+        optionSet.add(WebKit::ContentWorldOption::AllowNodeSerialization);
     Ref world = API::ContentWorld::sharedWorldWithName(configuration.name, optionSet);
     checkContentWorldOptions(world, configuration);
     return wrapper(WTFMove(world)).autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h
@@ -50,8 +50,11 @@ WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 /*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
 @property (nonatomic) BOOL disableLegacyBuiltinOverrides;
 
-/*! @abstract A boolean indicating whether node info can be returned from JS to ObjC. */
-@property (nonatomic) BOOL allowNodeInfo;
+/*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
+@property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA, WK_XROS_TBA);
+
+/*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */
+@property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(WK_MAC_TBA, WK_IOS_TBA, WK_XROS_TBA);
 
 @end
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -121,9 +121,14 @@ void InjectedBundleScriptWorld::setAllowAutofill()
     m_world->setAllowAutofill();
 }
 
-void InjectedBundleScriptWorld::setNodeInfoEnabled()
+void InjectedBundleScriptWorld::setAllowJSHandleCreation()
 {
-    m_world->setNodeInfoEnabled();
+    m_world->setAllowJSHandleCreation();
+}
+
+void InjectedBundleScriptWorld::setAllowNodeSerialization()
+{
+    m_world->setAllowNodeSerialization();
 }
 
 void InjectedBundleScriptWorld::setAllowElementUserInfo()

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -60,7 +60,8 @@ public:
     void makeAllShadowRootsOpen();
     void exposeClosedShadowRootsForExtensions();
     void disableOverrideBuiltinsBehavior();
-    void setNodeInfoEnabled();
+    void setAllowJSHandleCreation();
+    void setAllowNodeSerialization();
 
     const String& name() const { return m_name; }
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -134,8 +134,10 @@ InjectedBundleScriptWorld* WebUserContentController::addContentWorld(const Conte
             scriptWorld->setAllowElementUserInfo();
         if (world.options.contains(ContentWorldOption::DisableLegacyBuiltinOverrides))
             scriptWorld->disableOverrideBuiltinsBehavior();
-        if (world.options.contains(ContentWorldOption::AllowNodeInfo))
-            scriptWorld->setNodeInfoEnabled();
+        if (world.options.contains(ContentWorldOption::AllowJSHandleCreation))
+            scriptWorld->setAllowJSHandleCreation();
+        if (world.options.contains(ContentWorldOption::AllowNodeSerialization))
+            scriptWorld->setAllowNodeSerialization();
         return scriptWorld.ptr();
     }
     return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1185,7 +1185,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     }
 
     if (parameters.allowJSHandleInPageContentWorld)
-        InjectedBundleScriptWorld::normalWorldSingleton().setNodeInfoEnabled();
+        InjectedBundleScriptWorld::normalWorldSingleton().setAllowJSHandleCreation();
 }
 
 void WebPage::updateAfterDrawingAreaCreation(const WebPageCreationParameters& parameters)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm
@@ -67,7 +67,7 @@ TEST(JSHandle, Basic)
     [navigationDelegate waitForDidFinishNavigation];
 
     RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
-    worldConfiguration.get().allowNodeInfo = YES;
+    worldConfiguration.get().allowJSHandleCreation = YES;
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
 
     RetainPtr<id> result = [webView objectByEvaluatingJavaScript:@"window.webkit.createJSHandle(onlyframe.contentWindow)" inFrame:nil inContentWorld:world.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm
@@ -39,7 +39,7 @@ TEST(SerializedNode, Basic)
     [webView loadHTMLString:@"<div id='testid'><div>test</div></div><template id='outerTemplate'><template id='innerTemplate'><span>Contents</span></template></template>" baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
 
     RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
-    worldConfiguration.get().allowNodeInfo = YES;
+    worldConfiguration.get().allowNodeSerialization = YES;
     RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
 
     auto verifyNodeSerialization = [world, webView] (const char* constructor, const char* accessor, const char* expected, const char* className, const char* init = "deep:true") {


### PR DESCRIPTION
#### 78b7baa2211d9abb5b998ab551ce9ac7c18a33e4
<pre>
Separate JSHandle and serialized node enabling SPIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=297312">https://bugs.webkit.org/show_bug.cgi?id=297312</a>
<a href="https://rdar.apple.com/158197746">rdar://158197746</a>

Reviewed by Ryosuke Niwa.

Node info doesn&apos;t exist any more.
Bools to enable JSHandle and serialized nodes should be separate.

* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::allowJSHandleCreation const):
(WebCore::DOMWrapperWorld::setAllowJSHandleCreation):
(WebCore::DOMWrapperWorld::setAllowNodeSerialization):
(WebCore::DOMWrapperWorld::allowNodeSerialization const):
(WebCore::DOMWrapperWorld::setNodeInfoEnabled): Deleted.
(WebCore::DOMWrapperWorld::nodeInfoEnabled const): Deleted.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::shouldHaveWebKitNamespaceForWorld):
* Source/WebCore/page/WebKitJSHandle.idl:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WebKitSerializedNode.idl:
* Source/WebKit/Shared/ContentWorldData.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(+[WKContentWorld _worldWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::setAllowJSHandleCreation):
(WebKit::InjectedBundleScriptWorld::setAllowNodeSerialization):
(WebKit::InjectedBundleScriptWorld::setNodeInfoEnabled): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorld):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandle.mm:
(TestWebKitAPI::TEST(JSHandle, Basic)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SerializedNode.mm:
(TestWebKitAPI::TEST(SerializedNode, Basic)):

Canonical link: <a href="https://commits.webkit.org/298725@main">https://commits.webkit.org/298725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f218083ffe22ff267d08c6e01edb111f296da944

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66667 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce925bae-1272-4752-8e52-d7c4cad40236) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88217 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42753 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/84cbf1b8-281d-4f2f-9d91-4d72730bb69f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68628 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22295 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65850 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125318 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96950 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96734 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42005 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38952 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18596 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48485 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42360 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45695 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->