### PR TITLE
Prevent DisplayListRecorder from emptying the state stack

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -124,12 +124,12 @@ void Recorder::updateStateForSave(GraphicsContextState::Purpose purpose)
 
 bool Recorder::updateStateForRestore(GraphicsContextState::Purpose purpose)
 {
+    if (m_stateStack.size() <= 1)
+        return false;
+
     ASSERT(purpose == GraphicsContextState::Purpose::SaveRestore);
     appendStateChangeItemIfNecessary();
     GraphicsContext::restore(purpose);
-
-    if (!m_stateStack.size())
-        return false;
 
     m_stateStack.removeLast();
     return true;
@@ -194,12 +194,15 @@ void Recorder::updateStateForBeginTransparencyLayer(CompositeOperator compositeO
     m_stateStack.append(m_stateStack.last().cloneForTransparencyLayer());
 }
 
-void Recorder::updateStateForEndTransparencyLayer()
+bool Recorder::updateStateForEndTransparencyLayer()
 {
+    if (stateStack().size() <= 1)
+        return false;
     GraphicsContext::endTransparencyLayer();
     appendStateChangeItemIfNecessary();
     m_stateStack.removeLast();
     GraphicsContext::restore(GraphicsContextState::Purpose::TransparencyLayer);
+    return true;
 }
 
 void Recorder::updateStateForResetClip()

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -112,7 +112,7 @@ protected:
     WEBCORE_EXPORT void updateStateForSetCTM(const AffineTransform&);
     WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(float opacity);
     WEBCORE_EXPORT void updateStateForBeginTransparencyLayer(CompositeOperator, BlendMode);
-    WEBCORE_EXPORT void updateStateForEndTransparencyLayer();
+    [[nodiscard]] WEBCORE_EXPORT bool updateStateForEndTransparencyLayer();
     WEBCORE_EXPORT void updateStateForResetClip();
     WEBCORE_EXPORT void updateStateForClip(const FloatRect&);
     WEBCORE_EXPORT void updateStateForClipRoundedRect(const FloatRoundedRect&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -264,8 +264,8 @@ void RecorderImpl::beginTransparencyLayer(CompositeOperator compositeOperator, B
 
 void RecorderImpl::endTransparencyLayer()
 {
-    updateStateForEndTransparencyLayer();
-    m_items.append(EndTransparencyLayer());
+    if (updateStateForEndTransparencyLayer())
+        m_items.append(EndTransparencyLayer());
 }
 
 void RecorderImpl::drawRect(const FloatRect& rect, float lineWidth)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -365,8 +365,8 @@ void RemoteDisplayListRecorderProxy::beginTransparencyLayer(CompositeOperator co
 
 void RemoteDisplayListRecorderProxy::endTransparencyLayer()
 {
-    updateStateForEndTransparencyLayer();
-    send(Messages::RemoteDisplayListRecorder::EndTransparencyLayer());
+    if (updateStateForEndTransparencyLayer())
+        send(Messages::RemoteDisplayListRecorder::EndTransparencyLayer());
 }
 
 void RemoteDisplayListRecorderProxy::drawRect(const FloatRect& rect, float width)


### PR DESCRIPTION
#### f81876e4fa729dc843104242b0a84dbf2a044776
<pre>
Prevent DisplayListRecorder from emptying the state stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=297324">https://bugs.webkit.org/show_bug.cgi?id=297324</a>
<a href="https://rdar.apple.com/158214509">rdar://158214509</a>

Reviewed by Kimmo Kinnunen.

Adds checks to DisplayList Recorder to prevent it from completely emptying it&apos;s state stack.
This prevents crashes in the Vector overflow handler in subsequent uses of m_statestack.last().

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::updateStateForRestore):
(WebCore::DisplayList::Recorder::updateStateForEndTransparencyLayer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::endTransparencyLayer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::endTransparencyLayer):

Canonical link: <a href="https://commits.webkit.org/298678@main">https://commits.webkit.org/298678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c940a0e570f5ae10a04bac64a6fea8a3f1c3244

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66645 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ea19e0a-234a-433c-bea2-ee265f9f4fb0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b63598e-b525-41f5-9141-3a1213368db3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68608 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22304 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125299 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96930 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96714 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19899 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38933 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48466 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42341 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->