### PR TITLE
Add JS replacement for InjectedBundle::FormClient::didAssociateFormControls

### DIFF
--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -300,6 +300,7 @@
     "webkitBeforeTextInserted": { "defaultEventHandler": true },
     "webkitTransitionEnd": { "categories": ["CSSTransition"] },
     "webkitautofillrequest": { },
+    "webkitassociateformcontrols": { },
     "webkitbeginfullscreen": { },
     "webkitcurrentplaybacktargetiswirelesschanged": { },
     "webkitendfullscreen": { },

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -221,7 +221,7 @@ class EmptyChromeClient : public ChromeClient {
     
     bool isEmptyChromeClient() const final { return true; }
 
-    void didAssociateFormControls(const Vector<RefPtr<Element>>&, LocalFrame&) final { }
+    void didAssociateFormControls(const Vector<Ref<Element>>&, LocalFrame&) final { }
     bool shouldNotifyOnFormChanges() final { return false; }
 
     RefPtr<Icon> createIconForFiles(const Vector<String>& /* filenames */) final;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -598,7 +598,7 @@ public:
 
     virtual bool isEmptyChromeClient() const { return false; }
 
-    virtual void didAssociateFormControls(const Vector<RefPtr<Element>>&, LocalFrame&) { };
+    virtual void didAssociateFormControls(const Vector<Ref<Element>>&, LocalFrame&) { };
     virtual bool shouldNotifyOnFormChanges() { return false; };
 
     virtual void didAddHeaderLayer(GraphicsLayer&) { }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -95,12 +95,12 @@ WebFrame* webkitFrameGetWebFrame(WebKitFrame* frame)
 
 GRefPtr<JSCValue> webkitFrameGetJSCValueForElementInWorld(WebKitFrame* frame, Element& element, WebKitScriptWorld* world)
 {
-    Vector<RefPtr<Element>> elements = { RefPtr<Element>(&element) };
+    Vector<Ref<Element>> elements = { Ref<Element>(element) };
     auto values = webkitFrameGetJSCValuesForElementsInWorld(frame, elements, world);
     return values.takeLast();
 }
 
-Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame* frame, const Vector<RefPtr<Element>>& elements, WebKitScriptWorld* world)
+Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame* frame, const Vector<Ref<Element>>& elements, WebKitScriptWorld* world)
 {
     RefPtr wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
     auto jsContext = jscContextGetOrCreate(frame->priv->webFrame->jsContextForWorld(wkWorld.get()));
@@ -109,7 +109,7 @@ Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*
         JSValueRef jsValue = nullptr;
         {
             JSC::JSLockHolder lock(globalObject);
-            jsValue = toRef(globalObject, toJS(globalObject, globalObject, element.get()));
+            jsValue = toRef(globalObject, toJS(globalObject, globalObject, element.ptr()));
         }
         return jsValue ? jscContextGetOrCreateValue(jsContext.get(), jsValue) : nullptr;
     });

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFramePrivate.h
@@ -30,5 +30,5 @@
 WebKitFrame* webkitFrameCreate(WebKit::WebFrame*);
 WebKit::WebFrame* webkitFrameGetWebFrame(WebKitFrame*);
 GRefPtr<JSCValue> webkitFrameGetJSCValueForElementInWorld(WebKitFrame*, WebCore::Element&, WebKitScriptWorld*);
-Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*, const Vector<RefPtr<WebCore::Element>>&, WebKitScriptWorld*);
+Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*, const Vector<Ref<WebCore::Element>>&, WebKitScriptWorld*);
 void webkitFrameSetURI(WebKitFrame*, const CString&);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -428,7 +428,7 @@ public:
 #endif
     }
 
