### PR TITLE
Fix collapsed table row height without affecting row distribution

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6777,7 +6777,6 @@ webkit.org/b/285971 imported/w3c/web-platform-tests/css/css-tables/table-intrins
 webkit.org/b/285971 imported/w3c/web-platform-tests/css/css-tables/table-intrinsic-size-004.html [ ImageOnlyFailure ]
 webkit.org/b/285971 imported/w3c/web-platform-tests/css/css-tables/tentative/padding-percentage.html [ ImageOnlyFailure ]
 webkit.org/b/285971 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-border-spacing-001.html [ ImageOnlyFailure ]
-webkit.org/b/285971 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-border-spacing-002.html [ ImageOnlyFailure ]
 
 # New failures after re-importing css-overflow
 imported/w3c/web-platform-tests/css/css-overflow/margin-block-end-scroll-area-001.html [ Skip ]
@@ -7923,8 +7922,6 @@ webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/fixed-table-
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/fixed-table-layout-029.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/fixed-table-layout-030.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/fixed-table-layout-031.xht [ ImageOnlyFailure ]
-webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/row-visibility-001.xht [ ImageOnlyFailure ]
-webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/row-visibility-002.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-079.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-080.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-085.xht [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-001-expected.txt
@@ -9,5 +9,5 @@ Bottom table is identical to top except row 1 has been collapsed.
 row 2	
 
 PASS row visibility:collapse doesn't change table width, unlike display:none
-FAIL row visibility:collapse changes table height, unlike visibility:hidden assert_equals: expected 116 but got 222
+PASS row visibility:collapse changes table height, unlike visibility:hidden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-002-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-002-dynamic-expected.txt
@@ -9,5 +9,5 @@ Bottom table is identical to top except row 2 has been collapsed.
 row 1	
 
 PASS row visibility:collapse doesn't change table width, unlike display:none
-FAIL row visibility:collapse changes table height, unlike visibility:hidden assert_equals: row visibility:collapse changes table height, unlike visibility:hidden expected 116 but got 222
+PASS row visibility:collapse changes table height, unlike visibility:hidden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-003-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-003-dynamic-expected.txt
@@ -9,5 +9,5 @@ Bottom table is identical to top except row 1 has been collapsed.
 row 2	
 
 PASS row visibility:collapse doesn't change table width, unlike display:none
-FAIL row visibility:collapse changes table height, unlike visibility:hidden assert_equals: row visibility:collapse changes table height, unlike visibility:hidden expected 116 but got 222
+PASS row visibility:collapse changes table height, unlike visibility:hidden
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-005-expected.txt
@@ -5,6 +5,6 @@ Collapsed row should not contribute to overflow
 Collapsed section should not contribute to overflow
 
 
-FAIL collapsed row should not contribute to overflow assert_equals: expected 100 but got 150
-FAIL collapsed section should not contribute to overflow assert_equals: expected 50 but got 150
+PASS collapsed row should not contribute to overflow
+PASS collapsed section should not contribute to overflow
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-group-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-group-002-expected.txt
@@ -10,5 +10,5 @@ Bottom table is identical to top except row group of first two rows has been col
 row 3	
 
 PASS row group visibility:collapse doesn't change table width
-FAIL row group visibility:collapse changes table height assert_equals: row group visibility:collapse changes table height expected 116 but got 328
+PASS row group visibility:collapse changes table height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt
@@ -5,5 +5,5 @@ Setting row and column to visibility:collapse changes both height and width. The
 
 
 FAIL spanning col visibility:collapse changes table width assert_equals: spanning col visibility:collapse changes table width expected 112 but got 148
-FAIL spanning row visibility:collapse changes height assert_equals: spanning row visibility:collapse changes height expected 112 but got 148
+PASS spanning row visibility:collapse changes height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-002-expected.txt
@@ -5,5 +5,5 @@ Setting row and spanning column to visibility:collapse changes height and width.
 
 
 FAIL spanning row visibility:collapse doesn't change table width assert_equals: spanning row visibility:collapse doesn't change table width expected 45 but got 130
-FAIL spanning row visibility:collapse doesn't change height in this case assert_equals: spanning row visibility:collapse doesn't change height in this case expected 35 but got 75
+PASS spanning row visibility:collapse doesn't change height in this case
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-002-border-separate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-002-border-separate-expected.txt
@@ -26,7 +26,7 @@ This text should not intersect with the table.
 PASS spanning row visibility:collapse doesn't change table width
 PASS fourth row stays the same height
 PASS third row stays the same height
-FAIL spanning row visibility:collapse makes row height 0 assert_equals: spanning row visibility:collapse makes row height 0 expected 0 but got 30
+PASS spanning row visibility:collapse makes row height 0
 PASS first row stays the same height
-FAIL spanning cell shrinks to sum of remaining three rows' height assert_equals: spanning cell shrinks to sum of remaining three rows' height expected 90 but got 120
+PASS spanning cell shrinks to sum of remaining three rows' height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-002-expected.txt
@@ -26,7 +26,7 @@ This text should not intersect with the table.
 PASS spanning row visibility:collapse doesn't change table width
 PASS fourth row stays the same height
 PASS third row stays the same height
-FAIL spanning row visibility:collapse makes row height 0 assert_equals: spanning row visibility:collapse makes row height 0 expected 0 but got 29
+PASS spanning row visibility:collapse makes row height 0
 PASS first row stays the same height
-FAIL spanning cell shrinks to sum of remaining three rows' height assert_equals: spanning cell shrinks to sum of remaining three rows' height expected 87 but got 116
+PASS spanning cell shrinks to sum of remaining three rows' height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-003-border-separate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-003-border-separate-expected.txt
@@ -15,7 +15,7 @@ dddd
 eeee
 
 PASS spanning row visibility:collapse doesn't change table width
-FAIL collapsed row has zero height assert_equals: collapsed row has zero height expected 0 but got 30
+PASS collapsed row has zero height
 PASS first row height doesn't change
 PASS second row height doesn't change
 PASS fourth row height doesn't change

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-003-expected.txt
@@ -15,7 +15,7 @@ dddd
 eeee
 
 PASS spanning row visibility:collapse doesn't change table width
-FAIL collapsed row has zero height assert_equals: collapsed row has zero height expected 0 but got 29
+PASS collapsed row has zero height
 PASS first row height doesn't change
 PASS second row height doesn't change
 PASS fourth row height doesn't change

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-004-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-004-dynamic-expected.txt
@@ -25,9 +25,9 @@ dddd
 PASS spanning row visibility:collapse doesn't change table width
 PASS when third row is collapsed, first row stays the same height
 PASS when third row is collapsed, second row stays the same height
-FAIL third row visibility:collapse makes row height 0 assert_equals: third row visibility:collapse makes row height 0 expected 0 but got 29
+PASS third row visibility:collapse makes row height 0
 PASS when third row is collapsed, fourth row stays the same height
-FAIL spanning cell shrinks to sum of remaining three rows' height assert_equals: spanning cell shrinks to sum of remaining three rows' height expected 116 but got 145
+PASS spanning cell shrinks to sum of remaining three rows' height
 PASS when third row is visible, first row stays the same height
 PASS when third row is visible, second row stays the same height
 PASS when third row is visible, third row stays the same height
@@ -37,7 +37,7 @@ PASS when third row is visible, spanning cell stays the same height
 PASS (2nd collapse) spanning row visibility:collapse doesn't change table width
 PASS when third row is collapsed again, first row stays the same height
 PASS when third row is collapsed again, second row stays the same height
-FAIL (2nd collapse) third row visibility:collapse makes row height 0 assert_equals: (2nd collapse) third row visibility:collapse makes row height 0 expected 0 but got 29
+PASS (2nd collapse) third row visibility:collapse makes row height 0
 PASS when third row is collapsed again, fourth row stays the same height
-FAIL (2nd collapse) spanning cell shrinks to sum of remaining three rows' height assert_equals: (2nd collapse) spanning cell shrinks to sum of remaining three rows' height expected 116 but got 145
+PASS (2nd collapse) spanning cell shrinks to sum of remaining three rows' height
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2464
+layer at (0,0) size 785x2352
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2464
-  RenderBlock {HTML} at (0,0) size 785x2465
-    RenderBody {BODY} at (8,8) size 769x2441
+layer at (0,0) size 785x2352
+  RenderBlock {HTML} at (0,0) size 785x2353
+    RenderBody {BODY} at (8,8) size 769x2329
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x36
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -495,7 +495,7 @@ layer at (0,0) size 785x2464
                 text run at (0,0) width 26: "SIX"
       RenderBlock (anonymous) at (0,1378) size 769x19
         RenderBR {BR} at (0,0) size 0x17
-      RenderBlock {P} at (0,1412) size 769x225
+      RenderBlock {P} at (0,1412) size 769x201
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 426x17
             text run at (0,0) width 426: "The following table will have its rows and columns in red collapsed"
@@ -542,7 +542,7 @@ layer at (0,0) size 785x2464
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,112) size 769x18
           RenderBR {BR} at (0,0) size 0x17
