### PR TITLE
[WebXR + WebGPU] Return sensible values from some functions

### DIFF
--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.h
@@ -40,25 +40,25 @@ class XRCompositionLayer : public WebXRLayer {
 public:
     virtual ~XRCompositionLayer();
 
-    XRLayerLayout layout() const { RELEASE_ASSERT_NOT_REACHED(); }
+    XRLayerLayout layout() const { return XRLayerLayout::Stereo; }
 
-    bool blendTextureSourceAlpha() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setBlendTextureSourceAlpha(bool) { RELEASE_ASSERT_NOT_REACHED(); }
+    bool blendTextureSourceAlpha() const { return false; }
+    void setBlendTextureSourceAlpha(bool) { }
 
-    bool forceMonoPresentation() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setForceMonoPresentation(bool) { RELEASE_ASSERT_NOT_REACHED(); }
+    bool forceMonoPresentation() const { return false; }
+    void setForceMonoPresentation(bool) { }
 
-    float opacity() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setOpacity(float) { RELEASE_ASSERT_NOT_REACHED(); }
+    float opacity() const { return 1.f; }
+    void setOpacity(float) { }
 
-    uint32_t mipLevels() const { RELEASE_ASSERT_NOT_REACHED(); }
+    uint32_t mipLevels() const { return 1; }
 
-    XRLayerQuality quality() const { RELEASE_ASSERT_NOT_REACHED(); }
-    [[noreturn]] void setQuality(XRLayerQuality) { RELEASE_ASSERT_NOT_REACHED(); }
+    XRLayerQuality quality() const { return XRLayerQuality::Default; }
+    void setQuality(XRLayerQuality) { }
 
-    bool needsRedraw() const { RELEASE_ASSERT_NOT_REACHED(); }
+    bool needsRedraw() const { return true; }
 
-    [[noreturn]] void destroy() { RELEASE_ASSERT_NOT_REACHED(); }
+    void destroy() { }
 protected:
     explicit XRCompositionLayer(ScriptExecutionContext*);
 };

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.h
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.h
@@ -78,7 +78,7 @@ public:
     double nativeProjectionScaleFactor() const;
 
     ExceptionOr<Ref<XRProjectionLayer>> createProjectionLayer(ScriptExecutionContext&, std::optional<XRGPUProjectionLayerInit>);
-    RefPtr<XRGPUSubImage> getSubImage(XRCompositionLayer&, WebXRFrame&, std::optional<XREye>/* = "none"*/);
+    ExceptionOr<Ref<XRGPUSubImage>> getSubImage(XRProjectionLayer&, WebXRFrame&, std::optional<XREye>/* = "none"*/);
     ExceptionOr<Ref<XRGPUSubImage>> getViewSubImage(XRProjectionLayer&, WebXRView&);
     GPUTextureFormat getPreferredColorFormat();
 
@@ -91,6 +91,8 @@ public:
     // XRCubeLayer createCubeLayer(optional XRGPUCubeLayerInit init);
 private:
     XRGPUBinding(WebXRSession&, GPUDevice&);
+
+    ExceptionOr<Ref<XRGPUSubImage>> getSubImage(XRProjectionLayer&, XREye);
 
     RefPtr<WebGPU::XRBinding> m_backing;
     RefPtr<WebXRSession> m_session;

--- a/Source/WebCore/Modules/webxr/XRGPUBinding.idl
+++ b/Source/WebCore/Modules/webxr/XRGPUBinding.idl
@@ -40,7 +40,7 @@
     // XREquirectLayer createEquirectLayer(optional XRGPUEquirectLayerInit init);
     // XRCubeLayer createCubeLayer(optional XRGPUCubeLayerInit init);
 