-    void didAssociateFormControls(WebPage*, const Vector<RefPtr<Element>>& elements, WebFrame* frame) override
+    void didAssociateFormControls(WebPage*, const Vector<Ref<Element>>& elements, WebFrame* frame) override
     {
         auto* wkFrame = webkitFrameGetOrCreate(frame);
         if (!m_webPage->priv->formManagerMap.isEmpty()) {
@@ -440,7 +440,7 @@ public:
 #if !ENABLE(2022_GLIB_API)
         GRefPtr<GPtrArray> formElements = adoptGRef(g_ptr_array_sized_new(elements.size()));
         for (size_t i = 0; i < elements.size(); ++i)
-            g_ptr_array_add(formElements.get(), WebKit::kit(elements[i].get()));
+            g_ptr_array_add(formElements.get(), WebKit::kit(elements[i].ptr()));
 
         g_signal_emit(m_webPage, signals[FORM_CONTROLS_ASSOCIATED], 0, formElements.get());
         g_signal_emit(m_webPage, signals[FORM_CONTROLS_ASSOCIATED_FOR_FRAME], 0, formElements.get(), wkFrame);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -554,7 +554,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
             return [formDelegate _webProcessPlugInBrowserContextControllerShouldNotifyOnFormChanges:controller.get()];
         }
 
-        void didAssociateFormControls(WebKit::WebPage*, const Vector<RefPtr<WebCore::Element>>& elements, WebKit::WebFrame*) final
+        void didAssociateFormControls(WebKit::WebPage*, const Vector<Ref<WebCore::Element>>& elements, WebKit::WebFrame*) final
         {
             auto controller = m_controller.get();
             if (!controller)
@@ -564,7 +564,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
             if (![formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:didAssociateFormControls:)])
                 return;
             return [formDelegate _webProcessPlugInBrowserContextController:controller.get() didAssociateFormControls:createNSArray(elements, [] (auto& element) {
-                return wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element.get()));
+                return wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element.ptr()));
             }).get()];
         }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h
@@ -71,7 +71,7 @@ public:
     virtual bool shouldPerformActionInTextField(WebKit::WebPage*, WebCore::HTMLInputElement&, InputFieldAction, WebKit::WebFrame*) { return false; }
     virtual void willSubmitForm(WebKit::WebPage*, WebCore::HTMLFormElement*, WebKit::WebFrame*, WebKit::WebFrame*, const Vector<std::pair<WTF::String, WTF::String>>&, RefPtr<API::Object>& userData) { UNUSED_PARAM(userData); }
     virtual void willSendSubmitEvent(WebKit::WebPage*, WebCore::HTMLFormElement*, WebKit::WebFrame*, WebKit::WebFrame*, const Vector<std::pair<WTF::String, WTF::String>>&) { }
-    virtual void didAssociateFormControls(WebKit::WebPage*, const Vector<RefPtr<WebCore::Element>>&, WebKit::WebFrame*) { }
+    virtual void didAssociateFormControls(WebKit::WebPage*, const Vector<Ref<WebCore::Element>>&, WebKit::WebFrame*) { }
     virtual bool shouldNotifyOnFormChanges(WebKit::WebPage*) { return false; }
     virtual void willBeginInputSession(WebKit::WebPage*, WebCore::Element*, WebKit::WebFrame*, bool userIsInteracting, RefPtr<API::Object>& userData) { UNUSED_PARAM(userData); }
 };

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp
@@ -160,13 +160,13 @@ void InjectedBundlePageFormClient::willSubmitForm(WebPage* page, HTMLFormElement
     userData = adoptRef(toImpl(userDataToPass));
 }
 
