### PR TITLE
Begin expanding use of testRunner without injected bundle

### DIFF
--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -63,6 +63,7 @@
 
 namespace API {
 class Array;
+class CompletionListener;
 class Dictionary;
 class Data;
 class Point;
@@ -92,6 +93,7 @@ template<typename ImplType> struct ImplTypeInfo;
 
 WK_ADD_API_MAPPING(WKArrayRef, API::Array)
 WK_ADD_API_MAPPING(WKBooleanRef, API::Boolean)
+WK_ADD_API_MAPPING(WKCompletionListenerRef, API::CompletionListener);
 WK_ADD_API_MAPPING(WKContextMenuItemRef, WebContextMenuItem)
 WK_ADD_API_MAPPING(WKDataRef, API::Data)
 WK_ADD_API_MAPPING(WKDictionaryRef, API::Dictionary)

--- a/Source/WebKit/UIProcess/API/APICompletionListener.h
+++ b/Source/WebKit/UIProcess/API/APICompletionListener.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIObject.h"
+#include "WKBase.h"
+#include <wtf/CompletionHandler.h>
+
+namespace API {
+
+class CompletionListener : public API::ObjectImpl<API::Object::Type::CompletionListener> {
+public:
+    static Ref<CompletionListener> create(CompletionHandler<void(WKTypeRef)>&& completionHandler) { return adoptRef(*new CompletionListener(WTFMove(completionHandler))); }
+    void complete(WKTypeRef result) { m_completionHandler(result); }
+
+private:
+    explicit CompletionListener(CompletionHandler<void(WKTypeRef)>&& completionHandler)
+        : m_completionHandler(WTFMove(completionHandler)) { }
+
+    CompletionHandler<void(WKTypeRef)> m_completionHandler;
+};
+
+}
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(CompletionListener);

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -28,6 +28,7 @@
 #include "WKPagePrivate.h"
 
 #include "APIArray.h"
+#include "APICompletionListener.h"
 #include "APIContentWorld.h"
 #include "APIContextMenuClient.h"
 #include "APIData.h"
@@ -1183,26 +1184,6 @@ void WKPageSetPageInjectedBundleClient(WKPageRef pageRef, const WKPageInjectedBu
     toProtectedImpl(pageRef)->setInjectedBundleClient(wkClient);
 }
 
-class CompletionListener : public API::ObjectImpl<API::Object::Type::CompletionListener> {
-public:
-    static Ref<CompletionListener> create(CompletionHandler<void(WKTypeRef)>&& completionHandler) { return adoptRef(*new CompletionListener(WTFMove(completionHandler))); }
-    void complete(WKTypeRef result) { m_completionHandler(result); }
-
-private:
-    explicit CompletionListener(CompletionHandler<void(WKTypeRef)>&& completionHandler)
-        : m_completionHandler(WTFMove(completionHandler)) { }
-
-    CompletionHandler<void(WKTypeRef)> m_completionHandler;
-};
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(CompletionListener)
-static bool isType(const API::Object& object) { return object.type() == API::Object::Type::CompletionListener; }
-SPECIALIZE_TYPE_TRAITS_END()
-
-namespace WebKit {
-WK_ADD_API_MAPPING(WKCompletionListenerRef, CompletionListener);
-}
-
 void WKCompletionListenerComplete(WKCompletionListenerRef listener, WKTypeRef result)
 {
     toProtectedImpl(listener)->complete(result);
@@ -1230,7 +1211,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.willEnterFullScreen)
                 return completionHandler(false);
-            m_client.willEnterFullScreen(toAPI(protectedPage().get()), toAPI(CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef) mutable {
+            m_client.willEnterFullScreen(toAPI(protectedPage().get()), toAPI(API::CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef) mutable {
                 completionHandler(true);
             }).ptr()), m_client.base.clientInfo);
         }
@@ -1255,7 +1236,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.beganExitFullScreen)
                 return completionHandler();
-            m_client.beganExitFullScreen(toAPI(protectedPage().get()), toAPI(initialFrame), toAPI(finalFrame), toAPI(CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef) mutable {
+            m_client.beganExitFullScreen(toAPI(protectedPage().get()), toAPI(initialFrame), toAPI(finalFrame), toAPI(API::CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef) mutable {
                 completionHandler();
             }).ptr()), m_client.base.clientInfo);
         }
@@ -2256,7 +2237,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (!m_client.requestPointerLock)
                 return completionHandler(false);
 
