### PR TITLE
Many tests under LayoutTests/pointer-lock can run on iOS

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -338,14 +338,25 @@ http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html
 http/tests/security/contentSecurityPolicy/object-redirect-blocked3.html
 
 # Pointer-lock not supported on iOS: https://bugs.webkit.org/show_bug.cgi?id=216621
-pointer-lock
 http/tests/pointer-lock
 fast/shadow-dom/pointerlockelement-in-shadow-tree.html
 fast/shadow-dom/pointerlockelement-in-slot.html
 fast/js-promise/js-promise-invalid-context-access.html [ Skip ]
 imported/w3c/web-platform-tests/pointerlock [ Skip ]
 
-pointer-lock/pointer-lock-option-unadjusted-movement.html [ Pass ]
+# webkit.org/b/285901 EventSender.mouse[Up|Down|MoveTo] do not work on iOS
+pointer-lock/bug90391-move-then-window-open-crash.html [ Skip ]
+pointer-lock/mouse-event-delivery.html [ Skip ]
+pointer-lock/pointermove-movement-delta.html [ Skip ]
+
+# webkit.org/b/297360 3 pointer-lock tests are failing because of missing TestRunner support
+pointer-lock/pointerlockchange-event-on-lock-lost.html [ Skip ]
+pointer-lock/pointerlockchange-pointerlockerror-events.html [ Skip ]
+pointer-lock/pointerlockelement-null-when-pending.html [ Skip ]
+
+# webkit.org/b/216621 Pointer-lock not fully supported on iOS yet
+pointer-lock/lock-lost-on-esc-in-fullscreen.html [ Skip ]
+pointer-lock/locked-element-iframe-removed-from-dom.html [ Skip ]
 
 # FIXME: Media tests not supported on iOS
 http/tests/media

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -286,6 +286,8 @@ fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-page.html [ Skip ]
 # Pointer Lock can only check some of the API at the moment.
 pointer-lock/bug90391-move-then-window-open-crash.html
 pointer-lock/locked-element-iframe-removed-from-dom.html
+
+# webkit.org/b/297360 3 pointer-lock tests are failing because of missing TestRunner support
 pointer-lock/pointerlockchange-event-on-lock-lost.html
 pointer-lock/pointerlockchange-pointerlockerror-events.html
 pointer-lock/pointerlockelement-null-when-pending.html
@@ -1903,8 +1905,6 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker.html [
 
 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]
-
-webkit.org/b/229521 pointer-lock/lock-already-locked.html [ Pass Failure ]
 
 webkit.org/b/230327 imported/w3c/web-platform-tests/css/css-transforms/crashtests/transform-marquee-resize-div-image-001.html [ Pass Failure ]
 

--- a/LayoutTests/pointer-lock/lock-already-locked.html
+++ b/LayoutTests/pointer-lock/lock-already-locked.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test calling lock when already in a locked state.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetdiv1 = document.getElementById("target1");
     targetdiv2 = document.getElementById("target2");
@@ -59,6 +60,5 @@
     ];
     doNextStepWithUserGesture();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/pointer-lock/lock-element-not-in-dom.html
+++ b/LayoutTests/pointer-lock/lock-element-not-in-dom.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -11,6 +11,7 @@
 <script>
     description("Test locking an element not in a document is rejected and pointerlockerror event dispatched.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
 
@@ -28,6 +29,5 @@
     ];
     doNextStepWithUserGesture();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/pointer-lock/lock-lost-on-alert.html
+++ b/LayoutTests/pointer-lock/lock-lost-on-alert.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
 <script src="../resources/js-test.js"></script>
@@ -12,6 +12,7 @@
     description("Test that pointerlockchange event is dispatched when lock is lost.")
     window.jsTestIsAsync = true;
     shouldBeDefined("window.testRunner");
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
 

--- a/LayoutTests/pointer-lock/lock-lost-on-navigation.html
+++ b/LayoutTests/pointer-lock/lock-lost-on-navigation.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
     description("Test that pointerlockchange event is dispatched when lock is lost.")
     window.jsTestIsAsync = true;
     shouldBeDefined("window.testRunner");
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
 
@@ -30,7 +31,6 @@
     ];
     doNextStepWithUserGesture();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>
 

--- a/LayoutTests/pointer-lock/locked-element-removed-from-dom.html
+++ b/LayoutTests/pointer-lock/locked-element-removed-from-dom.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test removing a locked element from a document causes lock to be released.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetIframe1 = document.getElementById("iframe1");
     targetDiv2 = document.getElementById("target2");
@@ -50,6 +51,5 @@
     ];
     doNextStep();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/pointer-lock/mouse-event-api.html
+++ b/LayoutTests/pointer-lock/mouse-event-api.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -12,6 +12,5 @@
     shouldBe('mouseEvent.movementX', '1 / 4096');
     shouldBe('mouseEvent.movementY', '1 / 8196');
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/pointer-lock/pending-locked-element-removed-from-dom.html
+++ b/LayoutTests/pointer-lock/pending-locked-element-removed-from-dom.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../http/tests/resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
     description("Test removing an element with a pending pointer lock cancels the lock.")
     window.jsTestIsAsync = true;
     window.internals.settings.setPointerLockOptionsEnabled(true);
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv = document.getElementById("target");
 
@@ -47,6 +48,5 @@
     ];
     doNextStepWithUserGesture();
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/pointer-lock/pointer-lock-api.html
+++ b/LayoutTests/pointer-lock/pointer-lock-api.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../http/tests/resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -14,6 +14,5 @@
     element = document.createElement("div");
     shouldBeDefined("element.requestPointerLock");
 </script>
-<script src="../http/tests/resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/pointer-lock/pointerlock-interface.html
+++ b/LayoutTests/pointer-lock/pointerlock-interface.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <head>
     <title>PointerLock interface tests.</title>
     <link rel="help" href="https://w3c.github.io/pointerlock/">


### PR DESCRIPTION
#### c71f9ab03a693473b25e64dfaddc8bcb0e76605f
<pre>
Many tests under LayoutTests/pointer-lock can run on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=297354">https://bugs.webkit.org/show_bug.cgi?id=297354</a>
<a href="https://rdar.apple.com/158246804">rdar://158246804</a>

Reviewed by Lily Spiniolas and Aditya Keerthi.

Most of the requisite test harness support is in place and a sizeable
feature subset is testable, so let us start by enabling various layout
tests under the pointer-lock directory.

We mock pointing device availability in all tests, and as a drive-by
fix, migrate away from the outdated js-test-[pre|post] idiom.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
Drive-by: pointer-lock/lock-lost-on-alert.html is no longer failing on
macOS.
* LayoutTests/pointer-lock/lock-already-locked.html:
* LayoutTests/pointer-lock/lock-element-not-in-dom.html:
* LayoutTests/pointer-lock/lock-lost-on-alert.html:
* LayoutTests/pointer-lock/lock-lost-on-navigation.html:
* LayoutTests/pointer-lock/locked-element-removed-from-dom.html:
* LayoutTests/pointer-lock/mouse-event-api.html:
* LayoutTests/pointer-lock/pending-locked-element-removed-from-dom.html:
* LayoutTests/pointer-lock/pointer-lock-api.html:
* LayoutTests/pointer-lock/pointerlock-interface.html:

Canonical link: <a href="https://commits.webkit.org/298666@main">https://commits.webkit.org/298666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ec92f21fb68b829d67b052e93c5d3715ab0593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66737 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33cfba7c-a7b8-4011-9673-963f47f96960) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d6ac930-889c-4988-a985-cbe39047a817) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68678 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125384 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96993 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96777 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39019 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18569 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42959 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->