### PR TITLE
[CSS] Fix nesting selector resolution for print

### DIFF
--- a/LayoutTests/fast/css/nested-media-print-expected.html
+++ b/LayoutTests/fast/css/nested-media-print-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+  testRunner.setPrinting();
+</script>
+<style>
+  .square {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<div class="square"></div>
+</body>
+</html>
+

--- a/LayoutTests/fast/css/nested-media-print.html
+++ b/LayoutTests/fast/css/nested-media-print.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+  testRunner.setPrinting();
+</script>
+<style>
+  .square {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+  
+  @media print {
+    .square {
+      background-color: red;
+    }
+  }
+  
+  .square {
+    @media print {
+      background-color: green;
+    }
+  }
+</style>
+</head>
+<body>
+<div class="square"></div>
+</body>
+</html>
+

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -31,8 +31,7 @@ namespace Style {
 class RuleSetBuilder {
 public:
     enum class ShrinkToFit : bool { Enable, Disable };
-    enum class ShouldResolveNesting : bool { No, Yes };
-    RuleSetBuilder(RuleSet&, const MQ::MediaQueryEvaluator&, Resolver* = nullptr, ShrinkToFit = ShrinkToFit::Enable, ShouldResolveNesting = ShouldResolveNesting::No);
+    RuleSetBuilder(RuleSet&, const MQ::MediaQueryEvaluator&, Resolver* = nullptr, ShrinkToFit = ShrinkToFit::Enable);
     ~RuleSetBuilder();
 
     void addRulesFromSheet(const StyleSheetContents&, const MQ::MediaQueryList& sheetQuery = { });
@@ -89,8 +88,6 @@ private:
     RuleSet::CascadeLayerIdentifier m_currentCascadeLayerIdentifier { 0 };
     Vector<const CSSSelectorList*> m_selectorListStack;
     Vector<CSSParserEnum::NestedContextType> m_ancestorStack;
-    const ShouldResolveNesting m_builderShouldResolveNesting { ShouldResolveNesting::No };
-    bool m_shouldResolveNestingForSheet { false };
 
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
     RuleSet::ScopeRuleIdentifier m_currentScopeIdentifier { 0 };

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -249,7 +249,7 @@ std::optional<DynamicMediaQueryEvaluationChanges> ScopeRuleSets::evaluateDynamic
 
 void ScopeRuleSets::appendAuthorStyleSheets(std::span<const RefPtr<CSSStyleSheet>> styleSheets, MQ::MediaQueryEvaluator* mediaQueryEvaluator, InspectorCSSOMWrappers& inspectorCSSOMWrappers)
 {
-    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver, RuleSetBuilder::ShrinkToFit::Enable, RuleSetBuilder::ShouldResolveNesting::Yes);
+    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver, RuleSetBuilder::ShrinkToFit::Enable);
 
     RefPtr<CSSStyleSheet> previous;
     for (auto& cssSheet : styleSheets) {


### PR DESCRIPTION
#### e001647e607b10e6b8fa7de9636fb2b1d8fcf05d
<pre>
[CSS] Fix nesting selector resolution for print
<a href="https://bugs.webkit.org/show_bug.cgi?id=297232">https://bugs.webkit.org/show_bug.cgi?id=297232</a>
<a href="https://rdar.apple.com/158081814">rdar://158081814</a>

Reviewed by Antti Koivisto.

The boolean parameter to resolve nesting selector only-once is stopping
print style resolution to work properly because the selectors
are considered already resolved.

This patch completely changes the mechanism for the
necessary only-once nesting selector resolution : instead
of using a boolean, it relies on the fact that a style rule selector list
should never be empty : if it&apos;s empty, it is
because it has not been resolved yet.

* LayoutTests/fast/css/nested-media-print-expected.html: Added.
* LayoutTests/fast/css/nested-media-print.html: Added.

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::debugDescription const):
(WebCore::StyleRuleWithNesting::debugDescription const):

Improve debug logging

(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::m_originalSelectorList):
(WebCore::StyleRuleBase::invalidateResolvedSelectorListRecursively):

On CSSOM rule mutation, we need to clear all the child selectors because
they are incorrect now. They will be resolved again correctly at rule set building.

* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRule::adoptSelectorList):
(WebCore::StyleRule::wrapperAdoptSelectorList): Deleted.
(WebCore::StyleRuleWithNesting::wrapperAdoptOriginalSelectorList): Deleted.

Create a new inline setter for selector list.
Move wrapper* functions which are used by CSSOM to the .cpp file.

* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parserAppendRule):
(WebCore::StyleSheetContents::wrapperInsertRule):

Fix the detection of the selector list component count
to use the original selector list.

* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::RuleSetBuilder):
(WebCore::Style::m_shrinkToFit):
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addRulesFromSheetContents):
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):
(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
(WebCore::Style::RuleSetBuilder::addStyleRule):
(WebCore::Style::m_builderShouldResolveNesting): Deleted.
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::appendAuthorStyleSheets):

Remove boolean and resolve nesting selector whenever the selector list is empty.

Canonical link: <a href="https://commits.webkit.org/298843@main">https://commits.webkit.org/298843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca4c977d04c739b11356a426be5e8ca449c7259d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67417 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1611a903-dc73-4d1d-bcb1-c76afdd88b67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45093 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88729 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/16a8669a-68e4-4af5-9d51-0cb98e45940c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104798 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66569 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126038 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97386 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20450 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39735 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49209 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46419 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->