### PR TITLE
[Navigation API] navigate.back doesn't work in main frame when preceded by navigate.back in child frame (part 2)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.forward() goes to the nearest forward entry assert_equals: expected 0 but got 1
+PASS navigation.forward() goes to the nearest forward entry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.traverseTo() goes to the nearest entry when going forward assert_equals: expected 0 but got 2
+PASS navigation.traverseTo() goes to the nearest entry when going forward
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -766,11 +766,6 @@ void HistoryController::recursiveUpdateForSameDocumentNavigation()
     if (!m_provisionalItem)
         return;
 
-    // The provisional item may represent a different pending navigation.
-    // Don't commit it if it isn't a same document navigation.
-    if (m_currentItem && !protectedCurrentItem()->shouldDoSameDocumentNavigationTo(*protectedProvisionalItem()))
-        return;
-
     // Commit the provisional item.
     if (RefPtr provisionalItem = m_provisionalItem) {
         setCurrentItem(provisionalItem.releaseNonNull());


### PR DESCRIPTION
#### b6915afa938b99e8b6a2ec82d863aa6c8410a73c
<pre>
[Navigation API] navigate.back doesn&apos;t work in main frame when preceded by navigate.back in child frame (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297365">https://bugs.webkit.org/show_bug.cgi?id=297365</a>
<a href="https://rdar.apple.com/158259024">rdar://158259024</a>

Reviewed by Basuke Suzuki.

The test disambigaute-forward.html fails on this line:
&quot;assert_equals(navigation.currentEntry.index, start_index);&quot;
because the mainframe&apos;s back navigation fails.

This is what the test is doing:
1. Load a main frame and an iframe
2. Fragment navigate the main frame
3. Fragment navigate the iframe
4. Go back in the iframe (this succeeds)
5. Go back in the main frame (this fails to go back)

The main frame&apos;s m_entries correctly looks like:

MainFrame (URL: disambigaute-forward.html, itemID: A)
MainFrame (URL: disambigaute-forward.html#top, itemID: B)

But on the navigate.back, the item we&apos;re looking for is wrong. We&apos;re looking
for item B when we should have been looking for item A.

Why? On navigate.back, for most of the code path, we are correctly using item A.
But then:

FrameLoader::loadInSameDocument() ends up calling
HistoryController::recursiveUpdateForSameDocumentNavigation() which sets the
currentItem to the provisionalItem. The currentItem is the item we&apos;re looking for.
Up to this point, it has correctly been item A. But here, we set it to item B.

Turns out, the provisionalItem got set to item B by the iframe&apos;s back navigation
in HistoryController::recursiveSetProvisionalItem(). In the iframe&apos;s back, we
actually call recursiveSetProvisionalItem from the main frame&apos;s history controller.
This means that we set the provisional item for the main frame--even though the
main frame is not actually navigating. Since the main frame isn&apos;t navigating, this
provisional item does not get set to nullptr when the iframe&apos;s load finishes. So
later on, this causes the main frame&apos;s back to look for the wrong item and for the
back to fail.

On the iframe&apos;s back, this provisional item should have been cleared by
recursiveUpdateForSameDocumentNavigation. (If it was cleared, then on the main
frame&apos;s back, the currentItem would be correct and the back navigation would
succeed). But it doesn&apos;t get cleared because shouldDoSameDocumentNavigationTo is
false. The current item and provisional item for the main frame are both item B.
This is because the main frame&apos;s history controller&apos;s current item does not change
when the iframe navigates forward.

So this check is cutting off the correct recursive update of frames and later
preventing the main frame from navigating correctly.

This check was first added in <a href="https://commits.webkit.org/84130@main.">https://commits.webkit.org/84130@main.</a> The tests
added in that patch are still present in the codebase and pass even when this check
is removed. So we can safely remove it.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-traverseTo-forward-multiple-expected.txt:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::recursiveUpdateForSameDocumentNavigation):

Canonical link: <a href="https://commits.webkit.org/301092@main">https://commits.webkit.org/301092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8415573495459c731db9a858aa913d27aab89d69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/33849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9f11f2a-317b-48e6-9dbb-9691c7f66e67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/43876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/51747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95051 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62274 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88b8e016-f7b0-40ad-9d83-175639f8d16d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18a28166-b074-485b-aaa6-7b6af0701f20) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28592 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/73672 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/28817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/132875 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50388 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38351 "Found 1 new test failure: imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-insecure.sub.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/50764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102170 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/25754 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47193 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50243 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56004 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/49715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->