### PR TITLE
Storage Access API tests should set a cookie from a first-party context before setting cross-site cookies

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.js
@@ -27,6 +27,7 @@
   }
 
   promise_test(async (t) => {
+    await SetFirstPartyCookie(altRoot, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     const frame = await SetUpResponderFrame(t, altRootResponder);
     await SetDocumentCookieFromFrame(frame, domainCookieString);
 
@@ -52,6 +53,7 @@
   }, "Cross-origin fetches from a frame with storage-access are not credentialed by default");
 
   promise_test(async (t) => {
+    await SetFirstPartyCookie(altRoot, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     const frame = await SetUpResponderFrame(t, altRootResponder);
     await SetDocumentCookieFromFrame(frame, domainCookieString);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window-expected.txt
@@ -1,5 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: The string did not match the expected pattern.
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Unhandled rejection: The string did not match the expected pattern.
 
 TIMEOUT Same-site-initiated same-origin navigations preserve storage access Test timed out
 NOTRUN Same-site-initiated cross-origin navigations do not preserve storage access

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window.js
@@ -38,7 +38,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwNestedCrossOriginResponder);
 
@@ -52,7 +52,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwNestedCrossOriginResponder);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window-expected.txt
@@ -1,5 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: The string did not match the expected pattern.
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Unhandled rejection: The string did not match the expected pattern.
 
 TIMEOUT Self-initiated reloads preserve storage access Test timed out
 NOTRUN Self-initiated same-origin navigations preserve storage access

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.js
@@ -37,7 +37,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 
@@ -52,7 +52,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 
@@ -66,7 +66,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 
@@ -83,7 +83,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altWww);
+    await SetFirstPartyCookie(altWww);
 
     const frame = await SetUpResponderFrame(t, altWwwResponder);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Cross-site HTTP redirects from a frame with storage-access are not credentialed by default assert_true: frame has access to cookies after request. expected true got false
+PASS Cross-site HTTP redirects from a frame with storage-access are not credentialed by default
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window.js
@@ -24,6 +24,7 @@ async function SetUpResponderFrame(t, url) {
 }
 
 promise_test(async (t) => {
+  await SetFirstPartyCookie(altRoot, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
   const frame = await SetUpResponderFrame(t, altRootResponder);
   await SetDocumentCookieFromFrame(frame, domainCookieString);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
@@ -1,7 +1,8 @@
 Blocked access to external URL https://www.localhost:9443/storage-access-api/resources/script-with-cookie-header.py?script=embedded_responder.js
+Blocked access to external URL https://www.localhost:9443/storage-access-api/resources/set-document-cookie.html?initial-cookie=unpartitioned;Secure;SameSite=None;Path=/
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Grants have per-frame scope assert_false: frame1 should not have storage access initially. expected false got true
+FAIL Grants have per-frame scope assert_false: frame2 should still not have storage access. expected false got true
 TIMEOUT Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js
@@ -14,7 +14,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(wwwAlt);
+    await SetFirstPartyCookie(wwwAlt);
     const responder_html = `${wwwAlt}${url_suffix}`;
     const [frame1, frame2] = await Promise.all([
       CreateFrame(responder_html),
@@ -55,6 +55,8 @@
       CreateFrame(`${www}${url_suffix}`),
       CreateFrame(`${wwwAlt}${url_suffix}`),
     ]);
+    await SetFirstPartyCookie(www, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
+    await SetFirstPartyCookie(wwwAlt, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
 
     t.add_cleanup(async () => {
       await test_driver.delete_all_cookies();

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Workers don't inherit storage access assert_true: frame has access to cookies after request. expected true got false
-FAIL Workers don't observe parent's storage access assert_false: frame lacks storage access before request. expected false got true
+FAIL Workers don't inherit storage access assert_false: Worker's fetch is uncredentialed. expected false got true
+FAIL Workers don't observe parent's storage access assert_false: Worker's second fetch is uncredentialed. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window.js
@@ -28,7 +28,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+    await SetFirstPartyCookie(altRoot);
 
     const frame = await SetUpResponderFrame(t, altRootResponder);
     assert_true(await RequestStorageAccessInFrame(frame), "requestStorageAccess resolves without requiring a gesture.");
@@ -47,7 +47,7 @@
 
   promise_test(async (t) => {
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+    await SetFirstPartyCookie(altRoot);
 
     const frame = await SetUpResponderFrame(t, altRootResponder);
     assert_false(await FrameHasStorageAccess(frame), "frame lacks storage access before request.");

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL WebSocket inherits storage access assert_true: frame has access to cookies after request. expected true got false
+PASS WebSocket inherits storage access
 PASS WebSocket omits unpartitioned cookies without storage access
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.js
@@ -26,7 +26,7 @@ async function SetUpResponderFrame(t, url) {
 
 promise_test(async (t) => {
   await MaybeSetStorageAccess("*", "*", "blocked");
-  await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+  await SetFirstPartyCookie(altRoot);
 
   const frame = await SetUpResponderFrame(t, altRootResponder);
 
@@ -42,7 +42,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
 
   await MaybeSetStorageAccess("*", "*", "blocked");
-  await SetFirstPartyCookieAndUnsetStorageAccessPermission(altRoot);
+  await SetFirstPartyCookie(altRoot);
   const frame = await SetUpResponderFrame(t, altRootResponder);
 
   assert_false(cookieStringHasCookie("cookie", "unpartitioned",

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window.js
@@ -19,6 +19,8 @@ const canUseAutogrant = topLevelDocument ||
           testPrefix.includes('cross-origin') ||
           testPrefix.includes('ABA');
 
+const initialCookie = "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/";
+
 if (!topLevelDocument) {
   // WPT synthesizes a top-level HTML test for this JS file, and in that case we
   // don't want to, or need to, call set_test_context.
@@ -32,6 +34,7 @@ promise_test(async () => {
 
 // Most tests need to start with the feature in "prompt" state.
 async function CommonSetup() {
+  await SetFirstPartyCookie(location.origin, initialCookie);
   if (!canUseAutogrant) {
     await test_driver.set_permission({ name: 'storage-access' }, 'prompt');
   }
@@ -76,6 +79,7 @@ promise_test(
 if (!canUseAutogrant) {
   promise_test(
       async t => {
+        await SetFirstPartyCookie(location.origin, initialCookie);
         await test_driver.set_permission(
             {name: 'storage-access'}, 'denied');
 
@@ -89,6 +93,7 @@ if (!canUseAutogrant) {
 } else {
   promise_test(
       async () => {
+        await SetFirstPartyCookie(location.origin, initialCookie);
         await document.requestStorageAccess();
 
         assert_true(await CanAccessCookiesViaHTTP(), 'After obtaining storage access, subresource requests from the frame should send and set cookies.');

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/set-document-cookie.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/set-document-cookie.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+  <script>
+    'use strict';
+
+    let query = window.location.search;
+    let cookieString = '';
+    if (query && query.length > 1)
+      cookieString = decodeURIComponent(query.slice(1));
+
+    document.cookie = cookieString;
+
+    window.opener.postMessage('set-document-cookie-complete', '*');
+    window.close();
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window.js
@@ -122,7 +122,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -147,7 +147,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -303,7 +303,7 @@ promise_test(async t => {
 promise_test(async t => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess('*', '*', 'blocked');
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(https_origin);
+    await SetFirstPartyCookie(https_origin);
     addCommonCleanupCallback(t);
 
     const iframe_params = new URLSearchParams([['script',
@@ -337,7 +337,7 @@ promise_test(async t => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -377,7 +377,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
 
     await grantStorageAccessForEmbedSite(t, cross_site);
@@ -416,7 +416,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
     await grantStorageAccessForEmbedSite(t, cross_site);
 
@@ -456,7 +456,7 @@ promise_test(async (t) => {
 promise_test(async (t) => {
     const key = '{{uuid()}}';
     await MaybeSetStorageAccess("*", "*", "blocked");
-    await SetFirstPartyCookieAndUnsetStorageAccessPermission(cross_site);
+    await SetFirstPartyCookie(cross_site);
     addCommonCleanupCallback(t);
     await grantStorageAccessForEmbedSite(t, cross_site);
 


### PR DESCRIPTION
#### a67594c5a9d574c94f84063d065986bedf70de81
<pre>
Storage Access API tests should set a cookie from a first-party context before setting cross-site cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=297352">https://bugs.webkit.org/show_bug.cgi?id=297352</a>
<a href="https://rdar.apple.com/158246663">rdar://158246663</a>

Reviewed by Anne van Kesteren.

Safari’s cookie policy requires a cookie to be set in a first-party context before any cross-site cookie
can be set. Several Storage Access API tests fail because of this policy. This patch updates the tests to
set cookies in a first-party context first, rather than in a cross-site iframe.

Tests will not progress until PR #49349 lands, which will allow tests to control third-party cookie
blocking in WebKit.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/helpers.js:
(async SetFirstPartyCookie):
(async SetFirstPartyCookieAndUnsetStorageAccessPermission): Deleted.
(async HasUnpartitionedCookie): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-fetch.sub.https.window.js:
(async return):
(async SetUpResponderFrame):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window.js:
(async promise_test):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.js:
(async promise_test):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-fetch.sub.https.window.js:
(async return):
(async SetUpResponderFrame):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window.js:
(async const):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window.js:
(async return):
(async SetUpResponderFrame):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.js:
(async promise_test):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window.js:
(async CommonSetup):
(canUseAutogrant.promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/set-document-cookie.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window.js:
(async promise_test):

Canonical link: <a href="https://commits.webkit.org/298703@main">https://commits.webkit.org/298703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a69ad5248ed630717787cb37de00a1c72f1423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116421 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/36082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/26633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/36776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119370 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/36776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/26633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/36776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/26633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/66159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/36776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/44670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/26633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18587 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/43203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143647 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/143647 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->