### PR TITLE
Miscellaneous minor code clean ups and improvements.

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSREntry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -227,7 +227,7 @@ void* prepareOSREntry(VM& vm, CallFrame* callFrame, CodeBlock* codeBlock, Byteco
     //    would have otherwise just kept running albeit less quickly.
     
     unsigned frameSizeForCheck = jitCode->common.requiredRegisterCountForExecutionAndExit();
-    if (!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck - 1).offset()])) [[unlikely]] {
+    if (!vm.ensureJSStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck - 1).offset()])) [[unlikely]] {
         dataLogLnIf(Options::verboseOSR(), "    OSR failed because stack growth failed.");
         return nullptr;
     }
@@ -398,7 +398,7 @@ CodePtr<ExceptionHandlerPtrTag> prepareCatchOSREntry(VM& vm, CallFrame* callFram
     }
 
     unsigned frameSizeForCheck = dfgCommon->requiredRegisterCountForExecutionAndExit();
-    if (!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck).offset()])) [[unlikely]]
+    if (!vm.ensureJSStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(frameSizeForCheck).offset()])) [[unlikely]]
         return nullptr;
 
     auto instruction = baselineCodeBlock->instructions().at(callFrame->bytecodeIndex());

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1663,7 +1663,7 @@ bool A64DOpcodeMoveWide::handlePotentialDataPointer(void* ptr)
             else if (offset == VM::callFrameForCatchOffset())
                 description = "vm.callFrameForCatch";
             else if (ptr == vm.addressOfSoftStackLimit())
-                description = "vm.m_softStackLimit";
+                description = "vm.softStackLimit()";
             else if (ptr == &vm.osrExitIndex)
                 description = "vm.osrExitIndex";
             else if (ptr == &vm.osrExitJumpDestination)

--- a/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,7 +130,7 @@ void* prepareOSREntry(
     }
     
     int stackFrameSize = entryCode->common.requiredRegisterCountForExecutionAndExit();
-    if (!vm.ensureStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(stackFrameSize - 1).offset()])) [[unlikely]] {
+    if (!vm.ensureJSStackCapacityFor(&callFrame->registers()[virtualRegisterForLocal(stackFrameSize - 1).offset()])) [[unlikely]] {
         dataLogLnIf(Options::verboseOSR(), "    OSR failed because stack growth failed.");
         return nullptr;
     }

--- a/Source/JavaScriptCore/heap/HandleBlock.h
+++ b/Source/JavaScriptCore/heap/HandleBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,8 +55,8 @@ private:
 
     static constexpr size_t s_blockMask = ~(blockSize - 1);
 
-    HandleBlock* m_prev;
-    HandleBlock* m_next;
+    HandleBlock* m_prev; // Required by DoublyLinkedListNode.
+    HandleBlock* m_next; // Required by DoublyLinkedListNode.
     HandleSet* m_handleSet;
 };
 

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -880,14 +880,8 @@ void Heap::assertMarkStacksEmpty()
 void Heap::gatherStackRoots(ConservativeRoots& roots)
 {
     m_machineThreads->gatherConservativeRoots(roots, *m_jitStubRoutines, *m_codeBlocks, m_currentThreadState, m_currentThread);
-}
-
-void Heap::gatherJSStackRoots(ConservativeRoots& roots)
-{
 #if ENABLE(C_LOOP)
     vm().interpreter.cloopStack().gatherConservativeRoots(roots, *m_jitStubRoutines, *m_codeBlocks);
-#else
-    UNUSED_PARAM(roots);
 #endif
 }
 
@@ -3006,7 +3000,6 @@ void Heap::addCoreConstraints()
                 ConservativeRoots conservativeRoots(*this);
 
                 gatherStackRoots(conservativeRoots);
-                gatherJSStackRoots(conservativeRoots);
                 gatherScratchBufferRoots(conservativeRoots);
 
                 SetRootMarkReasonScope rootScope(visitor, RootMarkReason::ConservativeScan);

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -734,7 +734,6 @@ private:
     void prepareForMarking();
     
     void gatherStackRoots(ConservativeRoots&);
-    void gatherJSStackRoots(ConservativeRoots&);
     void gatherScratchBufferRoots(ConservativeRoots&);
     void beginMarking();
     void visitCompilerWorklistWeakReferences();