-    XRGPUSubImage getSubImage(XRCompositionLayer layer, WebXRFrame frame, optional XREye eye = "none");
+    XRGPUSubImage getSubImage(XRProjectionLayer layer, WebXRFrame frame, optional XREye eye = "none");
     XRGPUSubImage getViewSubImage(XRProjectionLayer layer, WebXRView view);
 
     GPUTextureFormat getPreferredColorFormat();

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
@@ -98,27 +98,26 @@ uint32_t XRProjectionLayer::textureArrayLength() const
 
 bool XRProjectionLayer::ignoreDepthValues() const
 {
-    RELEASE_ASSERT_NOT_REACHED();
+    return false;
 }
 
 std::optional<float> XRProjectionLayer::fixedFoveation() const
 {
-    RELEASE_ASSERT_NOT_REACHED();
+    return 1.0;
 }
 
 void XRProjectionLayer::setFixedFoveation(std::optional<float>)
 {
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 WebXRRigidTransform* XRProjectionLayer::deltaPose() const
 {
-    RELEASE_ASSERT_NOT_REACHED();
+    return m_transform.get();
 }
 
-void XRProjectionLayer::setDeltaPose(WebXRRigidTransform*)
+void XRProjectionLayer::setDeltaPose(WebXRRigidTransform* deltaPose)
 {
-    RELEASE_ASSERT_NOT_REACHED();
+    m_transform = deltaPose;
 }
 
 WebCore::WebGPU::XRProjectionLayer& XRProjectionLayer::backing()

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.h
@@ -57,9 +57,9 @@ public:
 
     bool ignoreDepthValues() const;
     std::optional<float> fixedFoveation() const;
-    [[noreturn]] void setFixedFoveation(std::optional<float>);
+    void setFixedFoveation(std::optional<float>);
     WebXRRigidTransform* deltaPose() const;
-    [[noreturn]] void setDeltaPose(WebXRRigidTransform*);
+    void setDeltaPose(WebXRRigidTransform*);
 
     // WebXRLayer
     void startFrame(PlatformXR::FrameData&) final;
@@ -73,6 +73,7 @@ private:
 
     const Ref<WebCore::WebGPU::XRProjectionLayer> m_backing;
     std::optional<PlatformXR::FrameData::LayerData> m_layerData;
+    RefPtr<WebXRRigidTransform> m_transform;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### a9d12a05e30c114b18777ceba7c1c0e952663ce0
<pre>
[WebXR + WebGPU] Return sensible values from some functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=297378">https://bugs.webkit.org/show_bug.cgi?id=297378</a>
<a href="https://rdar.apple.com/158275211">rdar://158275211</a>

Reviewed by Dan Glastonbury.

There isn&apos;t a lot of WebGPU + WebXR content so we don&apos;t observe
any use cases of these functions, but we can return some sensible
values to avoid crashing the web content process when they are used.

* Source/WebCore/Modules/webxr/XRCompositionLayer.h:
(WebCore::XRCompositionLayer::layout const):
(WebCore::XRCompositionLayer::blendTextureSourceAlpha const):
(WebCore::XRCompositionLayer::setBlendTextureSourceAlpha):
(WebCore::XRCompositionLayer::forceMonoPresentation const):
(WebCore::XRCompositionLayer::setForceMonoPresentation):
(WebCore::XRCompositionLayer::opacity const):
(WebCore::XRCompositionLayer::setOpacity):
(WebCore::XRCompositionLayer::mipLevels const):
(WebCore::XRCompositionLayer::quality const):
(WebCore::XRCompositionLayer::setQuality):
(WebCore::XRCompositionLayer::needsRedraw const):
(WebCore::XRCompositionLayer::destroy):
* Source/WebCore/Modules/webxr/XRGPUBinding.cpp:
(WebCore::XRGPUBinding::getSubImage):
(WebCore::XRGPUBinding::getViewSubImage):
* Source/WebCore/Modules/webxr/XRGPUBinding.h:
* Source/WebCore/Modules/webxr/XRGPUBinding.idl:
* Source/WebCore/Modules/webxr/XRProjectionLayer.cpp:
(WebCore::XRProjectionLayer::ignoreDepthValues const):
(WebCore::XRProjectionLayer::fixedFoveation const):
(WebCore::XRProjectionLayer::setFixedFoveation):
(WebCore::XRProjectionLayer::deltaPose const):
(WebCore::XRProjectionLayer::setDeltaPose):
* Source/WebCore/Modules/webxr/XRProjectionLayer.h:

Canonical link: <a href="https://commits.webkit.org/298702@main">https://commits.webkit.org/298702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ea99544471812128d6fa44525539f110ac4e3a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66949 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44637 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68832 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66126 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108498 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125594 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32502 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48761 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44341 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->