### PR TITLE
Remove unused function HistoryController::replaceCurrentItem

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -1114,18 +1114,6 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
     }
 }
 
-void HistoryController::replaceCurrentItem(RefPtr<HistoryItem>&& item)
-{
-    if (!item)
-        return;
-
-    m_previousItem = nullptr;
-    if (m_provisionalItem)
-        m_provisionalItem = WTFMove(item);
-    else
-        m_currentItem = WTFMove(item);
-}
-
 RefPtr<HistoryItem> HistoryController::protectedCurrentItem() const
 {
     return m_currentItem;

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -83,7 +83,6 @@ public:
     WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
     void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;
-    WEBCORE_EXPORT void replaceCurrentItem(RefPtr<HistoryItem>&&);
 
     HistoryItem* previousItem() const { return m_previousItem.get(); }
     RefPtr<HistoryItem> protectedPreviousItem() const;


### PR DESCRIPTION
#### d26ff1b96eb26ab9054a085369d2352f240a84e9
<pre>
Remove unused function HistoryController::replaceCurrentItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=297388">https://bugs.webkit.org/show_bug.cgi?id=297388</a>
<a href="https://rdar.apple.com/158293340">rdar://158293340</a>

Reviewed by NOBODY (OOPS!).

It&apos;s unused.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::replaceCurrentItem): Deleted.
* Source/WebCore/loader/HistoryController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d26ff1b96eb26ab9054a085369d2352f240a84e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116315 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35976 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66876 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37b8063f-a57b-4578-a152-a01a11b273e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118204 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36670 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/439ca2f7-5c27-4725-ab9e-07423b87dcde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119264 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/36670 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68775 "Passed tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/36670 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66053 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/36670 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125521 "Built successfully") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43209 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97052 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43574 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96844 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39159 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43096 "Hash d26ff1b9 for PR 49383 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48688 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42563 "Hash d26ff1b9 for PR 49383 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45907 "Hash d26ff1b9 for PR 49383 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44268 "Hash d26ff1b9 for PR 49383 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->