### PR TITLE
Resync `html/anonymous-iframe` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-iframe-popup.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-iframe-popup.tentative.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Cross-origin popup from normal/anonymous iframes. assert_equals: Opener from anonymous iframe should be blocked. expected null but got object "[object Window]"
-FAIL Same-origin popup from normal/anonymous iframes. assert_equals: Opener from anonymous iframe should be blocked. expected null but got object "[object Window]"
+FAIL Cross-origin popup from normal/credentiallessiframes. assert_equals: Opener from credentialless iframe should be blocked. expected null but got object "[object Window]"
+FAIL Same-origin popup from normal/credentialless iframes. assert_equals: Opener from credentialless iframe should be blocked. expected null but got object "[object Window]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-iframe-popup.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-iframe-popup.tentative.https.window.js
@@ -6,7 +6,7 @@
 
 const {ORIGIN, REMOTE_ORIGIN} = get_host_info();
 const control_iframe = document.createElement('iframe');
-const anonymous_iframe = document.createElement('iframe');
+const iframe_credentialless = document.createElement('iframe');
 
 promise_setup(async t => {
   const createControlIframe = new Promise(async resolve => {
@@ -15,18 +15,18 @@ promise_setup(async t => {
     document.body.append(control_iframe);
   });
 
-  const createAnonymousIframe = new Promise(async resolve => {
-    anonymous_iframe.onload = resolve;
-    anonymous_iframe.src = ORIGIN + `/common/blank.html`;
-    anonymous_iframe.anonymous = true;
-    document.body.append(anonymous_iframe);
+  const createIframeCredentialless = new Promise(async resolve => {
+    iframe_credentialless.onload = resolve;
+    iframe_credentialless.src = ORIGIN + `/common/blank.html`;
+    iframe_credentialless.credentialless = true;
+    document.body.append(iframe_credentialless);
   });
 
-  await Promise.all([createControlIframe, createAnonymousIframe]);
+  await Promise.all([createControlIframe, createIframeCredentialless]);
 });
 
 // Create cross-origin popup from iframes. The opener should be blocked for
-// anonymous iframe and work for normal iframe.
+// credentialless iframe and work for normal iframe.
 promise_test(async t => {
   const control_token = token();
   const control_src = REMOTE_ORIGIN + executor_path + `&uuid=${control_token}`;
@@ -36,17 +36,18 @@ promise_test(async t => {
     control_popup.opener, control_iframe.contentWindow,
     "Opener from normal iframe should be available.");
 
-  const anonymous_token = token();
-  const anonymous_src =
-    REMOTE_ORIGIN + executor_path + `&uuid=${anonymous_token}`;
-  const anonymous_popup = anonymous_iframe.contentWindow.open(anonymous_src);
-  add_completion_callback(() => send(anonymous_token, "close();"));
-  assert_equals(
-    anonymous_popup, null, "Opener from anonymous iframe should be blocked.");
-}, 'Cross-origin popup from normal/anonymous iframes.');
+  const credentialless_token = token();
+  const credentialless_src =
+    REMOTE_ORIGIN + executor_path + `&uuid=${credentialless_token}`;
+  const credentialless_popup =
+    iframe_credentialless.contentWindow.open(credentialless_src);
+  add_completion_callback(() => send(credentialless_token, "close();"));
+  assert_equals(credentialless_popup, null,
+    "Opener from credentialless iframe should be blocked.");
+}, 'Cross-origin popup from normal/credentiallessiframes.');
 
 // Create a same-origin popup from iframes. The opener should be blocked for
-// anonymous iframe and work for normal iframe.
+// credentialless iframe and work for normal iframe.
 promise_test(async t => {
   const control_token = token();
   const control_src = ORIGIN + executor_path + `&uuid=${control_token}`;
@@ -56,11 +57,11 @@ promise_test(async t => {
     control_popup.opener, control_iframe.contentWindow,
     "Opener from normal iframe should be available.");
 
-  const anonymous_token = token();
-  const anonymous_src =
-    ORIGIN + executor_path + `&uuid=${anonymous_token}`;
-  const anonymous_popup = anonymous_iframe.contentWindow.open(anonymous_src);
-  add_completion_callback(() => send(anonymous_token, "close();"));
-  assert_equals(
-    anonymous_popup, null, "Opener from anonymous iframe should be blocked.");
-}, 'Same-origin popup from normal/anonymous iframes.');
+  const credentialless_token = token();
+  const credentialless_src =
+    ORIGIN + executor_path + `&uuid=${credentialless_token}`;
+  const credentialless_popup = iframe_credentialless.contentWindow.open(credentialless_src);
+  add_completion_callback(() => send(credentialless_token, "close();"));
+  assert_equals(credentialless_popup, null,
+    "Opener from credentialless iframe should be blocked.");
+}, 'Same-origin popup from normal/credentialless iframes.');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-window.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-window.tentative.https.window-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Anonymous (false => true) => window not reused. assert_true: expected true got undefined
-FAIL Anonymous (true => false) => window not reused. assert_false: expected false got undefined
-FAIL Anonymous (true => true) => window reused. assert_true: expected true got undefined
+FAIL Credentialless (false => true) => window not reused. assert_true: expected true got undefined
+FAIL Credentialless (true => false) => window not reused. assert_false: expected false got undefined
+FAIL Credentialless (true => true) => window reused. assert_true: expected true got undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-window.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-window.tentative.https.window.js
@@ -7,44 +7,44 @@ const {ORIGIN} = get_host_info();
 promise_test_parallel(async t => {
   const iframe = document.createElement("iframe");
   iframe.src = ORIGIN + "/common/blank.html?pipe=status(204)";
-  iframe.anonymous = false;
+  iframe.credentialless = false;
   document.body.appendChild(iframe);
-  iframe.anonymous = true;
+  iframe.credentialless = true;
   iframe.contentWindow.modified = true;
   iframe.src = ORIGIN + "/common/blank.html";
   // Wait for navigation to complete.
   await new Promise(resolve => iframe.onload = resolve);
-  assert_true(iframe.anonymous);
-  assert_true(iframe.contentWindow.isAnonymouslyFramed);
+  assert_true(iframe.credentialless);
+  assert_true(iframe.contentWindow.credentialless);
   assert_equals(undefined, iframe.contentWindow.modified);
-}, "Anonymous (false => true) => window not reused.");
+}, "Credentialless (false => true) => window not reused.");
 
 promise_test_parallel(async t => {
   const iframe = document.createElement("iframe");
   iframe.src = ORIGIN + "/common/blank.html?pipe=status(204)";
-  iframe.anonymous = true;
+  iframe.credentialless = true;
   document.body.appendChild(iframe);
-  iframe.anonymous = false;
+  iframe.credentialless = false;
   iframe.contentWindow.modified = true;
   iframe.src = ORIGIN + "/common/blank.html";
   // Wait for navigation to complete.
   await new Promise(resolve => iframe.onload = resolve);
-  assert_false(iframe.anonymous);
-  assert_false(iframe.contentWindow.isAnonymouslyFramed);
+  assert_false(iframe.credentialless);
+  assert_false(iframe.contentWindow.credentialless);
   assert_equals(undefined, iframe.contentWindow.modified);
-}, "Anonymous (true => false) => window not reused.");
+}, "Credentialless (true => false) => window not reused.");
 
 promise_test_parallel(async t => {
   const iframe = document.createElement("iframe");
-  iframe.anonymous = true;
+  iframe.credentialless = true;
   iframe.src = ORIGIN + "/common/blank.html?pipe=status(204)";
   document.body.appendChild(iframe);
-  iframe.anonymous = true;
+  iframe.credentialless = true;
   iframe.contentWindow.modified = true;
   iframe.src = ORIGIN + "/common/blank.html";
   // Wait for navigation to complete.
   await new Promise(resolve => iframe.onload = resolve);
-  assert_true(iframe.anonymous);
-  assert_true(iframe.contentWindow.isAnonymouslyFramed);
+  assert_true(iframe.credentialless);
+  assert_true(iframe.contentWindow.credentialless);
   assert_true(iframe.contentWindow.modified);
-}, "Anonymous (true => true) => window reused.");
+}, "Credentialless (true => true) => window reused.");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cache-storage.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cache-storage.tentative.https.window.js
@@ -33,27 +33,27 @@ promise_test(async test => {
   const key_1 = token();
   const key_2 = token();
 
-  // 2 actors: An anonymous iframe and a normal one.
-  const iframe_anonymous = newAnonymousIframe(origin);
+  // 2 actors: A credentialless iframe and a normal one.
+  const iframe_credentialless = newIframeCredentialless(origin);
   const iframe_normal = newIframe(origin);
   const response_queue_1 = token();
   const response_queue_2 = token();
 
   // 1. Each of them store a value in CacheStorage with different keys.
-  send(iframe_anonymous , store_script(key_1, "value_1", response_queue_1));
+  send(iframe_credentialless , store_script(key_1, "value_1", response_queue_1));
   send(iframe_normal, store_script(key_2, "value_2", response_queue_2));
   assert_equals(await receive(response_queue_1), "stored");
   assert_equals(await receive(response_queue_2), "stored");
 
   // 2. Each of them tries to retrieve the value from opposite side, without
   //    success.
-  send(iframe_anonymous , load_script(key_2, response_queue_1));
+  send(iframe_credentialless , load_script(key_2, response_queue_1));
   send(iframe_normal, load_script(key_1, response_queue_2));
   assert_equals(await receive(response_queue_1), "not found");
   assert_equals(await receive(response_queue_2), "not found");
 
   // 3. Each of them tries to retrieve the value from their side, with success:
-  send(iframe_anonymous , load_script(key_1, response_queue_1));
+  send(iframe_credentialless , load_script(key_1, response_queue_1));
   send(iframe_normal, load_script(key_2, response_queue_2));
   assert_equals(await receive(response_queue_1), "value_1");
   assert_equals(await receive(response_queue_2), "value_2");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie-store.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie-store.tentative.https.window.js
@@ -5,18 +5,18 @@
 // META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
 // META: script=./resources/common.js
 
-// A set of tests, checking cookies defined from within an anonymous iframe
+// A set of tests, checking cookies defined from within a credentialless iframe
 // continue to work.
 
 const same_origin = get_host_info().HTTPS_ORIGIN;
 const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
 const cookie_key = token()
 
-const anonymous_iframe = newAnonymousIframe(cross_origin);
+const credentialless_iframe = newIframeCredentialless(cross_origin);
 
 // Install some helper functions in the child to observe Cookies:
 promise_setup(async () => {
-  await send(anonymous_iframe, `
+  await send(credentialless_iframe, `
     window.getMyCookie = () => {
       const value = "; " + document.cookie;
       const parts = value.split("; ${cookie_key}=");
@@ -44,7 +44,7 @@ promise_setup(async () => {
 
 promise_test(async test => {
   const this_token = token();
-  send(anonymous_iframe, `
+  send(credentialless_iframe, `
     document.cookie = "${cookie_key}=cookie_value_1";
     send("${this_token}", getMyCookie());
   `);
@@ -54,7 +54,7 @@ promise_test(async test => {
 
 promise_test(async test => {
   const resource_token = token();
-  send(anonymous_iframe, `
+  send(credentialless_iframe, `
     fetch("${showRequestHeaders(cross_origin, resource_token)}");
   `);
 
@@ -68,7 +68,7 @@ promise_test(async test => {
   const resource_url = cross_origin + "/common/blank.html?pipe=" +
     `|header(Set-Cookie,${cookie_key}=cookie_value_2;Path=/common/dispatcher)`;
   const this_token = token();
-  send(anonymous_iframe, `
+  send(credentialless_iframe, `
     const next_cookie_value = nextCookieValue();
     fetch("${resource_url}");
     send("${this_token}", await next_cookie_value);
@@ -82,7 +82,7 @@ promise_test(async test => {
   const resource_url = cross_origin + "/common/blank.html?pipe=" +
     `|header(Set-Cookie,${cookie_key}=cookie_value_3;Path=/common/dispatcher)`;
   const this_token = token();
-  send(anonymous_iframe, `
+  send(credentialless_iframe, `
     const next_cookie_value = nextCookieValue();
     const iframe = document.createElement("iframe");
     iframe.src = "${resource_url}";

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt
@@ -1,13 +1,13 @@
 
 PASS Setup
-FAIL Anonymous same-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL Anonymous cross-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL same_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
-FAIL same_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
-FAIL cross_origin anonymous iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
+FAIL Credentialless same-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
+FAIL Credentialless cross-origin iframe is loaded without credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL same_origin credentialless iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
+FAIL same_origin credentialless iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin credentialless iframe can't send cross_origin credentials assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin credentialless iframe can't send same_origin credentials assert_equals: expected (undefined) undefined but got (string) "same_origin"
+FAIL same_origin credentialless iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
+FAIL same_origin credentialless iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin credentialless iframe can't send cross_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "cross_origin"
+FAIL cross_origin credentialless iframe can't send same_origin credentials on child iframe assert_equals: expected (undefined) undefined but got (string) "same_origin"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.js
@@ -6,7 +6,7 @@
 
 const same_origin = get_host_info().HTTPS_ORIGIN;
 const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
-const cookie_key = "anonymous_iframe_load_cookie";
+const cookie_key = "credentialless_iframe_load_cookie";
 const cookie_same_origin = "same_origin";
 const cookie_cross_origin = "cross_origin";
 
@@ -15,12 +15,12 @@ const cookieFromResource = async resource_token => {
   return parseCookies(headers)[cookie_key];
 };
 
-// Load an anonymous iframe, return the HTTP request cookies.
-const cookieFromAnonymousIframeRequest = async (iframe_origin) => {
+// Load a credentialless iframe, return the HTTP request cookies.
+const cookieFromCredentiallessIframeRequest = async (iframe_origin) => {
   const resource_token = token();
   let iframe = document.createElement("iframe");
   iframe.src = `${showRequestHeaders(iframe_origin, resource_token)}`;
-  iframe.anonymous = true;
+  iframe.credentialless = true;
   document.body.appendChild(iframe);
   return await cookieFromResource(resource_token);
 };
@@ -46,48 +46,48 @@ promise_test_parallel(async test => {
 
   promise_test_parallel(async test => {
     assert_equals(
-      await cookieFromAnonymousIframeRequest(same_origin),
+      await cookieFromCredentiallessIframeRequest(same_origin),
       undefined
     );
-  }, "Anonymous same-origin iframe is loaded without credentials");
+  }, "Credentialless same-origin iframe is loaded without credentials");
 
   promise_test_parallel(async test => {
     assert_equals(
-      await cookieFromAnonymousIframeRequest(cross_origin),
+      await cookieFromCredentiallessIframeRequest(cross_origin),
       undefined
     );
-  }, "Anonymous cross-origin iframe is loaded without credentials");
+  }, "Credentialless cross-origin iframe is loaded without credentials");
 
-  let iframe_same_origin = newAnonymousIframe(same_origin);
-  let iframe_cross_origin = newAnonymousIframe(cross_origin);
+  const iframe_same_origin = newIframeCredentialless(same_origin);
+  const iframe_cross_origin = newIframeCredentialless(cross_origin);
 
   promise_test_parallel(async test => {
     assert_equals(
       await cookieFromResourceInIframe(iframe_same_origin, same_origin),
       undefined
     );
-  }, "same_origin anonymous iframe can't send same_origin credentials");
+  }, "same_origin credentialless iframe can't send same_origin credentials");
 
   promise_test_parallel(async test => {
     assert_equals(
       await cookieFromResourceInIframe(iframe_same_origin, cross_origin),
       undefined
     );
-  }, "same_origin anonymous iframe can't send cross_origin credentials");
+  }, "same_origin credentialless iframe can't send cross_origin credentials");
 
   promise_test_parallel(async test => {
     assert_equals(
       await cookieFromResourceInIframe(iframe_cross_origin, cross_origin),
       undefined
     );
-  }, "cross_origin anonymous iframe can't send cross_origin credentials");
+  }, "cross_origin credentialless iframe can't send cross_origin credentials");
 
   promise_test_parallel(async test => {
     assert_equals(
       await cookieFromResourceInIframe(iframe_cross_origin, same_origin),
       undefined
     );
-  }, "cross_origin anonymous iframe can't send same_origin credentials");
+  }, "cross_origin credentialless iframe can't send same_origin credentials");
 
   promise_test_parallel(async test => {
     assert_equals(
@@ -95,7 +95,7 @@ promise_test_parallel(async test => {
                                        "iframe"),
       undefined
     );
-  }, "same_origin anonymous iframe can't send same_origin credentials "
+  }, "same_origin credentialless iframe can't send same_origin credentials "
                         + "on child iframe");
 
   promise_test_parallel(async test => {
@@ -104,8 +104,8 @@ promise_test_parallel(async test => {
                                        "iframe"),
       undefined
     );
-  }, "same_origin anonymous iframe can't send cross_origin credentials "
-                        + "on child iframe");
+  }, "same_origin credentialless iframe can't send cross_origin credentials "
+    + "on child iframe");
 
   promise_test_parallel(async test => {
     assert_equals(
@@ -113,8 +113,8 @@ promise_test_parallel(async test => {
                                        "iframe"),
       undefined
     );
-  }, "cross_origin anonymous iframe can't send cross_origin credentials "
-                        + "on child iframe");
+  }, "cross_origin credentialless iframe can't send cross_origin credentials "
+    + "on child iframe");
 
   promise_test_parallel(async test => {
     assert_equals(
@@ -122,7 +122,7 @@ promise_test_parallel(async test => {
                                        "iframe"),
       undefined
     );
-  }, "cross_origin anonymous iframe can't send same_origin credentials "
-                        + "on child iframe");
+  }, "cross_origin credentialless iframe can't send same_origin credentials "
+    + "on child iframe");
 
 }, "Setup")

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window-expected.txt
@@ -1,15 +1,15 @@
 
-PASS Parent embeds same-origin anonymous iframe
-PASS Parent embeds cross-origin anonymous iframe
-FAIL COEP:require-corp parent embeds same-origin anonymous iframe assert_equals: expected "load" but got "block"
-FAIL COEP:require-corp parent embeds cross-origin anonymous iframe assert_equals: expected "load" but got "block"
-PASS COEP:credentialless parent embeds same-origin anonymous iframe
-PASS COEP:credentialless parent embeds cross-origin anonymous iframe
-FAIL COOP:same-origin + COEP:require-corp embeds same-origin anonymous iframe assert_equals: expected "load" but got "block"
-FAIL COOP:same-origin + COEP:require-corp embeds cross-origin anonymous iframe assert_equals: expected "load" but got "block"
-PASS COOP:same-origin + COEP:credentialless embeds same-origin anonymous iframe
-PASS COOP:same-origin + COEP:credentialless embeds cross-origin anonymous iframe
-PASS Parents embeds a CSP:frame-ancestore anonymous iframe
-PASS Cross-Origin-Isolated parent embeds same-origin COEP anonymous iframe
-FAIL Cross-Origin-Isolated parent embeds cross-origin COEP anonymous iframe assert_equals: expected "load" but got "block"
+PASS Parent embeds same-origin credentialless iframe
+PASS Parent embeds cross-origin credentialless iframe
+FAIL COEP:require-corp parent embeds same-origin credentialless iframe assert_equals: expected "load" but got "block"
+FAIL COEP:require-corp parent embeds cross-origin credentialless iframe assert_equals: expected "load" but got "block"
+PASS COEP:credentialless parent embeds same-origin credentialless iframe
+PASS COEP:credentialless parent embeds cross-origin credentialless iframe
+FAIL COOP:same-origin + COEP:require-corp embeds same-origin credentialless iframe assert_equals: expected "load" but got "block"
+FAIL COOP:same-origin + COEP:require-corp embeds cross-origin credentialless iframe assert_equals: expected "load" but got "block"
+PASS COOP:same-origin + COEP:credentialless embeds same-origin credentialless iframe
+PASS COOP:same-origin + COEP:credentialless embeds cross-origin credentialless iframe
+PASS Parents embeds a CSP:frame-ancestors credentialless iframe
+PASS Cross-Origin-Isolated parent embeds same-origin COEP credentialless iframe
+FAIL Cross-Origin-Isolated parent embeds cross-origin COEP credentialless iframe assert_equals: expected "load" but got "block"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.js
@@ -1,10 +1,17 @@
-// META: variant=?1-2
-// META: variant=?3-4
-// META: variant=?5-6
-// META: variant=?7-8
-// META: variant=?9-10
-// META: variant=?11-12
+// META: variant=?1-1
+// META: variant=?2-2
+// META: variant=?3-3
+// META: variant=?4-4
+// META: variant=?5-5
+// META: variant=?6-6
+// META: variant=?7-7
+// META: variant=?8-8
+// META: variant=?9-9
+// META: variant=?10-10
+// META: variant=?11-11
+// META: variant=?12-12
 // META: variant=?13-last
+// META: timeout=long
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/common/subset-tests.js
@@ -17,27 +24,27 @@ const {REMOTE_ORIGIN} = get_host_info();
 
 // variant = 1
 subsetTest(embeddingTest,
-  "Parent embeds same-origin anonymous iframe", {
+  "Parent embeds same-origin credentialless iframe", {
   expectation: EXPECT_LOAD,
 });
 
 // variant = 2
 subsetTest(embeddingTest,
-  "Parent embeds cross-origin anonymous iframe", {
+  "Parent embeds cross-origin credentialless iframe", {
   child_origin: REMOTE_ORIGIN,
   expectation: EXPECT_LOAD,
 });
 
 // variant = 3
 subsetTest(embeddingTest,
-  "COEP:require-corp parent embeds same-origin anonymous iframe", {
+  "COEP:require-corp parent embeds same-origin credentialless iframe", {
   parent_headers: coep_require_corp,
   expectation: EXPECT_LOAD,
 });
 
 // variant = 4
 subsetTest(embeddingTest,
-  "COEP:require-corp parent embeds cross-origin anonymous iframe", {
+  "COEP:require-corp parent embeds cross-origin credentialless iframe", {
   parent_headers: coep_require_corp,
   child_origin: REMOTE_ORIGIN,
   expectation: EXPECT_LOAD,
@@ -45,14 +52,14 @@ subsetTest(embeddingTest,
 
 // variant = 5
 subsetTest(embeddingTest,
-  "COEP:credentialless parent embeds same-origin anonymous iframe", {
+  "COEP:credentialless parent embeds same-origin credentialless iframe", {
   parent_headers: coep_credentialless,
   expectation: EXPECT_LOAD,
 });
 
 // variant = 6
 subsetTest(embeddingTest,
-  "COEP:credentialless parent embeds cross-origin anonymous iframe", {
+  "COEP:credentialless parent embeds cross-origin credentialless iframe", {
   parent_headers: coep_credentialless,
   child_origin: REMOTE_ORIGIN,
   expectation: EXPECT_LOAD,
@@ -61,7 +68,7 @@ subsetTest(embeddingTest,
 // variant = 7
 // Regression test for https://crbug.com/1314369
 subsetTest(embeddingTest,
-  "COOP:same-origin + COEP:require-corp embeds same-origin anonymous iframe", {
+  "COOP:same-origin + COEP:require-corp embeds same-origin credentialless iframe", {
   parent_headers: coop_same_origin + coep_require_corp,
   expectation: EXPECT_LOAD,
 });
@@ -69,7 +76,7 @@ subsetTest(embeddingTest,
 // variant = 8
 // Regression test for https://crbug.com/1314369
 subsetTest(embeddingTest,
-  "COOP:same-origin + COEP:require-corp embeds cross-origin anonymous iframe", {
+  "COOP:same-origin + COEP:require-corp embeds cross-origin credentialless iframe", {
   parent_headers: coop_same_origin + coep_require_corp,
   child_origin: REMOTE_ORIGIN,
   expectation: EXPECT_LOAD,
@@ -78,7 +85,7 @@ subsetTest(embeddingTest,
 // variant = 9
 // Regression test for https://crbug.com/1314369
 subsetTest(embeddingTest,
-  "COOP:same-origin + COEP:credentialless embeds same-origin anonymous iframe", {
+  "COOP:same-origin + COEP:credentialless embeds same-origin credentialless iframe", {
   parent_headers: coop_same_origin + coep_credentialless,
   expectation: EXPECT_LOAD,
 });
@@ -86,7 +93,7 @@ subsetTest(embeddingTest,
 // variant = 10
 // Regression test for https://crbug.com/1314369
 subsetTest(embeddingTest,
-  "COOP:same-origin + COEP:credentialless embeds cross-origin anonymous iframe", {
+  "COOP:same-origin + COEP:credentialless embeds cross-origin credentialless iframe", {
   parent_headers: coop_same_origin + coep_credentialless,
   child_origin: REMOTE_ORIGIN,
   expectation: EXPECT_LOAD,
@@ -94,14 +101,14 @@ subsetTest(embeddingTest,
 
 // variant = 11
 subsetTest(embeddingTest,
-  "Parents embeds a CSP:frame-ancestore anonymous iframe", {
-  child_headers: "|headers(Content-Security-Policy,frame-ancestors 'none')",
+  "Parents embeds a CSP:frame-ancestors credentialless iframe", {
+  child_headers: "|header(Content-Security-Policy,frame-ancestors 'none')",
   expectation: EXPECT_BLOCK,
 });
 
 // variant = 12
 subsetTest(embeddingTest,
-  "Cross-Origin-Isolated parent embeds same-origin COEP anonymous iframe", {
+  "Cross-Origin-Isolated parent embeds same-origin COEP credentialless iframe", {
   parent_headers: coop_same_origin + coep_require_corp,
   child_headers: coop_same_origin + coep_require_corp,
   expectation: EXPECT_LOAD,
@@ -109,7 +116,7 @@ subsetTest(embeddingTest,
 
 // variant = 13
 subsetTest(embeddingTest,
-  "Cross-Origin-Isolated parent embeds cross-origin COEP anonymous iframe", {
+  "Cross-Origin-Isolated parent embeds cross-origin COEP credentialless iframe", {
   parent_headers: coop_same_origin + coep_require_corp,
   child_headers: coop_same_origin + coep_require_corp,
   child_origin: REMOTE_ORIGIN,

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame-bypass.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame-bypass.tentative.https.window.js
@@ -1,6 +1,7 @@
 // META: script=/common/get-host-info.sub.js
 // META: script=/common/utils.js
 // META: script=/common/dispatcher/dispatcher.js
+// META: script=/fenced-frame/resources/utils.js
 // META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
 // META: script=./resources/common.js
 // META: timeout=long
@@ -12,22 +13,22 @@ setup(() => {
 
 // 4 actors:
 //                         A (this document)
-//   ┌─────────────────────┴──┐
-// ┌─┼───────────────────┐    D  (anonymous-iframe)
-// │ B (fenced-frame)    │
-// │ │                   │
-// │ C (anonymous-iframe)│
-// └─────────────────────┘
+//   ┌─────────────────────┴───────┐
+// ┌─┼────────────────────────┐    D  (credentialless-iframe)
+// │ B (fenced-frame)         │
+// │ │                        │
+// │ C (credentialless-iframe)│
+// └──────────────────────────┘
 //
-// This test whether the two anonymous iframe can communicate and bypass the
+// This test whether the two credentialless iframe can communicate and bypass the
 // fencedframe boundary. This shouldn't happen.
 promise_test(async test => {
   const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
   const msg_queue = token();
 
-  // Create the the 3 actors.
-  const anonymous_iframe_1 = newAnonymousIframe(cross_origin);
-  const fenced_frame = newFencedFrame(cross_origin);
+  // Create the 3 actors.
+  const iframe_credentialless_1 = newIframeCredentialless(cross_origin);
+  const fenced_frame = await newFencedFrame(cross_origin);
   send(fenced_frame, `
     const importScript = ${importScript};
     await importScript("/common/utils.js");
@@ -36,22 +37,22 @@ promise_test(async test => {
     await importScript("/html/anonymous-iframe/resources/common.js");
     const support_loading_mode_fenced_frame =
       "|header(Supports-Loading-Mode,fenced-frame)";
-    const anonymous_iframe_2 =
-      newAnonymousIframe("${cross_origin}", support_loading_mode_fenced_frame);
-    send("${msg_queue}", anonymous_iframe_2);
+    const iframe_credentialless_2 = newIframeCredentialless("${cross_origin}",
+      support_loading_mode_fenced_frame);
+    send("${msg_queue}", iframe_credentialless_2);
   `);
-  const anonymous_iframe_2 = await receive(msg_queue);
+  const iframe_credentialless_2 = await receive(msg_queue);
 
-  // Try to communicate using BroadCastChannel, in between the two
-  // AnonymousIframe.
+  // Try to communicate using BroadCastChannel, in between the credentialless
+  // iframes.
   const bc_key = token();
-  send(anonymous_iframe_1, `
+  send(iframe_credentialless_1, `
     const bc = new BroadcastChannel("${bc_key}");
     bc.onmessage = event => send("${msg_queue}", event.data);
     send("${msg_queue}", "BroadcastChannel registered");
   `);
   assert_equals(await receive(msg_queue), "BroadcastChannel registered");
-  await send(anonymous_iframe_2, `
+  await send(iframe_credentialless_2, `
     const bc = new BroadcastChannel("${bc_key}");
     bc.postMessage("Can communicate");
   `);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame.tentative.https.window.js
@@ -10,30 +10,35 @@ setup(() => {
     "HTMLFencedFrameElement is not supported.");
 })
 
-// Check whether this anonymous bit propagates toward FencedFrame. It shouldn't.
+// Check whether this credentialless bit propagates toward FencedFrame. It
+// shouldn't.
 promise_test(async test => {
   const origin = get_host_info().HTTPS_ORIGIN;
   const msg_queue = token();
 
-  // 1. Create an anonymous iframe.
-  const frame_anonymous = newAnonymousIframe(origin);
+  // 1. Create a credentialless iframe.
+  const iframe_credentialless = newIframeCredentialless(origin);
 
   // 2. Create a FencedFrame within it.
-  send(frame_anonymous, `
+  send(iframe_credentialless, `
     const importScript = ${importScript};
     await importScript("/common/utils.js");
+    await importScript("/fenced-frame/resources/utils.js");
     await importScript("/html/cross-origin-embedder-policy/credentialless" +
       "/resources/common.js");
     await importScript("/html/anonymous-iframe/resources/common.js");
-    const frame_fenced = newFencedFrame("${origin}");
+    const frame_fenced = await newFencedFrame("${origin}");
     send("${msg_queue}", frame_fenced);
   `);
+  // TODO: Properly generate a fenced frame to check credentialless.
+  assert_true(false, "Fenced frame cannot be created.");
   const frame_fenced = await receive(msg_queue);
 
-  // 3. Expect it not to be considered anonymous.
+  // 3. Expect it not to be considered credentialless.
   send(frame_fenced, `
-    send("${msg_queue}", window.isAnonymouslyFramed);
+    send("${msg_queue}", window.credentialless);
   `);
+  // TODO: Properly generate a fenced frame which can perform this check.
   assert_equals(await receive(msg_queue), "false",
-    "Check window.isAnonymouslyFramed in FencedFrame");
-}, 'FencedFrame within an AnonymousIframe is not anonymous')
+    "Check window.credentialless in FencedFrame");
+}, 'FencedFrame within a credentialless iframe is not credentialless')

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Same-origin credentialless iframe can't request storage access assert_equals: expected "false" but got "true"
+PASS Cross-origin credentialless iframe can't request storage access
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.js
@@ -1,0 +1,30 @@
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
+// META: script=./resources/common.js
+
+setup(() => {
+  assert_implements(document.hasStorageAccess,
+    "requestStorageAccess is not supported.");
+})
+
+const hasStorageAccess = (iframe) => {
+  const reply = token();
+  send(iframe, `
+    send("${reply}", await document.hasStorageAccess());
+  `);
+  return receive(reply);
+}
+
+promise_test(async test => {
+  const same_origin = window.origin;
+  const iframe = newIframeCredentialless(same_origin);
+  assert_equals(await hasStorageAccess(iframe), "false");
+}, "Same-origin credentialless iframe can't request storage access");
+
+promise_test(async test => {
+  const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+  const iframe = newIframeCredentialless(cross_origin);
+  assert_equals(await hasStorageAccess(iframe), "false");
+}, "Cross-origin credentialless iframe can't request storage access");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL indexeddb assert_equals: expected (undefined) undefined but got (string) "5811617b-bb57-41fc-a41d-a9637cd4af8d"
+FAIL indexeddb assert_equals: expected (undefined) undefined but got (string) "a6aeecb3-6e0c-439a-a488-99e62bd51ae0"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window.js
@@ -50,11 +50,11 @@ const read_script = (done) => `
 `;
 
 promise_test(async test => {
-  // 4 actors: 2 anonymous iframe and 2 normal iframe.
+  // 4 actors: 2 credentialless iframe and 2 normal iframe.
   const origin = get_host_info().HTTPS_REMOTE_ORIGIN;
   const iframes = [
-    newAnonymousIframe(origin),
-    newAnonymousIframe(origin),
+    newIframeCredentialless(origin),
+    newIframeCredentialless(origin),
     newIframe(origin),
     newIframe(origin),
   ];
@@ -80,8 +80,8 @@ promise_test(async test => {
   }));
 
 
-  // Verify the two anonymous iframe share the same state and the normal iframe
-  // share a second state
+  // Verify the two credentialless iframe share the same state and the normal
+  // iframe share a second state
   assert_equals(states[0][keys[0]], values[0]);
   assert_equals(states[0][keys[1]], values[1]);
   assert_equals(states[0][keys[2]], undefined);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Initial empty document inherits from parent's document. assert_false: expected false got undefined
-FAIL Initial empty document inherits from its's iframe's anonymous attribute. assert_false: expected false got undefined
+FAIL Initial empty document inherits from its's iframe's credentialless attribute. assert_false: expected false got undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window.js
@@ -5,17 +5,17 @@ const {ORIGIN} = get_host_info();
 
 promise_test_parallel(async t => {
   const parent = document.createElement("iframe");
-  parent.anonymous = true;
+  parent.credentialless = true;
   document.body.appendChild(parent);
   parent.src = ORIGIN + "/common/blank.html";
   // Wait for navigation to complete.
   await new Promise(resolve => parent.onload = resolve);
-  assert_true(parent.anonymous);
+  assert_true(parent.credentialless);
 
   const child = document.createElement("iframe");
   parent.contentDocument.body.appendChild(child);
-  assert_false(child.anonymous);
-  assert_true(child.contentWindow.isAnonymouslyFramed);
+  assert_false(child.credentialless);
+  assert_true(child.contentWindow.credentialless);
 }, "Initial empty document inherits from parent's document.");
 
 promise_test_parallel(async t => {
@@ -24,11 +24,11 @@ promise_test_parallel(async t => {
   parent.src = ORIGIN + "/common/blank.html";
   // Wait for navigation to complete.
   await new Promise(resolve => parent.onload = resolve);
-  assert_false(parent.anonymous);
+  assert_false(parent.credentialless);
 
   const child = document.createElement("iframe");
-  child.anonymous = true;
+  child.credentialless = true;
   parent.contentDocument.body.appendChild(child);
-  assert_true(child.anonymous);
-  assert_true(child.contentWindow.isAnonymouslyFramed);
-}, "Initial empty document inherits from its's iframe's anonymous attribute.");
+  assert_true(child.credentialless);
+  assert_true(child.contentWindow.credentialless);
+}, "Initial empty document inherits from its's iframe's credentialless attribute.");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Local storage is correctly partitioned with regards to credentialless iframe in initial empty documents. assert_equals: Credentialless iframe can't access credentialled context expected "" but got "value_E"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.js
@@ -1,0 +1,74 @@
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
+// META: script=./resources/common.js
+
+// This test verifies the behavior of the initial empty document nested inside
+// credentialless iframes.
+//
+// The following tree of frames and documents is used:
+//  A
+//  ├──B (credentialless)
+//  │  └──D (initial empty document)
+//  └──C (control)
+//     └──E (initial empty document)
+//
+// Storage used for D and E must be different.
+promise_test(async test => {
+  const iframe_B = newIframeCredentialless(origin);
+  const iframe_C = newIframe(origin);
+
+  // Create iframe_D and store a value in localStorage.
+  const key_D = token();
+  const value_D = "value_D";
+  const queue_B = token();
+  send(iframe_B, `
+    const iframe_D = document.createElement("iframe");
+    document.body.appendChild(iframe_D);
+    iframe_D.contentWindow.localStorage.setItem("${key_D}","${value_D}");
+    send("${queue_B}", "Done");
+  `);
+
+  // Create iframe_E and store a value in localStorage.
+  const key_E = token();
+  const value_E = "value_E";
+  const queue_C = token();
+  send(iframe_C, `
+    const iframe_E = document.createElement("iframe");
+    document.body.appendChild(iframe_E);
+    iframe_E.contentWindow.localStorage.setItem("${key_E}","${value_E}");
+    send("${queue_C}", "Done");
+  `);
+
+  assert_equals(await receive(queue_B), "Done");
+  assert_equals(await receive(queue_C), "Done");
+
+  // Try to load both values from both contexts:
+  send(iframe_B, `
+    const iframe_D = document.querySelector("iframe");
+    const value_D = iframe_D.contentWindow.localStorage.getItem("${key_D}");
+    const value_E = iframe_D.contentWindow.localStorage.getItem("${key_E}");
+    send("${queue_B}", value_D);
+    send("${queue_B}", value_E);
+  `);
+  send(iframe_C, `
+    const iframe_E = document.querySelector("iframe");
+    const value_D = iframe_E.contentWindow.localStorage.getItem("${key_D}");
+    const value_E = iframe_E.contentWindow.localStorage.getItem("${key_E}");
+    send("${queue_C}", value_D);
+    send("${queue_C}", value_E);
+  `);
+
+  // Verify the credentialless iframe and the normal one do not have access to
+  // each other.
+  assert_equals(await receive(queue_B), value_D, // key_D
+    "Credentialless iframe can access credentialless context");
+  assert_equals(await receive(queue_B), "",      // key_E
+    "Credentialless iframe can't access credentialled context");
+  assert_equals(await receive(queue_C), "",      // key_D
+    "Credentialled iframe can't access credentialless context");
+  assert_equals(await receive(queue_C), value_E, // key_E
+    "Credentialled iframe can access credentialled context");
+}, "Local storage is correctly partitioned with regards to credentialless " +
+   "iframe in initial empty documents.");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window-expected.txt
@@ -1,5 +1,3 @@
 
-PASS Setup
-FAIL same_origin anonymous iframe can't access the localStorage assert_equals: expected "" but got "same_origin"
-FAIL cross_origin anonymous iframe can't access the localStorage assert_equals: expected "" but got "cross_origin"
+FAIL Local storage is correctly partitioned with regards to credentialless iframe assert_equals: expected "not found" but got "value_1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.js
@@ -4,49 +4,54 @@
 // META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
 // META: script=./resources/common.js
 
-const same_origin = get_host_info().HTTPS_ORIGIN;
-const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
-const local_storage_key = "coep_credentialless_iframe_local_storage";
-const local_storage_same_origin = "same_origin";
-const local_storage_cross_origin = "cross_origin";
+// Make |iframe| to store |key|=|value| into LocalStorage.
+const store = async (iframe, key, value) => {
+  const response_queue = token();
+  send(iframe, `
+    localStorage.setItem("${key}", "${value}");
+    send("${response_queue}", "stored");
+  `);
+  assert_equals(await receive(response_queue), "stored");
+};
 
-promise_test_parallel(async test => {
-  // Add an item in the localStorage on same_origin.
-  localStorage.setItem(local_storage_key, local_storage_same_origin);
+// Make |iframe| to load |key| in LocalStorage. Check it matches the
+// |expected_value|.
+const load = async (iframe, key, expected_value) => {
+  const response_queue = token();
+  send(iframe, `
+    const value = localStorage.getItem("${key}");
+    send("${response_queue}", value || "not found");
+  `);
+  assert_equals(await receive(response_queue), expected_value);
+};
 
-  // Add an item in the localStorage on cross_origin.
-  {
-    const w_token = token();
-    const w_url = cross_origin + executor_path + `&uuid=${w_token}`;
-    const w = window.open(w_url);
-    const reply_token = token();
-    send(w_token, `
-      localStorage.setItem("${local_storage_key}",
-                           "${local_storage_cross_origin}");
-      send("${reply_token}", "done");
-    `);
-    assert_equals(await receive(reply_token), "done");
-    w.close();
-  }
+promise_test(async test => {
+  const origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+  const key_1 = token();
+  const key_2 = token();
 
-  promise_test_parallel(async test => {
-    let iframe = newAnonymousIframe(same_origin);
-    let reply_token = token();
-    send(iframe, `
-      let value = localStorage.getItem("${local_storage_key}");
-      send("${reply_token}", value);
-    `)
-    assert_equals(await receive(reply_token), "")
-  }, "same_origin anonymous iframe can't access the localStorage");
+  // 4 actors: 2 credentialless iframe and 2 normal iframe.
+  const iframe_credentialless_1 = newIframeCredentialless(origin);
+  const iframe_credentialless_2 = newIframeCredentialless(origin);
+  const iframe_normal_1 = newIframe(origin);
+  const iframe_normal_2 = newIframe(origin);
 
-  promise_test_parallel(async test => {
-    let iframe = newAnonymousIframe(cross_origin);
-    let reply_token = token();
-    send(iframe, `
-      let value = localStorage.getItem("${local_storage_key}");
-      send("${reply_token}", value);
-    `)
-    assert_equals(await receive(reply_token), "")
-  }, "cross_origin anonymous iframe can't access the localStorage");
+  // 1. Store a value in one credentialless iframe and one normal iframe.
+  await Promise.all([
+    store(iframe_credentialless_1, key_1, "value_1"),
+    store(iframe_normal_1, key_2, "value_2"),
+  ]);
 
-}, "Setup")
+  // 2. Check what each of them can retrieve.
+  await Promise.all([
+    load(iframe_credentialless_1, key_1, "value_1"),
+    load(iframe_credentialless_2, key_1, "value_1"),
+    load(iframe_credentialless_1, key_2, "not found"),
+    load(iframe_credentialless_2, key_2, "not found"),
+
+    load(iframe_normal_1, key_1, "not found"),
+    load(iframe_normal_2, key_1, "not found"),
+    load(iframe_normal_1, key_2, "value_2"),
+    load(iframe_normal_2, key_2, "value_2"),
+  ]);
+}, "Local storage is correctly partitioned with regards to credentialless iframe");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Same-origin credentialless iframe can't request storage access assert_equals: expected "failed" but got "success"
+PASS Cross-origin credentialless iframe can't request storage access
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.js
@@ -1,0 +1,35 @@
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
+// META: script=./resources/common.js
+
+setup(() => {
+  assert_implements(document.requestStorageAccess,
+    "requestStorageAccess is not supported.");
+})
+
+const requestStorageAccess = (iframe) => {
+  const reply = token();
+  send(iframe, `
+    try {
+      await document.requestStorageAccess();
+      send("${reply}", "success");
+    } catch {
+      send("${reply}", "failed");
+    }
+  `);
+  return receive(reply);
+}
+
+promise_test(async test => {
+  const same_origin = window.origin;
+  const iframe = newIframeCredentialless(same_origin);
+  assert_equals(await requestStorageAccess(iframe), "failed");
+}, "Same-origin credentialless iframe can't request storage access");
+
+promise_test(async test => {
+  const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+  const iframe = newIframeCredentialless(cross_origin);
+  assert_equals(await requestStorageAccess(iframe), "failed");
+}, "Cross-origin credentialless iframe can't request storage access");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_implements: requestStorageAccessFor is not supported. undefined
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.js
@@ -1,0 +1,35 @@
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
+// META: script=./resources/common.js
+
+setup(() => {
+  assert_implements(document.requestStorageAccessFor,
+    "requestStorageAccessFor is not supported.");
+})
+
+const requestStorageAccessFor = (iframe, origin) => {
+  const reply = token();
+  send(iframe, `
+    try {
+      await document.requestStorageAccessFor("${origin}");
+      send("${reply}", "success");
+    } catch {
+      send("${reply}", "failed");
+    }
+  `);
+  return receive(reply);
+}
+
+promise_test(async test => {
+  const same_origin = window.origin;
+  const iframe = newIframeCredentialless(same_origin);
+  assert_equals(await requestStorageAccessFor(iframe, same_origin), "failed");
+}, "Same-origin credentialless iframe can't request storage access");
+
+promise_test(async test => {
+  const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+  const iframe = newIframeCredentialless(cross_origin);
+  assert_equals(await requestStorageAccessFor(iframe, cross_origin), "failed");
+}, "Cross-origin credentialless iframe can't request storage access");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt
@@ -1,4 +1,4 @@
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/html/cross-origin-embedder-policy/resources/navigate-none.sub.html?postMessageTo=top' in a frame because of Cross-Origin-Embedder-Policy.
 
-FAIL Loading an anonymous iframe with COEP: require-corp is allowed. assert_true: The anonymous iframe should be allowed. expected true got false
+FAIL Loading a credentialless iframe with COEP: require-corp is allowed. assert_true: The credentialless iframe should be allowed. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window.js
@@ -23,9 +23,9 @@ promise_test(async t => {
     resolve(false);
   });
 
-  // Create an anonymous child iframe.
+  // Create a credentialless child iframe.
   const child = document.createElement("iframe");
-  child.anonymous = true;
+  child.credentialless = true;
   t.add_cleanup(() => child.remove());
 
   child.src = "/html/cross-origin-embedder-policy/resources/" +
@@ -33,11 +33,11 @@ promise_test(async t => {
   document.body.append(child);
 
   assert_true(await iframe_allowed(child),
-              "The anonymous iframe should be allowed.");
+              "The credentialless iframe should be allowed.");
 
-  // Create a child of the anonymous iframe. Even if the grandchild
-  // does not have the 'anonymous' attribute set, it inherits the
-  // anonymous property from the parent.
+  // Create a child of the credentialless iframe. Even if the grandchild
+  // does not have the 'credentialless' attribute set, it inherits the
+  // credentialless property from the parent.
   const grandchild = child.contentDocument.createElement("iframe");
 
   grandchild.src = "/html/cross-origin-embedder-policy/resources/" +
@@ -45,5 +45,5 @@ promise_test(async t => {
   child.contentDocument.body.append(grandchild);
 
   assert_true(await iframe_allowed(grandchild),
-             "The child of the anonymous iframe should be allowed.");
-}, 'Loading an anonymous iframe with COEP: require-corp is allowed.');
+             "The child of the credentialless iframe should be allowed.");
+}, 'Loading a credentialless iframe with COEP: require-corp is allowed.');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/resources/common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/resources/common.js
@@ -1,12 +1,12 @@
-// Create an anonymous iframe. The new document will execute any scripts sent
-// toward the token it returns.
-const newAnonymousIframe = (child_origin, opt_headers) => {
+// Create a credentialless iframe. The new document will execute any scripts
+// sent toward the token it returns.
+const newIframeCredentialless = (child_origin, opt_headers) => {
   opt_headers ||= "";
   const sub_document_token = token();
   let iframe = document.createElement('iframe');
   iframe.src = child_origin + executor_path + opt_headers +
     `&uuid=${sub_document_token}`;
-  iframe.anonymous = true;
+  iframe.credentialless = true;
   document.body.appendChild(iframe);
   return sub_document_token;
 };
@@ -17,7 +17,7 @@ const newIframe = (child_origin) => {
   const sub_document_token = token();
   let iframe = document.createElement('iframe');
   iframe.src = child_origin + executor_path + `&uuid=${sub_document_token}`;
-  iframe.anonymous = false
+  iframe.credentialless = false
   document.body.appendChild(iframe);
   return sub_document_token;
 };
@@ -33,15 +33,15 @@ const newPopup = (test, origin) => {
 
 // Create a fenced frame. The new document will execute any scripts sent
 // toward the token it returns.
-const newFencedFrame = (child_origin) => {
+const newFencedFrame = async (child_origin) => {
   const support_loading_mode_fenced_frame =
     "|header(Supports-Loading-Mode,fenced-frame)";
   const sub_document_token = token();
-  const fencedframe = document.createElement('fencedframe');
-  fencedframe.src = child_origin + executor_path +
+  const url = child_origin + executor_path +
     support_loading_mode_fenced_frame +
     `&uuid=${sub_document_token}`;
-  document.body.appendChild(fencedframe);
+  const urn = await generateURNFromFledge(url, []);
+  attachFencedFrame(urn);
   return sub_document_token;
 };
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/resources/embedding-test.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/resources/embedding-test.js
@@ -10,7 +10,7 @@ setup({ explicit_timeout: true });
 const EXPECT_LOAD = "load";
 const EXPECT_BLOCK = "block";
 
-// Load an anonymous iframe. Control both the parent and the child headers.
+// Load a credentialless iframe. Control both the parent and the child headers.
 // Check whether it loaded or not.
 const embeddingTest = (description, {
   parent_headers,
@@ -41,7 +41,7 @@ const embeddingTest = (description, {
     // The parent creates its child:
     await send(parent_token, `
       const iframe = document.createElement("iframe");
-      iframe.anonymous = true;
+      iframe.credentialless = true;
       iframe.src = "${child_url}";
       document.body.appendChild(iframe);
     `);
@@ -63,8 +63,8 @@ const embeddingTest = (description, {
     //   timing out. False-negative are not a problem, they just need not to
     //   overwhelm the true-negative, which is trivial to get.
     step_timeout(() => send(reply_token, "block"), expectation == EXPECT_BLOCK
-      ? 2000
-      : 6000
+      ? 1500
+      : 3500
     );
 
     assert_equals(await receive(reply_token), expectation);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anonymous iframes get partitioned service workers. assert_false: expected false got true
+FAIL credentialless iframes get partitioned service workers. assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window.js
@@ -4,26 +4,26 @@ const sw_url = location.pathname.replace(/[^/]*$/, '') +
       "./resources/serviceworker-partitioning-helper.js";
 
 promise_test(async t => {
-  // Create 4 iframes (two normal and two anonymous ones) and register
+  // Create 4 iframes (two normal and two credentialless ones) and register
   // a serviceworker with the same scope and url in all of them.
   //
   // Registering the same service worker again with the same url and
-  // scope is a no-op. However, anonymous iframes get partitioned
+  // scope is a no-op. However, credentialless iframes get partitioned
   // service workers, so we should have a total of 2 service workers
-  // at the end (one for the normal iframes and one for the anonymous
+  // at the end (one for the normal iframes and one for the credentialless
   // ones).
   let iframes = await Promise.all([
-    { name: "normal", anonymous: false},
-    { name: "normal_control", anonymous: false},
-    { name: "anonymous", anonymous: true},
-    { name: "anonymous_control", anonymous: true},
-  ].map(async ({name, anonymous}) => {
+    { name: "normal", credentialless: false},
+    { name: "normal_control", credentialless: false},
+    { name: "credentialless", credentialless: true},
+    { name: "credentialless_control", credentialless: true},
+  ].map(async ({name, credentialless}) => {
 
     let iframe = await new Promise(resolve => {
       let iframe = document.createElement('iframe');
       iframe.onload = () => resolve(iframe);
       iframe.src = '/common/blank.html';
-      if (anonymous) iframe.anonymous = true;
+      if (credentialless) iframe.credentialless = true;
       document.body.append(iframe);
     });
 
@@ -58,28 +58,28 @@ promise_test(async t => {
   // "normal_control" iframes.
   assert_true(!!msgs[0]["normal"]);
   assert_true(!!msgs[0]["normal_control"]);
-  assert_false(!!msgs[0]["anonymous"]);
-  assert_false(!!msgs[0]["anonymous_control"]);
+  assert_false(!!msgs[0]["credentialless"]);
+  assert_false(!!msgs[0]["credentialless_control"]);
 
   // The "normal_control" iframe shares the same serviceworker as the "normal"
   // iframe.
   assert_true(!!msgs[1]["normal"]);
   assert_true(!!msgs[1]["normal_control"]);
-  assert_false(!!msgs[1]["anonymous"]);
-  assert_false(!!msgs[1]["anonymous_control"]);
+  assert_false(!!msgs[1]["credentialless"]);
+  assert_false(!!msgs[1]["credentialless_control"]);
 
-  // The "anonymous" iframe serviceworker belongs to the "anonymous" and the
-  // "anonymous_control" iframes.
+  // The "credentialless" iframe serviceworker belongs to the "credentialless"
+  // and the "credentialless_control" iframes.
   assert_false(!!msgs[2]["normal"]);
   assert_false(!!msgs[2]["normal_control"]);
-  assert_true(!!msgs[2]["anonymous"]);
-  assert_true(!!msgs[2]["anonymous_control"]);
+  assert_true(!!msgs[2]["credentialless"]);
+  assert_true(!!msgs[2]["credentialless_control"]);
 
-  // The "anonymous_control" iframe shares the same serviceworker as
-  // the "anonymous" iframe.
+  // The "credentialless_control" iframe shares the same serviceworker as the
+  // "credentialless" iframe.
   assert_false(!!msgs[3]["normal"]);
   assert_false(!!msgs[3]["normal_control"]);
-  assert_true(!!msgs[3]["anonymous"]);
-  assert_true(!!msgs[3]["anonymous_control"]);
+  assert_true(!!msgs[3]["credentialless"]);
+  assert_true(!!msgs[3]["credentialless_control"]);
 
-}, "Anonymous iframes get partitioned service workers.");
+}, "credentialless iframes get partitioned service workers.");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window-expected.txt
@@ -1,5 +1,3 @@
 
-PASS Setup
-FAIL same_origin anonymous iframe can't access the sessionStorage assert_equals: expected "" but got "same_origin"
-PASS cross_origin anonymous iframe can't access the sessionStorage
+FAIL Session storage is correctly partitioned with regards to credentialless iframe assert_equals: expected "not found" but got "value_1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window.js
@@ -4,49 +4,54 @@
 // META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
 // META: script=./resources/common.js
 
-const same_origin = get_host_info().HTTPS_ORIGIN;
-const cross_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
-const session_storage_key = "coep_credentialless_iframe_session_storage";
-const session_storage_same_origin = "same_origin";
-const session_storage_cross_origin = "cross_origin";
+// Make |iframe| to store |key|=|value| into sessionStorage.
+const store = async (iframe, key, value) => {
+  const response_queue = token();
+  send(iframe, `
+    sessionStorage.setItem("${key}", "${value}");
+    send("${response_queue}", "stored");
+  `);
+  assert_equals(await receive(response_queue), "stored");
+};
 
-promise_test_parallel(async test => {
-  // Add an item in the sessionStorage on same_origin.
-  sessionStorage.setItem(session_storage_key, session_storage_same_origin);
+// Make |iframe| to load |key| in sessionStorage. Check it matches the
+// |expected_value|.
+const load = async (iframe, key, expected_value) => {
+  const response_queue = token();
+  send(iframe, `
+    const value = sessionStorage.getItem("${key}");
+    send("${response_queue}", value || "not found");
+  `);
+  assert_equals(await receive(response_queue), expected_value);
+};
 
-  // Add an item in the sessionStorage on cross_origin.
-  {
-    const w_token = token();
-    const w_url = cross_origin + executor_path + `&uuid=${w_token}`;
-    const w = window.open(w_url);
-    const reply_token = token();
-    send(w_token, `
-      sessionStorage.setItem("${session_storage_key}",
-                           "${session_storage_cross_origin}");
-      send("${reply_token}", "done");
-    `);
-    assert_equals(await receive(reply_token), "done");
-    w.close();
-  }
+promise_test(async test => {
+  const origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+  const key_1 = token();
+  const key_2 = token();
 
-  promise_test_parallel(async test => {
-    let iframe = newAnonymousIframe(same_origin);
-    let reply_token = token();
-    send(iframe, `
-      let value = sessionStorage.getItem("${session_storage_key}");
-      send("${reply_token}", value);
-    `)
-    assert_equals(await receive(reply_token), "")
-  }, "same_origin anonymous iframe can't access the sessionStorage");
+  // 4 actors: 2 credentialless iframe and 2 normal iframe.
+  const iframe_credentialless_1 = newIframeCredentialless(origin);
+  const iframe_credentialless_2 = newIframeCredentialless(origin);
+  const iframe_normal_1 = newIframe(origin);
+  const iframe_normal_2 = newIframe(origin);
 
-  promise_test_parallel(async test => {
-    let iframe = newAnonymousIframe(cross_origin);
-    let reply_token = token();
-    send(iframe, `
-      let value = sessionStorage.getItem("${session_storage_key}");
-      send("${reply_token}", value);
-    `)
-    assert_equals(await receive(reply_token), "")
-  }, "cross_origin anonymous iframe can't access the sessionStorage");
+  // 1. Store a value in one credentialless iframe and one normal iframe.
+  await Promise.all([
+    store(iframe_credentialless_1, key_1, "value_1"),
+    store(iframe_normal_1, key_2, "value_2"),
+  ]);
 
-}, "Setup")
+  // 2. Check what each of them can retrieve.
+  await Promise.all([
+    load(iframe_credentialless_1, key_1, "value_1"),
+    load(iframe_credentialless_2, key_1, "value_1"),
+    load(iframe_credentialless_1, key_2, "not found"),
+    load(iframe_credentialless_2, key_2, "not found"),
+
+    load(iframe_normal_1, key_1, "not found"),
+    load(iframe_normal_2, key_1, "not found"),
+    load(iframe_normal_1, key_2, "value_2"),
+    load(iframe_normal_2, key_2, "value_2"),
+  ]);
+}, "Session storage is correctly partitioned with regards to credentialless iframe");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anonymous iframes get partitioned shared workers. assert_true: The "normal" iframe's sharedworker should return {"normal": true, "normal_control": true}, but instead returned {"anonymous":true,"anonymous_control":true,"normal":true,"normal_control":true} expected true got false
+FAIL credentialless iframes get partitioned shared workers. assert_true: The "normal" iframe's sharedworker should return {"normal": true, "normal_control": true}, but instead returned {"normal_control":true,"normal":true,"credentialless":true,"credentialless_control":true} expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window.js
@@ -4,25 +4,25 @@ const sw_url = location.pathname.replace(/[^/]*$/, '') +
       "./resources/sharedworker-partitioning-helper.js";
 
 promise_test(async t => {
-  // Create 4 iframes (two normal and two anonymous ones) and create
+  // Create 4 iframes (two normal and two credentialless ones) and create
   // a shared worker with the same url in all of them.
   //
   // Creating the same shared worker again with the same url is a
-  // no-op. However, anonymous iframes get partitioned shared workers,
+  // no-op. However, credentialless iframes get partitioned shared workers,
   // so we should have a total of 2 shared workers at the end (one for
-  // the normal iframes and one for the anonymous ones).
+  // the normal iframes and one for the credentialless ones).
   let iframes = await Promise.all([
-    { name: "normal", anonymous: false},
-    { name: "normal_control", anonymous: false},
-    { name: "anonymous", anonymous: true},
-    { name: "anonymous_control", anonymous: true},
-  ].map(async ({name, anonymous}) => {
+    { name: "normal", credentialless: false},
+    { name: "normal_control", credentialless: false},
+    { name: "credentialless", credentialless: true},
+    { name: "credentialless_control", credentialless: true},
+  ].map(async ({name, credentialless}) => {
 
     let iframe = await new Promise(resolve => {
       let iframe = document.createElement('iframe');
       iframe.onload = () => resolve(iframe);
       iframe.src = '/common/blank.html';
-      if (anonymous) iframe.anonymous = true;
+      if (credentialless) iframe.credentialless = true;
       document.body.append(iframe);
     });
 
@@ -54,8 +54,8 @@ promise_test(async t => {
   // "normal_control" iframes.
   assert_true(!!msgs[0]["normal"] &&
               !!msgs[0]["normal_control"] &&
-              !msgs[0]["anonymous"] &&
-              !msgs[0]["anonymous_control"],
+              !msgs[0]["credentialless"] &&
+              !msgs[0]["credentialless_control"],
               'The "normal" iframe\'s sharedworker should return ' +
               '{"normal": true, "normal_control": true}, ' +
               'but instead returned ' + JSON.stringify(msgs[0]));
@@ -64,30 +64,30 @@ promise_test(async t => {
   // iframe.
   assert_true(!!msgs[1]["normal"] &&
               !!msgs[1]["normal_control"] &&
-              !msgs[1]["anonymous"] &&
-              !msgs[1]["anonymous_control"],
+              !msgs[1]["credentialless"] &&
+              !msgs[1]["credentialless_control"],
               'The "normal_control" iframe\'s sharedworker should return ' +
               '{"normal": true, "normal_control": true}, ' +
               'but instead returned ' + JSON.stringify(msgs[1]));
 
-  // The "anonymous" iframe sharedworker belongs to the "anonymous" and the
-  // "anonymous_control" iframes.
+  // The "credentialless" iframe sharedworker belongs to the "credentialless" and the
+  // "credentialless_control" iframes.
   assert_true(!msgs[2]["normal"] &&
               !msgs[2]["normal_control"] &&
-              !!msgs[2]["anonymous"] &&
-              !!msgs[2]["anonymous_control"],
-              'The "anonymous" iframe\'s sharedworker should return ' +
-              '{"anonymous": true, "anonymous_control": true}, ' +
+              !!msgs[2]["credentialless"] &&
+              !!msgs[2]["credentialless_control"],
+              'The "credentialless" iframe\'s sharedworker should return ' +
+              '{"credentialless": true, "credentialless_control": true}, ' +
               'but instead returned ' + JSON.stringify(msgs[2]));
 
-  // The "anonymous_control" iframe shares the same sharedworker as
-  // the "anonymous" iframe.
+  // The "credentialless_control" iframe shares the same sharedworker as
+  // the "credentialless" iframe.
   assert_true(!msgs[3]["normal"] &&
               !msgs[3]["normal_control"] &&
-              !!msgs[3]["anonymous"] &&
-              !!msgs[3]["anonymous_control"],
-              'The "anonymous_control" iframe\'s sharedworker should return ' +
-              '{"anonymous": true, "anonymous_control": true}, ' +
+              !!msgs[3]["credentialless"] &&
+              !!msgs[3]["credentialless_control"],
+              'The "credentialless_control" iframe\'s sharedworker should return ' +
+              '{"credentialless": true, "credentialless_control": true}, ' +
               'but instead returned ' + JSON.stringify(msgs[3]));
 
-}, "Anonymous iframes get partitioned shared workers.");
+}, "credentialless iframes get partitioned shared workers.");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/w3c-import.log
@@ -22,12 +22,17 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame-bypass.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/web-lock.tentative.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/web-lock.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/web-lock.tentative.https.window.js
@@ -37,39 +37,39 @@ promise_test(async test => {
   const key_1 = token();
   const key_2 = token();
 
-  // 2 actors: An anonymous iframe and a normal one.
-  const iframe_anonymous = newAnonymousIframe(origin);
+  // 2 actors: A credentialless iframe and a normal one.
+  const iframe_credentialless = newIframeCredentialless(origin);
   const iframe_normal = newIframe(origin);
   const response_queue_1 = token();
   const response_queue_2 = token();
 
   // 1. Hold two different locks on both sides.
-  send(iframe_anonymous, acquire_script(key_1, response_queue_1));
+  send(iframe_credentialless, acquire_script(key_1, response_queue_1));
   send(iframe_normal, acquire_script(key_2, response_queue_2));
   assert_equals(await receive(response_queue_1), "locked");
   assert_equals(await receive(response_queue_2), "locked");
-  await assertHeldKeys(iframe_anonymous, [key_1]);
+  await assertHeldKeys(iframe_credentialless, [key_1]);
   await assertHeldKeys(iframe_normal, [key_2]);
 
   // 2. Try to acquire the lock with the same key on the opposite side. It
   //    shouldn't block, because they are partitioned.
-  send(iframe_anonymous , acquire_script(key_2, response_queue_1));
+  send(iframe_credentialless , acquire_script(key_2, response_queue_1));
   send(iframe_normal, acquire_script(key_1, response_queue_2));
   assert_equals(await receive(response_queue_1), "locked");
   assert_equals(await receive(response_queue_2), "locked");
-  await assertHeldKeys(iframe_anonymous, [key_1, key_2]);
+  await assertHeldKeys(iframe_credentialless, [key_1, key_2]);
   await assertHeldKeys(iframe_normal, [key_1, key_2]);
 
   // 3. Cleanup: release the 4 locks (2 on each sides).
-  send(iframe_anonymous, release_script(response_queue_1));
+  send(iframe_credentialless, release_script(response_queue_1));
   assert_equals(await receive(response_queue_1), "unlocked");
   assert_equals(await receive(response_queue_1), "unlocked");
-  await assertHeldKeys(iframe_anonymous, []);
+  await assertHeldKeys(iframe_credentialless, []);
   await assertHeldKeys(iframe_normal, [key_1, key_2]);
 
   send(iframe_normal, release_script(response_queue_2));
   assert_equals(await receive(response_queue_2), "unlocked");
   assert_equals(await receive(response_queue_2), "unlocked");
-  await assertHeldKeys(iframe_anonymous, []);
+  await assertHeldKeys(iframe_credentialless, []);
   await assertHeldKeys(iframe_normal, []);
 })

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window-expected.txt
@@ -1,0 +1,5 @@
+
+PASS set cookies
+PASS Worker spawned from normal iframe can access global cookies
+FAIL Worker spawned from credentialless iframe can't access global cookies assert_equals: expected (undefined) undefined but got (string) "cookie_value"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.js
@@ -1,0 +1,70 @@
+// META: timeout=long
+// META: variant=?worker=dedicated_worker
+// META: variant=?worker=shared_worker
+// META: variant=?worker=service_worker
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/html/cross-origin-embedder-policy/credentialless/resources/common.js
+// META: script=./resources/common.js
+
+// Execute the same set of tests for every type of worker.
+// - DedicatedWorkers
+// - SharedWorkers
+// - ServiceWorkers.
+const params = new URLSearchParams(document.location.search);
+const worker_param = params.get("worker") || "dedicated_worker";
+
+const cookie_key = token();
+const cookie_value = "cookie_value";
+const cookie_origin = get_host_info().HTTPS_REMOTE_ORIGIN;
+
+// Create worker spawned from `context` and return its uuid.
+const workerFrom = context => {
+  const reply = token();
+  send(context, `
+    for(deps of [
+      "/common/utils.js",
+      "/resources/testharness.js",
+      "/html/cross-origin-embedder-policy/credentialless/resources/common.js",
+    ]) {
+      await new Promise(resolve => {
+        const script = document.createElement("script");
+        script.src = deps;
+        script.onload = resolve;
+        document.body.appendChild(script);
+      });
+    }
+
+    const worker_constructor = environments["${worker_param}"];
+    const headers = "";
+    const [worker, error] = worker_constructor(headers);
+    send("${reply}", worker);
+  `);
+  return receive(reply);
+};
+
+// Set a cookie from a top-level document.
+promise_test(async test => {
+  await setCookie(cookie_origin, cookie_key, cookie_value);
+}, "set cookies");
+
+// Control: iframe is not credentialless. The worker can access cookies.
+promise_test(async test => {
+  const headers = token();
+  send(await workerFrom(newIframe(cookie_origin)), `
+    fetch("${showRequestHeaders(cookie_origin, headers)}");
+  `);
+  const cookie = parseCookies(JSON.parse(await receive(headers)));
+  assert_equals(cookie[cookie_key], cookie_value)
+}, "Worker spawned from normal iframe can access global cookies");
+
+// Experiment: iframe is credentialless.
+promise_test(async test => {
+  const headers = token();
+  send(await workerFrom(newIframeCredentialless(cookie_origin)), `
+    fetch("${showRequestHeaders(cookie_origin, headers)}");
+  `);
+  const cookie = parseCookies(JSON.parse(await receive(headers)));
+  assert_equals(cookie[cookie_key], undefined)
+}, "Worker spawned from credentialless iframe can't access global cookies");

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Same-origin credentialless iframe can't request storage access assert_equals: expected "failed" but got "success"
+FAIL Cross-origin credentialless iframe can't request storage access assert_equals: expected "failed" but got "success"
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/html/cross-origin-embedder-policy/resources/navigate-none.sub.html?postMessageTo=top' in a frame because of Cross-Origin-Embedder-Policy.
+
+FAIL Loading a credentialless iframe with COEP: require-corp is allowed. assert_true: The credentialless iframe should be allowed. expected true got false
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Local storage is correctly partitioned with regards to credentialless iframe assert_equals: expected "not found" but got "value_2"
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Same-origin credentialless iframe can't request storage access assert_equals: expected "failed" but got "success"
+FAIL Cross-origin credentialless iframe can't request storage access assert_equals: expected "failed" but got "success"
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/html/cross-origin-embedder-policy/resources/navigate-none.sub.html?postMessageTo=top' in a frame because of Cross-Origin-Embedder-Policy.
+
+FAIL Loading a credentialless iframe with COEP: require-corp is allowed. assert_true: The credentialless iframe should be allowed. expected true got false
+


### PR DESCRIPTION
#### d496804bab0a4678d7d59a23a44ac60ce8eb8f85
<pre>
Resync `html/anonymous-iframe` from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=297341">https://bugs.webkit.org/show_bug.cgi?id=297341</a>
<a href="https://rdar.apple.com/158239880">rdar://158239880</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/fa80f49be6ced958bce13b11c5d7bbc1c9a68d47">https://github.com/web-platform-tests/wpt/commit/fa80f49be6ced958bce13b11c5d7bbc1c9a68d47</a>

* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-iframe-popup.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-iframe-popup.tentative.https.window.js:
(promise_setup.async t.async const):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-window.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/anonymous-window.tentative.https.window.js:
(promise_test_parallel.async t):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cache-storage.tentative.https.window.js:
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie-store.tentative.https.window.js:
(promise_setup.async await):
(promise_setup):
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/cookie.tentative.https.window.js:
(const.cookieFromCredentiallessIframeRequest.async iframe_origin):
(promise_test_parallel.async test.promise_test_parallel.async test):
(promise_test_parallel.async test):
(const.cookieFromAnonymousIframeRequest.async iframe_origin): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame-bypass.tentative.https.window.js:
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/fenced-frame.tentative.https.window.js:
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/hasStorageAccess.tentative.https.window.js: Added.
(setup):
(const.hasStorageAccess):
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/indexeddb.tentative.https.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/initial-empty-document.tentative.https.window.js:
(promise_test_parallel.async t):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage-initial-empty-document.tentative.https.window.js: Added.
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window.js:
(const.store.async iframe):
(const.load.async iframe):
(promise_test.async test):
(promise_test_parallel.async test.async promise_test_parallel): Deleted.
(promise_test_parallel.async test): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window.js: Added.
(setup):
(const.requestStorageAccess):
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccessFor.tentative.https.window.js: Added.
(setup):
(const.requestStorageAccessFor):
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window.js:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/resources/common.js:
(const.newIframeCredentialless):
(const.newIframe):
(const.newFencedFrame.async child_origin):
(const.newAnonymousIframe): Deleted.
(const.newFencedFrame): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/resources/embedding-test.js:
(const.embeddingTest):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/serviceworker-partitioning.tentative.https.window.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window.js:
(const.store.async iframe):
(const.load.async iframe):
(promise_test.async test):
(promise_test_parallel.async test.async promise_test_parallel): Deleted.
(promise_test_parallel.async test): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/sharedworker-partitioning.tentative.https.window.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/web-lock.tentative.https.window.js:
(promise_test.async test):
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/anonymous-iframe/worker-cookies.tentative.https.window.js: Added.
(promise_test.async test):
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/anonymous-iframe/local-storage.tentative.https.window-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/requestStorageAccess.tentative.https.window-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/anonymous-iframe/require-corp-embed-anonymous-iframe.tentative.https.window-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/299417@main">https://commits.webkit.org/299417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e16224d04582b1525ad681a81b42924f299e836e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6206ade-58b1-4d8d-8270-aa057b5a74b2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47175 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90241 "Found 1 new test failure: imported/w3c/web-platform-tests/encoding/encodeInto.any.serviceworker.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59756 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da730092-c343-4e4b-b498-7eef73a08097) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70746 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9808939f-59af-463a-92fa-770c9fa284e9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68764 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128152 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98900 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98680 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42384 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18940 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45689 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45155 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48499 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46839 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->