### PR TITLE
dNR: stop serializing rule identifiers with their actions and introduce a new action type instead

### DIFF
--- a/Source/WTF/wtf/PlatformEnableCocoa.h
+++ b/Source/WTF/wtf/PlatformEnableCocoa.h
@@ -1014,7 +1014,7 @@
 #define ENABLE_WK_WEB_EXTENSIONS 1
 #endif
 
-// When this is enabled, CurrentContentRuleListFileVersion, currentDeclarativeNetRequestRuleTranslatorVersion, and currentBackgroundContentListenerStateVersion need to be bumped.
+// When this is enabled, currentDeclarativeNetRequestRuleTranslatorVersion and currentBackgroundContentListenerStateVersion need to be bumped.
 #if !defined(ENABLE_DNR_ON_RULE_MATCHED_DEBUG)
 #define ENABLE_DNR_ON_RULE_MATCHED_DEBUG 0
 #endif

--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -63,10 +63,6 @@ uint32_t ContentExtension::findFirstIgnoreRule() const
         if (serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnorePreviousRulesAction, ActionData> || serializedActions[currentActionIndex] == WTF::alternativeIndexV<IgnoreFollowingRulesAction, ActionData>)
             return currentActionIndex;
         currentActionIndex += DeserializedAction::serializedLength(serializedActions, currentActionIndex);
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-        // FIXME: <rdar://157879177> We shouldn't unconditionally add 4 bytes here to accomodate identifiers, as all rule lists do not serialize identifiers.
-        currentActionIndex += sizeof(uint32_t);
-#endif
     }
     return std::numeric_limits<uint32_t>::max();
 }

--- a/Source/WebCore/contentextensions/ContentExtensionActions.h
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.h
@@ -233,6 +233,20 @@ struct WEBCORE_EXPORT RedirectAction {
     void applyToRequest(ResourceRequest&, const URL&);
 };
 
+struct ReportIdentifierAction {
+    double identifier;
+
+    ReportIdentifierAction isolatedCopy() const { return { identifier }; }
+    friend bool operator==(const ReportIdentifierAction&, const ReportIdentifierAction&) = default;
+    void serialize(Vector<uint8_t>& vector) const
+    {
+        vector.reserveCapacity(vector.size() + sizeof(identifier));
+        vector.append(asByteSpan(identifier));
+    }
+    static ReportIdentifierAction deserialize(std::span<const uint8_t> span) { return { reinterpretCastSpanStartTo<double>(span) }; }
+    static size_t serializedLength(std::span<const uint8_t>) { return sizeof(identifier); }
+};
+
 using ActionData = Variant<
     BlockLoadAction,
     BlockCookiesAction,
@@ -242,7 +256,8 @@ using ActionData = Variant<
     IgnoreFollowingRulesAction,
     MakeHTTPSAction,
     ModifyHeadersAction,
-    RedirectAction
+    RedirectAction,
+    ReportIdentifierAction
 >;
 
 inline void add(Hasher& hasher, const ModifyHeadersAction::ModifyHeaderInfo::AppendOperation& operation)

--- a/Source/WebCore/contentextensions/ContentExtensionError.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionError.cpp
@@ -56,12 +56,8 @@ const std::error_category& contentExtensionErrorCategory()
                 return "Invalid object in the top level array.";
             case ContentExtensionError::JSONInvalidRule:
                 return "Invalid rule.";
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
             case ContentExtensionError::JSONInvalidRuleIdentifier:
                 return "Invalid rule identifier, which must be an integer.";
-            case ContentExtensionError::JSONRulesMissingIdentifier:
-                return "All rules must have an identifier or no identifiers.";
-#endif
             case ContentExtensionError::JSONContainsNoRules:
                 return "Empty extension.";
             case ContentExtensionError::JSONInvalidTrigger:

--- a/Source/WebCore/contentextensions/ContentExtensionError.h
+++ b/Source/WebCore/contentextensions/ContentExtensionError.h
@@ -42,10 +42,7 @@ enum class ContentExtensionError {
     JSONTopLevelStructureNotAnArray,
     JSONInvalidObjectInTopLevelArray,
     JSONInvalidRule,
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     JSONInvalidRuleIdentifier,
-    JSONRulesMissingIdentifier,
-#endif
     JSONContainsNoRules,
 
     JSONInvalidTrigger,

--- a/Source/WebCore/contentextensions/ContentExtensionRule.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.cpp
@@ -32,16 +32,9 @@
 
 namespace WebCore::ContentExtensions {
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-ContentExtensionRule::ContentExtensionRule(Trigger&& trigger, Action&& action, uint32_t identifier)
-#else
 ContentExtensionRule::ContentExtensionRule(Trigger&& trigger, Action&& action)
-#endif
     : m_trigger(WTFMove(trigger))
     , m_action(WTFMove(action))
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-    , m_identifier(identifier)
-#endif
 {
     ASSERT(!m_trigger.urlFilter.isEmpty());
 }
@@ -95,16 +88,7 @@ DeserializedAction DeserializedAction::deserialize(std::span<const uint8_t> seri
     auto serializedActionSize = serializedActions.size();
     RELEASE_ASSERT(location < serializedActionSize, location, serializedActionSize);
 
-    uint32_t identifier = location;
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-    // FIXME: <rdar://157879177> We shouldn't unconditionally deserialize an identifier here, as all rule lists do not serialize identifiers.
-    size_t identifierLocation = location + serializedLength(serializedActions, location);
-    RELEASE_ASSERT(identifierLocation < serializedActionSize);
-
-    identifier = reinterpretCastSpanStartTo<uint32_t>(serializedActions.subspan(identifierLocation));
-#endif
-
-    return { identifier, VariantDeserializer<ActionData>::deserialize(serializedActions.subspan(location + 1), serializedActions[location]) };
+    return { location, VariantDeserializer<ActionData>::deserialize(serializedActions.subspan(location + 1), serializedActions[location]) };
 }
 
 size_t DeserializedAction::serializedLength(std::span<const uint8_t> serializedActions, uint32_t location)

--- a/Source/WebCore/contentextensions/ContentExtensionRule.h
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.h
@@ -146,19 +146,10 @@ private:
 
 class ContentExtensionRule {
 public:
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-    WEBCORE_EXPORT ContentExtensionRule(Trigger&&, Action&&, uint32_t identifier);
-
-    uint32_t identifier() const { return m_identifier; }
-
-    ContentExtensionRule isolatedCopy() const & { return { m_trigger.isolatedCopy(), m_action.isolatedCopy(), m_identifier }; }
-    ContentExtensionRule isolatedCopy() && { return { WTFMove(m_trigger).isolatedCopy(), WTFMove(m_action).isolatedCopy(), m_identifier }; }
-#else
     WEBCORE_EXPORT ContentExtensionRule(Trigger&&, Action&&);
 
     ContentExtensionRule isolatedCopy() const & { return { m_trigger.isolatedCopy(), m_action.isolatedCopy() }; }
     ContentExtensionRule isolatedCopy() && { return { WTFMove(m_trigger).isolatedCopy(), WTFMove(m_action).isolatedCopy() }; }
-#endif
 
     const Trigger& trigger() const { return m_trigger; }
     const Action& action() const { return m_action; }
@@ -168,10 +159,6 @@ public:
 private:
     Trigger m_trigger;
     Action m_action;
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-    uint32_t m_identifier;
-#endif
 };
 
 } // namespace WebCore::ContentExtensions

--- a/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
+++ b/Source/WebCore/contentextensions/ContentRuleListMatchedRule.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-
 #include <optional>
 
 namespace WebCore {
@@ -34,5 +32,3 @@ struct ContentRuleListMatchedRule {
 };
 
 } // namespace WebCore
-
-#endif

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -146,9 +146,7 @@ struct AppHighlight;
 struct ApplePayAMSUIRequest;
 struct CharacterRange;
 struct ContactsRequestData;
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 struct ContentRuleListMatchedRule;
-#endif
 struct ContentRuleListResults;
 struct DataDetectorElementInfo;
 struct DateTimeChooserParameters;
@@ -559,10 +557,7 @@ public:
     virtual void disableSuddenTermination() { }
 
     virtual void contentRuleListNotification(const URL&, const ContentRuleListResults&) { };
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     virtual void contentRuleListMatchedRule(const ContentRuleListMatchedRule&) { };
-#endif
 
 #if PLATFORM(WIN)
     virtual void AXStartFrameLoad() = 0;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6147,10 +6147,6 @@ struct WebCore::ContentRuleListResults {
     Vector<std::pair<String, WebCore::ContentRuleListResults::Result>> results;
 };
 
-#endif
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-
 struct WebCore::ContentRuleListMatchedRule {
     WebCore::ContentRuleListMatchedRule::Request request;
     WebCore::ContentRuleListMatchedRule::MatchedRule rule;

--- a/Source/WebKit/UIProcess/API/APINavigationClient.h
+++ b/Source/WebKit/UIProcess/API/APINavigationClient.h
@@ -44,9 +44,7 @@
 #endif
 
 namespace WebCore {
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 struct ContentRuleListMatchedRule;
-#endif
 struct ContentRuleListResults;
 class ResourceError;
 class ResourceRequest;
@@ -138,10 +136,7 @@ public:
     }
 
     virtual void contentRuleListNotification(WebKit::WebPageProxy&, WTF::URL&&, WebCore::ContentRuleListResults&&) { };
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     virtual void contentRuleListMatchedRule(WebKit::WebPageProxy&, WebCore::ContentRuleListMatchedRule&&) { };
-#endif
 
     virtual void shouldGoToBackForwardListItem(WebKit::WebPageProxy&, WebKit::WebBackForwardListItem&, bool inBackForwardCache, CompletionHandler<void(bool)>&& completionHandler)
     {

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -49,9 +49,7 @@ class Navigation;
 
 namespace WebCore {
 class SecurityOriginData;
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 struct ContentRuleListMatchedRule;
-#endif
 }
 
 namespace WebKit {
@@ -157,8 +155,6 @@ private:
 
 #if ENABLE(CONTENT_EXTENSIONS)
         void contentRuleListNotification(WebPageProxy&, URL&&, WebCore::ContentRuleListResults&&) final;
-#endif
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
         void contentRuleListMatchedRule(WebPageProxy&, WebCore::ContentRuleListMatchedRule&&) final;
 #endif
         void decidePolicyForNavigationAction(WebPageProxy&, Ref<API::NavigationAction>&&, Ref<WebFramePolicyListenerProxy>&&) override;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -75,6 +75,7 @@
 #import "_WKSameDocumentNavigationTypeInternal.h"
 #import <JavaScriptCore/ConsoleTypes.h>
 #import <WebCore/AuthenticationMac.h>
+#import <WebCore/ContentRuleListMatchedRule.h>
 #import <WebCore/ContentRuleListResults.h>
 #import <WebCore/Credential.h>
 #import <WebCore/SecurityOriginData.h>
@@ -91,10 +92,6 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 #import "WKWebViewConfigurationPrivate.h"
 #import "WebExtensionController.h"
-#endif
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-#import <WebCore/ContentRuleListMatchedRule.h>
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
@@ -761,16 +758,16 @@ void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy
             [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protectedNavigationState()->webView().get() contentRuleListWithIdentifier:pair.first.createNSString().get() performedAction:wrapper(API::ContentRuleListAction::create(WTFMove(pair.second)).get()) forURL:url.createNSURL().get()];
     }
 }
-#endif
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 void NavigationState::NavigationClient::contentRuleListMatchedRule(WebPageProxy& page, WebCore::ContentRuleListMatchedRule&& matchedRule)
 {
     if (!m_navigationState)
         return;
 
+#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     if (RefPtr extensionController = page.webExtensionController())
         extensionController->handleContentRuleListMatchedRule(page.identifier(), matchedRule);
+#endif
 }
 #endif
     

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -449,10 +449,6 @@
 #include "ModelPresentationManagerProxy.h"
 #endif
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-#include <WebCore/ContentRuleListMatchedRule.h>
-#endif
-
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_URL_COROUTINE(process, url) MESSAGE_CHECK_BASE_COROUTINE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
@@ -8542,9 +8538,7 @@ void WebPageProxy::contentRuleListNotification(URL&& url, ContentRuleListResults
 {
     m_navigationClient->contentRuleListNotification(*this, WTFMove(url), WTFMove(results));
 }
-#endif
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 void WebPageProxy::contentRuleListMatchedRule(WebCore::ContentRuleListMatchedRule&& matchedRule)
 {
     m_navigationClient->contentRuleListMatchedRule(*this, WTFMove(matchedRule));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -254,9 +254,7 @@ struct CompositionHighlight;
 struct CompositionUnderline;
 struct ContactInfo;
 struct ContactsRequestData;
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 struct ContentRuleListMatchedRule;
-#endif
 struct ContentRuleListResults;
 struct CryptoKeyData;
 struct DataDetectorElementInfo;
@@ -2897,9 +2895,6 @@ private:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void contentRuleListNotification(URL&&, WebCore::ContentRuleListResults&&);
-#endif
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     void contentRuleListMatchedRule(WebCore::ContentRuleListMatchedRule&&);
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -480,9 +480,6 @@ messages -> WebPageProxy {
 
 #if ENABLE(CONTENT_EXTENSIONS)
     ContentRuleListNotification(URL url, struct WebCore::ContentRuleListResults results)
-#endif
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     ContentRuleListMatchedRule(struct WebCore::ContentRuleListMatchedRule matchedRule)
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -78,6 +78,7 @@
 #include <WebCore/AXObjectCache.h>
 #include <WebCore/BarcodeDetectorInterface.h>
 #include <WebCore/ColorChooser.h>
+#include <WebCore/ContentRuleListMatchedRule.h>
 #include <WebCore/ContentRuleListResults.h>
 #include <WebCore/CookieConsentDecisionResult.h>
 #include <WebCore/DataListSuggestionPicker.h>
@@ -173,10 +174,6 @@
 #if ENABLE(DAMAGE_TRACKING)
 #include "LayerTreeHost.h"
 #include <WebCore/Damage.h>
-#endif
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-#include <WebCore/ContentRuleListMatchedRule.h>
 #endif
 
 namespace WebKit {
@@ -1369,13 +1366,13 @@ void WebChromeClient::contentRuleListNotification(const URL& url, const ContentR
 #endif
 }
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
 void WebChromeClient::contentRuleListMatchedRule(const WebCore::ContentRuleListMatchedRule& matchedRule)
 {
+#if ENABLE(CONTENT_EXTENSIONS)
     if (RefPtr page = m_page.get())
         page->send(Messages::WebPageProxy::ContentRuleListMatchedRule(matchedRule));
-}
 #endif
+}
 
 bool WebChromeClient::layerTreeStateIsFrozen() const
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -40,9 +40,6 @@ enum class IsLoggedIn : uint8_t;
 enum class PointerLockRequestResult : uint8_t;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : uint8_t;
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-struct ContentRuleListMatchedRule;
-#endif
 struct SystemPreviewInfo;
 struct TextRecognitionOptions;
 }
@@ -252,10 +249,7 @@ private:
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&) final;
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;
-
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     void contentRuleListMatchedRule(const WebCore::ContentRuleListMatchedRule&) final;
-#endif
 
     bool testProcessIncomingSyncMessagesWhenWaitingForSyncReply() final;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -1623,14 +1623,11 @@ TEST_F(ContentExtensionTest, InvalidJSON)
     checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":\"\",\"request-headers\":[{\"operation\":\"remove\",\"header\":\"testheader\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersInvalidPriority);
     checkCompilerError("[{\"action\":{\"type\":\"modify-headers\",\"priority\":-1,\"request-headers\":[{\"operation\":\"remove\",\"header\":\"testheader\"}]},\"trigger\":{\"url-filter\":\"webkit.org\"}}]"_s, ContentExtensionError::JSONModifyHeadersInvalidPriority);
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":\"foo\"}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":null}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":false}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":[]}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
     checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":{}}]"_s, ContentExtensionError::JSONInvalidRuleIdentifier);