-            Ref listener = CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef) mutable { completionHandler(true); });
+            Ref listener = API::CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef) mutable { completionHandler(true); });
             m_client.requestPointerLock(toAPI(page), toAPI(listener.ptr()), m_client.base.clientInfo);
         }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2614,6 +2614,7 @@
 		F6113E25126CE1820057D0A7 /* APIUserContentURLPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = F6113E24126CE1820057D0A7 /* APIUserContentURLPattern.h */; };
 		F6113E29126CE19B0057D0A7 /* WKUserContentURLPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = F6113E27126CE19B0057D0A7 /* WKUserContentURLPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F634445612A885C8000612D8 /* APISecurityOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = F634445512A885C8000612D8 /* APISecurityOrigin.h */; };
+		FA0B9DB32E4DAA4D0029560E /* APICompletionListener.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0B9DB22E4DA71F0029560E /* APICompletionListener.h */; };
 		FA1ED3F42B76B93700C90F3B /* CoreIPCCFType.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA1ED3F32B76B90700C90F3B /* CoreIPCCFType.mm */; };
 		FA39AE682B23972B008F93CD /* CoreIPCAuditToken.h in Headers */ = {isa = PBXBuildFile; fileRef = FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */; };
 		FA4066E02D44733200A2E622 /* WKPageFullScreenClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FA4066DF2D4472CE00A2E622 /* WKPageFullScreenClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8634,6 +8635,7 @@
 		FA07D69C2CFFBB9700915660 /* NetworkTransportStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportStream.h; sourceTree = "<group>"; };
 		FA07D69D2CFFBB9700915660 /* NetworkTransportStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportStream.cpp; sourceTree = "<group>"; };
 		FA07D69E2CFFBBC800915660 /* NetworkTransportStreamCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkTransportStreamCocoa.mm; sourceTree = "<group>"; };
+		FA0B9DB22E4DA71F0029560E /* APICompletionListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APICompletionListener.h; sourceTree = "<group>"; };
 		FA13529B2C7E70140049C1BC /* NetworkTransportSessionCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkTransportSessionCocoa.mm; sourceTree = "<group>"; };
 		FA1473272B06EE6200765CC1 /* SandboxExtension.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SandboxExtension.serialization.in; sourceTree = "<group>"; };
 		FA1A7DE42E012DB3005E394B /* RemotePageVideoPresentationManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageVideoPresentationManagerProxy.h; sourceTree = "<group>"; };
@@ -15082,6 +15084,7 @@
 				2E5C770C1FA7D429005932C3 /* APIAttachment.h */,
 				99C81D5B1C20E817005C4C82 /* APIAutomationClient.h */,
 				990D28B31C6526D400986977 /* APIAutomationSessionClient.h */,
+				FA0B9DB22E4DA71F0029560E /* APICompletionListener.h */,
 				7C89D2B11A6B068C003A5FDE /* APIContentRuleList.cpp */,
 				7C89D2B21A6B068C003A5FDE /* APIContentRuleList.h */,
 				5C4609E522430FA6009943C2 /* APIContentRuleListAction.cpp */,
@@ -17114,6 +17117,7 @@
 				99C81D5D1C21F38B005C4C82 /* APIAutomationClient.h in Headers */,
 				990D28C01C6553F100986977 /* APIAutomationSessionClient.h in Headers */,
 				1A3DD206125E5A2F004515E6 /* APIClient.h in Headers */,
