### PR TITLE
AX: avoid including AXObjectCache.h from page/Chrome.h

### DIFF
--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -31,15 +31,18 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "FrameInlines.h"
 #include "Gamepad.h"
 #include "GamepadManager.h"
 #include "GamepadProvider.h"
 #include "LocalDOMWindow.h"
+#include "LocalFrame.h"
 #include "Navigator.h"
 #include "Page.h"
 #include "PermissionsPolicy.h"
 #include "PlatformGamepad.h"
+#include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HTMLElement.h"
 
+#include "AXObjectCache.h"
 #include "CSSMarkup.h"
 #include "CSSParserFastPaths.h"
 #include "CSSPropertyNames.h"

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -83,6 +83,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
 #include "LocalFrameView.h"
+#include "LocalizedStrings.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
 #include "MediaController.h"

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "AXObjectCache.h"
 #include "Cursor.h"
 #include "DisabledAdaptations.h"
 #include "FocusDirection.h"

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -29,6 +29,7 @@
 
 #include "DeviceClient.h"
 #include "Document.h"
+#include "NodeInlines.h"
 #include "SecurityOrigin.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "EventHandler.h"
 
+#include "AXObjectCache.h"
 #include "AutoscrollController.h"
 #include "BackForwardController.h"
 #include "CachedImage.h"

--- a/Source/WebCore/page/ImageOverlayController.cpp
+++ b/Source/WebCore/page/ImageOverlayController.cpp
@@ -31,6 +31,7 @@
 #include "ContainerNodeInlines.h"
 #include "Document.h"
 #include "Editor.h"
+#include "FloatQuad.h"
 #include "FrameSelection.h"
 #include "GraphicsContext.h"
 #include "HTMLElement.h"

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "InteractionRegion.h"
 
+#include "AXObjectCache.h"
 #include "AccessibilityObject.h"
 #include "BorderShape.h"
 #include "Document.h"

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.mm
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.mm
@@ -35,6 +35,7 @@
 #import "GraphicsLayer.h"
 #import "GraphicsLayerFactory.h"
 #import "ImageBuffer.h"
+#import "Page.h"
 #import <wtf/Seconds.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 

--- a/Source/WebCore/platform/mac/WidgetMac.mm
+++ b/Source/WebCore/platform/mac/WidgetMac.mm
@@ -44,6 +44,7 @@
 #import <wtf/Ref.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @interface NSWindow (WebWindowDetails)
 - (BOOL)_needsToResetDragMargins;

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -29,6 +29,8 @@
 #include "BadgeClient.h"
 #include "CacheStorageProvider.h"
 #include "Chrome.h"
+#include "Document.h"
+#include "DocumentInlines.h"
 #include "ErrorEvent.h"
 #include "EventLoop.h"
 #include "EventNames.h"

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInternal.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInternal.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/InspectorFrontendClient.h>
 #include <WebCore/InspectorPageAgent.h>
 #include <WebCore/LocalFrame.h>
+#include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/NavigationAction.h>
 #include <WebCore/NotImplemented.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -62,6 +62,7 @@
 #include <PDFKit/PDFKit.h>
 #include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #include <WebCore/AXCoreObject.h>
+#include <WebCore/AXObjectCache.h>
 #include <WebCore/AffineTransform.h>
 #include <WebCore/AutoscrollController.h>
 #include <WebCore/BitmapImage.h>

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -41,6 +41,7 @@
 #include <WebCore/TextAnimationTypes.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TextIterator.h>
+#include <WebCore/VisibleUnits.h>
 #include <WebCore/WritingToolsTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -45,6 +45,7 @@
 #import "WebPreferencesKeys.h"
 #import "WebProcess.h"
 #import "WebRemoteObjectRegistry.h"
+#import <WebCore/AXObjectCache.h>
 #import <WebCore/Chrome.h>
 #import <WebCore/ChromeClient.h>
 #import <WebCore/DeprecatedGlobalSettings.h>

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -37,6 +37,7 @@
 #import "RemoteScrollingUIState.h"
 #import "WebPage.h"
 #import "WebProcess.h"
+#import <WebCore/AXObjectCache.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameView.h>

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -60,6 +60,7 @@
 #include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/JSValueRef.h>
+#include <WebCore/AXObjectCache.h>
 #include <WebCore/ArchiveResource.h>
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/Chrome.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -181,6 +181,7 @@
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/ProfilerDatabase.h>
 #include <JavaScriptCore/SamplingProfiler.h>
+#include <WebCore/AXObjectCache.h>
 #include <WebCore/AnimationTimelinesController.h>
 #include <WebCore/AppHighlight.h>
 #include <WebCore/ArchiveResource.h>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -71,6 +71,7 @@
 #import "WebTouchEvent.h"
 #import <CoreText/CTFont.h>
 #import <WebCore/AXRemoteTokenIOS.h>
+#import <WebCore/AccessibilityObject.h>
 #import <WebCore/Autofill.h>
 #import <WebCore/AutofillElements.h>
 #import <WebCore/BoundaryPointInlines.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -68,6 +68,7 @@
 #import <WebCore/FileChooser.h>
 #import <WebCore/FileIconLoader.h>
 #import <WebCore/FloatRect.h>
+#import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/GraphicsLayer.h>
 #import <WebCore/HTMLInputElement.h>
 #import <WebCore/HTMLNames.h>
@@ -78,9 +79,11 @@
 #import <WebCore/IntPoint.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalFrame.h>
+#import <WebCore/LocalFrameInlines.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/ModalContainerTypes.h>
 #import <WebCore/NavigationAction.h>
+#import <WebCore/NodeInlines.h>
 #import <WebCore/NotImplemented.h>
 #import <WebCore/Page.h>
 #import <WebCore/PlatformScreen.h>

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -120,6 +120,7 @@
 #import <WebCore/Page.h>
 #import <WebCore/PrintContext.h>
 #import <WebCore/Range.h>
+#import <WebCore/RenderStyleInlines.h>
 #import <WebCore/RenderView.h>
 #import <WebCore/RenderWidget.h>
 #import <WebCore/SharedBuffer.h>


### PR DESCRIPTION
#### c7231c5d29934dcbdd6ae65aedc88c792c0c7ef3
<pre>
AX: avoid including AXObjectCache.h from page/Chrome.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=297384">https://bugs.webkit.org/show_bug.cgi?id=297384</a>
<a href="https://rdar.apple.com/158280756">rdar://158280756</a>

Reviewed by Tyler Wilcock.

page/Chrome.h is included all over the place, we should avoid
including AXObjectCache, which is much more specialized.

A surprising number of source files were inadvertently relying on the
transitive dependencies of AXObjectCache.h

* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
* Source/WebCore/html/HTMLElement.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/DeviceController.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/ImageOverlayController.cpp:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
* Source/WebCore/platform/mac/WidgetMac.mm:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
* Source/WebKit/WebProcess/Inspector/WebInspectorInternal.cpp:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:

Canonical link: <a href="https://commits.webkit.org/298707@main">https://commits.webkit.org/298707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51c5ace221c8b4e2666a67459fcba5797df6b9f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44649 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22533 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125606 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32515 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97115 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96910 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24659 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42197 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20103 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42648 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/45988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->