-        RenderTable {TABLE} at (0,130) size 138x94 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,130) size 138x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 138x18
             RenderInline {B} at (52,0) size 33x17
               RenderText {#text} at (52,0) size 33x17
@@ -551,7 +551,7 @@ layer at (0,0) size 785x2464
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 136x74
+          RenderTableSection {TBODY} at (1,19) size 136x50
             RenderTableRow {TR} at (0,2) size 136x22
               RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
@@ -562,27 +562,27 @@ layer at (0,0) size 785x2464
               RenderTableCell {TD} at (68,2) size 66x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 62x17
                   text run at (2,2) width 62: "C13 large"
-            RenderTableRow {TR} at (0,26) size 136x22
-              RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+            RenderTableRow {TR} at (0,26) size 136x-2
+              RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (35,26) size 31x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (35,14) size 31x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (68,26) size 66x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (68,14) size 66x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,50) size 136x22
-              RenderTableCell {TD} at (2,50) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,26) size 136x22
+              RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (35,50) size 31x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (35,26) size 31x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C32"
-              RenderTableCell {TD} at (68,50) size 66x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (68,26) size 66x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1652) size 769x235
+      RenderBlock {P} at (0,1628) size 769x213
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 745x17
             text run at (0,0) width 745: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,7 +641,7 @@ layer at (0,0) size 785x2464
               RenderTableCell {TD} at (155,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,126) size 188x108 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,126) size 188x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 188x18
             RenderInline {B} at (78,0) size 32x17
               RenderText {#text} at (78,0) size 32x17
@@ -651,7 +651,7 @@ layer at (0,0) size 785x2464
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 186x88
+          RenderTableSection {TBODY} at (1,19) size 186x66
             RenderTableRow {TR} at (0,0) size 186x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
@@ -665,37 +665,37 @@ layer at (0,0) size 785x2464
               RenderTableCell {TD} at (155,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 186x22
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+            RenderTableRow {TR} at (0,22) size 186x0
+              RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (31,33) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,13) size 120x17
+              RenderTableCell {TD} at (31,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,2) size 120x17
                   text run at (2,2) width 120: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (155,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (155,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,44) size 186x22
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 186x22
+              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (155,44) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (155,22) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,66) size 186x22
-              RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,44) size 186x22
+              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (31,66) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (31,44) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (93,66) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (93,44) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (155,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (155,44) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1902) size 769x271
+      RenderBlock {P} at (0,1856) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 455x17
             text run at (0,0) width 455: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -761,39 +761,39 @@ layer at (0,0) size 785x2464
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,126) size 769x18
           RenderBR {BR} at (0,0) size 0x17
