### PR TITLE
[GTK][WPE][OpenXR] Add immersive mode API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImmersiveMode.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImmersiveMode.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "WebKitTestServer.h"
+#include "WebViewTest.h"
+
+static WebKitTestServer* kHttpsServer = nullptr;
+
+static const char indexHTML[] =
+"<html><body>"
+"<input id='enterXR' type=\"button\" value=\"click to enter experience\"/>"
+"<script>"
+"document.getElementById('enterXR').addEventListener('click', () => {"
+"  navigator.xr.requestSession('immersive-vr').then(session => {"
+"    console.log('XR session started');"
+"    session.addEventListener('end', (event) => {"
+"        console.log('XR session ended');"
+"    });"
+"  }).catch(err => console.error(`XR session failed to start: ${err}`));"
+"});"
+"</script></body></html>";
+
+class ImmersiveModeTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(ImmersiveModeTest);
+
+    static void isImmersiveModeEnabledChanged(GObject*, GParamSpec*, ImmersiveModeTest* test)
+    {
+        g_signal_handlers_disconnect_by_func(test->webView(), reinterpret_cast<void*>(isImmersiveModeEnabledChanged), test);
+        g_main_loop_quit(test->m_mainLoop);
+    }
+
+    static gboolean permissionRequestCallback(WebKitWebView*, WebKitPermissionRequest *request, ImmersiveModeTest* test)
+    {
+        g_assert_true(WEBKIT_IS_XR_PERMISSION_REQUEST(request));
+        g_assert_true(test->m_isExpectingPermissionRequest);
+
+        webkit_permission_request_allow(request);
+
+        g_signal_handlers_disconnect_by_func(test->webView(), reinterpret_cast<void*>(permissionRequestCallback), test);
+
+        return TRUE;
+    }
+
+    void waitUntilIsImmersiveModeEnabledChanged()
+    {
+        g_signal_connect(m_webView.get(), "notify::is-immersive-mode-enabled", G_CALLBACK(isImmersiveModeEnabledChanged), this);
+        g_main_loop_run(m_mainLoop);
+    }
+
+    void leaveImmersiveModeAndWaitUntilImmersiveModeChanged()
+    {
+        webkit_web_view_leave_immersive_mode(m_webView.get());
+
+        if (webkit_web_view_is_immersive_mode_enabled(m_webView.get()))
+            waitUntilIsImmersiveModeEnabledChanged();
+    }
+
+    void clickOnEnterXRButtonAndWaitUntilImmersiveModeChanged()
+    {
+        g_signal_connect(m_webView.get(), "permission-request", G_CALLBACK(permissionRequestCallback), this);
+
+        m_isExpectingPermissionRequest = true;
+
+        runJavaScriptAndWaitUntilFinished("document.getElementById('enterXR').focus()", nullptr);
+        runJavaScriptAndWaitUntilFinished("document.getElementById('enterXR').click();", nullptr);
+
+        if (!webkit_web_view_is_immersive_mode_enabled(m_webView.get()))
+            waitUntilIsImmersiveModeEnabledChanged();
+    }
+
+    bool m_isExpectingPermissionRequest { false };
+};
+
+#if USE(SOUP2)
+static void serverCallback(SoupServer*, SoupMessage* message, const char* path, GHashTable*, SoupClientContext*, gpointer)
+#else
+static void serverCallback(SoupServer*, SoupServerMessage* message, const char* path, GHashTable*, gpointer)
+#endif
+{
+    g_assert(soup_server_message_get_method(message) == SOUP_METHOD_GET);
+
+    if (g_str_equal(path, "/xr-session/")) {
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+
+        auto* responseBody = soup_server_message_get_response_body(message);
+        soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, indexHTML, strlen(indexHTML));
+        soup_message_body_complete(responseBody);
+    } else
+        g_assert_not_reached();
+}
+
+static void testWebKitImmersiveModeLeaveImmersiveModeAndWaitUntilImmersiveModeChanged(ImmersiveModeTest* test, gconstpointer)
+{
+    if (!g_getenv("WITH_OPENXR_RUNTIME")) {
+        g_test_skip("Unable to run without an OpenXR runtime");
+        return;
+    }
+
+    WebViewTest::NetworkPolicyGuard guard(test, WEBKIT_TLS_ERRORS_POLICY_IGNORE);
+
+    g_assert_false(webkit_web_view_is_immersive_mode_enabled(test->m_webView.get()));
+
+    test->loadURI(kHttpsServer->getURIForPath("/xr-session/").data());
+    test->waitUntilLoadFinished();
+    test->showInWindow();
+
+    test->clickOnEnterXRButtonAndWaitUntilImmersiveModeChanged();
+    g_assert_true(webkit_web_view_is_immersive_mode_enabled(test->m_webView.get()));
+
+    test->leaveImmersiveModeAndWaitUntilImmersiveModeChanged();
+    g_assert_false(webkit_web_view_is_immersive_mode_enabled(test->m_webView.get()));
+}
+
+void beforeAll()
+{
+    kHttpsServer = new WebKitTestServer(WebKitTestServer::ServerHTTPS);
+    kHttpsServer->run(serverCallback);
+
+    ImmersiveModeTest::add("WebKitImmersiveMode", "leave-immersive-mode", testWebKitImmersiveModeLeaveImmersiveModeAndWaitUntilImmersiveModeChanged);
+}
+
+void afterAll()
+{
+    delete kHttpsServer;
+}

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -168,6 +168,10 @@ ADD_WK2_TEST(TestDOMElement ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestDOME
 ADD_WK2_TEST(TestGeolocationManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestGeolocationManager.cpp)
 ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp)
 
+if (ENABLE_WEBXR AND USE_OPENXR)
+    ADD_WK2_TEST(TestWebKitImmersiveMode ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImmersiveMode.cpp)
+endif ()
+
 if (ENABLE_WK_WEB_EXTENSIONS)
     ADD_WK2_TEST(TestWebKitWebExtensionMatchPattern ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp)
 endif ()

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -516,5 +516,12 @@
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/284812"}}
             }
         }
+    },
+    "TestWebKitImmersiveMode": {
+        "subtests": {
+            "/webkit/WebKitImmersiveMode/leave-immersive-mode": {
+                "expected": {"all" : {"status": ["SKIP"], "bug": "webkit.org/b/297261"}}
+            }
+        }
     }
 }


### PR DESCRIPTION
#### ceac33c0bd54474ec182f9ba874d7a232c8a9916
<pre>
[GTK][WPE][OpenXR] Add immersive mode API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=297320">https://bugs.webkit.org/show_bug.cgi?id=297320</a>

Reviewed by Adrian Perez de Castro.

This adds an API test that validates entering an immersive session,
querying the immersive session mode and leving it.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitImmersiveMode.cpp: Added.
(ImmersiveModeTest::isImmersiveModeEnabledChanged):
(ImmersiveModeTest::permissionRequestCallback):
(ImmersiveModeTest::waitUntilIsImmersiveModeEnabledChanged):
(ImmersiveModeTest::leaveImmersiveModeAndWaitUntilImmersiveModeChanged):
(ImmersiveModeTest::clickOnEnterXRButtonAndWaitUntilImmersiveModeChanged):
(serverCallback):
(testWebKitImmersiveModeLeaveImmersiveModeAndWaitUntilImmersiveModeChanged):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/299623@main">https://commits.webkit.org/299623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5c8e0f51b1d2c150639bdfa119dc121b017bbb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25353 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128859 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99446 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44715 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43097 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46395 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->