### PR TITLE
[GTK][WPE] Do not use PlartformDisplay::sharedDisplay in GLFenceEGL

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -385,6 +385,11 @@ bool GLContext::unmakeCurrentImpl()
     return display ? eglMakeCurrent(display->eglDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT) : false;
 }
 
+unsigned GLContext::glVersion() const
+{
+    return version();
+}
+
 bool GLContext::makeContextCurrent()
 {
     if (isCurrent())
@@ -486,7 +491,7 @@ unsigned GLContext::versionFromString(const char* versionStringAsChar)
     return parseIntegerAllowingTrailingJunk<unsigned>(versionDigits[0]).value_or(0) * 100 + parseIntegerAllowingTrailingJunk<unsigned>(versionDigits[1]).value_or(0) * 10;
 }
 
-unsigned GLContext::version()
+unsigned GLContext::version() const
 {
     if (!m_version) {
         auto* versionString = reinterpret_cast<const char*>(::glGetString(GL_VERSION));

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -88,7 +88,7 @@ public:
     WEBCORE_EXPORT ~GLContext();
 
     RefPtr<GLDisplay> display() const;
-    unsigned version();
+    unsigned version() const;
     EGLConfig config() const { return m_config; }
 
     WEBCORE_EXPORT bool makeContextCurrent();
@@ -156,6 +156,7 @@ private:
     GLContextWrapper::Type type() const override { return GLContextWrapper::Type::Native; }
     bool makeCurrentImpl() override;
     bool unmakeCurrentImpl() override;
+    unsigned glVersion() const override;
 
 #if ENABLE(MEDIA_TELEMETRY)
     EGLDisplay eglDisplay() const final;
@@ -167,7 +168,7 @@ private:
 #endif
 
     ThreadSafeWeakPtr<GLDisplay> m_display;
-    unsigned m_version { 0 };
+    mutable unsigned m_version { 0 };
     EGLContext m_context { nullptr };
     EGLSurface m_surface { nullptr };
     EGLConfig m_config { nullptr };

--- a/Source/WebCore/platform/graphics/egl/GLContextWrapper.h
+++ b/Source/WebCore/platform/graphics/egl/GLContextWrapper.h
@@ -30,6 +30,7 @@ public:
     virtual Type type() const = 0;
     virtual bool makeCurrentImpl() = 0;
     virtual bool unmakeCurrentImpl() = 0;
+    virtual unsigned glVersion() const = 0;
 
     bool isCurrent() const;
     void didMakeContextCurrent();

--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -21,6 +21,7 @@
 #include "GLFence.h"
 
 #include "GLContext.h"
+#include "GLDisplay.h"
 #include "GLFenceEGL.h"
 #include "GLFenceGL.h"
 #include "PlatformDisplay.h"
@@ -36,78 +37,77 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GLFence);
 
-const GLFence::Capabilities& GLFence::capabilities()
+static inline bool eglVersionSupportsFences(const GLDisplay& display)
 {
-    static Capabilities capabilities;
-#if HAVE(GL_FENCE)
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        auto& display = PlatformDisplay::sharedDisplay();
-        const auto& extensions = display.eglExtensions();
-        if (display.eglCheckVersion(1, 5)) {
-            capabilities.eglSupported = true;
-            capabilities.eglServerWaitSupported = true;
-        } else {
-            capabilities.eglSupported = extensions.KHR_fence_sync;
-            capabilities.eglServerWaitSupported = extensions.KHR_wait_sync;
-        }
-#if OS(UNIX)
-        capabilities.eglExportableSupported = extensions.ANDROID_native_fence_sync;
-#endif
-        capabilities.glSupported = GLContext::versionFromString(reinterpret_cast<const char*>(glGetString(GL_VERSION))) >= 300;
-    });
-#endif
-    return capabilities;
+    return display.checkVersion(1, 5);
 }
 
-bool GLFence::isSupported()
+static inline bool eglExtensionsSupportFences(const GLDisplay& display)
 {
-    const auto& fenceCapabilities = capabilities();
-    return fenceCapabilities.eglSupported || fenceCapabilities.glSupported;
+    return display.extensions().KHR_fence_sync;
 }
 
