### PR TITLE
Begin implementing `test_driver.set_storage_access()`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
@@ -2,6 +2,6 @@ Blocked access to external URL https://www.localhost:9443/storage-access-api/res
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Grants have per-frame scope assert_true: frame1 should now have cookie access. expected true got false
+FAIL Grants have per-frame scope assert_true: requestStorageAccess doesn't require a gesture since the permission has already been granted. expected true got false
 TIMEOUT Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Workers don't inherit storage access assert_true: frame has access to cookies after request. expected true got false
-FAIL Workers don't observe parent's storage access assert_true: frame has access to cookies after request. expected true got false
+FAIL Workers don't inherit storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
+FAIL Workers don't observe parent's storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL WebSocket inherits storage access assert_true: frame has access to cookies after request. expected true got false
+FAIL WebSocket inherits storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
 PASS WebSocket omits unpartitioned cookies without storage access
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify StorageAccessAPIBeyondCookies for Blob Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for blobStorage" but got "Unable to load handle in same-origin context for blobStorage"
+FAIL Verify StorageAccessAPIBeyondCookies for Blob Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for blobStorage" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify StorageAccessAPIBeyondCookies for None assert_equals: Storage Access API should not allow access for empty requests. expected "HasAccess for none" but got "Unable to load handle in same-origin context for none"
+FAIL Verify StorageAccessAPIBeyondCookies for None assert_equals: Storage Access API should not allow access for empty requests. expected "HasAccess for none" but got "Unable to load handle in cross-site context for all"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
@@ -8,7 +8,7 @@ FAIL 'Activate-Storage-Access: retry' is a no-op on a request without an `allowe
 FAIL 'Activate-Storage-Access: retry' is a no-op on a request from an origin that does not match its `allowed-origin` value. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `retry` is a no-op on a request with a `none` Storage Access status. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `load` header grants storage access to frame. assert_true: frame should have storage access because of the `load` header expected true got false
-PASS Activate-Storage-Access `load` is honored for `active` cases.
+FAIL Activate-Storage-Access `load` is honored for `active` cases. assert_true: expected true got false
 PASS Activate-Storage-Access `load` header is a no-op for requests without storage access.
 FAIL Sec-Fetch-Storage-Access is `inactive` for ABA case. assert_array_equals: value is undefined, expected array
 FAIL Storage Access can be activated for ABA cases by retrying. assert_array_equals: value is undefined, expected array

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -703,3 +703,23 @@ window.test_driver_internal.get_computed_role = async function (element, context
 
     return context.internals.getComputedRole(element);
 }
+
+/**
+ *
+ * @param {string} origin
+ * @param {string} embedding_origin
+ * @param {boolean} blocked
+ * @returns {Promise<void>}
+ */
+window.test_driver_internal.set_storage_access = async function (origin, embedding_origin, blocked, context=null) {
+    // FIXME: This function should support setting storage access for specific origins.
+    if (origin != "*" || embedding_origin != "*")
+        throw new Error("Unsupported value for origin or embedding_origin");
+
+    context = context ?? window;
+    return new Promise((resolve) => {
+        context.testRunner.setStatisticsShouldBlockThirdPartyCookies(blocked, () => {
+            blocked ? context.testRunner.statisticsClearInMemoryAndPersistentStore(resolve) : resolve();
+        });
+    });
+}


### PR DESCRIPTION
#### 8ad40b810c5019c0e7cc92c41fef317b42617a9d
<pre>
Begin implementing `test_driver.set_storage_access()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297349">https://bugs.webkit.org/show_bug.cgi?id=297349</a>
<a href="https://rdar.apple.com/158245659">rdar://158245659</a>

Reviewed by BJ Burg.

* LayoutTests/resources/testdriver-vendor.js:
(async if):
(window.test_driver_internal.set_storage_access):
This implements the portion of set_storage_access() related to third-party cookie access. Currently, it
only works when both the origin and the embedding origin are “*”, but here are no tests that require
setting access for specific origins.

<a href="https://privacycg.github.io/storage-access/#set-storage-access-command">https://privacycg.github.io/storage-access/#set-storage-access-command</a>

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt:
Rebaseline test results. This will enable third-party cookie blocking for these tests, so these tests are
not expected to work until future changes are made to run tests in this configuration (PR #49358 and
PR #49351)

Canonical link: <a href="https://commits.webkit.org/298661@main">https://commits.webkit.org/298661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4389f64b184a177b46916be40e604508bfd982fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122262 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72333d38-2d67-42de-bfb5-3ef661e60b57) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44454 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/480b304c-a501-43bc-b4cc-37829bc78f46) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68693 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22373 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65943 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22514 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32360 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100458 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/42072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18562 "Failed to push commit to Webkit repository") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/42986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44157 "Build is in progress. Recent messages:") | | | | 
<!--EWS-Status-Bubble-End-->