### PR TITLE
REGRESSION(297757@main): Layout tests can timeout on Tahoe bots

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#import "APIContentRuleListStore.h"
 #import "ScriptTrackingPrivacyFilter.h"
 #import <wtf/CompletionHandler.h>
 #import <wtf/ContinuousApproximateTime.h>
@@ -187,9 +188,13 @@ public:
     void prepare(CompletionHandler<void(WKContentRuleList *, bool)>&&);
     void getSource(CompletionHandler<void(String&&)>&&);
 
+    void setContentRuleListStore(API::ContentRuleListStore&);
+
 private:
     friend class NeverDestroyed<ResourceMonitorURLsController, MainRunLoopAccessTraits>;
     ResourceMonitorURLsController() = default;
+
+    RefPtr<API::ContentRuleListStore> m_contentRuleListStore;
 };
 
 #define HAVE_RESOURCE_MONITOR_URLS_GET_SOURCE 1

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -30,6 +30,7 @@
 #import "APIContentRuleListStore.h"
 #import "NetworkCacheFileSystem.h"
 #import "WKErrorInternal.h"
+#import "WebPrivacyHelpers.h"
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
@@ -211,6 +212,17 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
         } else
             rawHandler(source.createNSString().get());
     });
+#endif
+}
+
++ (void)_setContentRuleListStoreForResourceMonitorURLsControllerForTesting:(WKContentRuleListStore *)store
+{
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    RetainPtr protectedStore = store;
+    Ref apiStore = *(protectedStore->_contentRuleListStore);
+    WebKit::ResourceMonitorURLsController::singleton().setContentRuleListStore(apiStore.get());
+#else
+    UNUSED_PARAM(store);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
@@ -34,6 +34,7 @@
 - (void)_corruptContentRuleListActionsMatchingEverythingForIdentifier:(NSString *)identifier;
 - (void)_invalidateContentRuleListHeaderForIdentifier:(NSString *)identifier;
 - (void)_getContentRuleListSourceForIdentifier:(NSString *)identifier completionHandler:(void (^)(NSString *))completionHandler;
++ (void)_setContentRuleListStoreForResourceMonitorURLsControllerForTesting:(WKContentRuleListStore *)store;
 
 + (instancetype)defaultStoreWithLegacyFilename;
 + (instancetype)storeWithURLAndLegacyFilename:(NSURL *)url;

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -191,6 +191,11 @@ void TestController::cocoaPlatformInitialize(const Options& options)
 #if ENABLE(DATA_DETECTION)
     m_appStoreURLSwizzler = makeUnique<InstanceMethodSwizzler>(NSURL.class, @selector(iTunesStoreURL), reinterpret_cast<IMP>(swizzledAppStoreURL));
 #endif
+
+    String resourceMonitorContentRuleListStoreFolder = makeString(String::fromUTF8(dumpRenderTreeTemp), "/ResourceMonitorContentRuleList/"_s, getpid());
+    RetainPtr<NSURL> url = [NSURL fileURLWithPath:resourceMonitorContentRuleListStoreFolder.createNSString().get()];
+
+    [WKContentRuleListStore _setContentRuleListStoreForResourceMonitorURLsControllerForTesting:[WKContentRuleListStore storeWithURL:url.get()]];
 }
 
 #if ENABLE(IMAGE_ANALYSIS)


### PR DESCRIPTION
#### 94e372f5f1bcd3d47e2912fb2d352e641d49a952
<pre>
REGRESSION(297757@main): Layout tests can timeout on Tahoe bots
<a href="https://rdar.apple.com/157769284">rdar://157769284</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297385">https://bugs.webkit.org/show_bug.cgi?id=297385</a>

Reviewed by Alex Christensen.

Before this change, each ContentRuleListStore had 3 queues for various operations.
After this change, all ContentRuleListStores shared the same global queue for all operations.

The goal here was to coordinate all access to the directory and files on disk for the store,
but the change had bad ramifications in our regression test environment.

When doing a `run-webkit-tests` run, we fire up many instances of WebKitTestRunner, and each points to the
same default ContentRuleListStore on disk.
Most WebKit UI-process apps only ever have a single UI process, so this bit is unique to running lots of WKTRs.

When there were 3 queues for store operations, the read operations were always finishing very quickly,
even in the case where multiple WKTR instances point to the same directory.

But with the 1 global queue per-UI process, read operations are blocked on slower writes, which are made much slower
by &quot;multiple WKTR hammering the same file(s) with writing&quot;

All of the above is true for all Cocoa platforms.
The timeout problem manifests on Tahoe because there, WebKit manages a built-in ContentRuleList.

As written above, there&apos;s multiple layers to what exacerbates this problem, and we may need to address more than one.
But the lowest hanging fruit is giving each WKTR instance its own WKContentRuleListStore for the built-in list,
therefore removing the &quot;multiple WKTR hammering the same file(s) with writing&quot; problem.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::setContentRuleListStore):
(WebKit::ResourceMonitorURLsController::prepare):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(+[WKContentRuleListStore _setContentRuleListStoreForResourceMonitorURLsControllerForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaPlatformInitialize):

Canonical link: <a href="https://commits.webkit.org/298729@main">https://commits.webkit.org/298729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b91b6e4ae48e482a765ce25457e326447c9b2226

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122544 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68900 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22605 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66225 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125693 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32572 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100707 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20166 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48860 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42735 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->