### PR TITLE
Make WebKitTestRunner a little less platform dependent

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -946,7 +946,8 @@ WKRetainPtr<WKPageConfigurationRef> TestController::generatePageConfiguration(co
 {
     if (!m_context || !m_mainWebView || !m_mainWebView->viewSupportsOptions(options)) {
         auto contextConfiguration = generateContextConfiguration(options);
-        m_context = platformAdjustContext(adoptWK(WKContextCreateWithConfiguration(contextConfiguration.get())).get(), contextConfiguration.get());
+        m_preferences = adoptWK(WKPreferencesCreate());
+        m_context = adoptWK(WKContextCreateWithConfiguration(contextConfiguration.get()));
 
         auto localhostAliases = adoptWK(WKMutableArrayCreate());
         for (const auto& alias : m_localhostAliases)
@@ -3661,7 +3662,7 @@ void TestController::setUseDarkAppearanceForTesting(bool useDarkAppearance)
 
 void TestController::terminateGPUProcess()
 {
-    WKContextTerminateGPUProcess(platformContext());
+    WKContextTerminateGPUProcess(context());
 }
 
 void TestController::terminateNetworkProcess()
@@ -3671,7 +3672,7 @@ void TestController::terminateNetworkProcess()
 
 void TestController::terminateServiceWorkers()
 {
-    WKContextTerminateServiceWorkers(platformContext());
+    WKContextTerminateServiceWorkers(context());
 }
 
 #if !PLATFORM(COCOA)
@@ -3695,12 +3696,6 @@ void TestController::platformCreateWebView(WKPageConfigurationRef configuration,
 UniqueRef<PlatformWebView> TestController::platformCreateOtherPage(PlatformWebView* parentView, WKPageConfigurationRef configuration, const TestOptions& options)
 {
     return makeUniqueRef<PlatformWebView>(configuration, options);
-}
-
-WKContextRef TestController::platformAdjustContext(WKContextRef context, WKContextConfigurationRef)
-{
-    m_preferences = adoptWK(WKPreferencesCreate());
-    return context;
 }
 
 unsigned TestController::imageCountInGeneralPasteboard() const
@@ -4367,27 +4362,27 @@ void TestController::removeAllCookies(CompletionHandler<void(WKTypeRef)>&& compl
 void TestController::addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type, WKDictionaryRef properties)
 {
     bool isDefault = false;
-    WKAddMockMediaDevice(platformContext(), persistentID, label, type, properties, isDefault);
+    WKAddMockMediaDevice(context(), persistentID, label, type, properties, isDefault);
 }
 
 void TestController::clearMockMediaDevices()
 {
-    WKClearMockMediaDevices(platformContext());
+    WKClearMockMediaDevices(context());
 }
 
 void TestController::removeMockMediaDevice(WKStringRef persistentID)
 {
-    WKRemoveMockMediaDevice(platformContext(), persistentID);
+    WKRemoveMockMediaDevice(context(), persistentID);
 }
 
 void TestController::setMockMediaDeviceIsEphemeral(WKStringRef persistentID, bool isEphemeral)
 {
-    WKSetMockMediaDeviceIsEphemeral(platformContext(), persistentID, isEphemeral);
+    WKSetMockMediaDeviceIsEphemeral(context(), persistentID, isEphemeral);
 }
 
 void TestController::resetMockMediaDevices()
 {
-    WKResetMockMediaDevices(platformContext());
+    WKResetMockMediaDevices(context());
 }
 
 void TestController::setMockCameraOrientation(uint64_t rotation, WKStringRef persistentId)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -489,7 +489,6 @@ private:
     void platformInitialize(const Options&);
     void platformInitializeDataStore(WKPageConfigurationRef, const TestOptions&);
     void platformDestroy();
-    WKContextRef platformAdjustContext(WKContextRef, WKContextConfigurationRef);
     void platformInitializeContext();
     void platformEnsureGPUProcessConfiguredForOptions(const TestOptions&);
     void platformCreateWebView(WKPageConfigurationRef, const TestOptions&);
@@ -508,7 +507,6 @@ private:
     void platformWillRunTest(const TestInvocation&);
     void platformRunUntil(bool& done, WTF::Seconds timeout);
     void platformDidCommitLoadForFrame(WKPageRef, WKFrameRef);
-    WKContextRef platformContext();
     void initializeInjectedBundlePath();
     void initializeTestPluginDirectory();
     void installUserScript(const TestInvocation&);

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -131,11 +131,6 @@ void TestController::abortModal()
 {
 }
 
-WKContextRef TestController::platformContext()
-{
-    return m_context.get();
-}
-
 const char* TestController::platformLibraryPathForTesting()
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp
+++ b/Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp
@@ -100,11 +100,6 @@ void TestController::setHidden(bool hidden)
     WKViewSetVisible(m_mainWebView->platformView(), !hidden);
 }
 
-WKContextRef TestController::platformContext()
-{
-    return m_context.get();
-}
-
 bool TestController::platformResetStateToConsistentValues(const TestOptions&)
 {
     return true;

--- a/Tools/WebKitTestRunner/win/TestControllerWin.cpp
+++ b/Tools/WebKitTestRunner/win/TestControllerWin.cpp
@@ -197,11 +197,6 @@ void TestController::abortModal()
     notImplemented();
 }
 
-WKContextRef TestController::platformContext()
-{
-    return m_context.get();
-}
-
 const char* TestController::platformLibraryPathForTesting()
 {
     notImplemented();

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -123,11 +123,6 @@ void TestController::abortModal()
 {
 }
 
-WKContextRef TestController::platformContext()
-{
-    return m_context.get();
-}
-
 const char* TestController::platformLibraryPathForTesting()
 {
     return nullptr;


### PR DESCRIPTION
#### 13be90fc161eecf26d53b631797cbf45b7df2a6a
<pre>
Make WebKitTestRunner a little less platform dependent
<a href="https://bugs.webkit.org/show_bug.cgi?id=297348">https://bugs.webkit.org/show_bug.cgi?id=297348</a>
<a href="https://rdar.apple.com/158245251">rdar://158245251</a>

Reviewed by Brady Eidson.

Before WKWebViewConfiguration and WKPageConfigurationRef were bridge castable to each other
we needed to have the PlatformWebView&apos;s configuration be a platform-specific object, so we
decided to have a global WKWebViewConfiguration to copy from.  I fixed that in 276566@main
so we can now use shared code to configuration the PlatformWebView.  This is a big step in
that direction.

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::generatePageConfiguration):
(WTR::TestController::terminateGPUProcess):
(WTR::TestController::terminateServiceWorkers):
(WTR::TestController::addMockMediaDevice):
(WTR::TestController::clearMockMediaDevices):
(WTR::TestController::removeMockMediaDevice):
(WTR::TestController::setMockMediaDeviceIsEphemeral):
(WTR::TestController::resetMockMediaDevices):
(WTR::TestController::platformAdjustContext): Deleted.
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::globalWebsiteDataStoreDelegateClient):
(WTR::TestController::platformInitializeDataStore):
(WTR::TestController::platformCreateWebView):
(WTR::TestController::removeAllSessionCredentials):
(WTR::TestController::injectUserScript):
(WTR::TestController::getBackgroundFetchIdentifier):
(WTR::TestController::abortBackgroundFetch):
(WTR::TestController::pauseBackgroundFetch):
(WTR::TestController::resumeBackgroundFetch):
(WTR::TestController::simulateClickBackgroundFetch):
(WTR::TestController::backgroundFetchState):
(WTR::globalWebViewConfiguration): Deleted.
(WTR::initializeWebViewConfiguration): Deleted.
(WTR::TestController::platformContext): Deleted.
(WTR::TestController::platformAdjustContext): Deleted.
* Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp:
(WTR::TestController::platformContext): Deleted.
* Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp:
(WTR::TestController::platformContext): Deleted.
* Tools/WebKitTestRunner/win/TestControllerWin.cpp:
(WTR::TestController::platformContext): Deleted.
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::TestController::platformContext): Deleted.

Canonical link: <a href="https://commits.webkit.org/298664@main">https://commits.webkit.org/298664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4edde70e5de020a328fa8323a34278c3856b1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66736 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f1731ebd-55e3-4cec-9b00-c00cce35f136) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88266 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef4701fe-c1a9-41a1-acc0-4a741ffa51a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68677 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22355 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65915 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125383 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96992 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96776 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42057 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39018 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18567 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42958 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42425 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44129 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->