-        RenderTable {TABLE} at (0,144) size 126x108 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,144) size 126x64 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 126x18
             RenderInline {B} at (47,0) size 32x17
               RenderText {#text} at (47,0) size 32x17
                 text run at (47,0) width 32: "after"
-          RenderTableSection {TBODY} at (1,19) size 124x44
-            RenderTableRow {TR} at (0,0) size 124x22
-              RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+          RenderTableSection {TBODY} at (1,19) size 124x0
+            RenderTableRow {TR} at (0,0) size 124x0
+              RenderTableCell {TD} at (0,-11) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (31,0) size 31x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (31,-11) size 31x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (62,0) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (62,-11) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C13"
-              RenderTableCell {TD} at (93,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (93,-11) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 124x22
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+            RenderTableRow {TR} at (0,0) size 124x0
+              RenderTableCell {TD} at (0,-11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (31,22) size 31x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (31,-11) size 31x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (62,22) size 31x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (62,-11) size 31x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C23"
-              RenderTableCell {TD} at (93,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (93,-11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C24"
-          RenderTableSection {TBODY} at (1,63) size 124x44
+          RenderTableSection {TBODY} at (1,19) size 124x44
             RenderTableRow {TR} at (0,0) size 124x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
@@ -820,9 +820,9 @@ layer at (0,0) size 785x2464
               RenderTableCell {TD} at (93,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-        RenderBlock (anonymous) at (0,252) size 769x18
+        RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x17
-      RenderBlock {P} at (0,2188) size 769x253
+      RenderBlock {P} at (0,2098) size 769x231
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 755x35
             text run at (0,0) width 554: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -883,7 +883,7 @@ layer at (0,0) size 785x2464
               RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,144) size 188x108 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,144) size 188x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 188x18
             RenderInline {B} at (78,0) size 32x17
               RenderText {#text} at (78,0) size 32x17
@@ -893,7 +893,7 @@ layer at (0,0) size 785x2464
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 186x88
+          RenderTableSection {TBODY} at (1,19) size 186x66
             RenderTableRow {TR} at (0,0) size 186x22
               RenderTableCell {TD} at (155,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
@@ -907,33 +907,33 @@ layer at (0,0) size 785x2464
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 186x22
-              RenderTableCell {TD} at (155,22) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+            RenderTableRow {TR} at (0,22) size 186x0
+              RenderTableCell {TD} at (155,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (31,33) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,13) size 120x17
+              RenderTableCell {TD} at (31,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,2) size 120x17
                   text run at (2,2) width 120: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,44) size 186x22
-              RenderTableCell {TD} at (155,44) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 186x22
+              RenderTableCell {TD} at (155,22) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,66) size 186x22
-              RenderTableCell {TD} at (155,66) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,44) size 186x22
+              RenderTableCell {TD} at (155,44) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (93,66) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (93,44) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (33,2) size 27x17
                   text run at (33,2) width 27: "C42"
-              RenderTableCell {TD} at (31,66) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (31,44) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (33,2) size 27x17
                   text run at (33,2) width 27: "C43"
-              RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x2685
+layer at (0,0) size 800x2563
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x2685
-  RenderBlock {HTML} at (0,0) size 800x2686
-    RenderBody {BODY} at (8,8) size 784x2662
+layer at (0,0) size 800x2563
+  RenderBlock {HTML} at (0,0) size 800x2564
+    RenderBody {BODY} at (8,8) size 784x2540
       RenderBlock {H1} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 432x36
           text run at (0,1) width 432: "Example 4: Some simple tables."
@@ -495,7 +495,7 @@ layer at (0,0) size 800x2685
                 text run at (0,0) width 26: "SIX"
       RenderBlock (anonymous) at (0,1505) size 784x21
         RenderBR {BR} at (0,0) size 0x19
-      RenderBlock {P} at (0,1541) size 784x245
+      RenderBlock {P} at (0,1541) size 784x219
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 435x19
             text run at (0,0) width 435: "The following table will have its rows and columns in red collapsed"
@@ -542,7 +542,7 @@ layer at (0,0) size 800x2685
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,122) size 784x20
           RenderBR {BR} at (0,0) size 0x19
-        RenderTable {TABLE} at (0,142) size 138x102 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,142) size 138x76 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 138x20
             RenderInline {B} at (52,0) size 34x19
               RenderText {#text} at (52,0) size 34x19
@@ -551,7 +551,7 @@ layer at (0,0) size 800x2685
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 136x80
+          RenderTableSection {TBODY} at (1,21) size 136x54
             RenderTableRow {TR} at (0,2) size 136x24
               RenderTableCell {TD} at (2,2) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
@@ -562,27 +562,27 @@ layer at (0,0) size 800x2685
               RenderTableCell {TD} at (67,2) size 67x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x19
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,28) size 136x24
-              RenderTableCell {TD} at (2,28) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+            RenderTableRow {TR} at (0,28) size 136x-2
+              RenderTableCell {TD} at (2,15) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (34,28) size 32x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (34,15) size 32x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (67,28) size 67x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (67,15) size 67x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,54) size 136x24
-              RenderTableCell {TD} at (2,54) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,28) size 136x24
+              RenderTableCell {TD} at (2,28) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (34,54) size 32x24 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,28) size 32x24 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C32"
-              RenderTableCell {TD} at (67,54) size 67x24 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (67,28) size 67x24 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1801) size 784x257
+      RenderBlock {P} at (0,1775) size 784x233
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 756x19
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,7 +641,7 @@ layer at (0,0) size 800x2685
               RenderTableCell {TD} at (153,72) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,138) size 187x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,138) size 187x94 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 187x20
             RenderInline {B} at (76,0) size 34x19
               RenderText {#text} at (76,0) size 34x19
@@ -651,7 +651,7 @@ layer at (0,0) size 800x2685
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 185x96
+          RenderTableSection {TBODY} at (1,21) size 185x72
             RenderTableRow {TR} at (0,0) size 185x24
               RenderTableCell {TD} at (0,0) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
@@ -665,37 +665,37 @@ layer at (0,0) size 800x2685
               RenderTableCell {TD} at (153,0) size 32x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 185x24
-              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+            RenderTableRow {TR} at (0,24) size 185x0
+              RenderTableCell {TD} at (0,12) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,36) size 124x24 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,14) size 119x19
+              RenderTableCell {TD} at (30,24) size 124x24 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,2) size 119x19
                   text run at (2,2) width 119: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (153,24) size 32x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (153,12) size 32x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,48) size 185x24
