### PR TITLE
[visionOS] Transition from fullscreen to dock isn't as smooth as it could be

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -300,9 +300,7 @@ private:
 
     enum class AcceleratedVideoMode: uint8_t {
         Layer = 0,
-        StagedVideoRenderer,
         VideoRenderer,
-        StagedLayer
     };
     AcceleratedVideoMode acceleratedVideoMode() const;
     void setLayerRequiresFlush();
@@ -340,7 +338,6 @@ private:
     PlatformTimeRanges m_buffered;
 
     RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
-    RefPtr<VideoMediaSampleRenderer> m_expiringVideoRenderer;
 
     RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;


### PR DESCRIPTION
#### 4187f71b1153e0f79384580df9abd135e04a37e1
<pre>
[visionOS] Transition from fullscreen to dock isn&apos;t as smooth as it could be
<a href="https://bugs.webkit.org/show_bug.cgi?id=297377">https://bugs.webkit.org/show_bug.cgi?id=297377</a>
<a href="https://rdar.apple.com/158274410">rdar://158274410</a>

Reviewed by Andy Estes.

Adopt VideoMediaSampleRenderer::changeRenderer in MediaPlayerPrivateWebM

We no longer need to stage an AVSBDL or AVSBVR through an intermediary
VideoMediaSampleRenderer when going in or out of dock mode. We can simply
change from one to another without losing the currently displayed frame
and without performing an internal seek.

Ensuring a much smoother fullscreen animation, while simplifying the code.

For now we only adopt changeRenderer for WebM. MSE player will be done in
a follow-up change.

Manually tested on device.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
 - Remove StagedLayer and StagedVideoRenderer state, we can directly switch
   between Layer from/to VideoRenderer.
 - As the VideoMediaSampleRenderer enqueues samples on another thread concurrently
   it is important to delay the destruction of the AVSBDL or the AVSBVR until
   after the change of renderer has completed.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
 - Stop propagating error using NSNotificationCenter, there&apos;s a dedicated callback for that and webm only ever use a decompression session
 - VideoMediaSampleRenderer::changeRenderer API
 - Clarify with assertion on which thread a renderer getter method can be called.

Canonical link: <a href="https://commits.webkit.org/298745@main">https://commits.webkit.org/298745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d5d65d88dc1427c40550aa3d84e986af65d44d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67108 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44793 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68936 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125750 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32620 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24687 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20212 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48917 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42792 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->