### PR TITLE
AX: Merge AccessibilityAttachment into AccessibilityRenderObject

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -564,7 +564,7 @@ accessibility/AXTextMarker.cpp
 accessibility/AXTextRun.cpp
 accessibility/AXTreeStore.cpp
 accessibility/AXUtilities.cpp
-accessibility/AccessibilityAttachment.cpp
+accessibility/AXAttachmentHelpers.cpp
 accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityLabel.cpp
 accessibility/AccessibilityList.cpp

--- a/Source/WebCore/accessibility/AXAttachmentHelpers.cpp
+++ b/Source/WebCore/accessibility/AXAttachmentHelpers.cpp
@@ -25,66 +25,32 @@
  */
 
 #include "config.h"
-#include "AccessibilityAttachment.h"
-
-#include "HTMLAttachmentElement.h"
-#include "HTMLNames.h"
-#include "LocalizedStrings.h"
-#include "RenderAttachment.h"
 
 #if ENABLE(ATTACHMENT_ELEMENT)
+#include "AXAttachmentHelpers.h"
+
+#include "AXCoreObject.h"
+#include "HTMLAttachmentElement.h"
 
 namespace WebCore {
 
 using namespace HTMLNames;
 
-AccessibilityAttachment::AccessibilityAttachment(AXID axID, RenderAttachment& renderer, AXObjectCache& cache)
-    : AccessibilityRenderObject(axID, renderer, cache)
+bool AXAttachmentHelpers::hasProgress(const HTMLAttachmentElement& attachmentElement, float* progress)
 {
-}
-
-Ref<AccessibilityAttachment> AccessibilityAttachment::create(AXID axID, RenderAttachment& renderer, AXObjectCache& cache)
-{
-    return adoptRef(*new AccessibilityAttachment(axID, renderer, cache));
-}
-
-bool AccessibilityAttachment::hasProgress(float* progress) const
-{
-    auto& progressString = getAttribute(progressAttr);
-    bool validProgress;
+    auto& progressString = attachmentElement.getAttribute(progressAttr);
+    bool validProgress = false;
     float result = std::max<float>(std::min<float>(progressString.toFloat(&validProgress), 1), 0);
     if (progress)
         *progress = result;
     return validProgress;
 }
 
-float AccessibilityAttachment::valueForRange() const
+void AXAttachmentHelpers::accessibilityText(const HTMLAttachmentElement& attachmentElement, Vector<AccessibilityText>& textOrder)
 {
-    float progress = 0;
-    hasProgress(&progress);
-    return progress;
-}
-
-HTMLAttachmentElement* AccessibilityAttachment::attachmentElement() const
-{
-    ASSERT(is<HTMLAttachmentElement>(node()));
-    return dynamicDowncast<HTMLAttachmentElement>(node());
-}
-
-bool AccessibilityAttachment::computeIsIgnored() const
-{
-    return false;
-}
-
-void AccessibilityAttachment::accessibilityText(Vector<AccessibilityText>& textOrder) const
-{
-    RefPtr attachmentElement = this->attachmentElement();
-    if (!attachmentElement)
-        return;
-
-    auto title = attachmentElement->attachmentTitle();
-    auto& subtitle = attachmentElement->attachmentSubtitle();
-    auto& action = getAttribute(actionAttr);
+    auto title = attachmentElement.attachmentTitle();
+    auto& subtitle = attachmentElement.attachmentSubtitle();
+    auto& action = attachmentElement.getAttribute(actionAttr);
 
     if (action.length())
         textOrder.append(AccessibilityText(WTFMove(action), AccessibilityTextSource::Action));

--- a/Source/WebCore/accessibility/AXAttachmentHelpers.h
+++ b/Source/WebCore/accessibility/AXAttachmentHelpers.h
@@ -28,35 +28,19 @@
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-#include "AccessibilityRenderObject.h"
+#include <wtf/Forward.h>
 
 namespace WebCore {
 
 class HTMLAttachmentElement;
-class RenderAttachment;
+struct AccessibilityText;
 
-class AccessibilityAttachment final : public AccessibilityRenderObject {
+class AXAttachmentHelpers {
 public:
-    static Ref<AccessibilityAttachment> create(AXID, RenderAttachment&, AXObjectCache&);
-    HTMLAttachmentElement* attachmentElement() const;
-    bool hasProgress(float* progress = nullptr) const;
-
-private:
-    explicit AccessibilityAttachment(AXID, RenderAttachment&, AXObjectCache&);
-
-    AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Button; }
-
-    bool isAttachmentElement() const final { return true; }
-
-    float valueForRange() const final;
-    bool computeIsIgnored() const final;
-    void accessibilityText(Vector<AccessibilityText>&) const final;
+    static bool hasProgress(const HTMLAttachmentElement&, float* progress = nullptr);
+    static void accessibilityText(const HTMLAttachmentElement&, Vector<AccessibilityText>&);
 };
 
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityAttachment) \
-    static bool isType(const WebCore::AccessibilityObject& object) { return object.isAttachmentElement(); } \
-SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1063,6 +1063,9 @@ public:
     virtual float valueForRange() const = 0;
     virtual float maxValueForRange() const = 0;
     virtual float minValueForRange() const = 0;
+#if ENABLE(ATTACHMENT_ELEMENT)
+    virtual bool hasProgress() const { return false; }
+#endif
     AXCoreObject* selectedRadioButton();
     AXCoreObject* selectedTabItem();
     virtual int layoutCount() const = 0;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -39,7 +39,6 @@
 #include "AXTextMarker.h"
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"
-#include "AccessibilityAttachment.h"
 #include "AccessibilityImageMapLink.h"
 #include "AccessibilityLabel.h"
 #include "AccessibilityList.h"
@@ -718,11 +717,6 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
     if (is<RenderProgress>(renderer) || is<RenderMeter>(renderer)
         || is<HTMLProgressElement>(node) || is<HTMLMeterElement>(node))
         return AccessibilityProgressIndicator::create(AXID::generate(), renderer, *this);
-
-#if ENABLE(ATTACHMENT_ELEMENT)
-    if (auto* renderAttachment = dynamicDowncast<RenderAttachment>(renderer))
-        return AccessibilityAttachment::create(AXID::generate(), *renderAttachment, *this);
-#endif
 
     // input type=range
     if (is<RenderSlider>(renderer))

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -26,8 +26,10 @@
 #include "AXSearchManager.h"
 
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityObject.h"
+#include "Logging.h"
 #include "TextIterator.h"
 
 namespace WebCore {

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityNodeObject.h"
 
+#include "AXAttachmentHelpers.h"
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXObjectCache.h"
@@ -52,6 +53,7 @@
 #include "FloatRect.h"
 #include "FrameLoader.h"
 #include "FrameSelection.h"
+#include "HTMLAttachmentElement.h"
 #include "HTMLAudioElement.h"
 #include "HTMLButtonElement.h"
 #include "HTMLCanvasElement.h"
@@ -1042,6 +1044,14 @@ float AccessibilityNodeObject::valueForRange() const
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(node()); input && input->isRangeControl())
         return input->valueAsNumber();
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+    if (RefPtr attachmentElement = dynamicDowncast<HTMLAttachmentElement>(node())) {
+        float progress = 0;
+        if (AXAttachmentHelpers::hasProgress(*attachmentElement, &progress))
+            return progress;
+    }
+#endif
+
     if (!isRangeControl())
         return 0.0f;
 
@@ -1053,6 +1063,15 @@ float AccessibilityNodeObject::valueForRange() const
 
     return isSpinButton() ? 0 : std::midpoint(minValueForRange(), maxValueForRange());
 }
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+bool AccessibilityNodeObject::hasProgress() const
+{
+    if (RefPtr attachmentElement = dynamicDowncast<HTMLAttachmentElement>(node()))
+        return AXAttachmentHelpers::hasProgress(*attachmentElement);
+    return false;
+}
+#endif
 
 float AccessibilityNodeObject::maxValueForRange() const
 {
@@ -2000,6 +2019,13 @@ void AccessibilityNodeObject::helpText(Vector<AccessibilityText>& textOrder) con
 
 void AccessibilityNodeObject::accessibilityText(Vector<AccessibilityText>& textOrder) const
 {
+#if ENABLE(ATTACHMENT_ELEMENT)
+    if (RefPtr attachmentElement = dynamicDowncast<HTMLAttachmentElement>(node())) {
+        AXAttachmentHelpers::accessibilityText(*attachmentElement, textOrder);
+        return;
+    }
+#endif
+
     labelText(textOrder);
     alternativeText(textOrder);
     visibleText(textOrder);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -86,6 +86,10 @@ public:
     float minValueForRange() const override;
     float stepValueForRange() const override;
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+    bool hasProgress() const final;
+#endif
+
     std::optional<AccessibilityOrientation> orientationFromARIA() const;
     std::optional<AccessibilityOrientation> explicitOrientation() const override { return orientationFromARIA(); }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -113,12 +113,14 @@ public:
     virtual bool isAccessibilityListBoxOptionInstance() const { return false; }
     bool isAXIsolatedObjectInstance() const final { return false; }
 
-    virtual bool isAttachmentElement() const { return false; }
     bool isSecureField() const override { return false; }
     bool isContainedBySecureField() const;
     bool isNativeTextControl() const override { return false; }
     virtual bool isSearchField() const { return false; }
     bool isAttachment() const override { return false; }
+#if ENABLE(ATTACHMENT_ELEMENT)
+    virtual bool isAttachmentElement() const { return false; }
+#endif
     bool isMediaTimeline() const { return false; }
     virtual bool isSliderThumb() const { return false; }
     bool isLabel() const { return isAccessibilityLabelInstance() || labelForObjects().size(); }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -594,6 +594,13 @@ bool AccessibilityRenderObject::isAttachment() const
     return renderer && renderer->isRenderWidget();
 }
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+bool AccessibilityRenderObject::isAttachmentElement() const
+{
+    return is<HTMLAttachmentElement>(node());
+}
+#endif
+
 bool AccessibilityRenderObject::isOffScreen() const
 {
     if (!m_renderer)
@@ -1110,6 +1117,11 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     // Allow the platform to decide if the attachment is ignored or not.
     if (isAttachment())
         return accessibilityIgnoreAttachment();
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+    if (isAttachmentElement())
+        return false;
+#endif
 
 #if PLATFORM(COCOA)
     // If this widget has an underlying AX object, don't ignore it.
@@ -2251,6 +2263,11 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
 
 #if ENABLE(APPLE_PAY)
     if (isApplePayButton())
+        return AccessibilityRole::Button;
+#endif
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+    if (isAttachmentElement())
         return AccessibilityRole::Button;
 #endif
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -73,6 +73,9 @@ public:
     bool isNonLayerSVGObject() const final;
 
     bool isAttachment() const final;
+#if ENABLE(ATTACHMENT_ELEMENT)
+    bool isAttachmentElement() const final;
+#endif
     bool isDetached() const final { return !m_renderer && AccessibilityNodeObject::isDetached(); }
     bool isOffScreen() const final;
     bool hasBoldFont() const final;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -34,7 +34,6 @@
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
 #import "AXUtilities.h"
-#import "AccessibilityAttachment.h"
 #import "AccessibilityRenderObject.h"
 #import "AccessibilityScrollView.h"
 #import "AccessibilityTable.h"
@@ -1599,8 +1598,10 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return [NSString stringWithFormat:@"%.2f", backingObject->valueForRange()];
     }
 
-    if (auto* attachment = dynamicDowncast<AccessibilityAttachment>(backingObject.get()); attachment && attachment->hasProgress())
+#if ENABLE(ATTACHMENT_ELEMENT)
+    if (backingObject->isAttachmentElement() && backingObject->hasProgress())
         return [NSString stringWithFormat:@"%.2f", backingObject->valueForRange()];
+#endif
 
     return nil;
 }
@@ -1648,7 +1649,11 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return NO;
 
-    return is<AccessibilityAttachment>(self.axBackingObject);
+#if ENABLE(ATTACHMENT_ELEMENT)
+    return self.axBackingObject->isAttachmentElement();
+#else
+    return NO;
+#endif
 }
 
 - (BOOL)accessibilityIsComboBox


