### PR TITLE
Update UIKit_SPI.swiftinterface with accurate delegate methods

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface
+++ b/Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface
@@ -58,7 +58,9 @@ extension UIKit_SPI.UITextEffectView {
     @_Concurrency.MainActor public init(chunk: UIKit_SPI.UITextEffectTextChunk, view: UIKit_SPI.UITextEffectView, delegate: any UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate, fromColor: UIKit.UIColor = UIDirectionalLightEffectView.Configuration.pondering.fillColor)
     public protocol Delegate {
       func performReplacementAndGeneratePreview(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UIKit.UITargetedPreview?
+      func performAnimatedReplacement(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async
       @_Concurrency.MainActor func replacementEffectDidComplete(_ effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect)
+      func performReplacement(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async
     }
     public struct AnimationParameters {
       public let duration: Foundation.TimeInterval
@@ -70,6 +72,7 @@ extension UIKit_SPI.UITextEffectView {
 extension UIKit_SPI.UITextEffectView.ReplacementTextEffect.Delegate {
   public func performReplacementAndGeneratePreview(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -> UIKit.UITargetedPreview?
   public func performReplacement(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async
+  public func performAnimatedReplacement(for chunk: UIKit_SPI.UITextEffectTextChunk, effect: UIKit_SPI.UITextEffectView.ReplacementTextEffect, animation: UIKit_SPI.UITextEffectView.ReplacementTextEffect.AnimationParameters) async
 }
 extension UIKit_SPI.UITextEffectView {
   @_Concurrency.MainActor public class PonderingEffect : UIKit_SPI.UITextEffectView.TextEffect {


### PR DESCRIPTION
#### d364d35760edc06fa7c03c5a3ce0539a8dbb7204
<pre>
Update UIKit_SPI.swiftinterface with accurate delegate methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=297302">https://bugs.webkit.org/show_bug.cgi?id=297302</a>
<a href="https://rdar.apple.com/158176339">rdar://158176339</a>

Reviewed by Richard Robinson.

On internal builds, WKTextAnimationManager binds to these symbols from
UITextEffectView.ReplacementTextEffect.Delegate. These symbols
correspond to the unimplemented methods of the Delegate protocol, which
have default implementation provided via extensions:

    UIKit.UITextEffectView.ReplacementTextEffect.__allocating_init(chunk: UIKit.UITextEffectTextChunk, view: UIKit.UITextEffectView, delegate: UIKit.UITextEffectView.ReplacementTextEffect.Delegate, fromColor: __C.UIColor) -&gt; UIKit.UITextEffectView.ReplacementTextEffect
    method descriptor for UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performAnimatedReplacement(for: UIKit.UITextEffectTextChunk, effect: UIKit.UITextEffectView.ReplacementTextEffect, animation: UIKit.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -&gt; ()
    method descriptor for UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performReplacement(for: UIKit.UITextEffectTextChunk, effect: UIKit.UITextEffectView.ReplacementTextEffect, animation: UIKit.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -&gt; ()
    (extension in UIKit):UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performAnimatedReplacement(for: UIKit.UITextEffectTextChunk, effect: UIKit.UITextEffectView.ReplacementTextEffect, animation: UIKit.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -&gt; ()
    async function pointer to (extension in UIKit):UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performAnimatedReplacement(for: UIKit.UITextEffectTextChunk, effect: UIKit.UITextEffectView.ReplacementTextEffect, animation: UIKit.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -&gt; ()
    (extension in UIKit):UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performReplacement(for: UIKit.UITextEffectTextChunk, effect: UIKit.UITextEffectView.ReplacementTextEffect, animation: UIKit.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -&gt; ()
    async function pointer to (extension in UIKit):UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performReplacement(for: UIKit.UITextEffectTextChunk, effect: UIKit.UITextEffectView.ReplacementTextEffect, animation: UIKit.UITextEffectView.ReplacementTextEffect.AnimationParameters) async -&gt; ()
    UIKit.UITextEffectView.PonderingEffect.__allocating_init(chunk: UIKit.UITextEffectTextChunk, view: UIKit.UITextEffectView, lightConfiguration: UIKit.UIDirectionalLightEffectView.Configuration) -&gt; UIKit.UITextEffectView.PonderingEffect
    UIKit.UITextEffectView.__allocating_init(source: UIKit.UITextEffectViewSource) -&gt; UIKit.UITextEffectView

Because these are implicitly implemented, I believe they need to be
added to WKTextAnimationManager&apos;s witness table such that a function
that takes a ReplacementTextEffect.Delegate could be passed a
WKTextAnimationManager and call one of these default implementations.
This means that the open source code was probably broken due to missing
members. I noticed the issue because the type had a different SPI
footprint on internal vs. public builds.

Fix by adding the other protocol requirements to
UIKit_SPI.swiftinterface.

* Source/WebKit/Platform/spi/ios/UIKit_SPI.swiftinterface:

Canonical link: <a href="https://commits.webkit.org/298662@main">https://commits.webkit.org/298662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed36f9474ff951cbc59663b07745147fddaa6c78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66676 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b770862a-73e1-4686-94fd-736bf93d9aae) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88222 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42759 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b586174e-9e4f-4d25-b301-9f3efabf5298) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68633 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28218 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65859 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125327 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96954 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96738 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19900 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48494 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->