### PR TITLE
Do not use synthetic signposts

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -328,40 +328,55 @@ enum WTFOSSignpostType {
 // These work like WTF{Emit,Begin,End}Signpost, but offset the timestamp associated with the event
 // by timeDelta (which should of type WTF::Seconds).
 #define WTFEmitSignpostWithTimeDelta(pointer, name, timeDelta, ...) \
-    WTFEmitSignpostWithType(WTFOSSignpostTypeEmitEvent, os_signpost_event_emit, (pointer), name, (timeDelta), " %{signpost.description:event_time}llu", "" __VA_ARGS__)
+    WTFEmitSignpostWithType(WTFOSSignpostTypeEmitEvent, os_signpost_event_emit, (pointer), name, WTFCurrentContinuousTime(timeDelta), " %{signpost.description:event_time}llu", "" __VA_ARGS__)
 
 #define WTFBeginSignpostWithTimeDelta(pointer, name, timeDelta, ...) \
-    WTFEmitSignpostWithType(WTFOSSignpostTypeBeginInterval, os_signpost_interval_begin, (pointer), name, (timeDelta), " %{signpost.description:begin_time}llu", "" __VA_ARGS__)
+    WTFEmitSignpostWithType(WTFOSSignpostTypeBeginInterval, os_signpost_interval_begin, (pointer), name, WTFCurrentContinuousTime(timeDelta), " %{signpost.description:begin_time}llu", "" __VA_ARGS__)
 
 #define WTFEndSignpostWithTimeDelta(pointer, name, timeDelta, ...) \
-    WTFEmitSignpostWithType(WTFOSSignpostTypeEndInterval, os_signpost_interval_end, (pointer), name, (timeDelta), " %{signpost.description:end_time}llu", "" __VA_ARGS__)
+    WTFEmitSignpostWithType(WTFOSSignpostTypeEndInterval, os_signpost_interval_end, (pointer), name, WTFCurrentContinuousTime(timeDelta), " %{signpost.description:end_time}llu", "" __VA_ARGS__)
 
 #define WTFEmitSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) \
-    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeEmitEvent, os_signpost_event_emit, (pointer), name, (timeDelta), " %{signpost.description:event_time}llu", "" __VA_ARGS__)
+    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeEmitEvent, os_signpost_event_emit, (pointer), name, WTFCurrentContinuousTime(timeDelta), " %{signpost.description:event_time}llu", "" __VA_ARGS__)
 
 #define WTFBeginSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) \
-    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeBeginInterval, os_signpost_interval_begin, (pointer), name, (timeDelta), " %{signpost.description:begin_time}llu", "" __VA_ARGS__)
+    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeBeginInterval, os_signpost_interval_begin, (pointer), name, WTFCurrentContinuousTime(timeDelta), " %{signpost.description:begin_time}llu", "" __VA_ARGS__)
 
 #define WTFEndSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) \
-    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeEndInterval, os_signpost_interval_end, (pointer), name, (timeDelta), " %{signpost.description:end_time}llu", "" __VA_ARGS__)
+    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeEndInterval, os_signpost_interval_end, (pointer), name, WTFCurrentContinuousTime(timeDelta), " %{signpost.description:end_time}llu", "" __VA_ARGS__)
 
