### PR TITLE
Add a tool to gather safer C++ statistics per project

### DIFF
--- a/Tools/Scripts/compute-safer-cpp-statistics
+++ b/Tools/Scripts/compute-safer-cpp-statistics
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import argparse
+
+from webkitpy.safer_cpp.checkers import Checker
+
+# FIXME: Make this configurable
+EXCLUDED_DIRNAMES = ['CoordinatedGraphics', 'atoms', 'cairo', 'curl', 'gbm', 'glib', 'gstreamer', 'gtk', 'libwpe', 'linux', 'manette', 'playstation', 'skia', 'socket', 'soup', 'unified-sources', 'unix', 'wc', 'win', 'wpe']
+RELEVANT_FILE_EXTENSIONS = ['.c', '.cpp', '.h', '.m', '.mm']
+
+
+def parser():
+    parser = argparse.ArgumentParser(description='Automated tooling for gathering statistics about safer CPP', epilog='Example: compute-safer-cpp-statisticsfor -p WebKit --build-configuration Release')
+    parser.add_argument(
+        '--project', '-p',
+        choices=Checker.projects(),
+        required=True,
+        help='Specify which project expectations you want to update'
+    )
+    parser.add_argument(
+        '--build-configuration', '-b',
+        required=True,
+        help='Specify build configuration (e.g. Debug, Release-iphonesimulator) to look for derived sources'
+    )
+    parser.add_argument(
+        '--checker', '-c',
+        choices=[checker.name() for checker in Checker.enumerate()],
+        help='Specify the checker to gather statistics (e.g. UncountedCallArgsChecker). When omitted, all checkers are included'
+    )
+    parser.add_argument(
+        '--ignore', '-i',
+        help='Specify the directory to ignore relative to the project root (e.g. WebProcess for Source/WebKit/WebProcess)'
+    )
+    parser.add_argument(
+        '--csv',
+        help='Specify a path to a CSV file to be generated. CSV file will not be generated if omitted'
+    )
+    return parser.parse_args()
+
+
+def matching_checkers(checker):
+    if not checker:
+        return Checker.enumerate()
+    matching_checker = Checker.find_checker_by_name(checker)
+    if not checker:
+        print('Did not find a checker matching {}'.format(checker))
+        return None
+    return [matching_checker]
+
+
+def load_expectations(checker_list, project):
+    file_to_expectations_map = {}
+    for checker in checker_list:
+        expectations_path = checker.expectations_path(project)
+        if not os.path.isfile(expectations_path):
+            return
+        with open(expectations_path) as expectation_file:
+            for file_key in expectation_file:
+                file_key = file_key.strip()
+                file_to_expectations_map.setdefault(file_key, set())
+                file_to_expectations_map[file_key].add(checker.name())
+    return file_to_expectations_map
+
+def count_number_of_lines(file_path):
+    with open(file_path) as file_handle:
+        return sum(1 for _ in file_handle)
+    
+
+def enumerate_relevant_files(root_dir_path, dir_to_ignore=None):
+    file_path_list = []
+    for (dirpath, dirnames, filenames) in os.walk(root_dir_path):
+        dirname, base = os.path.split(dirpath)
+        is_excluded_dir = base in EXCLUDED_DIRNAMES or os.path.basename(dirname) in EXCLUDED_DIRNAMES
+        relative_path = os.path.relpath(dirpath, root_dir_path)
+        if is_excluded_dir or (dir_to_ignore and relative_path.startswith(dir_to_ignore)):
+            print('Excluding: ' + relative_path)
+            continue
+        for filename in filenames:
+            file_path = os.path.abspath(os.path.join(dirpath, filename))
+            (_, ext) = os.path.splitext(file_path)
+            if ext not in RELEVANT_FILE_EXTENSIONS:
+                continue
+            file_path_list.append(file_path)
+    return file_path_list
+
+
+def gather_statistics(line_counts, checkers, file_to_expectations_map, dir_path, dir_to_ignore=None):
+    for file_path in enumerate_relevant_files(dir_path, dir_to_ignore):
+        file_key = os.path.relpath(file_path, dir_path)
+        number_of_lines = count_number_of_lines(file_path)
+        expected_checkers = file_to_expectations_map.get(file_key)
+        if expected_checkers:
+            line_counts['unsafe'] += number_of_lines
+        else:
+            line_counts['safe'] += number_of_lines
+        for checker in checkers:
+            per_checker_counts = line_counts['checkers'][checker.name()]
+            if expected_checkers and checker.name() in expected_checkers:
+                per_checker_counts['unsafe'] += number_of_lines
+            else:
+                per_checker_counts['safe'] += number_of_lines
+
+
+def safe_ratio(line_counts):
+    return line_counts['safe'] / (line_counts['safe'] + line_counts['unsafe'])
+
+
+def print_percentage(label, line_counts):
+    return print('{}: {:.2f}% safe'.format(label, safe_ratio(line_counts) * 100))
+
+
+def main():
+    args = parser()
+
+    checkers = matching_checkers(args.checker)
+    if not checkers:
+        return
+
+    file_to_expectations_map = load_expectations(checkers, args.project)
+    line_counts = {'safe': 0, 'unsafe': 0, 'checkers': {}}
+    for checker in checkers:
+        line_counts['checkers'][checker.name()] = {'safe': 0, 'unsafe': 0}
+
+    project = args.project
+    project_path = Checker.enumerate()[0].project_path(project)
+    gather_statistics(line_counts, checkers, file_to_expectations_map, project_path, args.ignore)
+
+    derived_sources_path = Checker.enumerate()[0].derived_sources_path(project, args.build_configuration)
+    gather_statistics(line_counts, checkers, file_to_expectations_map, derived_sources_path)
+
+    print_percentage('Overall', line_counts)
+    for checker in checkers:
+        print_percentage(checker.name(), line_counts['checkers'][checker.name()])
+
+    if not args.csv:
+        return
+
+    with open(args.csv, 'w') as csv_file:
+        print(',' + ','.join([checker.name() for checker in checkers]), file=csv_file)
+        print('Coverage,' + ','.join([str(safe_ratio(line_counts['checkers'][checker.name()])) for checker in checkers]), file=csv_file)
+        for file_key in sorted(file_to_expectations_map.keys()):
+            if args.ignore and file_key.startswith(args.ignore):
+                continue
+            csv_file.write(file_key + ',')
+            for checker in checkers:
+                csv_file.write('FAIL,' if checker.name() in file_to_expectations_map[file_key] else ',')
+            csv_file.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/Scripts/webkitpy/safer_cpp/checkers.py
+++ b/Tools/Scripts/webkitpy/safer_cpp/checkers.py
@@ -27,7 +27,9 @@
 import os
 
 
