### PR TITLE
[webkitapipy] Fix minor loading and dependency tracking bugs

### DIFF
--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/program_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/program_unittest.py
@@ -38,6 +38,9 @@ def create_sdk_dir(root: Path):
     lib = sdk / 'usr/lib/libobjc.tbd'
     lib.parent.mkdir(parents=True)
     lib.touch()
+    merged_lib = sdk / 'usr/lib/swift/libswiftQuickLook.dylib'
+    merged_lib.parent.mkdir(parents=True)
+    merged_lib.symlink_to('../../../System/Library/Frameworks/QuickLook.framework/QuickLook')
     return sdk
 
 
@@ -135,3 +138,11 @@ class CLITest(TestCase):
         # It works around rdar://153937150 by tracking the framework's tbd as
         # an input.
         self.assertIn(f'{self.framework}/foo.tbd', result.dependencies)
+
+    def test_does_not_load_merged_swiftoverlays(self):
+        result = self.call(self.framework / 'foo')
+        self.assertNotIn(f'{self.sdk_dir}/usr/lib/swift/libswiftQuickLook.dylib', result.dependencies)
+
+    def test_depends_on_primary_file(self):
+        result = self.call(self.framework / 'foo')
+        self.assertIn(f'{self.framework}/foo', result.dependencies)

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/reporter.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/reporter.py
@@ -28,6 +28,9 @@ class Reporter:
     def format_diagnostic(self, diag: Diagnostic) -> str:
         raise NotImplementedError
 
+    def has_errors(self) -> bool:
+        return bool(self.issues)
+
     def finished(self):
         pass
 
@@ -86,7 +89,7 @@ class BuildToolReporter(Reporter):
         return entry
 
     def finished(self):
-        if self.issues:
+        if any(d for d in self.issues if isinstance(d, MissingName)):
             if self.suggested_allowlists:
                 allowlists = '│ \n    '.join(map(str, self.suggested_allowlists))
                 allowlist_entry = self.allowlist_entry().replace('\n', '\n│     ')

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -452,13 +452,13 @@ class SDKDB:
                 # FIXME: split(',') falls apart if an allowlist path contains a
                 # comma. We could improve this by using quote() in the query
                 # and unquoting here.
-                for path in allowlist_paths.split(','):
+                for path in sorted(set(allowlist_paths.split(','))):
                     yield UnusedAllowedName(name=allowed_name, file=Path(path),
                                             kind=allowed_kind)
             elif allow_found and export_found:
                 # Allowed but also exported => unnecessary allowlist entry to
                 # remove.
-                for path in allowlist_paths.split(','):
+                for path in sorted(set(allowlist_paths.split(','))):
                     yield UnnecessaryAllowedName(name=allowed_name,
                                                  file=Path(path),
                                                  kind=allowed_kind,


### PR DESCRIPTION
#### bfbc68b18dd0ebcdc60eb92e40b16e341fcdc1ef
<pre>
[webkitapipy] Fix minor loading and dependency tracking bugs
<a href="https://bugs.webkit.org/show_bug.cgi?id=297375">https://bugs.webkit.org/show_bug.cgi?id=297375</a>
<a href="https://rdar.apple.com/158270615">rdar://158270615</a>

Reviewed by Brianna Fan.

* Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py:
  - Some libraries in /usr/lib/swift have been replaced with symlinks to
    a larger framework, as those swift overlays have been merged. As a
    result, the SDK_ALLOWLIST entries for public swift overlays cause
    the entire framework to be treated as API. Change loading logic to
    ignore symlinks.
  - Due to the above change, load from libobjc.A.tbd instead of its
    libobjc.tbd symlink.
  - Emit load error messages in a format consumable by build systems.
  - Add a missing use_input() call on the executable being analyzed,
    otherwise audit-spi will not run when only the top-level binary has
    been rebuilt.
  - Remove unused imports.
* Tools/Scripts/libraries/webkitapipy/webkitapipy/program_unittest.py:
(create_sdk_dir):
(CLITest.test_loads_partial_sdkdb_for_main_file):
(CLITest):
(CLITest.test_does_not_load_merged_swiftoverlays):
(CLITest.test_depends_on_primary_file):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/reporter.py:
  - Only print the suggested allowlist entry when a MissingName
    diagnostic has been emitted.
(Reporter.has_errors):
(BuildToolReporter.finished):
* Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py:
(SDKDB.audit): Only emit at most one diagnostic per item in an allowlist
  entry. Previously the &quot;same&quot; diagnostic could be emitted multiple times
  when an allowlist entry corresponded to multiple items in the cache
  (e.g. a selector implemented in two or more places).

Canonical link: <a href="https://commits.webkit.org/298768@main">https://commits.webkit.org/298768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7698de55576657c25728240085665022f8e50f12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26854 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44882 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119578 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/29499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/104624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/116003 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/66370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/22889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/100826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18616 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/43414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->