-std::unique_ptr<GLFence> GLFence::create()
+static inline bool glContextSupportsFences(GLContextWrapper* context)
+{
+    return context->glVersion() >= 300;
+}
+
+bool GLFence::isSupported(const GLDisplay& display)
+{
+    auto* context = GLContextWrapper::currentContext();
+    if (!context)
+        return false;
+
+    if (eglVersionSupportsFences(display) || eglExtensionsSupportFences(display))
+        return true;
+
+    return glContextSupportsFences(context);
+}
+
+std::unique_ptr<GLFence> GLFence::create(const GLDisplay& display)
 {
 #if HAVE(GL_FENCE)
-    if (!GLContextWrapper::currentContext())
+    auto* context = GLContextWrapper::currentContext();
+    if (!context)
         return nullptr;
 
-    const auto& fenceCapabilities = capabilities();
-    if (fenceCapabilities.eglSupported && fenceCapabilities.eglServerWaitSupported)
-        return GLFenceEGL::create();
+    if (eglVersionSupportsFences(display))
+        return GLFenceEGL::create(display);
 
-    if (fenceCapabilities.glSupported)
+    // Prefer EGL if server wait is supported,
+    if (eglExtensionsSupportFences(display) && display.extensions().KHR_wait_sync)
+        return GLFenceEGL::create(display);
+
+    if (glContextSupportsFences(context))
         return GLFenceGL::create();
 
-    if (fenceCapabilities.eglSupported)
-        return GLFenceEGL::create();
+    if (eglExtensionsSupportFences(display))
+        return GLFenceEGL::create(display);
 #endif
     return nullptr;
 }
 
 #if OS(UNIX)
-std::unique_ptr<GLFence> GLFence::createExportable()
+std::unique_ptr<GLFence> GLFence::createExportable(const GLDisplay& display)
 {
 #if HAVE(GL_FENCE)
     if (!GLContextWrapper::currentContext())
         return nullptr;
 
-    const auto& fenceCapabilities = capabilities();
-    if (fenceCapabilities.eglSupported && fenceCapabilities.eglExportableSupported)
-        return GLFenceEGL::createExportable();
+    if (display.extensions().ANDROID_native_fence_sync)
+        return GLFenceEGL::createExportable(display);
 #endif
     return nullptr;
 }
 