-    checkCompilerError("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"},\"_identifier\":1},{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\"}}]"_s, ContentExtensionError::JSONRulesMissingIdentifier);
-#endif
 }
 
 TEST_F(ContentExtensionTest, StrictPrefixSeparatedMachines1)
@@ -3433,37 +3430,96 @@ TEST_F(ContentExtensionTest, IgnoreFollowingRules)
     testRequest(backend, mainDocumentRequest("https://www.w3.org/"_s), { variantIndex<ContentExtensions::BlockLoadAction> });
 }
 
-#if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-TEST_F(ContentExtensionTest, RuleIdentifiers)
+TEST_F(ContentExtensionTest, ReportIdentifierAction)
 {
-    static constexpr auto jsonRuleListJSONString = "["
-        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"A\"},\"_identifier\":1},"
-        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\"AAA\"},\"trigger\":{\"url-filter\":\"B\"},\"_identifier\":2}"
-    "]"_s;
+    // Different identifiers
+    auto backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/first\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https://www.example.com/second\"},\"_identifier\":2}"_s
+    "]"_s);
 
-    auto extension = InMemoryCompiledContentExtension::create(jsonRuleListJSONString);
-    const auto& data = extension->data();
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/first"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://www.example.com/second"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
 
-    // Should be 17 bytes total
-    ASSERT_EQ(data.actions.size(), 17u);
+    // Different action types and identifiers
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"cookies\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".hidden\"},\"trigger\":{\"url-filter\":\"css\"},\"_identifier\":2},"_s
+        "{\"action\":{\"type\":\"notify\",\"notification\":\"test\"},\"trigger\":{\"url-filter\":\"notify\"},\"_identifier\":3}"_s
+    "]"_s);
 