+				FA0B9DB32E4DAA4D0029560E /* APICompletionListener.h in Headers */,
 				7C89D2B41A6B068C003A5FDE /* APIContentRuleList.h in Headers */,
 				7C3A06A81AAB903E009D74BA /* APIContentRuleListStore.h in Headers */,
 				5183722223CE97410003CF83 /* APIContentWorld.h in Headers */,

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -152,7 +152,6 @@ interface TestRunner {
     attribute double databaseMaxQuota;
 
     // Text search testing.
-    Promise<boolean> findString(DOMString target, object optionsArray);
     undefined findStringMatchesInPage(DOMString target, object optionsArray);
     undefined indicateFindMatch(unsigned long matchIndex);
     undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -329,14 +329,6 @@ static std::optional<WKFindOptions> findOptionsFromArray(JSContextRef context, J
     return options;
 }
 
-void TestRunner::findString(JSContextRef context, JSStringRef target, JSValueRef optionsArrayAsValue, JSValueRef callback)
-{
-    postMessageWithAsyncReply(context, "FindString", createWKDictionary({
-        { "String", toWK(target) },
-        { "FindOptions", adoptWK(WKUInt64Create(findOptionsFromArray(context, optionsArrayAsValue).value_or(WKFindOptions { }))) },
-    }), callback);
-}
-
 void TestRunner::findStringMatchesInPage(JSContextRef context, JSStringRef target, JSValueRef optionsArrayAsValue)
 {
     if (auto options = findOptionsFromArray(context, optionsArrayAsValue)) {

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -182,7 +182,6 @@ public:
     void addUserStyleSheet(JSStringRef source, bool allFrames);
 
     // Text search testing.
-    void findString(JSContextRef, JSStringRef, JSValueRef optionsArray, JSValueRef callback);
     void findStringMatchesInPage(JSContextRef, JSStringRef, JSValueRef optionsArray);
     void indicateFindMatch(JSContextRef, uint32_t index);
     void replaceFindMatchesAtIndices(JSContextRef, JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1027,6 +1027,7 @@ WKRetainPtr<WKPageConfigurationRef> TestController::generatePageConfiguration(co
     if (options.allowTestOnlyIPC())
         WKPageConfigurationSetAllowTestOnlyIPC(pageConfiguration.get(), true);
     WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(pageConfiguration.get(), true);
+    WKPageConfigurationSetAllowJSHandleInPageContentWorld(pageConfiguration.get(), true);
 
     m_userContentController = adoptWK(WKUserContentControllerCreate());
     WKPageConfigurationSetUserContentController(pageConfiguration.get(), userContentController());
@@ -1818,6 +1819,56 @@ void TestController::configureViewForTest(const TestInvocation& test)
     installUserScript(test);
 }
 
+static WKFindOptions findOptionsFromArray(WKArrayRef array)
+{
+    auto length = WKArrayGetSize(array);
+    WKFindOptions options { };
+    for (unsigned i = 0; i < length; ++i) {
+        auto optionName = (WKStringRef)WKArrayGetItemAtIndex(array, i);
+        ASSERT(WKGetTypeID(optionName) == WKStringGetTypeID());
+        if (WKStringIsEqualToUTF8CString(optionName, "CaseInsensitive"))
+            options |= kWKFindOptionsCaseInsensitive;
+        else if (WKStringIsEqualToUTF8CString(optionName, "AtWordStarts"))
+            options |= kWKFindOptionsAtWordStarts;
+        else if (WKStringIsEqualToUTF8CString(optionName, "TreatMedialCapitalAsWordStart"))
+            options |= kWKFindOptionsTreatMedialCapitalAsWordStart;
+        else if (WKStringIsEqualToUTF8CString(optionName, "Backwards"))
+            options |= kWKFindOptionsBackwards;
+        else if (WKStringIsEqualToUTF8CString(optionName, "WrapAround"))
+            options |= kWKFindOptionsWrapAround;
+        // FIXME: No kWKFindOptionsStartInSelection.
+    }
+    return options;
+}
+
+constexpr auto testRunnerJS = R"testRunnerJS(
+if (window.testRunner) {
+    testRunner.installTooltipDidChangeCallback = (callback) => window.webkit.messageHandlers.webkitTestRunner.postMessage(window.webkit.createJSHandle(callback));
+    testRunner.findString = (target, options) => window.webkit.messageHandlers.webkitTestRunner.postMessage([target, options]);
+}
+)testRunnerJS";
+
+static void didReceiveScriptMessage(WKScriptMessageRef message, WKCompletionListenerRef listener, const void *)
+{
+    // FIXME: Make JSHandle able to be sent as a member of a dictionary and use something other than WKGetTypeID to distinguish different messages.
+    WKTypeRef messageBody = WKScriptMessageGetBody(message);
+    if (WKGetTypeID(messageBody) == WKArrayGetTypeID()) {
+        auto array = (WKArrayRef)messageBody;
+        auto target = (WKStringRef)WKArrayGetItemAtIndex(array, 0);
+        ASSERT(WKGetTypeID(target) == WKStringGetTypeID());
+        ASSERT(WKGetTypeID(WKArrayGetItemAtIndex(array, 1)) == WKArrayGetTypeID());
+        auto options = findOptionsFromArray((WKArrayRef)WKArrayGetItemAtIndex(array, 1));
+        WKPageFindStringForTesting(TestController::singleton().mainWebView()->page(), (void*)WKRetain(listener), target, options, 0, [] (bool found, void* context) {
+            auto listener = (WKCompletionListenerRef)context;
+            WKCompletionListenerComplete(listener, adoptWK(WKBooleanCreate(found)).get());
+            WKRelease(listener);
+        });
+        return;
+    }
+    TestController::singleton().listenForTooltipChanges(WKScriptMessageGetFrameInfo(message), messageBody);
+    WKCompletionListenerComplete(listener, nullptr);
+}
+
 void TestController::installUserScript(const TestInvocation& test)
 {
     WKRetainPtr configuration = adoptWK(WKPageCopyPageConfiguration(mainWebView()->page()));
@@ -1828,15 +1879,10 @@ void TestController::installUserScript(const TestInvocation& test)
     if (!test.options().shouldInjectTestRunner())
         return;
 
-    WKRetainPtr js = toWK("if (window.testRunner) { testRunner.installTooltipDidChangeCallback = function (f) { window.webkit.messageHandlers.webkitTestRunner.postMessage(window.webkit.createJSHandle(f)) } }");
     constexpr bool forMainFrameOnly { true };
-    WKRetainPtr script = adoptWK(WKUserScriptCreateWithSource(js.get(), kWKInjectAtDocumentStart, forMainFrameOnly));
+    WKRetainPtr script = adoptWK(WKUserScriptCreateWithSource(toWK(testRunnerJS).get(), kWKInjectAtDocumentStart, forMainFrameOnly));
     WKUserContentControllerAddUserScript(controller.get(), script.get());
-
-    // FIXME: Generalize this to be able to be used for different test callbacks.
-    WKUserContentControllerAddScriptMessageHandler(controller.get(), toWK("webkitTestRunner").get(), [] (WKScriptMessageRef message, WKCompletionListenerRef, const void *) {
-        TestController::singleton().listenForTooltipChanges(WKScriptMessageGetFrameInfo(message), WKScriptMessageGetBody(message));
-    }, nullptr);
+    WKUserContentControllerAddScriptMessageHandler(controller.get(), toWK("webkitTestRunner").get(), didReceiveScriptMessage, nullptr);
 }
 
 #if ENABLE(CONTENT_EXTENSIONS) && !PLATFORM(COCOA)
@@ -2473,16 +2519,6 @@ void TestController::didReceiveAsyncMessageFromInjectedBundle(WKStringRef messag
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetResourceMonitorList"))
         return setResourceMonitorList(stringValue(messageBody), WTFMove(completionHandler));
-
-    if (WKStringIsEqualToUTF8CString(messageName, "FindString")) {
-        auto messageBodyDictionary = dictionaryValue(messageBody);
-        auto string = stringValue(messageBodyDictionary, "String");
-        auto findOptions = static_cast<WKFindOptions>(uint64Value(messageBodyDictionary, "FindOptions"));
-        return WKPageFindStringForTesting(TestController::singleton().mainWebView()->page(), completionHandler.leak(), string, findOptions, 0, [](bool found, void* context) {
-            auto completionHandler = WTF::adopt(static_cast<CompletionHandler<void(WKTypeRef)>::Impl*>(context));
-            completionHandler(WKBooleanCreate(found));
-        });
-    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetStorageAccessPermission")) {
         auto messageBodyDictionary = dictionaryValue(messageBody);

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -284,7 +284,6 @@ void TestController::platformCreateWebView(WKPageConfigurationRef configuration,
 #endif
     [cocoaConfiguration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     WKPageConfigurationSetShouldSendConsoleLogsToUIProcessForTesting(configuration, true);
-    WKPageConfigurationSetAllowJSHandleInPageContentWorld(configuration, true);
 
 #if USE(SYSTEM_PREVIEW)
     [cocoaConfiguration _setSystemPreviewEnabled:YES];


### PR DESCRIPTION
#### f2dedbce5408ee57c196c73dc04a997f27f743ce
<pre>
Begin expanding use of testRunner without injected bundle
<a href="https://bugs.webkit.org/show_bug.cgi?id=297386">https://bugs.webkit.org/show_bug.cgi?id=297386</a>
<a href="https://rdar.apple.com/158289068">rdar://158289068</a>

Reviewed by Brady Eidson.

* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
* Source/WebKit/UIProcess/API/APICompletionListener.h: Added.
(API::CompletionListener::create):
(API::CompletionListener::complete):
(API::CompletionListener::CompletionListener):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetFullScreenClientForTesting):
(WKPageSetPageUIClient):
(CompletionListener::create): Deleted.
(CompletionListener::complete): Deleted.
(CompletionListener::CompletionListener): Deleted.
* Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::findString): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::generatePageConfiguration):
(WTR::findOptionsFromArray):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):

Canonical link: <a href="https://commits.webkit.org/298700@main">https://commits.webkit.org/298700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b799d5f93e80c98a9d2aa5e4e873e8aae41c787

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116291 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66851 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88336 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3de7d7ae-e1ae-4f30-a23e-d549c10a0be4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68760 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22448 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66029 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125497 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97046 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96836 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20024 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39132 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18586 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48664 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42539 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44243 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->