-void InjectedBundlePageFormClient::didAssociateFormControls(WebPage* page, const Vector<RefPtr<WebCore::Element>>& elements, WebFrame* frame)
+void InjectedBundlePageFormClient::didAssociateFormControls(WebPage* page, const Vector<Ref<WebCore::Element>>& elements, WebFrame* frame)
 {
     if (!m_client.didAssociateFormControls && !m_client.didAssociateFormControlsForFrame)
         return;
 
     auto elementHandles = elements.map([](auto& element) -> RefPtr<API::Object> {
-        return InjectedBundleNodeHandle::getOrCreate(element.get());
+        return InjectedBundleNodeHandle::getOrCreate(element.ptr());
     });
     if (!m_client.didAssociateFormControlsForFrame) {
         m_client.didAssociateFormControls(toAPI(page), toAPI(API::Array::create(WTFMove(elementHandles)).ptr()), m_client.base.clientInfo);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.h
@@ -53,7 +53,7 @@ public:
     bool shouldPerformActionInTextField(WebPage*, WebCore::HTMLInputElement&, InputFieldAction, WebFrame*) override;
     void willSubmitForm(WebPage*, WebCore::HTMLFormElement*, WebFrame*, WebFrame* sourceFrame, const Vector<std::pair<String, String>>&, RefPtr<API::Object>& userData) override;
     void willSendSubmitEvent(WebPage*, WebCore::HTMLFormElement*, WebFrame*, WebFrame* sourceFrame, const Vector<std::pair<String, String>>&) override;
-    void didAssociateFormControls(WebPage*, const Vector<RefPtr<WebCore::Element>>&, WebFrame*) override;
+    void didAssociateFormControls(WebPage*, const Vector<Ref<WebCore::Element>>&, WebFrame*) override;
     bool shouldNotifyOnFormChanges(WebPage*) override;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1075,7 +1075,7 @@ RefPtr<Icon> WebChromeClient::createIconForFiles(const Vector<String>& filenames
 
 #endif
 
-void WebChromeClient::didAssociateFormControls(const Vector<RefPtr<Element>>& elements, WebCore::LocalFrame& frame)
+void WebChromeClient::didAssociateFormControls(const Vector<Ref<Element>>& elements, WebCore::LocalFrame& frame)
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     ASSERT(webFrame);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -232,7 +232,7 @@ private:
     void requestPointerUnlock(CompletionHandler<void(bool)>&&) final;
 #endif
 
-    void didAssociateFormControls(const Vector<RefPtr<WebCore::Element>>&, WebCore::LocalFrame&) final;
+    void didAssociateFormControls(const Vector<Ref<WebCore::Element>>&, WebCore::LocalFrame&) final;
     bool shouldNotifyOnFormChanges() final;
 
     bool selectItemWritingDirectionIsNatural() final;

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp
@@ -25,13 +25,13 @@
 
 #include "config.h"
 
-#if WK_HAVE_C_SPI
-
 #include "PlatformUtilities.h"
 #include "PlatformWebView.h"
 #include "Test.h"
 
 namespace TestWebKitAPI {
+
+#if WK_HAVE_C_SPI
 
 static bool didReceiveAllMessages = false;
 static bool receivedMessageForAddingForm = false;
@@ -71,7 +71,7 @@ static void setInjectedBundleClient(WKContextRef context)
     WKContextSetInjectedBundleClient(context, &injectedBundleClient.base);
 }
 
-TEST(WebKit, DidAssociateFormControls)
+TEST(WebKit, DidAssociateFormControlsWithInjectedBundle)
 {
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextForInjectedBundleTest("DidAssociateFormControlsTest"));
     setInjectedBundleClient(context.get());
@@ -81,6 +81,6 @@ TEST(WebKit, DidAssociateFormControls)
     Util::run(&didReceiveAllMessages);
 }
 
-} // namespace TestWebKitAPI
-
 #endif
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 802028539c2dc706ea8c5b57f0dc98c61a2be57b
<pre>
Add JS replacement for InjectedBundle::FormClient::didAssociateFormControls
<a href="https://bugs.webkit.org/show_bug.cgi?id=297376">https://bugs.webkit.org/show_bug.cgi?id=297376</a>
<a href="https://rdar.apple.com/158244851">rdar://158244851</a>

Reviewed by Ryosuke Niwa.

We introduce a JS event that is dispatched at the same time, but only in content worlds
where _WKContentWorldConfiguration.allowAutofill is YES.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didAssociateFormControl):
(WebCore::Document::didAssociateFormControlsTimerFired):
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::didAssociateFormControls):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController _setFormDelegate:]):
* Source/WebKit/WebProcess/InjectedBundle/APIInjectedBundleFormClient.h:
(API::InjectedBundle::FormClient::didAssociateFormControls):
(API::InjectedBundle::FormClient::shouldNotifyOnFormChanges):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.cpp:
(WebKit::InjectedBundlePageFormClient::didAssociateFormControls):
(WebKit::InjectedBundlePageFormClient::shouldNotifyOnFormChanges):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFormClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::didAssociateFormControls):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Tools/TestWebKitAPI/Tests/WebKit/DidAssociateFormControls.cpp:
(TestWebKitAPI::TEST(WebKit, DidAssociateFormControlsWithInjectedBundle)):
(TestWebKitAPI::TEST(WebKit, DidAssociateFormControls)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FormValidation.mm:
(TestWebKitAPI::TEST(FormValidation, FormValidationOnUnparentedWindowDoesNotCrash)):
(TestWebKitAPI::TEST(WebKit, DidAssociateFormControls)):
(TEST(FormValidation, PresentingFormValidationUIWithoutViewControllerDoesNotCrash)): Deleted.
(TEST(FormValidation, FormValidationOnUnparentedWindowDoesNotCrash)): Deleted.

Canonical link: <a href="https://commits.webkit.org/298736@main">https://commits.webkit.org/298736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b3797d4fc1618d27eefca086d4b200f69309ec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122557 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44749 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104507 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/68913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22616 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66238 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125706 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32584 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100716 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42265 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20175 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18601 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48873 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42748 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44453 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->