-              RenderTableCell {TD} at (0,48) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,24) size 185x24
+              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (153,48) size 32x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (153,24) size 32x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,72) size 185x24
-              RenderTableCell {TD} at (0,72) size 31x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,48) size 185x24
+              RenderTableCell {TD} at (0,48) size 31x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (30,72) size 63x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,48) size 63x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (92,72) size 62x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (92,48) size 62x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (153,72) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (153,48) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,2073) size 784x297
+      RenderBlock {P} at (0,2023) size 784x249
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 463x19
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -761,39 +761,39 @@ layer at (0,0) size 800x2685
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,138) size 784x20
           RenderBR {BR} at (0,0) size 0x19
-        RenderTable {TABLE} at (0,158) size 125x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,158) size 125x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 125x20
             RenderInline {B} at (45,0) size 34x19
               RenderText {#text} at (45,0) size 34x19
                 text run at (45,0) width 34: "after"
-          RenderTableSection {TBODY} at (1,21) size 123x48
-            RenderTableRow {TR} at (0,0) size 123x24
-              RenderTableCell {TD} at (0,0) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+          RenderTableSection {TBODY} at (1,21) size 123x0
+            RenderTableRow {TR} at (0,0) size 123x0
+              RenderTableCell {TD} at (0,-12) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (30,0) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (30,-12) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (61,0) size 32x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (61,-12) size 32x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C13"
-              RenderTableCell {TD} at (92,0) size 31x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (92,-12) size 31x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 123x24
-              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+            RenderTableRow {TR} at (0,0) size 123x0
+              RenderTableCell {TD} at (0,-12) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,24) size 32x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (30,-12) size 32x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (61,24) size 32x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (61,-12) size 32x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C23"
-              RenderTableCell {TD} at (92,24) size 31x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (92,-12) size 31x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C24"
-          RenderTableSection {TBODY} at (1,69) size 123x48
+          RenderTableSection {TBODY} at (1,21) size 123x48
             RenderTableRow {TR} at (0,0) size 123x24
               RenderTableCell {TD} at (0,0) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