-    // First byte is the first rule's variant, block, which is 0
-    ASSERT_EQ(data.actions[0], 0u);
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/cookies"_s)), Vector<Action>::from(Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/css"_s)), Vector<Action>::from(Action { ContentExtensions::ReportIdentifierAction { 2 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".hidden"_s } } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/notify"_s)), Vector<Action>::from(Action { ContentExtensions::NotifyAction { { "test"_s } } }, Action { ContentExtensions::ReportIdentifierAction { 3 } })));
 
-    // Next four bytes is the identifier of the first rule
-    ASSERT_EQ(reinterpretCastSpanStartTo<const uint32_t>(data.actions.subvector(1, 4).span()), 1u);
+    // With and without identifiers
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"with-id\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"without-id\"}}"_s
+    "]"_s);
 
-    // This byte is the second rule's variant, css-display-none, which is 2
-    ASSERT_EQ(data.actions[5], 2u);
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/with-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/without-id"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() })));
 
-    // These bytes are the second rule's selector string's size and actual characters
-    auto serializedSelectorLength = reinterpretCastSpanStartTo<const uint32_t>(data.actions.subvector(6, 7).span());
-    ASSERT_EQ(String::fromUTF8(data.actions.subvector(6, 7).span().subspan(sizeof(uint32_t), serializedSelectorLength - sizeof(uint32_t))), "AAA"_s);
+    // Multiple matches with one request
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"test\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block-cookies\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":2},"_s
+        "{\"action\":{\"type\":\"css-display-none\",\"selector\":\".ad\"},\"trigger\":{\"url-filter\":\"multi\"},\"_identifier\":3}"_s
+    "]"_s);
 
