### PR TITLE
[macOS Tahoe] fast/forms/range/slider-in-multi-column.html is a constant failure

### DIFF
--- a/LayoutTests/fast/forms/range/slider-in-multi-column.html
+++ b/LayoutTests/fast/forms/range/slider-in-multi-column.html
@@ -47,7 +47,7 @@ function pageY(runner) {
     return acc;
 }
 
-function testIt(formIndex, colIndex, ofsX, expected)
+function testIt(formIndex, colIndex, expected)
 {
     const form = document.getElementById("f" + formIndex);
     const column = document.getElementById("c" + formIndex + "0");
@@ -55,8 +55,14 @@ function testIt(formIndex, colIndex, ofsX, expected)
 
     const sliderId = "c" + formIndex + colIndex;
     const slider = document.getElementById(sliderId);
+    const sliderThumb = internals.shadowRoot(slider).querySelector('[useragentpart="-webkit-slider-thumb"]');
 
-    const clickX = pageX(column) + colWidth * colIndex + ofsX;
+    const sliderWidth = slider.offsetWidth;
+    const sliderThumbWidth = sliderThumb.offsetWidth;
+
+    const offsetX = ((expected - 2) / 100) * (sliderWidth - sliderThumbWidth) + sliderThumbWidth / 2;
+
+    const clickX = pageX(column) + colWidth * colIndex + offsetX;
     const clickY = pageY(column) + slider.offsetHeight / 2;
 
     eventSender.mouseMoveTo(clickX, clickY);
@@ -78,7 +84,7 @@ function test()
 
     for (var formIndex = 0; formIndex < numForms; formIndex++) {
         for (var colIndex = 0; colIndex < numCols; colIndex++) {
-          testIt(formIndex, colIndex, 23, 20);
+          testIt(formIndex, colIndex, 20);
         }
     }
 }

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -29,9 +29,6 @@ fast/forms/switch/zoom-approximates-transform-vertical-lr.html [ Pass ]
 fast/forms/switch/zoom-approximates-transform-vertical-rl.html [ Pass ] 
 fast/forms/switch/zoom-approximates-transform.html [ Pass ] 
 
-# rdar://154997421 (REGRESSION(Liquid Glass): [ Tahoe ] 5X fast/forms/range (layout-tests) are constant failures
-fast/forms/range/slider-in-multi-column.html [ Pass ]
-
 # Tests which pass only with form control refresh enabled (support added in Tahoe)
 fast/forms/appearance-default-button.html  [ Skip ]
 fast/forms/form-control-refresh [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2482,9 +2482,6 @@ fast/forms/switch/zoom-approximates-transform-vertical-lr.html [ ImageOnlyFailur
 fast/forms/switch/zoom-approximates-transform-vertical-rl.html [ ImageOnlyFailure ] 
 fast/forms/switch/zoom-approximates-transform.html [ ImageOnlyFailure ] 
 
-# rdar://154997421 (REGRESSION(Liquid Glass): [ Tahoe ] 5X fast/forms/range (layout-tests) are constant failures
-fast/forms/range/slider-in-multi-column.html [ Failure ]
-
 # Tests which pass only with form control refresh enabled
 fast/forms/appearance-default-button.html  [ Pass ]
 fast/forms/form-control-refresh [ Pass ]


### PR DESCRIPTION
#### 592f17114e7942f54379cf57e006b3e95f06e722
<pre>
[macOS Tahoe] fast/forms/range/slider-in-multi-column.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=297379">https://bugs.webkit.org/show_bug.cgi?id=297379</a>
<a href="https://rdar.apple.com/154997421">rdar://154997421</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

The failing test uses a hardcoded offset to drag the slider thumb and then
asserts that the slider has a specific value.

However, this approach is flawed since the slider value is function of the
both the position and the width of thumb. The width of the thumb affects
the current value, since no part of the thumb can be dragged beyond the bounds
of the track.

The width of the slider thumb changed with the form control redesign in
macOS Tahoe, and the hardcoded offset no longer results in the same slider
value. Fix by computing the offset necessary to achieve the desired value.

* LayoutTests/fast/forms/range/slider-in-multi-column.html:

2 is subtracted from the expected value in order to continue to test the `step`.

* LayoutTests/platform/mac-sequoia/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298673@main">https://commits.webkit.org/298673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e7ec80d047e7d81cd87766bf9035e9457a38c8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66813 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88313 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0be579ad-2cf6-49a4-901f-acb4822d4970) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104311 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68726 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65991 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22566 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32401 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100510 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42098 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19999 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18572 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43034 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42501 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45836 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->