### PR TITLE
Remove Visual Viewport idl definition for scrollend

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt
@@ -137,7 +137,7 @@ PASS VisualViewport interface: attribute height
 PASS VisualViewport interface: attribute scale
 PASS VisualViewport interface: attribute onresize
 PASS VisualViewport interface: attribute onscroll
-PASS VisualViewport interface: attribute onscrollend
+FAIL VisualViewport interface: attribute onscrollend assert_true: The prototype object must have a property "onscrollend" expected true got false
 PASS VisualViewport must be primary interface of self.visualViewport
 PASS Stringification of self.visualViewport
 PASS VisualViewport interface: self.visualViewport must inherit property "offsetLeft" with the proper type
@@ -149,7 +149,7 @@ PASS VisualViewport interface: self.visualViewport must inherit property "height
 PASS VisualViewport interface: self.visualViewport must inherit property "scale" with the proper type
 PASS VisualViewport interface: self.visualViewport must inherit property "onresize" with the proper type
 PASS VisualViewport interface: self.visualViewport must inherit property "onscroll" with the proper type
-PASS VisualViewport interface: self.visualViewport must inherit property "onscrollend" with the proper type
+FAIL VisualViewport interface: self.visualViewport must inherit property "onscrollend" with the proper type assert_inherits: property "onscrollend" not found in prototype chain
 FAIL CSSPseudoElement interface: operation getBoxQuads(optional BoxQuadOptions) assert_own_property: self does not have own property "CSSPseudoElement" expected property "CSSPseudoElement" missing
 FAIL CSSPseudoElement interface: operation convertQuadFromNode(DOMQuadInit, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: self does not have own property "CSSPseudoElement" expected property "CSSPseudoElement" missing
 FAIL CSSPseudoElement interface: operation convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) assert_own_property: self does not have own property "CSSPseudoElement" expected property "CSSPseudoElement" missing

--- a/Source/WebCore/page/VisualViewport.idl
+++ b/Source/WebCore/page/VisualViewport.idl
@@ -42,5 +42,4 @@
 
     attribute EventHandler onresize;
     attribute EventHandler onscroll;
-    [EnabledBySetting=ScrollendEventEnabled] attribute EventHandler onscrollend;
 };


### PR DESCRIPTION
#### 3bf428107e701795d77eb517a57e8eb62c8f8695
<pre>
Remove Visual Viewport idl definition for scrollend
<a href="https://bugs.webkit.org/show_bug.cgi?id=297381">https://bugs.webkit.org/show_bug.cgi?id=297381</a>
<a href="https://rdar.apple.com/158277808">rdar://158277808</a>

Reviewed by Tim Nguyen.

Remove Visual Viewport idl definition for scrollend, to be added back
once implmented.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/idlharness-expected.txt:
* Source/WebCore/page/VisualViewport.idl:

Canonical link: <a href="https://commits.webkit.org/298698@main">https://commits.webkit.org/298698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f00a23902efbb8a41a07291b4536d4115f3f39c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66919 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68812 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22504 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125564 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97086 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20076 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39206 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45946 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->