### PR TITLE
[GStreamer] Fix changing audio output sink when output element is not a bin

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -4581,17 +4581,31 @@ void MediaPlayerPrivateGStreamer::checkPlayingConsistency()
     }
 }
 
-static void applyAudioSinkDevice(GstElement* audioSinkBin, const String& deviceId)
+bool MediaPlayerPrivateGStreamer::applyAudioSinkDevice(GstElement* audioSink, const String& deviceId)
 {
-    for (auto* element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_sinks(GST_BIN_CAST(audioSinkBin)))) {
-        // pulsesink and alsasink have a "device" property, whilst pipewiresink has "target-object"
-        if (gstElementMatchesFactoryAndHasProperty(element, "pulsesink"_s, "device"_s) || gstElementMatchesFactoryAndHasProperty(element, "alsasink"_s, "device"_s))
-            g_object_set(element, "device", deviceId.utf8().data(), nullptr);
-        else if (gstElementMatchesFactoryAndHasProperty(element, "pipewiresink"_s, "target-object"_s))
-            g_object_set(element, "target-object", deviceId.utf8().data(), nullptr);
-        else if (GST_IS_BIN(element))
-            applyAudioSinkDevice(element, deviceId);
+    bool changed = false;
+
+    if (GST_IS_BIN(audioSink)) {
+        for (auto* element : GstIteratorAdaptor<GstElement>(gst_bin_iterate_sinks(GST_BIN_CAST(audioSink)))) {
+            if (applyAudioSinkDevice(element, deviceId))
+                changed = true;
+        }
+        return changed;
     }
+
+    // pulsesink and alsasink have a "device" property, whilst pipewiresink has "target-object"
+    if (gstElementMatchesFactoryAndHasProperty(audioSink, "pulsesink"_s, "device"_s) || gstElementMatchesFactoryAndHasProperty(audioSink, "alsasink"_s, "device"_s)) {
+        GST_DEBUG_OBJECT(pipeline(), "Setting '%s' property 'device' to '%s'", GST_OBJECT_NAME(audioSink), deviceId.utf8().data());
+        g_object_set(audioSink, "device", deviceId.utf8().data(), nullptr);
+        changed = true;
+    } else if (gstElementMatchesFactoryAndHasProperty(audioSink, "pipewiresink"_s, "target-object"_s)) {
+        GST_DEBUG_OBJECT(pipeline(), "Setting '%s' property 'target-object' to '%s'", GST_OBJECT_NAME(audioSink), deviceId.utf8().data());
+        g_object_set(audioSink, "target-object", deviceId.utf8().data(), nullptr);
+        changed = true;
+    } else
+        GST_DEBUG_OBJECT(pipeline(), "Skiping element '%s'", GST_OBJECT_NAME(audioSink));
+
+    return changed;
 }
 
 void MediaPlayerPrivateGStreamer::audioOutputDeviceChanged()
@@ -4600,8 +4614,16 @@ void MediaPlayerPrivateGStreamer::audioOutputDeviceChanged()
     if (!player)
         return;
 
+    auto* sink = audioSink();
+    if (!sink) {
+        GST_DEBUG_OBJECT(pipeline(), "No audio sink, skipping audio output device change");
+        return;
+    }
+
     auto deviceId = player->audioOutputDeviceId();
-    applyAudioSinkDevice(m_audioSink.get(), deviceId);
+    GST_DEBUG_OBJECT(pipeline(), "Switching to audio output device '%s'", deviceId.utf8().data());
+    [[maybe_unused]] bool succeeded = applyAudioSinkDevice(sink, deviceId);
+    GST_DEBUG_OBJECT(pipeline(), "%s to audio output device '%s'", succeeded ? "Changed" : "Could not change", deviceId.utf8().data());
 }
 
 String MediaPlayerPrivateGStreamer::codecForStreamId(TrackID streamId)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -645,6 +645,8 @@ private:
 
 private:
     std::optional<VideoFrameMetadata> videoFrameMetadata() final;
+    bool applyAudioSinkDevice(GstElement* audioSink, const String& deviceId);
+
     uint64_t m_sampleCount { 0 };
     uint64_t m_lastVideoFrameMetadataSampleCount { 0 };
     mutable PlatformTimeRanges m_buffered;


### PR DESCRIPTION
#### b0dfcc4fc6ee43622afaaeab5b9aecf40ab09dd7
<pre>
[GStreamer] Fix changing audio output sink when output element is not a bin
<a href="https://bugs.webkit.org/show_bug.cgi?id=297323">https://bugs.webkit.org/show_bug.cgi?id=297323</a>

Reviewed by NOBODY (OOPS!).

The applyAudioSinkDevice() function assumed that the passed element
would always be a bin, which would prevent switching audio outputs
correctly when MediaPlayerPrivateGStreamer::audioSink() returns a
non-bin element. This reorganizes the code to allow passing non-bin
elements.

While at it, sprinkle some debug logging and turn applyAudioSinkDevice()
into a method to allow doing so.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::applyAudioSinkDevice):
(WebCore::MediaPlayerPrivateGStreamer::audioOutputDeviceChanged):
(WebCore::applyAudioSinkDevice): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0dfcc4fc6ee43622afaaeab5b9aecf40ab09dd7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66659 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88208 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42747 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65844 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96941 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96725 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48479 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->