@@ -820,9 +820,9 @@ layer at (0,0) size 800x2685
               RenderTableCell {TD} at (92,24) size 31x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-        RenderBlock (anonymous) at (0,276) size 784x20
+        RenderBlock (anonymous) at (0,228) size 784x20
           RenderBR {BR} at (0,0) size 0x19
-      RenderBlock {P} at (0,2385) size 784x277
+      RenderBlock {P} at (0,2287) size 784x253
         RenderBlock (anonymous) at (0,0) size 784x40
           RenderText {#text} at (0,0) size 775x39
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -883,7 +883,7 @@ layer at (0,0) size 800x2685
               RenderTableCell {TD} at (0,72) size 31x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,158) size 187x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,158) size 187x94 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 187x20
             RenderInline {B} at (76,0) size 34x19
               RenderText {#text} at (76,0) size 34x19
@@ -893,7 +893,7 @@ layer at (0,0) size 800x2685
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 185x96
+          RenderTableSection {TBODY} at (1,21) size 185x72
             RenderTableRow {TR} at (0,0) size 185x24
               RenderTableCell {TD} at (153,0) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
@@ -907,33 +907,33 @@ layer at (0,0) size 800x2685
               RenderTableCell {TD} at (0,0) size 31x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 185x24
-              RenderTableCell {TD} at (153,24) size 32x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+            RenderTableRow {TR} at (0,24) size 185x0
+              RenderTableCell {TD} at (153,12) size 32x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,36) size 124x24 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,14) size 119x19
+              RenderTableCell {TD} at (30,24) size 124x24 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,2) size 119x19
                   text run at (2,2) width 119: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (0,12) size 31x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,48) size 185x24
