### PR TITLE
run-benchmark: Some plans point to WebKit SVN repository

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/content-animation.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/content-animation.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 120,
     "count": 5,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Animation/@r205680",
+    "local_git_archive": "PerformanceTests/Animation@908fbd47ddf27b975b278b1d6d22cc3c0e4ec8b7",
+    "github_source": "https://github.com/WebKit/WebKit/tree/908fbd47ddf27b975b278b1d6d22cc3c0e4ec8b7/PerformanceTests/Animation",
     "webserver_benchmark_patch": "data/patches/webserver/ContentAnimation.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/ContentAnimation.patch",
     "test_files": [

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 1200,
     "count": 5,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/JetStream/@r190897",
+    "local_git_archive": "PerformanceTests/JetStream@3e2f1f4881d91cbf488ad87a5bfa9e7f844de06f",
+    "github_source": "https://github.com/WebKit/WebKit/tree/3e2f1f4881d91cbf488ad87a5bfa9e7f844de06f/PerformanceTests/JetStream",
     "webserver_benchmark_patch": "data/patches/webserver/JetStream.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/JetStream.patch",
     "create_script": ["ruby", "create.rb"],

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.0.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 1200,
     "count": 5,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/JetStream2/@r286562",
+    "local_git_archive": "PerformanceTests/JetStream2@43136e0015ca5360a88787a0ffa52e9ced7b2481",
+    "github_source": "https://github.com/WebKit/WebKit/tree/43136e0015ca5360a88787a0ffa52e9ced7b2481/PerformanceTests/JetStream2",
     "entry_point": "index.html?report=true",
     "output_file": "jetstream2.result"
 }

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.0.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 1800,
     "count": 1,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/MotionMark/@r210459",
+    "local_git_archive": "PerformanceTests/MotionMark@119e2d3f1c8f23a32bde610b51b03dd3ab416f6a",
+    "github_source": "https://github.com/WebKit/WebKit/tree/119e2d3f1c8f23a32bde610b51b03dd3ab416f6a/PerformanceTests/MotionMark",
     "webserver_benchmark_patch": "data/patches/webserver/MotionMark.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
     "entry_point": "index.html",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.1.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 1800,
     "count": 1,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/MotionMark/@r278436",
+    "local_git_archive": "PerformanceTests/MotionMark@1d7c87a8cc9a4238f3b522fa311192924d91d46a",
+    "github_source": "https://github.com/WebKit/WebKit/tree/1d7c87a8cc9a4238f3b522fa311192924d91d46a/PerformanceTests/MotionMark",
     "webserver_benchmark_patch": "data/patches/webserver/MotionMark.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
     "entry_point": "index.html",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer1.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer1.0.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 300,
     "count": 5,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Speedometer/@r183695",
+    "local_git_archive": "PerformanceTests/Speedometer@4a78b14015a1ea8545d964a8a0a3c57e5b0bf869",
+    "github_source": "https://github.com/WebKit/WebKit/tree/4a78b14015a1ea8545d964a8a0a3c57e5b0bf869/PerformanceTests/Speedometer",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/Speedometer.patch",
     "entry_point": "Full.html",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan
@@ -1,7 +1,8 @@
 {
     "timeout": 600,
     "count": 4,
-    "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Speedometer/@r226694",
+    "local_git_archive": "PerformanceTests/Speedometer@62c9a5959d1121559ebc4dfe18d1fa275748b49d",
+    "github_source": "https://github.com/WebKit/WebKit/tree/62c9a5959d1121559ebc4dfe18d1fa275748b49d/PerformanceTests/Speedometer",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer2.patch",
     "signpost_patch": "data/patches/signposts/Speedometer2.patch",
     "entry_point": "index.html",


### PR DESCRIPTION
#### dddaa5680add665ca721b5985d4169c520fe45a5
<pre>
run-benchmark: Some plans point to WebKit SVN repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=297391">https://bugs.webkit.org/show_bug.cgi?id=297391</a>

Reviewed by Carlos Alberto Lopez Perez.

Fix plans so they point to the Git repository instead of the SVN one.

* Tools/Scripts/webkitpy/benchmark_runner/data/plans/content-animation.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.0.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.0.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.1.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer1.0.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan:

Canonical link: <a href="https://commits.webkit.org/298817@main">https://commits.webkit.org/298817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52a65ad7fb56c557dee3d94a1250c9d3d90e0496

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88375 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42858 "Build was cancelled. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68807 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115723 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98658 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97081 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39196 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43130 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42597 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->