### PR TITLE
Ignore gnu-folding-constant warning in testapi.c

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1196,14 +1196,18 @@ static void checkJSStringOOBUTF8(void)
     const size_t outCStringSize = cStringSize + sourceCStringSize;
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_CLANG_WARNINGS_BEGIN("gnu-folding-constant")
     char sourceCString[sourceCStringSize];
+IGNORE_CLANG_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_CLANG_WARNINGS_BEGIN("gnu-folding-constant")
     char outCString[outCStringSize];
+IGNORE_CLANG_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(outCString, 0x13, sizeof(outCString));
 
@@ -1231,7 +1235,9 @@ static void checkJSStringOOBUTF16(void)
     const size_t outCStringSize = cStringSize + sourceCStringSize;
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_CLANG_WARNINGS_BEGIN("gnu-folding-constant")
     char sourceCString[sourceCStringSize];
+IGNORE_CLANG_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
@@ -1243,7 +1249,9 @@ IGNORE_WARNINGS_END
     sourceCString[6] = '\x81';
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_CLANG_WARNINGS_BEGIN("gnu-folding-constant")
     char outCString[outCStringSize];
+IGNORE_CLANG_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(outCString, 0x13, sizeof(outCString));
 
@@ -1271,7 +1279,9 @@ static void checkJSStringOOBUTF16AtEnd(void)
     const size_t outCStringSize = cStringSize + sourceCStringSize;
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_CLANG_WARNINGS_BEGIN("gnu-folding-constant")
     char sourceCString[sourceCStringSize];
+IGNORE_CLANG_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
@@ -1283,7 +1293,9 @@ IGNORE_WARNINGS_END
     sourceCString[20] = '\x81';
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_CLANG_WARNINGS_BEGIN("gnu-folding-constant")
     char outCString[outCStringSize];
+IGNORE_CLANG_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(outCString, 0x13, sizeof(outCString));
 


### PR DESCRIPTION
#### 279f45f8887b0ba677a538c4114b4032107a4aa5
<pre>
Ignore gnu-folding-constant warning in testapi.c
<a href="https://bugs.webkit.org/show_bug.cgi?id=297321">https://bugs.webkit.org/show_bug.cgi?id=297321</a>

Reviewed by NOBODY (OOPS!).

The corresponding gcc warning was already ignored
but not the clang one.

* Source/JavaScriptCore/API/tests/testapi.c:
(checkJSStringOOBUTF8):
(checkJSStringOOBUTF16):
(checkJSStringOOBUTF16AtEnd):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/279f45f8887b0ba677a538c4114b4032107a4aa5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122144 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88193 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42732 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65826 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108197 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125294 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114616 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96711 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24877 "Failed to checkout and rebase branch from PR 49324") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19867 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38928 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48461 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143313 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42336 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36946 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->