--- a/Source/JavaScriptCore/interpreter/CLoopStack.cpp
+++ b/Source/JavaScriptCore/interpreter/CLoopStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,10 +52,8 @@ static size_t commitSize()
 
 static Lock stackStatisticsMutex;
 
-CLoopStack::CLoopStack(VM& vm)
-    : m_vm(vm)
-    , m_topCallFrame(vm.topCallFrame)
-    , m_softReservedZoneSizeInRegisters(0)
+CLoopStack::CLoopStack()
+    : m_softReservedZoneSizeInRegisters(0)
 {
     size_t capacity = Options::maxPerThreadStackUsage();
     capacity = WTF::roundUpToMultipleOf(pageSize(), capacity);
@@ -70,7 +68,7 @@ CLoopStack::CLoopStack(VM& vm)
     m_lastStackPointer = bottomOfStack;
     m_currentStackPointer = bottomOfStack;
 
-    m_topCallFrame = 0;
+    vm().topCallFrame = 0;
 }
 
 CLoopStack::~CLoopStack()
@@ -156,7 +154,7 @@ void CLoopStack::setSoftReservedZoneSize(size_t reservedZoneSize)
 bool CLoopStack::isSafeToRecurse() const
 {
     void* reservationLimit = reinterpret_cast<int8_t*>(reservationTop() + m_softReservedZoneSizeInRegisters);
-    return !m_topCallFrame || (m_topCallFrame->topOfFrame() > reservationLimit);
+    return !vm().topCallFrame || (vm().topCallFrame->topOfFrame() > reservationLimit);
 }
 
 size_t CLoopStack::committedByteCount()