-              RenderTableCell {TD} at (153,48) size 32x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,24) size 185x24
+              RenderTableCell {TD} at (153,24) size 32x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,48) size 31x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,72) size 185x24
-              RenderTableCell {TD} at (153,72) size 32x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,48) size 185x24
+              RenderTableCell {TD} at (153,48) size 32x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (92,72) size 62x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (92,48) size 62x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (32,2) size 28x19
                   text run at (32,2) width 28: "C42"
-              RenderTableCell {TD} at (30,72) size 63x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,48) size 63x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (32,2) size 28x19
                   text run at (32,2) width 28: "C43"
-              RenderTableCell {TD} at (0,72) size 31x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,48) size 31x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2466
+layer at (0,0) size 785x2354
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2466
-  RenderBlock {HTML} at (0,0) size 785x2467
-    RenderBody {BODY} at (8,8) size 769x2443
+layer at (0,0) size 785x2354
+  RenderBlock {HTML} at (0,0) size 785x2355
+    RenderBody {BODY} at (8,8) size 769x2331
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x37
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -495,7 +495,7 @@ layer at (0,0) size 785x2466
                 text run at (0,0) width 26: "SIX"
       RenderBlock (anonymous) at (0,1380) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,1414) size 769x225
+      RenderBlock {P} at (0,1414) size 769x201
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 435x18
             text run at (0,0) width 435: "The following table will have its rows and columns in red collapsed"
