### PR TITLE
AX: Add AXObjectRareData with fields from AccessibilityTable to set up the removal of this subclass

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -558,6 +558,7 @@ accessibility/AXGeometryManager.cpp
 accessibility/AXLogger.cpp
 accessibility/AXLoggerBase.cpp
 accessibility/AXObjectCache.cpp
+accessibility/AXObjectRareData.cpp
 accessibility/AXRemoteFrame.cpp
 accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp

--- a/Source/WebCore/accessibility/AXObjectRareData.cpp
+++ b/Source/WebCore/accessibility/AXObjectRareData.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXObjectRareData.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(AXObjectRareData);
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectRareData.h
+++ b/Source/WebCore/accessibility/AXObjectRareData.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AXCoreObject.h"
+#include "AccessibilityObject.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXObjectRareData);
+class AXObjectRareData : public CanMakeCheckedPtr<AXObjectRareData> {
+    WTF_MAKE_NONCOPYABLE(AXObjectRareData);
+    WTF_MAKE_COMPACT_TZONE_ALLOCATED(AXObjectRareData);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AXObjectRareData);
+public:
+    AXObjectRareData() = default;
+
+    unsigned rowCount() { return m_tableRows.size(); }
+    unsigned columnCount() { return m_tableColumns.size(); }
+
+private:
+    // Begin table-related fields.
+    AXCoreObject::AccessibilityChildrenVector m_tableRows;
+    AXCoreObject::AccessibilityChildrenVector m_tableColumns;
+    // 2D matrix of the cells assigned to each "slot" in the table.
+    // ("Slot" as defined here: https://html.spec.whatwg.org/multipage/tables.html#concept-slots)
+    Vector<Vector<Markable<AXID>>> m_cellSlots;
+
+    RefPtr<AccessibilityObject> m_tableHeaderContainer;
+    bool m_isExposable;
+    bool m_isAriaTable;
+    // End table-related fields.
+
+}; // class AXObjectRareData
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -26,8 +26,10 @@
 #include "AXSearchManager.h"
 
 #include "AXLogger.h"
+#include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AccessibilityObject.h"
+#include "Logging.h"
 #include "TextIterator.h"
 
 namespace WebCore {

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -35,6 +35,7 @@
 #include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
+#include "AXObjectRareData.h"
 #include "AXRemoteFrame.h"
 #include "AXSearchManager.h"
 #include "AXTextMarker.h"
@@ -4338,6 +4339,19 @@ AccessibilityObject* AccessibilityObject::containingWebArea() const
     CheckedPtr cache = axObjectCache();
     RefPtr root = cache ? dynamicDowncast<AccessibilityScrollView>(cache->getOrCreate(frameView.get())) : nullptr;
     return root ? root->webAreaObject() : nullptr;
+}
+
+AXObjectRareData& AccessibilityObject::ensureRareData()
+{
+    if (!hasRareData())
+        m_rareDataWithBitfields.setPointer(makeUnique<AXObjectRareData>());
+    return *rareData();
+}
+
+void AccessibilityObject::clearRareData()
+{
+    ASSERT(hasRareData());
+    m_rareDataWithBitfields.setPointer(nullptr);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -37,6 +37,7 @@
 #include "Path.h"
 #include "TextIterator.h"
 #include <iterator>
+#include <wtf/CompactUniquePtrTuple.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>
@@ -53,6 +54,12 @@ OBJC_CLASS NSString;
 OBJC_CLASS NSValue;
 OBJC_CLASS NSView;
 #endif
+
+namespace WebCore {
+class AXObjectRareData;
+}
+
+WTF_ALLOW_COMPACT_POINTERS_TO_INCOMPLETE_TYPE(WebCore::AXObjectRareData);
 
 namespace WebCore {
 
@@ -938,10 +945,16 @@ private:
 
     virtual CommandType commandType() const;
 
+    bool hasRareData() const { return !!m_rareDataWithBitfields.pointer(); }
+    AXObjectRareData* rareData() const { return m_rareDataWithBitfields.pointer(); }
+    AXObjectRareData& ensureRareData();
+    void clearRareData();
+
 protected: // FIXME: Make the data members private.
     AccessibilityChildrenVector m_children;
 private:
     const WeakPtr<AXObjectCache> m_axObjectCache;
+    CompactUniquePtrTuple<AXObjectRareData, uint16_t> m_rareDataWithBitfields;
 #if PLATFORM(IOS_FAMILY)
     InlineTextPrediction m_lastPresentedTextPrediction;
     InlineTextPrediction m_lastPresentedTextPredictionComplete;


### PR DESCRIPTION
#### 9d8bbadec0867327e7bd5c91a87efc1e10f53156
<pre>
AX: Add AXObjectRareData with fields from AccessibilityTable to set up the removal of this subclass
<a href="https://bugs.webkit.org/show_bug.cgi?id=297404">https://bugs.webkit.org/show_bug.cgi?id=297404</a>
<a href="https://rdar.apple.com/158329174">rdar://158329174</a>

Reviewed by NOBODY (OOPS!).

This new AXObjectRareData mirrors the pattern used by Node.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectRareData.cpp: Added.
(WebCore::AccessibilityObject::ensureRareData):
* Source/WebCore/accessibility/AXObjectRareData.h: Added.
(WebCore::AXObjectRareData::rowCount):
(WebCore::AXObjectRareData::columnCount):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::clearRareData):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::hasRareData const):
(WebCore::AccessibilityObject::rareData const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38e733f55f131f28c000363135bd218a0ce77bcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122444 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66948 "Hash 38e733f5 for PR 49393 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88396 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/66948 "Hash 38e733f5 for PR 49393 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68831 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22519 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125593 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97104 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96899 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42184 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20091 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39235 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48760 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42635 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->