### PR TITLE
Web Inspector: (REGRESSION 297671@main) Oversized font-sizes in Audits and Graphics tabs

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestCaseContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestCaseContentView.css
@@ -39,7 +39,7 @@
     -webkit-backdrop-filter: blur(20px);
 }
 
-.content-view-container > .content-view.audit-test-case.manager-editing > header h1 > img {
+.content-view-container > .content-view.audit-test-case.manager-editing > header > .information > h1 > img {
     width: 0.75em;
     min-width: 12px;
     height: 0.75em;
@@ -65,12 +65,16 @@
     padding-inline-end: calc(var(--audit-test-horizontal-space) / 2);
 }
 
-.content-view.audit-test-case > header h1 {
+.content-view.audit-test-case > header > .information > h1 {
     display: flex;
     align-items: center;
 }
 
-.content-view.audit-test-case > header h1 > img {
+section > .content-view.audit-test-case > header > .information > h1 {
+    font-size: 1.5em;
+}
+
+.content-view.audit-test-case > header > .information > h1 > img {
     width: 1em;
     height: 1em;
     min-width: 16px;
@@ -78,7 +82,7 @@
     margin-inline-end: 0.25em;
 }
 
-.content-view.audit-test-case.manager-editing.disabled:not(.editable) > header h1 > img {
+.content-view.audit-test-case.manager-editing.disabled:not(.editable) > header > .information > h1 > img {
     opacity: 0.3;
     pointer-events: none;
 }
@@ -124,8 +128,13 @@
     margin-top: var(--audit-test-vertical-space);
 }
 
-.content-view.audit-test-case > section h1 {
+.content-view.audit-test-case > section > :is(.dom-nodes, .errors) > h1 {
     margin-bottom: 4px;
+    font-size: 1.5em;
+}
+
+section > .content-view.audit-test-case > section > :is(.dom-nodes, .errors) > h1 {
+    font-size: 1.17em;
 }
 
 .content-view.audit-test-case > section table {
@@ -165,7 +174,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .content-view.audit-test-case.manager-editing > header h1 > img {
+    .content-view.audit-test-case.manager-editing > header > .information > h1 > img {
         filter: var(--filter-invert);
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
@@ -33,7 +33,7 @@
     border-bottom: 1px solid var(--border-color);
 }
 
-.content-view-container > .content-view.audit-test > header h1 {
+.content-view-container > .content-view.audit-test > header > .information > h1 {
     font-size: 2em;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/GraphicsOverviewContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GraphicsOverviewContentView.css
@@ -54,6 +54,7 @@
 
 .content-view.graphics-overview > section > .header > h1 {
     margin: 0;
+    font-size: 1.5em;
 }
 
 .content-view.graphics-overview > section > .header > .navigation-bar {


### PR DESCRIPTION
#### 8f765ec201581048d2116c0ed3720dad069242b6
<pre>
Web Inspector: (REGRESSION 297671@main) Oversized font-sizes in Audits and Graphics tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=297333">https://bugs.webkit.org/show_bug.cgi?id=297333</a>
<a href="https://rdar.apple.com/158226427">rdar://158226427</a>

Reviewed by BJ Burg.

Some User Agent styles for headings nested in `&lt;section&gt;` elements were removed in <a href="https://commits.webkit.org/297671@main">https://commits.webkit.org/297671@main</a>

The removed styles basically adjusted the heading styles down for each nesting level.
For example: `section h1` looks like `h2`, `section section h1` looks like `h3`.

This patch replicates the removed styles for the DOM structure in the Audits and Graphics tabs.

Drive-by: replace descendant element selectors with explicit direct descendant element selectors
to match Web Inspector style, clarify the DOM structure in CSS, and avoid unintentional styles.

* Source/WebInspectorUI/UserInterface/Views/AuditTestCaseContentView.css:
(.content-view-container &gt; .content-view.audit-test-case.manager-editing &gt; header &gt; .information &gt; h1 &gt; img):
(.content-view.audit-test-case &gt; header &gt; .information &gt; h1):
(section &gt; .content-view.audit-test-case &gt; header &gt; .information &gt; h1):
(.content-view.audit-test-case &gt; header &gt; .information &gt; h1 &gt; img):
(.content-view.audit-test-case.manager-editing.disabled:not(.editable) &gt; header &gt; .information &gt; h1 &gt; img):
(.content-view.audit-test-case &gt; section &gt; :is(.dom-nodes, .errors) &gt; h1):
(section &gt; .content-view.audit-test-case &gt; section &gt; :is(.dom-nodes, .errors) &gt; h1):
(@media (prefers-color-scheme: dark) .content-view.audit-test-case.manager-editing &gt; header &gt; .information &gt; h1 &gt; img):
(.content-view-container &gt; .content-view.audit-test-case.manager-editing &gt; header h1 &gt; img): Deleted.
(.content-view.audit-test-case &gt; header h1): Deleted.
(.content-view.audit-test-case &gt; header h1 &gt; img): Deleted.
(.content-view.audit-test-case.manager-editing.disabled:not(.editable) &gt; header h1 &gt; img): Deleted.
(.content-view.audit-test-case &gt; section h1): Deleted.
(@media (prefers-color-scheme: dark) .content-view.audit-test-case.manager-editing &gt; header h1 &gt; img): Deleted.
* Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css:
(.content-view-container &gt; .content-view.audit-test &gt; header &gt; .information &gt; h1):
(.content-view-container &gt; .content-view.audit-test &gt; header h1): Deleted.
* Source/WebInspectorUI/UserInterface/Views/GraphicsOverviewContentView.css:
(.content-view.graphics-overview &gt; section &gt; .header &gt; h1):

Canonical link: <a href="https://commits.webkit.org/298633@main">https://commits.webkit.org/298633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de18ad03fb213ba240753b56a30a99f929a575b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/116117 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/35778 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/26322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66672 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/36472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44366 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66672 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/119065 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/36472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/26322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/36472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/26322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/65855 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/36472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43011 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/44366 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43376 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/26322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24612 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26322 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/38957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/42898 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/48490 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42365 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45700 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44069 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->