### PR TITLE
[ New-Test ] [ iPad ] TestWebKitAPI.SiteIsolation.HitTesting is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -5341,6 +5341,7 @@ TEST(SiteIsolation, HitTesting)
 
     HTTPServer server({
         { "/example"_s, { makeString(
+            "<meta name='viewport' content='width=device-width,initial-scale=1'>"
             "<iframe id=iframeid1 src='https://webkit.org/webkitframe'></iframe>"
             "<iframe id=iframeid2 src='/exampleframe'></iframe>"
             "<div id=mainframediv>"_s, text, text, "</div>"_s
@@ -5394,13 +5395,7 @@ TEST(SiteIsolation, HitTesting)
         hitTestPointInMainFrame(340, 40, "[object Text] undefined, child of exampleiframediv");
         hitTestPointInMainFrame(40, 240, "[object Text] undefined, child of mainframediv");
         hitTestPointInMainFrame(300, 240, "[object Text] undefined, child of mainframediv");
-        hitTestPointInMainFrame(340, 300,
-#if PLATFORM(MAC)
-            "[object Text] undefined, child of mainframediv"
-#else
-            "[object HTMLDivElement] mainframediv, child of "
-#endif
-        );
+        hitTestPointInMainFrame(340, 300, "[object Text] undefined, child of mainframediv");
 
         RetainPtr iframe = [webView firstChildFrame];
         auto hitTestPointInIFrame = [=] (size_t x, size_t y, const char* expected) {


### PR DESCRIPTION
#### 9df40b452a6e75383a4efda6eb080467c6e890d3
<pre>
[ New-Test ] [ iPad ] TestWebKitAPI.SiteIsolation.HitTesting is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=297339">https://bugs.webkit.org/show_bug.cgi?id=297339</a>
<a href="https://rdar.apple.com/158238815">rdar://158238815</a>

Reviewed by Wenson Hsieh.

Use a meta viewport tag to make the layout more similar on all platforms.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, HitTesting)):

Canonical link: <a href="https://commits.webkit.org/298665@main">https://commits.webkit.org/298665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ca2995eacf450602166eda23e96a1ff7ad02cf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66745 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d96e384b-3dd8-4301-a1df-e4309b145433) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7165d6a7-6eae-43f1-9143-5736c8f2918e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68682 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65924 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125392 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32345 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/96996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96780 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42058 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19953 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18568 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42967 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42434 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->