@@ -542,7 +542,7 @@ layer at (0,0) size 785x2466
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,112) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-        RenderTable {TABLE} at (0,130) size 138x94 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,130) size 138x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 138x18
             RenderInline {B} at (52,0) size 34x18
               RenderText {#text} at (52,0) size 34x18
@@ -551,7 +551,7 @@ layer at (0,0) size 785x2466
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 136x74
+          RenderTableSection {TBODY} at (1,19) size 136x50
             RenderTableRow {TR} at (0,2) size 136x22
               RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
@@ -562,27 +562,27 @@ layer at (0,0) size 785x2466
               RenderTableCell {TD} at (67,2) size 67x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x18
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,26) size 136x22
-              RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+            RenderTableRow {TR} at (0,26) size 136x-2
+              RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (34,26) size 32x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (34,14) size 32x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (67,26) size 67x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (67,14) size 67x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,50) size 136x22
-              RenderTableCell {TD} at (2,50) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,26) size 136x22
+              RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (34,50) size 32x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,26) size 32x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C32"
-              RenderTableCell {TD} at (67,50) size 67x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (67,26) size 67x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1654) size 769x235
+      RenderBlock {P} at (0,1630) size 769x213
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 756x18
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,7 +641,7 @@ layer at (0,0) size 785x2466
               RenderTableCell {TD} at (153,66) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,126) size 187x108 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,126) size 187x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 187x18
             RenderInline {B} at (76,0) size 34x18
               RenderText {#text} at (76,0) size 34x18
@@ -651,7 +651,7 @@ layer at (0,0) size 785x2466
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 185x88
+          RenderTableSection {TBODY} at (1,19) size 185x66
             RenderTableRow {TR} at (0,0) size 185x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
@@ -665,37 +665,37 @@ layer at (0,0) size 785x2466
               RenderTableCell {TD} at (153,0) size 32x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 185x22
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+            RenderTableRow {TR} at (0,22) size 185x0
+              RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,33) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,13) size 119x18
+              RenderTableCell {TD} at (30,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,2) size 119x18
                   text run at (2,2) width 119: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (153,22) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (153,11) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,44) size 185x22
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 185x22
+              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (153,44) size 32x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (153,22) size 32x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,66) size 185x22
-              RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,44) size 185x22
+              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (30,66) size 63x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,44) size 63x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (92,66) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (92,44) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (153,66) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (153,44) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1904) size 769x271
+      RenderBlock {P} at (0,1858) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 463x18
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -761,39 +761,39 @@ layer at (0,0) size 785x2466
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,126) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-        RenderTable {TABLE} at (0,144) size 125x108 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,144) size 125x64 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 125x18
             RenderInline {B} at (45,0) size 34x18
               RenderText {#text} at (45,0) size 34x18
                 text run at (45,0) width 34: "after"
-          RenderTableSection {TBODY} at (1,19) size 123x44
-            RenderTableRow {TR} at (0,0) size 123x22
-              RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+          RenderTableSection {TBODY} at (1,19) size 123x0
+            RenderTableRow {TR} at (0,0) size 123x0
+              RenderTableCell {TD} at (0,-11) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (30,0) size 32x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (30,-11) size 32x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (61,0) size 32x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (61,-11) size 32x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C13"
-              RenderTableCell {TD} at (92,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (92,-11) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 123x22
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+            RenderTableRow {TR} at (0,0) size 123x0
+              RenderTableCell {TD} at (0,-11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,22) size 32x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (30,-11) size 32x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (61,22) size 32x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (61,-11) size 32x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C23"
-              RenderTableCell {TD} at (92,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (92,-11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C24"
-          RenderTableSection {TBODY} at (1,63) size 123x44
+          RenderTableSection {TBODY} at (1,19) size 123x44
             RenderTableRow {TR} at (0,0) size 123x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
@@ -820,9 +820,9 @@ layer at (0,0) size 785x2466
               RenderTableCell {TD} at (92,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderBlock (anonymous) at (0,252) size 769x18
+        RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,2190) size 769x253
+      RenderBlock {P} at (0,2100) size 769x231
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 747x36
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -883,7 +883,7 @@ layer at (0,0) size 785x2466
               RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,144) size 187x108 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTable {TABLE} at (0,144) size 187x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 187x18
             RenderInline {B} at (76,0) size 34x18
               RenderText {#text} at (76,0) size 34x18
@@ -893,7 +893,7 @@ layer at (0,0) size 785x2466
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 185x88
+          RenderTableSection {TBODY} at (1,19) size 185x66
             RenderTableRow {TR} at (0,0) size 185x22
               RenderTableCell {TD} at (153,0) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
@@ -907,33 +907,33 @@ layer at (0,0) size 785x2466
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 185x22
-              RenderTableCell {TD} at (153,22) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+            RenderTableRow {TR} at (0,22) size 185x0
+              RenderTableCell {TD} at (153,11) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,33) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,13) size 119x18
+              RenderTableCell {TD} at (30,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,2) size 119x18
                   text run at (2,2) width 119: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,44) size 185x22
-              RenderTableCell {TD} at (153,44) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 185x22
+              RenderTableCell {TD} at (153,22) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,66) size 185x22
-              RenderTableCell {TD} at (153,66) size 32x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,44) size 185x22
+              RenderTableCell {TD} at (153,44) size 32x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (92,66) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (92,44) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (32,2) size 28x18
                   text run at (32,2) width 28: "C42"