-    // The last four bytes is the identifier of the second rule
-    ASSERT_EQ(reinterpretCastSpanStartTo<const uint32_t>(data.actions.subvector(13, 4).span()), 2u);
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/multi-test"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockCookiesAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } }, Action { ContentExtensions::ReportIdentifierAction { 3 } }, Action { ContentExtensions::CSSDisplayNoneSelectorAction { { ".ad"_s } } })));
+
+    // With conditions
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"if-domain\":[\"example.com\"]},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"ads\",\"unless-domain\":[\"trusted.com\"]},\"_identifier\":2}"_s
+    "]"_s);
+
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://example.com/"_s)),
+        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://other.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://cdn.com/ads.js"_s, "https://trusted.com/"_s)), Vector<Action>()));
+
+    // With resource types
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"script\"]},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"track\",\"resource-type\":[\"image\"]},\"_identifier\":2}"_s
+    "]"_s);
+
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.js"_s, ResourceType::Script)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.png"_s, ResourceType::Image)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/track.html"_s)), Vector<Action>()));
+
+    // With ignore rules
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"ignore-previous-rules\"},\"trigger\":{\"url-filter\":\"ignore-previous\"}},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"block-me\"},\"_identifier\":2}"_s
+    "]"_s);
+
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/block-me"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } }, Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/ignore-previous-block-me"_s)),
+        Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } }), true));
+
+    // With load types
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"third-party\"]},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"analytics\",\"load-type\":[\"first-party\"]},\"_identifier\":2}"_s
+    "]"_s);
+
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, subResourceRequest("https://analytics.com/track.js"_s, "https://example.com/"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/analytics"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
+
+    // With complex regex
+    backend = makeBackend("["_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"^https://[a-z]+\\\\.ads\\\\.com/\"},\"_identifier\":1},"_s
+        "{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"\\\\.jpg\\\\?.*tracking\"},\"_identifier\":2}"_s
+    "]"_s);
+
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://cdn.ads.com/banner"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 1 } })));
+    ASSERT_TRUE(actionsEqual(allActionsForResourceLoad(backend, mainDocumentRequest("https://example.com/image.jpg?tracking=123"_s)), Vector<Action>::from(Action { ContentExtensions::BlockLoadAction() }, Action { ContentExtensions::ReportIdentifierAction { 2 } })));
 }