### PR DESCRIPTION
#### 8beef5fc0982dc02e4984c97c525e1947afeea0e
<pre>
AX: Merge AccessibilityAttachment into AccessibilityRenderObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=297400">https://bugs.webkit.org/show_bug.cgi?id=297400</a>
<a href="https://rdar.apple.com/158325218">rdar://158325218</a>

Reviewed by Tyler Wilcock.

Merge the logic from AccessibilityAttachment into AccessibilityRenderObject
and AccessibilityNodeObject as part of our effort to flatten our class
hierarchy.

A new helper class, AXAttachmentHelpers, was added to encapsulate the
HTMLAttachmentElement-specific logic.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXAttachmentHelpers.cpp: Renamed from Source/WebCore/accessibility/AccessibilityAttachment.cpp.
(WebCore::AXAttachmentHelpers::hasProgress):
(WebCore::AXAttachmentHelpers::accessibilityText):
* Source/WebCore/accessibility/AXAttachmentHelpers.h: Renamed from Source/WebCore/accessibility/AccessibilityAttachment.h.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::hasProgress const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
* Source/WebCore/accessibility/AXSearchManager.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::valueForRange const):
(WebCore::AccessibilityNodeObject::hasProgress const):
(WebCore::AccessibilityNodeObject::accessibilityText const):
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::isAttachmentElement const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::isAttachmentElement const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityValue]):
(-[WebAccessibilityObjectWrapper accessibilityIsAttachmentElement]):

Canonical link: <a href="https://commits.webkit.org/298740@main">https://commits.webkit.org/298740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37c361162fcc579a4d5fbc118599b16cf08ab7f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66956 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88401 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42875 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68838 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66133 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125601 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97109 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24682 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39243 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43177 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44348 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->