### PR TITLE
[webkitapipy] Use "?" to represent unknown class

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py
@@ -30,7 +30,7 @@ from .allow import AllowList, AllowedSPI, PermanentlyAllowedReason
 Toml = b'''
 [key1."rdar://123456789"]
 symbols = ["_TemporarilyAllowedSymbol"]
-selectors = ["_initWithTemporarilyAllowedData:"]
+selectors = [{ name = "_initWithTemporarilyAllowedData:", class = "?" }]
 classes = ["NSTemporarilyAllowed"]
 
 [key2.not-web-essential]

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -53,7 +53,7 @@ R_MissingSelector = MissingName(name='initWithData:', file=F_Client, arch='arm64
 A = AllowList.from_dict({'sdkdb-unittest':
                          {'rdar://12345':
                           {'classes': ['WKDoesntExist'],
-                           'selectors': ['initWithData:'],
+                           'selectors': [{'name': 'initWithData:', 'class': '?'}],
                            'symbols': ['_WKDoesntExistLibraryVersion']}}})
 A_File = Path('/allowed.toml')
 A_Hash = 23456
@@ -71,7 +71,7 @@ R_Uses_Own_Selector = APIReport(
 A_Conditional = AllowList.from_dict(
     {'sdkdb-unittest': {'rdar://12345': {
         'classes': ['WKDoesntExist'],
-        'selectors': ['initWithData:'],
+        'selectors': [{'name': 'initWithData:', 'class': '?'}],
         'symbols': ['_WKDoesntExistLibraryVersion'],
         'requires': ['ENABLE_FEATURE']}
     }}
@@ -80,7 +80,7 @@ A_Conditional = AllowList.from_dict(
 A_NegatedConditional = AllowList.from_dict(
     {'sdkdb-unittest': {'rdar://12345': {
         'classes': ['WKDoesntExist'],
-        'selectors': ['initWithData:'],
+        'selectors': [{'name': 'initWithData:', 'class': '?'}],
         'symbols': ['_WKDoesntExistLibraryVersion'],
         'requires': ['!ENABLE_FEATURE']}
     }}
@@ -89,7 +89,7 @@ A_NegatedConditional = AllowList.from_dict(
 A_MultipleConditions = AllowList.from_dict(
     {'sdkdb-unittest': {'rdar://12345': {
         'classes': ['WKDoesntExist'],
-        'selectors': ['initWithData:'],
+        'selectors': [{'name': 'initWithData:', 'class': '?'}],
         'symbols': ['_WKDoesntExistLibraryVersion'],
         'requires': ['ENABLE_A', 'ENABLE_B', '!ENABLE_C']}
     }}
@@ -293,7 +293,9 @@ class TestSDKDB(TestCase):
         self.add_allowlist()
         self.reconnect()
 
-        other_allowlist = AllowList.from_dict({'test': {'legacy': {'selectors': ['initWithData:']}}})
+        other_allowlist = AllowList.from_dict(
+            {'test': {'legacy': {'selectors': [{'name': 'initWithData:',
+                                                'class': '?'}]}}})
         other_file = Path('/allowed2.toml')
         with self.sdkdb:
             self.sdkdb._cache_hit_preparing_to_insert(other_file, 34567890)
@@ -306,7 +308,9 @@ class TestSDKDB(TestCase):
         self.reconnect()
         self.add_library()
 
-        other_allowlist = AllowList.from_dict({'test': {'legacy': {'selectors': ['initWithData:']}}})
+        other_allowlist = AllowList.from_dict(
+            {'test': {'legacy': {'selectors': [{'name': 'initWithData:',
+                                                'class': '?'}]}}})
         other_file = Path('/allowed2.toml')
         with self.sdkdb:
             self.sdkdb._cache_hit_preparing_to_insert(other_file, 34567890)
@@ -324,7 +328,9 @@ class TestSDKDB(TestCase):
         self.add_allowlist()
         self.add_library()
 
-        other_allowlist = AllowList.from_dict({'test': {'legacy': {'selectors': ['initWithData:']}}})
+        other_allowlist = AllowList.from_dict(
+            {'test': {'legacy': {'selectors': [{'name': 'initWithData:',
+                                                'class': '?'}]}}})
         other_file = Path('/allowed2.toml')
         with self.sdkdb:
             self.sdkdb._cache_hit_preparing_to_insert(other_file, 34567890)


### PR DESCRIPTION
#### 93eb9fa1ae00d745872b670fd1902aedb55f2b65
<pre>
[webkitapipy] Use &quot;?&quot; to represent unknown class
<a href="https://bugs.webkit.org/show_bug.cgi?id=297370">https://bugs.webkit.org/show_bug.cgi?id=297370</a>
<a href="https://rdar.apple.com/158265152">rdar://158265152</a>

Reviewed by Brianna Fan.

Follow-up to format changes in <a href="https://commits.webkit.org/298571@main.">https://commits.webkit.org/298571@main.</a>
Instead of allowing the selector to be not-class-bound string, or a
dictionary without a &quot;class&quot; key, require a class. The intention is to
encourage developers to provide a class binding when one is known, to
make allowlisted selectors more precise.

As a drive-by, refactor how tomli is used to simplify loading code and
provide a parsing error message that can be consumed by build systems.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py:
(AllowList.from_dict):
(AllowList.from_file):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py:
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py:
(TestSDKDB.test_audit_allowed_name_in_loaded_and_unloaded_allowlist):
(TestSDKDB.test_audit_unnecessary_allow_in_loaded_and_unloaded_allowlist):
(TestSDKDB.test_audit_unused_allow_multiple_allowlists):

Canonical link: <a href="https://commits.webkit.org/298694@main">https://commits.webkit.org/298694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1167f0cd6a499a5976cf2fe2e271fae47cf82e72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66789 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff2dee50-3d9e-403f-8a33-f2325fd3d4f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118118 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36584 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44478 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88297 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 19 flakes 44 failures") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42820 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8a301a5d-6a25-4d74-9900-2f816882cb54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68708 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115603 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22398 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125435 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97011 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96796 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24652 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39070 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43010 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42477 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->