-#endif
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### f4f5e767d0b6eec1351fa9fb1f1224287a668edc
<pre>
dNR: stop serializing rule identifiers with their actions and introduce a new action type instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=297338">https://bugs.webkit.org/show_bug.cgi?id=297338</a>
<a href="https://rdar.apple.com/157879177">rdar://157879177</a>

Reviewed by Timothy Hatcher and Alex Christensen.

This patch stops serializing rule identifiers with their actions. Previously, the goal was to have
a rule&apos;s identifier be serialized with its action, and we&apos;d write a bit to the metadata to indicate
if serialized actions included identifiers. This meant that every rule had to have an identifier.

Now, during parsing, if a rule has an identifier, we create another rule that has the same trigger
but the new action type, ReportIdentifierAction. If we encounter this action while processing a load,
we publish the notification. Splitting out a rule&apos;s identifier into a separate rule has the benefit
of not requiring all rules to have an identifier, as well as being able to combine actions during
serialization. However, the downside is that we&apos;re consuming more memory than the aforementioned
approach.

Also, per the recommendation of @achristensen07, I removed the compile time guards from the content
extensions code. However, I did leave them for the web extensions code, as it&apos;s common practice.

Modified the pre-existing tests to verify this change.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::findFirstIgnoreRule const):
* Source/WebCore/contentextensions/ContentExtensionActions.h:
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::serializeActions):
* Source/WebCore/contentextensions/ContentExtensionError.cpp:
(WebCore::ContentExtensions::contentExtensionErrorCategory):
* Source/WebCore/contentextensions/ContentExtensionError.h:
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::loadRule):
(WebCore::ContentExtensions::loadRuleIdentifier):
(WebCore::ContentExtensions::loadEncodedRules):
* Source/WebCore/contentextensions/ContentExtensionRule.cpp:
(WebCore::ContentExtensions::ContentExtensionRule::ContentExtensionRule):
(WebCore::ContentExtensions::DeserializedAction::deserialize):
* Source/WebCore/contentextensions/ContentExtensionRule.h:
(WebCore::ContentExtensions::ContentExtensionRule::isolatedCopy):
(WebCore::ContentExtensions::ContentExtensionRule::identifier const): Deleted.
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForPingLoad):
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForResourceMonitoring):
* Source/WebCore/contentextensions/ContentRuleListMatchedRule.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::contentRuleListNotification):
(WebCore::ChromeClient::contentRuleListMatchedRule):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APINavigationClient.h:
(API::NavigationClient::contentRuleListNotification):
(API::NavigationClient::contentRuleListMatchedRule):
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::contentRuleListMatchedRule):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::contentRuleListNotification):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::contentRuleListMatchedRule):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:
(TestWebKitAPI::TEST_F(ContentExtensionTest, InvalidJSON)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, ReportIdentifierAction)):
(TestWebKitAPI::TEST_F(ContentExtensionTest, RuleIdentifiers)): Deleted.

Canonical link: <a href="https://commits.webkit.org/299028@main">https://commits.webkit.org/299028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2b825f6b6f7810ea1a61c80b599984dacf067b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69504 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ff3db45-4b22-4408-9289-ddbae85a73e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89177 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/44985 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5b4e1fe-76e9-4dcc-a80a-09fac1822e0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105364 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69685 "Found 40 new API test failures: /WPE/TestDownloads:beforeAll, /WPE/TestWebKitPolicyClient:beforeAll, /WPE/TestWebKitSecurityOrigin:beforeAll, /WPE/TestEditor:beforeAll, /WPE/TestUIClient:beforeAll, /TestWebCore:GStreamerTest.harnessDecodeMP4Video, /WPE/TestFrame:beforeAll, /WPE/TestBackForwardList:beforeAll, /WPEPlatform/TestDisplayWayland:/wpe-platform/DisplayWayland/available-input-devices, /WPEPlatform/TestDisplayDefault:/wpe-platform/Display/default ... (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9d0aad1f-1628-44f9-abc7-3641636818f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23481 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67275 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109608 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126723 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116007 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97848 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97636 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40758 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18760 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49947 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43729 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37244 "Found 1 new JSC binary failure: testapi, Found 20033 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47078 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45422 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->