### PR TITLE
Fire scrollend events for stateless scrolls

### DIFF
--- a/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend-expected.txt
@@ -1,0 +1,5 @@
+PASS windowScrollendEventCount == 1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend.html
+++ b/LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend.html
@@ -1,0 +1,60 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+.snap {
+    width: 100%;
+    height: 100%;
+}
+
+#extra-tall {
+    height: 150%;
+}
+
+.output {
+    color: white;
+    position: fixed;
+    top: 0;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+var windowScrollendEventCount = 0;
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+    window.addEventListener('scrollend', () => {
+        ++windowScrollendEventCount;
+    }, false);
+
+    await UIHelper.statelessMouseWheelScrollAt(100, 100, 0, -1);
+    await UIHelper.statelessMouseWheelScrollAt(200, 200, 0, -1);
+    await UIHelper.ensurePresentationUpdate();
+    setTimeout(function() {
+        shouldBe('windowScrollendEventCount == 1', 'true');
+        finishJSTest();
+    }, 100);
+});
+</script>
+</head>
+<body>
+    <div class="snap" id="first-container" style="background: #80475E"></div>
+    <div class="snap" id="extra-tall" style="background: #CC5A71"></div>
+    <div class="snap" style="background: #32228B"></div>
+    <div class="output">
+        <pre id="description"></pre>
+        <pre id="console"></pre>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -208,6 +208,8 @@ private:
     bool shouldOverrideMomentumScrolling() const;
     void discreteSnapTransitionTimerFired();
     void scheduleDiscreteScrollSnap(const FloatSize& delta);
+    void scrollendTimerFired();
+    void scheduleScrollendTimer();
 
     bool modifyScrollDeltaForStretching(const PlatformWheelEvent&, FloatSize&, bool isHorizontallyStretched, bool isVerticallyStretched);
     bool applyScrollDeltaWithStretching(const PlatformWheelEvent&, FloatSize, bool isHorizontallyStretched, bool isVerticallyStretched);
@@ -283,6 +285,7 @@ private:
 
     Deque<FloatSize> m_recentDiscreteWheelDeltas;
     std::unique_ptr<ScrollingEffectsControllerTimer> m_discreteSnapTransitionTimer;
+    std::unique_ptr<ScrollingEffectsControllerTimer> m_discreteScrollendTimer;
 
 #if HAVE(RUBBER_BANDING)
     RectEdges<bool> m_rubberBandingEdges;


### PR DESCRIPTION
#### 526bbbc53262c146724bc269c757e579ecd4f44e
<pre>
Fire scrollend events for stateless scrolls
<a href="https://bugs.webkit.org/show_bug.cgi?id=297367">https://bugs.webkit.org/show_bug.cgi?id=297367</a>
<a href="https://rdar.apple.com/158261078">rdar://158261078</a>

Reviewed by Simon Fraser.

Add timer to fire scrollend event for a stateless scroll.

* LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/stateless-user-scroll-scrollend.html: Added.
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::stopAllTimers):
(WebCore::ScrollingEffectsController::handleWheelEvent):
(WebCore::ScrollingEffectsController::scheduleScrollendTimer):
(WebCore::ScrollingEffectsController::scrollendTimerFired):

Canonical link: <a href="https://commits.webkit.org/298671@main">https://commits.webkit.org/298671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7eaf9b1e822a4801815c075cca3bb9cb5f35ea38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66768 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e26bd29-b500-47bc-9c4d-0015f9384aab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/445cb5c8-c1a4-4234-bf37-e72222bb53be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68696 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22375 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65946 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32364 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24639 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42989 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48581 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->