### PR TITLE
[Navigation API] navigation-back-same-document-preventDefault.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.back() same-document preventDefault Can't find variable: navigateerror_called
+PASS navigation.back() same-document preventDefault
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault.html
@@ -19,6 +19,7 @@ promise_test(async t => {
 
   navigation.onnavigate = e => e.preventDefault();
 
+  let navigateerror_called = false;
   navigation.onnavigateerror = t.step_func(e => {
     assert_equals(e.constructor, ErrorEvent);
     assert_equals(e.filename, location.href);


### PR DESCRIPTION
#### 654d95964785df99c4e2fbe2e049371f9df0be91
<pre>
[Navigation API] navigation-back-same-document-preventDefault.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=297369">https://bugs.webkit.org/show_bug.cgi?id=297369</a>
<a href="https://rdar.apple.com/158264944">rdar://158264944</a>

Reviewed by Tim Nguyen.

The variable navigateerror_called was not declared.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-back-same-document-preventDefault.html:

Canonical link: <a href="https://commits.webkit.org/298674@main">https://commits.webkit.org/298674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ade9783684134320c0dc7f92efb8baf0c495eb20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122269 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66772 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47833929-5e18-4859-a331-f929d14ebe87) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66dc2970-7006-4004-b1ae-a1d1c0d18ffd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29172 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68699 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28278 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65950 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125418 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43106 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97010 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96795 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42070 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39053 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42993 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42460 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45795 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->