--- a/Source/JavaScriptCore/interpreter/CLoopStackInlines.h
+++ b/Source/JavaScriptCore/interpreter/CLoopStackInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,11 @@
 
 namespace JSC {
 
+ALWAYS_INLINE VM& CLoopStack::vm() const
+{
+    return *std::bit_cast<VM*>(std::bit_cast<uintptr_t>(this) - OBJECT_OFFSETOF(Interpreter, m_cloopStack) - OBJECT_OFFSETOF(VM, interpreter));
+}
+
 inline bool CLoopStack::ensureCapacityFor(Register* newTopOfStack)
 {
     if (newTopOfStack >= m_end)
@@ -41,20 +46,10 @@ inline bool CLoopStack::ensureCapacityFor(Register* newTopOfStack)
     return grow(newTopOfStack);
 }
 
-inline void* CLoopStack::currentStackPointer() const
-{
-    // One might be tempted to assert that m_currentStackPointer <= m_topCallFrame->topOfFrame()
-    // here. That assertion would be incorrect because this function may be called from function
-    // prologues (e.g. during a stack check) where m_currentStackPointer may be higher than
-    // m_topCallFrame->topOfFrame() because the stack pointer has not been initialized to point
-    // to frame top yet.
-    return m_currentStackPointer;
-}
-
 inline void CLoopStack::setCLoopStackLimit(Register* newTopOfStack)
 {
     m_end = newTopOfStack;
-    m_vm.setCLoopStackLimit(newTopOfStack);
+    vm().setCLoopStackLimit(newTopOfStack);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -286,7 +286,7 @@ unsigned sizeFrameForForwardArguments(JSGlobalObject* globalObject, CallFrame* c
 
     unsigned length = callFrame->argumentCount();
     CallFrame* calleeFrame = calleeFrameForVarargs(callFrame, numUsedStackSlots, length + 1);
-    if (!vm.ensureStackCapacityFor(calleeFrame->registers())) [[unlikely]]
+    if (!vm.ensureJSStackCapacityFor(calleeFrame->registers())) [[unlikely]]
         throwStackOverflowError(globalObject, scope);
 
     return length;
@@ -300,7 +300,7 @@ unsigned sizeFrameForVarargs(JSGlobalObject* globalObject, CallFrame* callFrame,
     RETURN_IF_EXCEPTION(scope, 0);
 
     CallFrame* calleeFrame = calleeFrameForVarargs(callFrame, numUsedStackSlots, length + 1);
-    if (length > maxArguments || !vm.ensureStackCapacityFor(calleeFrame->registers())) [[unlikely]] {
+    if (length > maxArguments || !vm.ensureJSStackCapacityFor(calleeFrame->registers())) [[unlikely]] {
         throwStackOverflowError(globalObject, scope);
         return 0;
     }
@@ -396,9 +396,6 @@ void setupForwardArgumentsFrameAndSetThis(JSGlobalObject* globalObject, CallFram
 }
 
 Interpreter::Interpreter()
-#if ENABLE(C_LOOP)
-    : m_cloopStack(vm())
-#endif
 {
 #if ASSERT_ENABLED
     static std::once_flag assertOnceKey;

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -181,6 +181,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
         inline VM& vm();
 #if ENABLE(C_LOOP)
         CLoopStack m_cloopStack;
+        friend class CLoopStack; // Only needed to enable CLoopStack::vm()'s implementation.
 #endif
         
 #if ENABLE(COMPUTED_GOTO_OPCODES)

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -569,7 +569,7 @@ LLINT_SLOW_PATH_DECL(stack_check)
     Register* topOfFrame = callFrame->topOfFrame();
     if (topOfFrame < reinterpret_cast<Register*>(callFrame)) [[likely]] {
         ASSERT(!vm.interpreter.cloopStack().containsAddress(topOfFrame));
-        if (vm.ensureStackCapacityFor(topOfFrame)) [[likely]]
+        if (vm.ensureJSStackCapacityFor(topOfFrame)) [[likely]]
             LLINT_RETURN_TWO(pc, 0);
     }
 #endif
@@ -2531,7 +2531,7 @@ static ALWAYS_INLINE int arityCheckFor(VM& vm, CallFrame* callFrame, CodeBlock* 
 
     Register* newStack = callFrame->registers() - WTF::roundUpToMultipleOf(stackAlignmentRegisters(), padding);
 
-    if (!vm.ensureStackCapacityFor(newStack)) [[unlikely]]
+    if (!vm.ensureJSStackCapacityFor(newStack)) [[unlikely]]
         return -1;
     return padding;
 }
@@ -2836,7 +2836,7 @@ extern "C" UGPRPair SYSV_ABI llint_throw_stack_overflow_error(VM* vm, ProtoCallF
 #if ENABLE(C_LOOP)
 extern "C" UGPRPair SYSV_ABI llint_stack_check_at_vm_entry(VM* vm, Register* newTopOfStack)
 {
-    bool success = vm->ensureStackCapacityFor(newTopOfStack);
+    bool success = vm->ensureJSStackCapacityFor(newTopOfStack);
     return encodeResult(reinterpret_cast<void*>(success), 0);
 }
 #endif

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1409,7 +1409,7 @@ size_t VM::committedStackByteCount()
 }
 
 #if ENABLE(C_LOOP)
-bool VM::ensureStackCapacityForCLoop(Register* newTopOfStack)
+bool VM::ensureJSStackCapacityForCLoop(Register* newTopOfStack)
 {
     return interpreter.cloopStack().ensureCapacityFor(newTopOfStack);
 }

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -704,7 +704,7 @@ public:
     size_t updateSoftReservedZoneSize(size_t softReservedZoneSize);
     
     static size_t committedStackByteCount();
-    inline bool ensureStackCapacityFor(Register* newTopOfStack);
+    inline bool ensureJSStackCapacityFor(Register* newTopOfStack);
 
     void* stackLimit() { return m_stackLimit; }
     void* softStackLimit() { return m_softStackLimit; }
@@ -1015,7 +1015,7 @@ private:
     JS_EXPORT_PRIVATE void setException(Exception*);
 
 #if ENABLE(C_LOOP)
-    bool ensureStackCapacityForCLoop(Register* newTopOfStack);
+    bool ensureJSStackCapacityForCLoop(Register* newTopOfStack);
     bool isSafeToRecurseSoftCLoop() const;
 #endif // ENABLE(C_LOOP)
 

--- a/Source/JavaScriptCore/runtime/VMInlines.h
+++ b/Source/JavaScriptCore/runtime/VMInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,12 +50,12 @@ inline ActiveScratchBufferScope::~ActiveScratchBufferScope()
         m_scratchBuffer->setActiveLength(0);
 }
 
-bool VM::ensureStackCapacityFor(Register* newTopOfStack)
+bool VM::ensureJSStackCapacityFor(Register* newTopOfStack)
 {
 #if !ENABLE(C_LOOP)
     return newTopOfStack >= m_softStackLimit;
 #else
-    return ensureStackCapacityForCLoop(newTopOfStack);
+    return ensureJSStackCapacityForCLoop(newTopOfStack);
 #endif
     
 }


### PR DESCRIPTION
#### 43e4bf6de8dc86f1a645ae5601f42a617b7e7ecf
<pre>
Miscellaneous minor code clean ups and improvements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297366">https://bugs.webkit.org/show_bug.cgi?id=297366</a>
<a href="https://rdar.apple.com/158259898">rdar://158259898</a>

Reviewed by Keith Miller.

1. Rename VM::ensureStackCapacityFor() to VM::ensureJSStackCapacityFor().  It is only
   checks the JS stack capacity.  For non-CLoop builds, this is the same as the native
   stack.  For CLoop builds, it only checks the CLoop stack.  So, let&apos;s rename it to
   clearly capture the purpose of the function so as to avoid ambiguity.

2. Change the symbollic disassembly of the address of the VM&apos;s softStackLimit to be
   &quot;vm.softStackLimit()&quot; (which is always true) instead of &quot;vm.m_softStackLimit&quot;
   (which will not be true soon in upcoming patches because we&apos;ll be moving the location
   of this field.

3. Added a comment in class HandleBlock to explain why the m_prev and m_next fields are
   needed.

4. Remove Heap::gatherJSStackRoots().  It is only used for the CLoop build, and the work
   it does can just be done in Heap::gatherStackRoots() (because that&apos;s the root driver
   and rationale for this work anyway).  It saves a useless call on non-CLoop builds
   unless the toolchain can optimize it away.

5. Remove the need to pass VM&amp; into CLoopStack.  The address of VM can always be computed
   from the address of CLoopStack.  So, there&apos;s no need to cache vm and the address of
   m_topCallFrame.  This also simplifies the construction code for CLoopStack&apos;s client.

6. Moved the inline definition of CLoopStack::currentStackPointer() to CLoopStack.h.
   There&apos;s nothing requiring that it be placed in CLoopStackInlines.h, and upcoming
   patch will need it in the .h.

* Source/JavaScriptCore/dfg/DFGOSREntry.cpp:
(JSC::DFG::prepareOSREntry):
(JSC::DFG::prepareCatchOSREntry):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64DOpcodeMoveWide::handlePotentialDataPointer):
* Source/JavaScriptCore/ftl/FTLOSREntry.cpp:
(JSC::FTL::prepareOSREntry):
* Source/JavaScriptCore/heap/HandleBlock.h:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::gatherStackRoots):
(JSC::Heap::addCoreConstraints):
(JSC::Heap::gatherJSStackRoots): Deleted.
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/interpreter/CLoopStack.cpp:
(JSC::CLoopStack::CLoopStack):
(JSC::CLoopStack::isSafeToRecurse const):
* Source/JavaScriptCore/interpreter/CLoopStack.h:
(JSC::CLoopStack::currentStackPointer const):
* Source/JavaScriptCore/interpreter/CLoopStackInlines.h:
(JSC::CLoopStack::vm const):
(JSC::CLoopStack::setCLoopStackLimit):
(JSC::CLoopStack::currentStackPointer const): Deleted.
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::sizeFrameForForwardArguments):
(JSC::sizeFrameForVarargs):
(JSC::Interpreter::Interpreter):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
(JSC::LLInt::arityCheckFor):
(JSC::LLInt::llint_stack_check_at_vm_entry):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::ensureJSStackCapacityForCLoop):
(JSC::VM::ensureStackCapacityForCLoop): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/VMInlines.h:
(JSC::VM::ensureJSStackCapacityFor):
(JSC::VM::ensureStackCapacityFor): Deleted.

Canonical link: <a href="https://commits.webkit.org/298656@main">https://commits.webkit.org/298656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f87f054e637755d9182d549226487af0ed5fb61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122254 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9940c48c-68e7-47dd-b424-ec69cf8b361f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44446 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31959fac-5f49-4c52-9563-04caaebd1687) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68688 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65935 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/108307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22511 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114725 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32356 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100455 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24633 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/42065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48570 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143422 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42445 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36970 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->