-              RenderTableCell {TD} at (30,66) size 63x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,44) size 63x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (32,2) size 28x18
                   text run at (32,2) width 28: "C43"
-              RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -329,8 +329,18 @@ LayoutUnit RenderTableSection::calcRowLogicalHeight()
         m_rowPos[r + 1] = std::max(m_rowPos[r + 1], m_rowPos[r]);
     }
 
-    ASSERT(!needsLayout());
+    for (size_t rowIndex = 0; rowIndex < totalRows; ++rowIndex) {
+        if (m_grid[rowIndex].rowRenderer && m_grid[rowIndex].rowRenderer->style().visibility() == Visibility::Collapse) {
+            auto delta = m_rowPos[rowIndex + 1] - m_rowPos[rowIndex];
+            if (delta > 0_lu) {
+                // Reduce height of collapsed row to 0 without affecting other rows
+                for (size_t adjustedRowIndex = rowIndex + 1; adjustedRowIndex <= totalRows; ++adjustedRowIndex)
+                    m_rowPos[adjustedRowIndex] -= delta;
+            }
+        }
+    }
 
+    ASSERT(!needsLayout());
     return m_rowPos[m_grid.size()];
 }
 


### PR DESCRIPTION
#### 703a3c5807b37e2f6a79400150b5b47d486e0c89
<pre>
Fix collapsed table row height without affecting row distribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=297380">https://bugs.webkit.org/show_bug.cgi?id=297380</a>
<a href="https://rdar.apple.com/158276634">rdar://158276634</a>

Reviewed by Alan Baradlay.

Previously, collapsed rows could retain nonzero height or shift subsequent rows,
causing failures in rowspan and collapsed-row cases.

This patch adds post-processe computed row heights: for each collapsed row, any
height is removed by shifting subsequent row positions up, making the collapsed
row height zero without altering other rows&apos; heights.

* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::calcRowLogicalHeight):
&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-002-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-003-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-group-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-002-border-separate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-003-border-separate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-004-dynamic-expected.txt:
* LayoutTests/TestExpectations: Unskip two tests

&gt; Rebaselines:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt:

Canonical link: <a href="https://commits.webkit.org/298783@main">https://commits.webkit.org/298783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0c66538575e231e6e71f284d3c7a42f4b312c56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67220 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31d04a69-9f2f-407c-a03c-9c7ba201dd68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44901 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0eafab2a-8ec5-437e-a6cf-87308f00196c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69059 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66389 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98895 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/22904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125858 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43547 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42375 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39509 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43433 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49028 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->