### PR TITLE
Adjust some ifdefs to match declarations

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if ENABLE(GAMEPAD) && PLATFORM(COCOA)
+#if ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebCore, CoreHaptics)
@@ -45,4 +45,4 @@ SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyPattern, N
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyParameterID, NSString *)
 SOFT_LINK_CONSTANT_FOR_SOURCE(WebCore, CoreHaptics, CHHapticPatternKeyParameterValue, NSString *)
 
-#endif // ENABLE(GAMEPAD) && PLATFORM(COCOA)
+#endif // ENABLE(GAMEPAD) && HAVE(WIDE_GAMECONTROLLER_SUPPORT)

--- a/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm
@@ -29,6 +29,8 @@
 #import <QuartzCore/CoreAnimation.h>
 #import <wtf/RetainPtr.h>
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
 @interface WKColorExtensionView () <CAAnimationDelegate>
 @end
 
@@ -123,3 +125,5 @@
 }
 
 @end
+
+#endif // ENABLE(CONTENT_INSET_BACKGROUND_FILL)


### PR DESCRIPTION
#### 3e63279183c679e2b002ae188d5c70743e229251
<pre>
Adjust some ifdefs to match declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=297359">https://bugs.webkit.org/show_bug.cgi?id=297359</a>
<a href="https://rdar.apple.com/158252766">rdar://158252766</a>

Reviewed by Alex Christensen.

Needed for accurate SPI checking.

* Source/WebCore/platform/gamepad/cocoa/CoreHapticsSoftLink.mm: Only
  bind to CoreHaptics APIs on platforms where they actually exist.
  Prevents these symbols from being falsely flagged as SPI on other
  configurations.

* Source/WebKit/UIProcess/Cocoa/WKColorExtensionView.mm:
  This class delegates to WKWebView via WKColorExtensionViewDelegate.
  The class compiles unconditionally, but the protocol conformance is
  only compiled when CONTENT_INSET_BACKGROUND_FILL is enabled. That same
  condition is also used to instantiate WKColorExtensionView, so the
  class was just being unnecessarily compiled on older releases.

  Wrap the implementation in ENABLE(CONTENT_INSET_BACKGROUND_FILL) to
  match its use site.

Canonical link: <a href="https://commits.webkit.org/298655@main">https://commits.webkit.org/298655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abdaf6d83051ff8e4be7fd9de33acd61574da82f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122227 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d089f0b2-5caa-40da-b070-3383b30d4219) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1a1adce-bdc5-4993-a6f9-de82d00a9116) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68670 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22349 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65908 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125376 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32337 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43429 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100430 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42050 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19943 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39011 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48543 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42418 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45753 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->