-#define WTFEmitSignpostWithType(type, emitMacro, pointer, name, timeDelta, timeFormat, format, ...) \
+
+// These work like WTF{Emit,Begin,End}Signpost, but specific platform timestamp associated with the event.
+#define WTFEmitSignpostWithSpecificTime(pointer, name, specificTime, ...) \
+    WTFEmitSignpostWithType(WTFOSSignpostTypeEmitEvent, os_signpost_event_emit, (pointer), name, (specificTime), " %{signpost.description:event_time}llu", "" __VA_ARGS__)
+
+#define WTFBeginSignpostWithSpecificTime(pointer, name, specificTime, ...) \
+    WTFEmitSignpostWithType(WTFOSSignpostTypeBeginInterval, os_signpost_interval_begin, (pointer), name, (specificTime), " %{signpost.description:begin_time}llu", "" __VA_ARGS__)
+
+#define WTFEndSignpostWithSpecificTime(pointer, name, specificTime, ...) \
+    WTFEmitSignpostWithType(WTFOSSignpostTypeEndInterval, os_signpost_interval_end, (pointer), name, (specificTime), " %{signpost.description:end_time}llu", "" __VA_ARGS__)
+
+#define WTFEmitSignpostAlwaysWithSpecificTime(pointer, name, specificTime, ...) \
+    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeEmitEvent, os_signpost_event_emit, (pointer), name, (specificTime), " %{signpost.description:event_time}llu", "" __VA_ARGS__)
+
+#define WTFBeginSignpostAlwaysWithSpecificTime(pointer, name, specificTime, ...) \
+    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeBeginInterval, os_signpost_interval_begin, (pointer), name, (specificTime), " %{signpost.description:begin_time}llu", "" __VA_ARGS__)
+
+#define WTFEndSignpostAlwaysWithSpecificTime(pointer, name, specificTime, ...) \
+    WTFEmitSignpostAlwaysWithType(WTFOSSignpostTypeEndInterval, os_signpost_interval_end, (pointer), name, (specificTime), " %{signpost.description:end_time}llu", "" __VA_ARGS__)
+
+#define WTFEmitSignpostWithType(type, emitMacro, pointer, name, specificTime, timeFormat, format, ...) \
     do { \
         if (WTFSignpostsEnabled()) [[unlikely]] \
-            WTFEmitSignpostAlwaysWithType(type, emitMacro, pointer, name, timeDelta, timeFormat, format, ##__VA_ARGS__); \
+            WTFEmitSignpostAlwaysWithType(type, emitMacro, pointer, name, specificTime, timeFormat, format, ##__VA_ARGS__); \
     } while (0)
 
-#define WTFEmitSignpostAlwaysWithType(type, emitMacro, pointer, name, timeDelta, timeFormat, format, ...) \
+#define WTFEmitSignpostAlwaysWithType(type, emitMacro, pointer, name, specificTime, timeFormat, format, ...) \
     do { \
         if (WTFSignpostIndirectLoggingEnabled) \
-            WTFEmitSignpostIndirectlyWithType(type, pointer, name, timeDelta, format, ##__VA_ARGS__); \
-        else { \
-            Seconds delta = (timeDelta); \
-            if (delta) \
-                WTFEmitSignpostDirectlyWithType(emitMacro, pointer, name, format timeFormat, ##__VA_ARGS__, WTFCurrentContinuousTime(delta)); \
-            else \
-                WTFEmitSignpostDirectlyWithType(emitMacro, pointer, name, format, ##__VA_ARGS__); \
-        } \
+            WTFEmitSignpostIndirectlyWithType(type, pointer, name, specificTime, format, ##__VA_ARGS__); \
+        else \
+            WTFEmitSignpostDirectlyWithType(emitMacro, pointer, name, format timeFormat, ##__VA_ARGS__, specificTime); \
     } while (0)
 
 #define WTFEmitSignpostDirectlyWithType(emitMacro, pointer, name, format, ...) \
@@ -372,8 +387,8 @@ enum WTFOSSignpostType {
         emitMacro(wtfHandle.get(), wtfSignpostID, #name, format, ##__VA_ARGS__); \
     } while (0)
 
-#define WTFEmitSignpostIndirectlyWithType(type, pointer, name, timeDelta, format, ...) \
-    SUPPRESS_UNCOUNTED_LOCAL os_log(WTFSignpostLogHandle(), "type=%d name=%d p=%" PRIuPTR " ts=%llu " format, type, WTFOSSignpostName ## name, reinterpret_cast<uintptr_t>(pointer), WTFCurrentContinuousTime(timeDelta), ##__VA_ARGS__)
+#define WTFEmitSignpostIndirectlyWithType(type, pointer, name, specificTime, format, ...) \
+    SUPPRESS_UNCOUNTED_LOCAL os_log(WTFSignpostLogHandle(), "type=%d name=%d p=%" PRIuPTR " ts=%llu " format, type, WTFOSSignpostName ## name, reinterpret_cast<uintptr_t>(pointer), specificTime, ##__VA_ARGS__)
 
 #define WTFSetCounter(name, value) do { } while (0)
 
@@ -411,7 +426,7 @@ enum WTFOSSignpostType {
     do { \
         IGNORE_WARNINGS_BEGIN("format-zero-length") \
         if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
-            annotator->mark((timeDelta), std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+            annotator->mark(SysprofAnnotator::currentContinuousTime(timeDelta), std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
         IGNORE_WARNINGS_END \
     } while (0)
 
@@ -421,6 +436,21 @@ enum WTFOSSignpostType {
 #define WTFEmitSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) WTFEmitSignpostWithTimeDelta((pointer), name, (timeDelta), ##__VA_ARGS__)
 #define WTFBeginSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) WTFBeginSignpostWithTimeDelta((pointer), name, (timeDelta), ##__VA_ARGS__)
 #define WTFEndSignpostAlwaysWithTimeDelta(pointer, name, timeDelta, ...) WTFEndSignpostWithTimeDelta((pointer), name, (timeDelta), ##__VA_ARGS__)
+
+#define WTFEmitSignpostWithSpecificTime(pointer, name, specificTime, ...) \
+    do { \
+        IGNORE_WARNINGS_BEGIN("format-zero-length") \
+        if (auto* annotator = SysprofAnnotator::singletonIfCreated()) \
+            annotator->mark(specificTime, std::span(_STRINGIFY(name)), "" __VA_ARGS__); \
+        IGNORE_WARNINGS_END \
+    } while (0)
+
+#define WTFBeginSignpostWithSpecificTime(pointer, name, specificTime, ...) WTFEmitSignpostWithSpecificTime((pointer), name, (specificTime), ##__VA_ARGS__)
+#define WTFEndSignpostWithSpecificTime(pointer, name, specificTime, ...) WTFEmitSignpostWithSpecificTime((pointer), name, (specificTime), ##__VA_ARGS__)
+
+#define WTFEmitSignpostAlwaysWithSpecificTime(pointer, name, specificTime, ...) WTFEmitSignpostWithSpecificTime((pointer), name, (specificTime), ##__VA_ARGS__)
+#define WTFBeginSignpostAlwaysWithSpecificTime(pointer, name, specificTime, ...) WTFBeginSignpostWithSpecificTime((pointer), name, (specificTime), ##__VA_ARGS__)
+#define WTFEndSignpostAlwaysWithSpecificTime(pointer, name, specificTime, ...) WTFEndSignpostWithSpecificTime((pointer), name, (specificTime), ##__VA_ARGS__)
 
 #define WTFSetCounter(name, value) \
     do { \
@@ -445,6 +475,14 @@ enum WTFOSSignpostType {
 #define WTFEmitSignpostAlwaysWithTimeDelta(pointer, name, ...) do { } while (0)
 #define WTFBeginSignpostAlwaysWithTimeDelta(pointer, name, ...) do { } while (0)
 #define WTFEndSignpostAlwaysWithTimeDelta(pointer, name, ...) do { } while (0)
+
+#define WTFEmitSignpostWithSpecificTime(pointer, name, ...) do { } while (0)
+#define WTFBeginSignpostWithSpecificTime(pointer, name, ...) do { } while (0)
+#define WTFEndSignpostWithSpecificTime(pointer, name, ...) do { } while (0)
+
+#define WTFEmitSignpostAlwaysWithSpecificTime(pointer, name, ...) do { } while (0)
+#define WTFBeginSignpostAlwaysWithSpecificTime(pointer, name, ...) do { } while (0)
+#define WTFEndSignpostAlwaysWithSpecificTime(pointer, name, ...) do { } while (0)
 
 #define WTFSetCounter(name, value) do { } while (0)
 

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -42,6 +42,11 @@ public:
         return s_annotator;
     }
 
+    static int64_t currentContinuousTime(Seconds timeDelta)
+    {
+        return SYSPROF_CAPTURE_CURRENT_TIME + timeDelta.microsecondsAs<int64_t>();
+    }
+
     void instantMark(std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(3, 4)
     {
         va_list args;
@@ -50,11 +55,11 @@ public:
         va_end(args);
     }
 
-    void mark(Seconds timeDelta, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
+    void mark(int64_t time, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
     {
         va_list args;
         va_start(args, description);
-        sysprof_collector_mark_vprintf(SYSPROF_CAPTURE_CURRENT_TIME, timeDelta.microsecondsAs<int64_t>(), m_processName, name.data(), description, args);
+        sysprof_collector_mark_vprintf(time, 0, m_processName, name.data(), description, args);
         va_end(args);
     }
 

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -472,7 +472,9 @@ ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& g
         if (correctedStartTime != correctedEndTime)
             correctedEndTime -= 1;
         auto message = measureName.utf8();
-        WTFEmitSignpostAlways(entry.ptr(), WebKitPerformance, "%{public}s %{public, signpost.description:begin_time}llu %{public, signpost.description:end_time}llu", message.data(), correctedStartTime, correctedEndTime);
+
+        WTFBeginSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedStartTime, "%" PUBLIC_LOG_STRING, message.data());
+        WTFEndSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedEndTime, "%" PUBLIC_LOG_STRING, message.data());
 #endif
     }
 


### PR DESCRIPTION
#### 50e6ed4537a493905e5375dda138dfd3279ba8ba
<pre>
Do not use synthetic signposts
<a href="https://bugs.webkit.org/show_bug.cgi?id=297382">https://bugs.webkit.org/show_bug.cgi?id=297382</a>
<a href="https://rdar.apple.com/158278306">rdar://158278306</a>

Reviewed by Ben Nham.

Synthetic signposts works well when it is directly emitted to
os_signpost. However WebContent process redirects os_log to UIProcess on
new OS and the entire message gets reinterpret as normal message
payload. So begin_time and end_time annotation does not work correctly
when it gets redirected.

This patch fixes this issue by avoiding synthetic signposts. Instead, we
introduce WTFEmitSignpostWithSpecificTime family. They allow us to
include spcific time point for signpost. And instead of combining begin
and end, we emit both with appropriate time point. So then each one gets
correctly redirected as begin and end signpost with specific time.

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::measure):

Canonical link: <a href="https://commits.webkit.org/298687@main">https://commits.webkit.org/298687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/159138e66d7babf9867849498fcd460347641077

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116257 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66817 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88316 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7698831c-49e7-4954-91d5-680887de8930) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68729 "Passed tests") | | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22421 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65995 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108367 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125463 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114785 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97026 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96811 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20002 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39098 "Hash 159138e6 for PR 49379 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48630 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143482 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42505 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36982 "Found 1 new JSC stress test failure: wasm.yaml/wasm/v8/import-function.js.wasm-eager-jettison (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->