-std::unique_ptr<GLFence> GLFence::importFD(UnixFileDescriptor&& fd)
+std::unique_ptr<GLFence> GLFence::importFD(const GLDisplay& display, UnixFileDescriptor&& fd)
 {
 #if HAVE(GL_FENCE)
     if (!GLContextWrapper::currentContext())
         return nullptr;
 
-    const auto& fenceCapabilities = capabilities();
-    if (fenceCapabilities.eglSupported && fenceCapabilities.eglExportableSupported)
-        return GLFenceEGL::importFD(WTFMove(fd));
+    if (display.extensions().ANDROID_native_fence_sync)
+        return GLFenceEGL::importFD(display, WTFMove(fd));
 #else
     UNUSED_PARAM(fd);
 #endif

--- a/Source/WebCore/platform/graphics/egl/GLFence.h
+++ b/Source/WebCore/platform/graphics/egl/GLFence.h
@@ -26,19 +26,18 @@
 #include <wtf/unix/UnixFileDescriptor.h>
 #endif
 
-typedef struct __GLsync* GLsync;
-
 namespace WebCore {
+class GLDisplay;
 
 class GLFence {
     WTF_MAKE_TZONE_ALLOCATED(GLFence);
     WTF_MAKE_NONCOPYABLE(GLFence);
 public:
-    static bool isSupported();
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> create();
+    static bool isSupported(const GLDisplay&);
+    WEBCORE_EXPORT static std::unique_ptr<GLFence> create(const GLDisplay&);
 #if OS(UNIX)
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> createExportable();
-    WEBCORE_EXPORT static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
+    WEBCORE_EXPORT static std::unique_ptr<GLFence> createExportable(const GLDisplay&);
+    WEBCORE_EXPORT static std::unique_ptr<GLFence> importFD(const GLDisplay&, WTF::UnixFileDescriptor&&);
 #endif
     virtual ~GLFence() = default;
 
@@ -50,14 +49,6 @@ public:
 
 protected:
     GLFence() = default;
-
-    struct Capabilities {
-        bool eglSupported { false };
-        bool eglServerWaitSupported { false };
-        bool eglExportableSupported { false };
-        bool glSupported { false };
-    };
-    static const Capabilities& capabilities();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.cpp
@@ -21,8 +21,7 @@
 #include "GLFenceEGL.h"
 
 #if HAVE(GL_FENCE)
-
-#include "PlatformDisplay.h"
+#include "GLDisplay.h"
 #include <wtf/Vector.h>
 
 #if USE(LIBEPOXY)
@@ -35,11 +34,10 @@
 
 namespace WebCore {
 
-static std::unique_ptr<GLFence> createEGLFence(EGLenum type, const Vector<EGLAttrib>& attributes)
+static std::unique_ptr<GLFence> createEGLFence(const GLDisplay& display, EGLenum type, const Vector<EGLAttrib>& attributes)
 {
     EGLSync sync = nullptr;
-    auto& display = PlatformDisplay::sharedDisplay();
-    if (display.eglCheckVersion(1, 5))
+    if (display.checkVersion(1, 5))
         sync = eglCreateSync(display.eglDisplay(), type, attributes.isEmpty() ? nullptr : attributes.span().data());
     else {
         Vector<EGLint> intAttributes = attributes.map<Vector<EGLint>>([] (EGLAttrib value) {
@@ -57,32 +55,33 @@ static std::unique_ptr<GLFence> createEGLFence(EGLenum type, const Vector<EGLAtt
 #else
     bool isExportable = false;
 #endif
-    return makeUnique<GLFenceEGL>(sync, isExportable);
+    return makeUnique<GLFenceEGL>(display, sync, isExportable);
 }
 
-std::unique_ptr<GLFence> GLFenceEGL::create()
+std::unique_ptr<GLFence> GLFenceEGL::create(const GLDisplay& display)
 {
-    return createEGLFence(EGL_SYNC_FENCE_KHR, { });
+    return createEGLFence(display, EGL_SYNC_FENCE_KHR, { });
 }
 
 #if OS(UNIX)
-std::unique_ptr<GLFence> GLFenceEGL::createExportable()
+std::unique_ptr<GLFence> GLFenceEGL::createExportable(const GLDisplay& display)
 {
-    return createEGLFence(EGL_SYNC_NATIVE_FENCE_ANDROID, { });
+    return createEGLFence(display, EGL_SYNC_NATIVE_FENCE_ANDROID, { });
 }
 
-std::unique_ptr<GLFence> GLFenceEGL::importFD(UnixFileDescriptor&& fd)
+std::unique_ptr<GLFence> GLFenceEGL::importFD(const GLDisplay& display, UnixFileDescriptor&& fd)
 {
     Vector<EGLAttrib> attributes = {
         EGL_SYNC_NATIVE_FENCE_FD_ANDROID, fd.release(),
         EGL_NONE
     };
-    return createEGLFence(EGL_SYNC_NATIVE_FENCE_ANDROID, attributes);
+    return createEGLFence(display, EGL_SYNC_NATIVE_FENCE_ANDROID, attributes);
 }
 #endif
 
-GLFenceEGL::GLFenceEGL(EGLSyncKHR sync, [[maybe_unused]] bool isExportable)
-    : m_sync(sync)
+GLFenceEGL::GLFenceEGL(const GLDisplay& display, EGLSyncKHR sync, [[maybe_unused]] bool isExportable)
+    : m_display(display)
+    , m_sync(sync)
 #if OS(UNIX)
     , m_isExportable(isExportable)
 #endif
@@ -91,34 +90,42 @@ GLFenceEGL::GLFenceEGL(EGLSyncKHR sync, [[maybe_unused]] bool isExportable)
 
 GLFenceEGL::~GLFenceEGL()
 {
-    auto& display = PlatformDisplay::sharedDisplay();
-    if (display.eglCheckVersion(1, 5))
-        eglDestroySync(display.eglDisplay(), m_sync);
+    auto display = m_display.get();
+    if (!display)
+        return;
+
+    if (display->checkVersion(1, 5))
+        eglDestroySync(display->eglDisplay(), m_sync);
     else
-        eglDestroySyncKHR(display.eglDisplay(), m_sync);
+        eglDestroySyncKHR(display->eglDisplay(), m_sync);
 }
 
 void GLFenceEGL::clientWait()
 {
-    auto& display = PlatformDisplay::sharedDisplay();
-    if (display.eglCheckVersion(1, 5))
-        eglClientWaitSync(display.eglDisplay(), m_sync, 0, EGL_FOREVER);
+    auto display = m_display.get();
+    if (!display)
+        return;
+
+    if (display->checkVersion(1, 5))
+        eglClientWaitSync(display->eglDisplay(), m_sync, 0, EGL_FOREVER);
     else
-        eglClientWaitSyncKHR(display.eglDisplay(), m_sync, 0, EGL_FOREVER_KHR);
+        eglClientWaitSyncKHR(display->eglDisplay(), m_sync, 0, EGL_FOREVER_KHR);
 }
 
 void GLFenceEGL::serverWait()
 {
-    if (!capabilities().eglServerWaitSupported) {
-        clientWait();
+    auto display = m_display.get();
+    if (!display)
         return;
-    }
 
-    auto& display = PlatformDisplay::sharedDisplay();
-    if (display.eglCheckVersion(1, 5))
-        eglWaitSync(display.eglDisplay(), m_sync, 0);
-    else
-        eglWaitSyncKHR(display.eglDisplay(), m_sync, 0);
+    if (display->checkVersion(1, 5))
+        eglWaitSync(display->eglDisplay(), m_sync, 0);
+    else {
+        if (display->extensions().KHR_wait_sync)
+            eglWaitSyncKHR(display->eglDisplay(), m_sync, 0);
+        else
+            eglClientWaitSyncKHR(display->eglDisplay(), m_sync, 0, EGL_FOREVER_KHR);
+    }
 }
 
 #if OS(UNIX)
@@ -127,7 +134,11 @@ UnixFileDescriptor GLFenceEGL::exportFD()
     if (!m_isExportable)
         return { };
 
-    return UnixFileDescriptor { eglDupNativeFenceFDANDROID(PlatformDisplay::sharedDisplay().eglDisplay(), m_sync), UnixFileDescriptor::Adopt };
+    auto display = m_display.get();
+    if (!display)
+        return { };
+
+    return UnixFileDescriptor { eglDupNativeFenceFDANDROID(display->eglDisplay(), m_sync), UnixFileDescriptor::Adopt };
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
+++ b/Source/WebCore/platform/graphics/egl/GLFenceEGL.h
@@ -22,6 +22,7 @@
 #if HAVE(GL_FENCE)
 
 #include "GLFence.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 
 typedef void* EGLSync;
 
@@ -29,12 +30,12 @@ namespace WebCore {
 
 class GLFenceEGL final : public GLFence {
 public:
-    static std::unique_ptr<GLFence> create();
+    static std::unique_ptr<GLFence> create(const GLDisplay&);
 #if OS(UNIX)
-    static std::unique_ptr<GLFence> createExportable();
-    static std::unique_ptr<GLFence> importFD(WTF::UnixFileDescriptor&&);
+    static std::unique_ptr<GLFence> createExportable(const GLDisplay&);
+    static std::unique_ptr<GLFence> importFD(const GLDisplay&, WTF::UnixFileDescriptor&&);
 #endif
-    GLFenceEGL(EGLSync, bool);
+    GLFenceEGL(const GLDisplay&, EGLSync, bool);
     virtual ~GLFenceEGL();
 
 private:
@@ -44,6 +45,7 @@ private:
     WTF::UnixFileDescriptor exportFD() override;
 #endif
 
+    ThreadSafeWeakPtr<GLDisplay> m_display;
     EGLSync m_sync { nullptr };
 #if OS(UNIX)
     bool m_isExportable { false };

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -234,7 +234,7 @@ void GraphicsContextGLTextureMapperGBM::prepareForDisplay()
         fenceFD = createExportedFence();
         if (!fenceFD) {
             GL_Flush();
-            fence = GLFence::create();
+            fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
         }
     });
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -1060,10 +1060,11 @@ inline std::unique_ptr<GLFence> createAcceleratedRenderingFence(T object)
 
     grContext->flush(object);
 
-    if (GLFence::isSupported()) {
+    auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
+    if (GLFence::isSupported(glDisplay)) {
         grContext->submit(GrSyncCpu::kNo);
 
-        if (auto fence = GLFence::create())
+        if (auto fence = GLFence::create(glDisplay))
             return fence;
     }
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -110,7 +110,8 @@ void ImageBufferSkiaAcceleratedBackend::prepareForDisplay()
     if (!image)
         return;
 
-    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(), GLFence::create()));
+    auto fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
+    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferNativeImage::create(image.releaseNonNull(), WTFMove(fence)));
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -385,7 +385,8 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
     if (contextAttributes().alpha)
         flags.add(TextureMapperFlags::ShouldBlend);
     auto fboSize = getInternalFramebufferSize();
-    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferRGB::create(m_compositorTextureID, fboSize, flags, GLFence::create()));
+    auto fence = GLFence::create(PlatformDisplay::sharedDisplay().glDisplay());
+    m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferRGB::create(m_compositorTextureID, fboSize, flags, WTFMove(fence)));
 #endif
 }
 
@@ -402,6 +403,15 @@ bool GraphicsContextGLTextureMapperANGLE::makeCurrentImpl()
 bool GraphicsContextGLTextureMapperANGLE::unmakeCurrentImpl()
 {
     return !!EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+}
+
+unsigned GraphicsContextGLTextureMapperANGLE::glVersion() const
+{
+    if (!m_version) {
+        auto* versionString = byteCast<char>(GL_GetString(GL_VERSION));
+        m_version = GLContext::versionFromString(versionString);
+    }
+    return m_version;
 }
 
 #if ENABLE(WEBXR)

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -76,9 +76,11 @@ private:
     GLContextWrapper::Type type() const override;
     bool makeCurrentImpl() override;
     bool unmakeCurrentImpl() override;
+    unsigned glVersion() const override;
 
     GCGLuint m_compositorTexture { 0 };
     bool m_isCompositorTextureInitialized { false };
+    mutable unsigned m_version { 0 };
 
 #if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GCGLuint m_textureID { 0 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -263,7 +263,7 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
     waitForContentsIfNeeded();
 
     if (m_fenceFD) {
-        if (auto fence = GLFence::importFD(WTFMove(m_fenceFD)))
+        if (auto fence = GLFence::importFD(PlatformDisplay::sharedDisplay().glDisplay(), WTFMove(m_fenceFD)))
             fence->serverWait();
     }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -72,7 +72,7 @@ CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeI
 
     auto* grContext = display.skiaGrContext();
     RELEASE_ASSERT(grContext);
-    grContext->flushAndSubmit(GLFence::isSupported() ? GrSyncCpu::kNo : GrSyncCpu::kYes);
+    grContext->flushAndSubmit(GLFence::isSupported(display.glDisplay()) ? GrSyncCpu::kNo : GrSyncCpu::kYes);
 
     unsigned textureID = 0;
     GrBackendTexture backendTexture;
@@ -84,7 +84,7 @@ CoordinatedPlatformLayerBufferNativeImage::CoordinatedPlatformLayerBufferNativeI
     if (!textureID)
         return;
 
-    m_buffer = CoordinatedPlatformLayerBufferRGB::create(textureID, m_image->size(), m_flags, GLFence::create());
+    m_buffer = CoordinatedPlatformLayerBufferRGB::create(textureID, m_image->size(), m_flags, GLFence::create(display.glDisplay()));
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -221,9 +221,10 @@ bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
 void CoordinatedAcceleratedTileBuffer::completePainting()
 {
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    if (GLFence::isSupported()) {
+    auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
+    if (GLFence::isSupported(glDisplay)) {
         grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);
-        m_fence = GLFence::create();
+        m_fence = GLFence::create(glDisplay);
         if (!m_fence)
             grContext->submit(GrSyncCpu::kYes);
     } else

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -179,7 +179,7 @@ void AcceleratedSurface::RenderTargetShareableBuffer::didRenderFrame(Vector<IntR
 void AcceleratedSurface::RenderTargetShareableBuffer::willRenderFrame()
 {
     if (m_releaseFenceFD) {
-        if (auto fence = GLFence::importFD(WTFMove(m_releaseFenceFD)))
+        if (auto fence = GLFence::importFD(PlatformDisplay::sharedDisplay().glDisplay(), WTFMove(m_releaseFenceFD)))
             fence->serverWait();
     }
 
@@ -190,11 +190,12 @@ void AcceleratedSurface::RenderTargetShareableBuffer::willRenderFrame()
 
 std::unique_ptr<GLFence> AcceleratedSurface::RenderTargetShareableBuffer::createRenderingFence(bool useExplicitSync) const
 {
+    auto& display = PlatformDisplay::sharedDisplay().glDisplay();
     if (useExplicitSync && supportsExplicitSync()) {
-        if (auto fence = GLFence::createExportable())
+        if (auto fence = GLFence::createExportable(display))
             return fence;
     }
-    return GLFence::create();
+    return GLFence::create(display);
 }
 
 void AcceleratedSurface::RenderTargetShareableBuffer::sync(bool useExplicitSync)


### PR DESCRIPTION
#### f36176a1c425678688779b55440ecc8cddbfb929
<pre>
[GTK][WPE] Do not use PlartformDisplay::sharedDisplay in GLFenceEGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=297315">https://bugs.webkit.org/show_bug.cgi?id=297315</a>

Reviewed by Miguel Gomez.

Create the GLFence with a GLDisplay and make GLFenceEGL keep a weak
reference. This allows to use GLFence for other displays too. This patch
removes the GLFence capabilities, since we can check all the
capabilities from the GLDisplay or current context.

Canonical link: <a href="https://commits.webkit.org/298879@main">https://commits.webkit.org/298879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5255de01a29725afaa158835b600b6a231cfc40b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88343 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42837 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; 11 flakes 27 failures; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125515 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97050 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43568 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96842 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39150 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18673 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48682 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->