### PR TITLE
`test_driver.set_permission()` should also set user interaction

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
@@ -2,6 +2,6 @@ Blocked access to external URL https://www.localhost:9443/storage-access-api/res
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Grants have per-frame scope assert_true: requestStorageAccess doesn't require a gesture since the permission has already been granted. expected true got false
+FAIL Grants have per-frame scope assert_false: frame1 should not have storage access initially. expected false got true
 TIMEOUT Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Workers don't inherit storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
-FAIL Workers don't observe parent's storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
+FAIL Workers don't inherit storage access assert_true: frame has access to cookies after request. expected true got false
+FAIL Workers don't observe parent's storage access assert_false: frame lacks storage access before request. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL WebSocket inherits storage access assert_true: requestStorageAccess resolves without requiring a gesture. expected true got false
+FAIL WebSocket inherits storage access assert_true: frame has access to cookies after request. expected true got false
 PASS WebSocket omits unpartitioned cookies without storage access
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify StorageAccessAPIBeyondCookies for Blob Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for blobStorage" but got "Unable to load handle in cross-site context for all"
+FAIL Verify StorageAccessAPIBeyondCookies for Blob Storage assert_equals: Storage Access API should be accessible and return first-party data expected "HasAccess for blobStorage" but got "Unable to load handle in same-origin context for blobStorage"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify StorageAccessAPIBeyondCookies for None assert_equals: Storage Access API should not allow access for empty requests. expected "HasAccess for none" but got "Unable to load handle in cross-site context for all"
+FAIL Verify StorageAccessAPIBeyondCookies for None assert_equals: Storage Access API should not allow access for empty requests. expected "HasAccess for none" but got "Unable to load handle in same-origin context for none"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
@@ -8,7 +8,7 @@ FAIL 'Activate-Storage-Access: retry' is a no-op on a request without an `allowe
 FAIL 'Activate-Storage-Access: retry' is a no-op on a request from an origin that does not match its `allowed-origin` value. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `retry` is a no-op on a request with a `none` Storage Access status. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `load` header grants storage access to frame. assert_true: frame should have storage access because of the `load` header expected true got false
-FAIL Activate-Storage-Access `load` is honored for `active` cases. assert_true: expected true got false
+PASS Activate-Storage-Access `load` is honored for `active` cases.
 PASS Activate-Storage-Access `load` header is a no-op for requests without storage access.
 FAIL Sec-Fetch-Storage-Access is `inactive` for ABA case. assert_array_equals: value is undefined, expected array
 FAIL Storage Access can be activated for ABA cases by retrying. assert_array_equals: value is undefined, expected array


### PR DESCRIPTION
#### 69b06af3f84e6bec5214efb3fadc9b61bc0ba929
<pre>
`test_driver.set_permission()` should also set user interaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=297363">https://bugs.webkit.org/show_bug.cgi?id=297363</a>
<a href="https://rdar.apple.com/158257063">rdar://158257063</a>

Reviewed by Aditya Keerthi.

Granting storage access permission requires a recent user interaction for the subframe’s domain. When a
test explicitly sets or revokes storage permission, it should also set or clear the user interaction for
that domain.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-dedicated-worker.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.blobStorage.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies.none.sub.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::setStorageAccessPermissionForTesting):

Canonical link: <a href="https://commits.webkit.org/298699@main">https://commits.webkit.org/298699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8c98bfa237fd48261f41dddaaf49d97aa648ec1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66806 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a63e46ad-4383-4d6e-8d7e-987bfb95977c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88307 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42823 "Found 4 new test failures: fast/dom/normalize-doesnt-check-string-length.html js/dom/call-link-info-recursion.html streams/readable-stream-lock-after-worker-terminates-crash.html webgl/2.0.y/conformance2/query/occlusion-query.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2383589-b2ad-4a17-a49f-ae6be691d8e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68719 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65984 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125452 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97024 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96809 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39087 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18585 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48619 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42494 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44198 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->