-EXPECTATIONS_PATH = '../../../../../Source/{project}/SaferCPPExpectations/{checker}Expectations'
+PROJECT_PATH = '../../../../../Source/{project}'
+EXPECTATIONS_PATH = PROJECT_PATH + '/SaferCPPExpectations/{checker}Expectations'
+DERIVED_SOURCES_DIR = '../../../../../WebKitBuild/{configuration}/DerivedSources/{project}'
 PROJECTS = ['JavaScriptCore', 'WebCore', 'WebDriver', 'WebGPU', 'WebInspectorUI', 'WebKit', 'WebKitLegacy', 'WTF']
 
 
@@ -41,6 +43,14 @@ class Checker(object):
 
     def description(self):
         return self._description
+
+    def project_path(self, project_name):
+        return os.path.abspath(os.path.join(__file__, PROJECT_PATH.format(project=project_name)))
+
+    def derived_sources_path(self, project_name, build_configuration):
+        assert(build_configuration.startswith('Release') or build_configuration.startswith('Debug'))
+        relpath = DERIVED_SOURCES_DIR.format(project=project_name, configuration=build_configuration)
+        return os.path.abspath(os.path.join(__file__, relpath))
 
     def expectations_path(self, project_name):
         path = os.path.join(__file__, EXPECTATIONS_PATH.format(project=project_name, checker=self.name()))


### PR DESCRIPTION
#### 6f763fdcae30f6a69ed587b9006d9509d6062684
<pre>
Add a tool to gather safer C++ statistics per project
<a href="https://bugs.webkit.org/show_bug.cgi?id=297372">https://bugs.webkit.org/show_bug.cgi?id=297372</a>

Reviewed by Brianna Fan.

Add compute-safer-cpp-statistics to gather safer C++ statistics.
The total reports the total pass rate across all checkers as well as pass rate per checker.

For example, as of this writing, we gather the following statistics for Source/WebKit:
Overall: 79.70% safe
ForwardDeclChecker: 99.74% safe
MemoryUnsafeCastChecker: 99.74% safe
NoUncheckedPtrMemberChecker: 100.00% safe
NoUncountedMemberChecker: 99.97% safe
NoUnretainedMemberChecker: 97.86% safe
RefCntblBaseVirtualDtor: 100.00% safe
RetainPtrCtorAdoptChecker: 97.35% safe
UncheckedCallArgsChecker: 97.37% safe
UncheckedLocalVarsChecker: 99.91% safe
UncountedCallArgsChecker: 89.88% safe
UncountedLambdaCapturesChecker: 99.92% safe
UncountedLocalVarsChecker: 100.00% safe
UnretainedCallArgsChecker: 91.14% safe
UnretainedLambdaCapturesChecker: 100.00% safe
UnretainedLocalVarsChecker: 100.00% safe

* Tools/Scripts/compute-safer-cpp-statistics: Added.
(parser):
(matching_checkers):
(load_expectations):
(count_number_of_lines):
(enumerate_relevant_files):
(gather_statistics):
(safe_ratio):
(print_percentage):
(main):
* Tools/Scripts/webkitpy/safer_cpp/checkers.py:
(Checker.project_path):
(Checker):
(Checker.derived_sources_path):

Canonical link: <a href="https://commits.webkit.org/298668@main">https://commits.webkit.org/298668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb0473acc6de396b0ab35398a9c5baee2651f1ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116233 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/35894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26440 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/66793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf90e82f-191a-4a71-9f8c-45d132b36388) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/66793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0b24967-2f13-47da-ba4c-9c8b7772c821) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/29191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104285 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115607 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22394 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65971 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22540 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100484 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/19977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18570 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/43014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->