### PR TITLE
[JSC] Do not use Variant for each of TypeDefinition kind

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -191,15 +191,11 @@ wasm/WasmTypeDefinition.h
 wasm/WasmTypeDefinitionInlines.h
 wasm/WasmWorklist.cpp
 wasm/js/JSWebAssembly.cpp
-wasm/js/JSWebAssemblyArray.h
-wasm/js/JSWebAssemblyException.cpp
 wasm/js/JSWebAssemblyHelpers.h
 wasm/js/JSWebAssemblyInstance.cpp
 wasm/js/JSWebAssemblyInstance.h
 wasm/js/JSWebAssemblyMemory.cpp
 wasm/js/JSWebAssemblyMemory.h
-wasm/js/JSWebAssemblyStruct.cpp
-wasm/js/JSWebAssemblyStruct.h
 wasm/js/WasmToJS.cpp
 wasm/js/WebAssemblyFunction.h
 wasm/js/WebAssemblyInstanceConstructor.cpp

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -60,7 +60,7 @@ JS_EXPORT_PRIVATE IterationMode getIterationMode(VM&, JSGlobalObject*, JSValue i
 JS_EXPORT_PRIVATE IterationMode getIterationMode(VM&, JSGlobalObject*, JSValue iterable, JSValue symbolIterator);
 
 template<typename CallBackType>
-static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSValue iterable, JSArray* array, const CallBackType& callback)
+static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSValue iterable, JSArray* array, NOESCAPE const CallBackType& callback)
 {
     UNUSED_PARAM(iterable);
 
@@ -84,7 +84,7 @@ static ALWAYS_INLINE void forEachInFastArray(JSGlobalObject* globalObject, JSVal
 }
 
 template<typename CallBackType>
-static ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, IterationRecord iterationRecord, const CallBackType& callback)
+static ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject, IterationRecord iterationRecord, NOESCAPE const CallBackType& callback)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -109,7 +109,7 @@ static ALWAYS_INLINE void forEachInIterationRecord(JSGlobalObject* globalObject,
 }
 
 template<typename CallBackType>
-void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, const CallBackType& callback)
+void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE const CallBackType& callback)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -128,7 +128,7 @@ void forEachInIterable(JSGlobalObject* globalObject, JSValue iterable, const Cal
 }
 
 template<typename CallBackType>
-void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue iteratorMethod, const CallBackType& callback)
+void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue iteratorMethod, NOESCAPE const CallBackType& callback)
 {
     auto& vm = getVM(&globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -172,7 +172,7 @@ void forEachInIterable(JSGlobalObject& globalObject, JSObject* iterable, JSValue
 }
 
 template<typename CallBackType>
-void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, const CallBackType& callback)
+void forEachInIteratorProtocol(JSGlobalObject* globalObject, JSValue iterable, NOESCAPE const CallBackType& callback)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -300,7 +300,7 @@ public:
 
     CallInformation callInformationFor(const TypeDefinition& type, CallRole role = CallRole::Caller) const
     {
-        const auto& signature = *type.as<FunctionSignature>();
+        SUPPRESS_UNCOUNTED_LOCAL const auto& signature = *type.as<FunctionSignature>();
         return callInformationFor(signature, role);
     }
 
@@ -396,7 +396,11 @@ private:
     }
 
 public:
-    CallInformation callInformationFor(const TypeDefinition& signature, CallRole role = CallRole::Callee) const { return callInformationFor(*signature.as<FunctionSignature>(), role); }
+    CallInformation callInformationFor(const TypeDefinition& signature, CallRole role = CallRole::Callee) const
+    {
+        SUPPRESS_UNCOUNTED_LOCAL auto& functionSignature = *signature.as<FunctionSignature>();
+        return callInformationFor(functionSignature, role);
+    }
     CallInformation callInformationFor(const FunctionSignature& signature, CallRole role = CallRole::Callee) const
     {
         size_t gpArgumentCount = 0;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -639,7 +639,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmToJSExitIterateResults, bool, (JS
     NativeCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    const FunctionSignature* signature = type->as<FunctionSignature>();
+    SUPPRESS_UNCOUNTED_LOCAL const FunctionSignature* signature = type->as<FunctionSignature>();
 
     auto wasmCallInfo = wasmCallingConvention().callInformationFor(*type, CallRole::Callee);
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -45,7 +45,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace Wasm {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeDefinition);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TypeInformation);
 
 String TypeDefinition::toString() const
@@ -55,23 +54,22 @@ String TypeDefinition::toString() const
 
 void TypeDefinition::dump(PrintStream& out) const
 {
-    if (is<FunctionSignature>())
+    switch (m_kind) {
+    case FunctionSignature::kind:
         return as<FunctionSignature>()->dump(out);
-
-    if (is<StructType>())
+    case StructType::kind:
         return as<StructType>()->dump(out);
-
-    if (is<ArrayType>())
+    case ArrayType::kind:
         return as<ArrayType>()->dump(out);
-
-    if (is<RecursionGroup>())
+    case RecursionGroup::kind:
         return as<RecursionGroup>()->dump(out);
-
-    if (is<Projection>())
+    case Projection::kind:
         return as<Projection>()->dump(out);
-
-    ASSERT(is<Subtype>());
-    return as<Subtype>()->dump(out);
+    case Subtype::kind:
+        return as<Subtype>()->dump(out);
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return;
 }
 
 String FunctionSignature::toString() const
@@ -98,8 +96,8 @@ void FunctionSignature::dump(PrintStream& out) const
     }
 }
 
-FunctionSignature::FunctionSignature(void* payload, FunctionArgCount argumentCount, FunctionArgCount returnCount)
-    : m_payload(static_cast<Type*>(payload))
+FunctionSignature::FunctionSignature(FunctionArgCount argumentCount, FunctionArgCount returnCount)
+    : TypeDefinition(kind)
     , m_argCount(argumentCount)
     , m_retCount(returnCount)
 { }
@@ -122,25 +120,31 @@ void StructType::dump(PrintStream& out) const
     out.print(")"_s);
 }
 
-StructType::StructType(void* payload, StructFieldCount fieldCount, const FieldType* fieldTypes)
-    : m_payload(static_cast<FieldType*>(payload))
-    , m_fieldCount(fieldCount)
+StructType::StructType(std::span<const FieldType> fieldTypes)
+    : TypeDefinition(kind)
+    , m_fieldCount(fieldTypes.size())
 {
     unsigned currentFieldOffset = 0;
-    for (unsigned fieldIndex = 0; fieldIndex < m_fieldCount; ++fieldIndex) {
+    auto fields = mutableFields();
+    for (unsigned fieldIndex = 0; fieldIndex < fieldTypes.size(); ++fieldIndex) {
         const auto& fieldType = fieldTypes[fieldIndex];
         m_hasRefFieldTypes |= isRefType(fieldType.type);
         m_hasRecursiveReference |= isRefWithRecursiveReference(fieldType.type);
-
-        getField(fieldIndex) = fieldType;
-
-        const auto& fieldStorageType = field(fieldIndex).type;
+        new (&fields[fieldIndex]) FieldType(fieldType);
+        const auto& fieldStorageType = fields[fieldIndex].type;
         currentFieldOffset = WTF::roundUpToMultipleOf(typeAlignmentInBytes(fieldStorageType), currentFieldOffset);
         fieldOffsetFromInstancePayload(fieldIndex) = currentFieldOffset;
         currentFieldOffset += typeSizeInBytes(fieldStorageType);
     }
 
     m_instancePayloadSize = WTF::roundUpToMultipleOf<sizeof(uint64_t)>(currentFieldOffset);
+}
+
+ArrayType::ArrayType(const FieldType& elementType)
+    : TypeDefinition(kind)
+    , m_hasRecursiveReference(isRefWithRecursiveReference(elementType.type))
+    , m_elementType(elementType)
+{
 }
 
 String ArrayType::toString() const
@@ -155,6 +159,17 @@ void ArrayType::dump(PrintStream& out) const
     out.print(comma, elementType().mutability ? "immutable "_s : "mutable "_s, makeString(elementType().type));
     out.print(")"_s);
 }
+
+RecursionGroup::RecursionGroup(std::span<const TypeIndex> types)
+    : TypeDefinition(kind)
+    , m_typeCount(types.size())
+{
+    for (unsigned i = 0; i < types.size(); ++i) {
+        TypeInformation::get(types[i]).ref();
+        mutableTypes()[i] = types[i];
+    }
+}
+
 
 String RecursionGroup::toString() const
 {
@@ -172,6 +187,18 @@ void RecursionGroup::dump(PrintStream& out) const
     out.print(")"_s);
 }
 
+Projection::Projection(TypeIndex recursionGroup, ProjectionIndex projectionIndex)
+    : TypeDefinition(kind)
+    , m_recursionGroup(recursionGroup)
+    , m_projectionIndex(projectionIndex)
+{
+    // An invalid index may show up here for placeholder references, in which
+    // case we should avoid trying to resolve the type index.
+    if (recursionGroup != TypeDefinition::invalidIndex)
+        TypeInformation::get(recursionGroup).ref();
+}
+
+
 String Projection::toString() const
 {
     return WTF::toString(*this);
@@ -185,8 +212,21 @@ void Projection::dump(PrintStream& out) const
         out.print("<current-rec-group>"_s);
     else
         TypeInformation::get(recursionGroup()).dump(out);
-    out.print("."_s, index());
+    out.print("."_s, projectionIndex());
     out.print(")"_s);
+}
+
+Subtype::Subtype(std::span<const TypeIndex> superTypes, TypeIndex underlyingType, bool isFinal)
+    : TypeDefinition(kind)
+    , m_final(isFinal)
+    , m_underlyingType(underlyingType)
+    , m_supertypeCount(superTypes.size())
+{
+    for (SupertypeCount i = 0; i < superTypes.size(); i++) {
+        mutableSuperTypes()[i] = superTypes[i];
+        TypeInformation::get(superTypes[i]).ref();
+    }
+    TypeInformation::get(underlyingType).ref();
 }
 
 String Subtype::toString() const
@@ -230,9 +270,9 @@ bool TypeDefinition::cleanup()
 
 bool Subtype::cleanup()
 {
-    if (supertypeCount() > 0)
-        TypeInformation::get(firstSuperType()).deref();
-    TypeInformation::get(underlyingType()).deref();
+    for (auto& type : superTypes())
+        TypeInformation::get(type).deref();
+    TypeInformation::get(m_underlyingType).deref();
     return true;
 }
 
@@ -247,8 +287,8 @@ bool Projection::cleanup()
 
 bool RecursionGroup::cleanup()
 {
-    for (RecursionGroupCount i = 0; i < typeCount(); i++)
-        TypeInformation::get(type(i)).deref();
+    for (auto& type : types())
+        TypeInformation::get(type).deref();
     return true;
 }
 
@@ -266,13 +306,13 @@ static unsigned computeSignatureHash(size_t returnCount, const Type* returnTypes
     return accumulator;
 }
 
-static unsigned computeStructTypeHash(size_t fieldCount, const FieldType* fields)
+static unsigned computeStructTypeHash(std::span<const FieldType> fields)
 {
     unsigned accumulator = 0x15d2546;
-    for (uint32_t i = 0; i < fieldCount; ++i) {
-        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<int8_t>::hash(static_cast<int8_t>(fields[i].type.typeCode())));
-        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<uint8_t>::hash(static_cast<uint8_t>(fields[i].type.index())));
-        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<uint8_t>::hash(static_cast<uint8_t>(fields[i].mutability)));
+    for (auto& field : fields) {
+        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<int8_t>::hash(static_cast<int8_t>(field.type.typeCode())));
+        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<uint8_t>::hash(static_cast<uint8_t>(field.type.index())));
+        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<uint8_t>::hash(static_cast<uint8_t>(field.mutability)));
     }
     return accumulator;
 }
@@ -286,27 +326,27 @@ static unsigned computeArrayTypeHash(FieldType elementType)
     return accumulator;
 }
 
-static unsigned computeRecursionGroupHash(size_t typeCount, const TypeIndex* types)
+static unsigned computeRecursionGroupHash(std::span<const TypeIndex> types)
 {
     unsigned accumulator = 0x9cfb89bb;
-    for (uint32_t i = 0; i < typeCount; ++i)
-        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(static_cast<TypeIndex>(types[i])));
+    for (auto& type : types)
+        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(type));
     return accumulator;
 }
 
-static unsigned computeProjectionHash(TypeIndex recursionGroup, ProjectionIndex index)
+static unsigned computeProjectionHash(TypeIndex recursionGroup, ProjectionIndex projectionIndex)
 {
     unsigned accumulator = 0xbeae6d4e;
-    accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(static_cast<TypeIndex>(recursionGroup)));
-    accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<uint32_t>::hash(static_cast<uint32_t>(index)));
+    accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(recursionGroup));
+    accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<ProjectionIndex>::hash(projectionIndex));
     return accumulator;
 }
 
-static unsigned computeSubtypeHash(SupertypeCount supertypeCount, const TypeIndex* superTypes, TypeIndex underlyingType, bool isFinal)
+static unsigned computeSubtypeHash(std::span<const TypeIndex> superTypes, TypeIndex underlyingType, bool isFinal)
 {
     unsigned accumulator = 0x3efa01b9;
-    if (supertypeCount > 0)
-        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(superTypes[0]));
+    for (auto& type : superTypes)
+        accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(type));
     accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<TypeIndex>::hash(underlyingType));
     accumulator = WTF::pairIntHash(accumulator, WTF::IntHash<bool>::hash(isFinal));
     return accumulator;
@@ -314,100 +354,94 @@ static unsigned computeSubtypeHash(SupertypeCount supertypeCount, const TypeInde
 
 unsigned TypeDefinition::hash() const
 {
-    if (is<FunctionSignature>()) {
+    switch (m_kind) {
+    case FunctionSignature::kind: {
         const FunctionSignature* signature = as<FunctionSignature>();
         return computeSignatureHash(signature->returnCount(), signature->storage(0), signature->argumentCount(), signature->storage(signature->returnCount()));
     }
-
-    if (is<StructType>()) {
+    case StructType::kind: {
         const StructType* structType = as<StructType>();
-        return computeStructTypeHash(structType->fieldCount(), structType->storage(0));
+        return computeStructTypeHash(structType->fields());
     }
-
-    if (is<ArrayType>()) {
+    case ArrayType::kind: {
         const ArrayType* arrayType = as<ArrayType>();
         return computeArrayTypeHash(arrayType->elementType());
     }
-
-    if (is<RecursionGroup>()) {
+    case RecursionGroup::kind: {
         const RecursionGroup* recursionGroup = as<RecursionGroup>();
-        return computeRecursionGroupHash(recursionGroup->typeCount(), recursionGroup->storage(0));
+        return computeRecursionGroupHash(recursionGroup->types());
     }
-
-    if (is<Projection>()) {
+    case Projection::kind: {
         const Projection* projection = as<Projection>();
-        return computeProjectionHash(projection->recursionGroup(), projection->index());
+        return computeProjectionHash(projection->recursionGroup(), projection->projectionIndex());
     }
-
-    ASSERT(is<Subtype>());
-    const Subtype* subtype = as<Subtype>();
-    return computeSubtypeHash(subtype->supertypeCount(), subtype->storage(1), subtype->underlyingType(), subtype->isFinal());
+    case Subtype::kind: {
+        const Subtype* subtype = as<Subtype>();
+        return computeSubtypeHash(subtype->superTypes(), subtype->underlyingType(), subtype->isFinal());
+    }
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return 0;
 }
 
-RefPtr<TypeDefinition> TypeDefinition::tryCreateFunctionSignature(FunctionArgCount returnCount, FunctionArgCount argumentCount)
+RefPtr<FunctionSignature> FunctionSignature::tryCreate(FunctionArgCount returnCount, FunctionArgCount argumentCount)
 {
     // We use WTF_MAKE_TZONE_ALLOCATED for this class.
-    auto result = tryFastMalloc(allocatedFunctionSize(returnCount, argumentCount));
+    auto result = tryFastMalloc(allocationSize(returnCount, argumentCount));
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<FunctionSignature>, argumentCount, returnCount);
-    return adoptRef(signature);
+    return adoptRef(*new (NotNull, memory) FunctionSignature(argumentCount, returnCount));
 }
 
-RefPtr<TypeDefinition> TypeDefinition::tryCreateStructType(StructFieldCount fieldCount, const FieldType* fields)
+RefPtr<StructType> StructType::tryCreate(std::span<const FieldType> fields)
 {
     // We use WTF_MAKE_TZONE_ALLOCATED for this class.
-    auto result = tryFastMalloc(allocatedStructSize(fieldCount));
+    auto result = tryFastMalloc(allocationSize(fields.size()));
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<StructType>, fieldCount, fields);
-    return adoptRef(signature);
+    return adoptRef(*new (NotNull, memory) StructType(fields));
 }
 
-RefPtr<TypeDefinition> TypeDefinition::tryCreateArrayType()
+RefPtr<ArrayType> ArrayType::tryCreate(const FieldType& elementType)
 {
     // We use WTF_MAKE_TZONE_ALLOCATED for this class.
-    auto result = tryFastMalloc(allocatedArraySize());
+    auto result = tryFastMalloc(allocationSize());
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<ArrayType>);
-    return adoptRef(signature);
+    return adoptRef(*new (NotNull, memory) ArrayType(elementType));
 }
 
-RefPtr<TypeDefinition> TypeDefinition::tryCreateRecursionGroup(RecursionGroupCount typeCount)
+RefPtr<RecursionGroup> RecursionGroup::tryCreate(std::span<const TypeIndex> types)
 {
     // We use WTF_MAKE_TZONE_ALLOCATED for this class.
-    auto result = tryFastMalloc(allocatedRecursionGroupSize(typeCount));
+    auto result = tryFastMalloc(allocationSize(types.size()));
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<RecursionGroup>, typeCount);
-    return adoptRef(signature);
+    return adoptRef(*new (NotNull, memory) RecursionGroup(types));
 }
 
-RefPtr<TypeDefinition> TypeDefinition::tryCreateProjection()
+RefPtr<Projection> Projection::tryCreate(TypeIndex recursionGroup, ProjectionIndex index)
 {
     // We use WTF_MAKE_TZONE_ALLOCATED for this class.
-    auto result = tryFastMalloc(allocatedProjectionSize());
+    auto result = tryFastMalloc(allocationSize());
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<Projection>);
-    return adoptRef(signature);
+    return adoptRef(*new (NotNull, memory) Projection(recursionGroup, index));
 }
 
-RefPtr<TypeDefinition> TypeDefinition::tryCreateSubtype(SupertypeCount count, bool isFinal)
+RefPtr<Subtype> Subtype::tryCreate(std::span<const TypeIndex> superTypes, TypeIndex underlyingType, bool isFinal)
 {
     // We use WTF_MAKE_TZONE_ALLOCATED for this class.
-    auto result = tryFastMalloc(allocatedSubtypeSize());
+    auto result = tryFastMalloc(allocationSize(superTypes.size()));
     void* memory = nullptr;
     if (!result.getValue(memory))
         return nullptr;
-    TypeDefinition* signature = new (NotNull, memory) TypeDefinition(WTF::InPlaceType<Subtype>, count, isFinal);
-    return adoptRef(signature);
+    return adoptRef(*new (NotNull, memory) Subtype(superTypes, underlyingType, isFinal));
 }
 
 // Recursive types are stored "tied" in the sense that the spec refers to here:
@@ -420,14 +454,17 @@ RefPtr<TypeDefinition> TypeDefinition::tryCreateSubtype(SupertypeCount count, bo
 // functions below are used to implement this substitution.
 Type TypeDefinition::substitute(Type type, TypeIndex projectee)
 {
-    if (isRefWithTypeIndex(type) && TypeInformation::get(type.index).is<Projection>()) {
-        const Projection* projection = TypeInformation::get(type.index).as<Projection>();
-        if (projection->isPlaceholder()) {
-            RefPtr<TypeDefinition> newProjection = TypeInformation::typeDefinitionForProjection(projectee, projection->index());
-            TypeKind kind = type.isNullable() ? TypeKind::RefNull : TypeKind::Ref;
-            // Calling module must have already taken ownership of all projections.
-            RELEASE_ASSERT(newProjection->refCount() > 2); // TypeInformation registry + RefPtr + owning module(s)
-            return Type { kind, newProjection->index() };
+    if (isRefWithTypeIndex(type)) {
+        auto& candidate = TypeInformation::get(type.index);
+        if (candidate.is<Projection>()) {
+            const Projection* projection = candidate.as<Projection>();
+            if (projection->isPlaceholder()) {
+                auto newProjection = TypeInformation::typeDefinitionForProjection(projectee, projection->projectionIndex());
+                TypeKind kind = type.isNullable() ? TypeKind::RefNull : TypeKind::Ref;
+                // Calling module must have already taken ownership of all projections.
+                RELEASE_ASSERT(newProjection->refCount() > 2); // TypeInformation registry + RefPtr + owning module(s)
+                return Type { kind, newProjection->index() };
+            }
         }
     }
 
@@ -437,10 +474,11 @@ Type TypeDefinition::substitute(Type type, TypeIndex projectee)
 // Perform a substitution as above but for a Subtype's parent type.
 static TypeIndex substituteParent(TypeIndex parent, TypeIndex projectee)
 {
-    if (TypeInformation::get(parent).is<Projection>()) {
-        const Projection* projection = TypeInformation::get(parent).as<Projection>();
+    auto& candidate = TypeInformation::get(parent);
+    if (candidate.is<Projection>()) {
+        const Projection* projection = candidate.as<Projection>();
         if (projection->isPlaceholder()) {
-            RefPtr<TypeDefinition> newProjection = TypeInformation::typeDefinitionForProjection(projectee, projection->index());
+            auto newProjection = TypeInformation::typeDefinitionForProjection(projectee, projection->projectionIndex());
             // Caller module must have already taken ownership of all its projections.
             RELEASE_ASSERT(newProjection->refCount() > 2); // tbl + RefPtr + owning module(s)
             return newProjection->index();
@@ -463,7 +501,7 @@ Ref<const TypeDefinition> TypeDefinition::replacePlaceholders(TypeIndex projecte
             return substitute(func->returnType(i), projectee);
         });
 
-        RefPtr<TypeDefinition> def = TypeInformation::typeDefinitionForFunction(newReturns, newArguments);
+        auto def = TypeInformation::typeDefinitionForFunction(newReturns, newArguments);
         return def.releaseNonNull();
     }
 
@@ -475,7 +513,7 @@ Ref<const TypeDefinition> TypeDefinition::replacePlaceholders(TypeIndex projecte
             return FieldType { substituted, field.mutability };
         });
 
-        RefPtr<TypeDefinition> def = TypeInformation::typeDefinitionForStruct(newFields);
+        auto def = TypeInformation::typeDefinitionForStruct(newFields);
         return def.releaseNonNull();
     }
 
@@ -483,7 +521,7 @@ Ref<const TypeDefinition> TypeDefinition::replacePlaceholders(TypeIndex projecte
         const ArrayType* arrayType = as<ArrayType>();
         FieldType field = arrayType->elementType();
         StorageType substituted = field.type.is<PackedType>() ? field.type : StorageType(substitute(field.type.as<Type>(), projectee));
-        RefPtr<TypeDefinition> def = TypeInformation::typeDefinitionForArray(FieldType { substituted, field.mutability });
+        auto def = TypeInformation::typeDefinitionForArray(FieldType { substituted, field.mutability });
         return def.releaseNonNull();
     }
 
@@ -494,7 +532,7 @@ Ref<const TypeDefinition> TypeDefinition::replacePlaceholders(TypeIndex projecte
             return substituteParent(subtype->superType(i), projectee);
         });
         // Subtype takes ownership of newUnderlyingType.
-        RefPtr<TypeDefinition> def = TypeInformation::typeDefinitionForSubtype(supertypes, newUnderlyingType->index(), subtype->isFinal());
+        auto def = TypeInformation::typeDefinitionForSubtype(supertypes, newUnderlyingType->index(), subtype->isFinal());
         return def.releaseNonNull();
     }
 
@@ -513,7 +551,7 @@ const TypeDefinition& TypeDefinition::unrollSlow() const
     const TypeDefinition& projectee = TypeInformation::get(projection.recursionGroup());
 
     const RecursionGroup& recursionGroup = *projectee.as<RecursionGroup>();
-    const TypeDefinition& underlyingType = TypeInformation::get(recursionGroup.type(projection.index()));
+    const TypeDefinition& underlyingType = TypeInformation::get(recursionGroup.type(projection.projectionIndex()));
 
     if (underlyingType.hasRecursiveReference()) {
         if (std::optional<TypeIndex> cachedUnrolling = TypeInformation::tryGetCachedUnrolling(index()))
@@ -573,7 +611,7 @@ bool TypeDefinition::isFinalType() const
     return true;
 }
 
-RefPtr<RTT> RTT::tryCreateRTT(RTTKind kind, DisplayCount displaySize)
+RefPtr<RTT> RTT::tryCreate(RTTKind kind, DisplayCount displaySize)
 {
     auto result = tryFastMalloc(allocatedRTTSize(displaySize));
     void* memory = nullptr;
@@ -589,7 +627,7 @@ bool RTT::isStrictSubRTT(const RTT& parent) const
     return &parent == displayEntry(displaySize() - parent.displaySize() - 1);
 }
 
-const TypeDefinition& TypeInformation::signatureForJSException()
+const FunctionSignature& TypeInformation::signatureForJSException()
 {
     return *singleton().m_Void_Externref;
 }
@@ -631,7 +669,7 @@ struct FunctionParameterTypes {
     // is not already in the set. See HashSet.h for details.
     static void translate(TypeHash& entry, const FunctionParameterTypes& params, unsigned)
     {
-        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateFunctionSignature(params.returnTypes.size(), params.argumentTypes.size());
+        auto signature = FunctionSignature::tryCreate(params.returnTypes.size(), params.argumentTypes.size());
         RELEASE_ASSERT(signature);
         bool hasRecursiveReference = false;
         bool argumentsOrResultsIncludeI64 = false;
@@ -639,7 +677,7 @@ struct FunctionParameterTypes {
         bool argumentsOrResultsIncludeExnref = false;
 
         for (unsigned i = 0; i < params.returnTypes.size(); ++i) {
-            signature->as<FunctionSignature>()->getReturnType(i) = params.returnTypes[i];
+            signature->getReturnType(i) = params.returnTypes[i];
             hasRecursiveReference |= isRefWithRecursiveReference(params.returnTypes[i]);
             argumentsOrResultsIncludeI64 |= params.returnTypes[i].isI64();
             argumentsOrResultsIncludeV128 |= params.returnTypes[i].isV128();
@@ -647,17 +685,17 @@ struct FunctionParameterTypes {
         }
 
         for (unsigned i = 0; i < params.argumentTypes.size(); ++i) {
-            signature->as<FunctionSignature>()->getArgumentType(i) = params.argumentTypes[i];
+            signature->getArgumentType(i) = params.argumentTypes[i];
             hasRecursiveReference |= isRefWithRecursiveReference(params.argumentTypes[i]);
             argumentsOrResultsIncludeI64 |= params.argumentTypes[i].isI64();
             argumentsOrResultsIncludeV128 |= params.argumentTypes[i].isV128();
             argumentsOrResultsIncludeExnref |= isExnref(params.argumentTypes[i]);
         }
 
-        signature->as<FunctionSignature>()->setHasRecursiveReference(hasRecursiveReference);
-        signature->as<FunctionSignature>()->setArgumentsOrResultsIncludeI64(argumentsOrResultsIncludeI64);
-        signature->as<FunctionSignature>()->setArgumentsOrResultsIncludeV128(argumentsOrResultsIncludeV128);
-        signature->as<FunctionSignature>()->setArgumentsOrResultsIncludeExnref(argumentsOrResultsIncludeExnref);
+        signature->setHasRecursiveReference(hasRecursiveReference);
+        signature->setArgumentsOrResultsIncludeI64(argumentsOrResultsIncludeI64);
+        signature->setArgumentsOrResultsIncludeV128(argumentsOrResultsIncludeV128);
+        signature->setArgumentsOrResultsIncludeExnref(argumentsOrResultsIncludeExnref);
 
         entry.key = WTFMove(signature);
     }
@@ -668,7 +706,7 @@ struct StructParameterTypes {
 
     static unsigned hash(const StructParameterTypes& params)
     {
-        return computeStructTypeHash(params.fields.size(), params.fields.span().data());
+        return computeStructTypeHash(params.fields.span());
     }
 
     static bool equal(const TypeHash& sig, const StructParameterTypes& params)
@@ -676,12 +714,14 @@ struct StructParameterTypes {
         if (!sig.key->is<StructType>())
             return false;
 
-        const StructType* structType = sig.key->as<StructType>();
-        if (structType->fieldCount() != params.fields.size())
+        auto structType = sig.key->as<StructType>();
+        auto fields = structType->fields();
+
+        if (fields.size() != params.fields.size())
             return false;
 
-        for (unsigned i = 0; i < structType->fieldCount(); ++i) {
-            if (structType->field(i) != params.fields[i])
+        for (size_t i = 0; i < fields.size(); ++i) {
+            if (fields[i] != params.fields[i])
                 return false;
         }
 
@@ -690,7 +730,7 @@ struct StructParameterTypes {
 
     static void translate(TypeHash& entry, const StructParameterTypes& params, unsigned)
     {
-        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateStructType(params.fields.size(), params.fields.span().data());
+        auto signature = StructType::tryCreate(params.fields.span());
         RELEASE_ASSERT(signature);
         entry.key = WTFMove(signature);
     }
@@ -719,13 +759,8 @@ struct ArrayParameterTypes {
 
     static void translate(TypeHash& entry, const ArrayParameterTypes& params, unsigned)
     {
-        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateArrayType();
+        auto signature = ArrayType::tryCreate(params.elementType);
         RELEASE_ASSERT(signature);
-
-        ArrayType* arrayType = signature->as<ArrayType>();
-        arrayType->getElementType() = params.elementType;
-        arrayType->setHasRecursiveReference(isRefWithRecursiveReference(params.elementType.type));
-
         entry.key = WTFMove(signature);
     }
 };
@@ -735,7 +770,7 @@ struct RecursionGroupParameterTypes {
 
     static unsigned hash(const RecursionGroupParameterTypes& params)
     {
-        return computeRecursionGroupHash(params.types.size(), params.types.span().data());
+        return computeRecursionGroupHash(params.types.span());
     }
 
     static bool equal(const TypeHash& sig, const RecursionGroupParameterTypes& params)
@@ -757,26 +792,19 @@ struct RecursionGroupParameterTypes {
 
     static void translate(TypeHash& entry, const RecursionGroupParameterTypes& params, unsigned)
     {
-        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateRecursionGroup(params.types.size());
+        auto signature = RecursionGroup::tryCreate(params.types.span());
         RELEASE_ASSERT(signature);
-
-        RecursionGroup* recursionGroup = signature->as<RecursionGroup>();
-        for (unsigned i = 0; i < params.types.size(); ++i) {
-            TypeInformation::get(params.types[i]).ref();
-            recursionGroup->getType(i) = params.types[i];
-        }
-
         entry.key = WTFMove(signature);
     }
 };
 
 struct ProjectionParameterTypes {
     const TypeIndex recursionGroup;
-    const ProjectionIndex index;
+    const ProjectionIndex projectionIndex;
 
     static unsigned hash(const ProjectionParameterTypes& params)
     {
-        return computeProjectionHash(params.recursionGroup, params.index);
+        return computeProjectionHash(params.recursionGroup, params.projectionIndex);
     }
 
     static bool equal(const TypeHash& sig, const ProjectionParameterTypes& params)
@@ -785,7 +813,7 @@ struct ProjectionParameterTypes {
             return false;
 
         const Projection* projection = sig.key->as<Projection>();
-        if (projection->recursionGroup() != params.recursionGroup || projection->index() != params.index)
+        if (projection->recursionGroup() != params.recursionGroup || projection->projectionIndex() != params.projectionIndex)
             return false;
 
         return true;
@@ -793,18 +821,9 @@ struct ProjectionParameterTypes {
 
     static void translate(TypeHash& entry, const ProjectionParameterTypes& params, unsigned)
     {
-        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateProjection();
-        RELEASE_ASSERT(signature);
-
-        Projection* projection = signature->as<Projection>();
-        // An invalid index may show up here for placeholder references, in which
-        // case we should avoid trying to resolve the type index.
-        if (params.recursionGroup != TypeDefinition::invalidIndex)
-            TypeInformation::get(params.recursionGroup).ref();
-        projection->getRecursionGroup() = params.recursionGroup;
-        projection->getIndex() = params.index;
-
-        entry.key = WTFMove(signature);
+        auto projection = Projection::tryCreate(params.recursionGroup, params.projectionIndex);
+        RELEASE_ASSERT(projection);
+        entry.key = WTFMove(projection);
     }
 };
 
@@ -815,7 +834,7 @@ struct SubtypeParameterTypes {
 
     static unsigned hash(const SubtypeParameterTypes& params)
     {
-        return computeSubtypeHash(params.superTypes.size(), params.superTypes.span().data(), params.underlyingType, params.isFinal);
+        return computeSubtypeHash(params.superTypes.span(), params.underlyingType, params.isFinal);
     }
 
     static bool equal(const TypeHash& sig, const SubtypeParameterTypes& params)
@@ -843,17 +862,8 @@ struct SubtypeParameterTypes {
 
     static void translate(TypeHash& entry, const SubtypeParameterTypes& params, unsigned)
     {
-        RefPtr<TypeDefinition> signature = TypeDefinition::tryCreateSubtype(params.superTypes.size(), params.isFinal);
+        auto signature = Subtype::tryCreate(params.superTypes.span(), params.underlyingType, params.isFinal);
         RELEASE_ASSERT(signature);
-
-        Subtype* subtype = signature->as<Subtype>();
-        if (params.superTypes.size() > 0) {
-            subtype->getSuperType(0) = params.superTypes[0];
-            TypeInformation::get(params.superTypes[0]).ref();
-        }
-        subtype->getUnderlyingType() = params.underlyingType;
-        TypeInformation::get(params.underlyingType).ref();
-
         entry.key = WTFMove(signature);
     }
 };
@@ -863,16 +873,17 @@ TypeInformation::TypeInformation()
 #define MAKE_THUNK_SIGNATURE(type, enc, str, val, ...) \
     do { \
         if (TypeKind::type != TypeKind::Void) { \
-            RefPtr<TypeDefinition> sig = TypeDefinition::tryCreateFunctionSignature(1, 0); \
+            auto sig = FunctionSignature::tryCreate(1, 0);                                 \
+            RELEASE_ASSERT(sig);                                                           \
             sig->ref();                                                                    \
-            sig->as<FunctionSignature>()->getReturnType(0) = Types::type;                  \
+            sig->getReturnType(0) = Types::type;                                           \
             if (Types::type.isI64())                                                       \
-                sig->as<FunctionSignature>()->setArgumentsOrResultsIncludeI64(true);       \
+                sig->setArgumentsOrResultsIncludeI64(true);                                \
             if (Types::type.isV128())                                                      \
-                sig->as<FunctionSignature>()->setArgumentsOrResultsIncludeV128(true);      \
+                sig->setArgumentsOrResultsIncludeV128(true);                               \
             if (isExnref(Types::type))                                                     \
-                sig->as<FunctionSignature>()->setArgumentsOrResultsIncludeExnref(true);    \
-            thunkTypes[linearizeType(TypeKind::type)] = sig->as<FunctionSignature>();      \
+                sig->setArgumentsOrResultsIncludeExnref(true);                             \
+            thunkTypes[linearizeType(TypeKind::type)] = sig.get();                         \
             m_typeSet.add(TypeHash { sig.releaseNonNull() });                              \
         }                                                                                  \
     } while (false);
@@ -881,27 +892,27 @@ TypeInformation::TypeInformation()
 
     // Make Void again because we don't use the one that has void in it.
     {
-        RefPtr<TypeDefinition> sig = TypeDefinition::tryCreateFunctionSignature(0, 0);
+        auto sig = FunctionSignature::tryCreate(0, 0);
         sig->ref();
         thunkTypes[linearizeType(TypeKind::Void)] = sig->as<FunctionSignature>();
         m_typeSet.add(TypeHash { sig.releaseNonNull() });
     }
-    m_I64_Void = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I64 }, { } }).iterator->key;
-    m_Void_I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32 } }).iterator->key;
-    m_Void_I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_Void_I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_Void_I32I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_I32_I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I32 }, { Wasm::Types::I32 } }).iterator->key;
-    m_I32_RefI32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I32 }, { anyrefType(), Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_Ref_RefI32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { anyrefType() }, { anyrefType(), Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_Arrayref_I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { arrayrefType(false) }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_Anyref_Externref = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { anyrefType() }, { externrefType() } }).iterator->key;
-    m_Void_Externref = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { externrefType() } }).iterator->key;
-    m_Void_I32AnyrefI32I32AnyrefI32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, anyrefType(), Wasm::Types::I32, Wasm::Types::I32, anyrefType(), Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
-    m_Void_I32AnyrefI32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, anyrefType(), Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key;
+    m_I64_Void = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I64 }, { } }).iterator->key->as<FunctionSignature>();
+    m_Void_I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Void_I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Void_I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Void_I32I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_I32_I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I32 }, { Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_I32_RefI32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { Wasm::Types::I32 }, { anyrefType(), Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Ref_RefI32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { anyrefType() }, { anyrefType(), Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Arrayref_I32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { arrayrefType(false) }, { Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Anyref_Externref = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { anyrefType() }, { externrefType() } }).iterator->key->as<FunctionSignature>();
+    m_Void_Externref = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { externrefType() } }).iterator->key->as<FunctionSignature>();
+    m_Void_I32AnyrefI32I32AnyrefI32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, anyrefType(), Wasm::Types::I32, Wasm::Types::I32, anyrefType(), Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
+    m_Void_I32AnyrefI32I32I32I32 = m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { { }, { Wasm::Types::I32, anyrefType(), Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32, Wasm::Types::I32 } }).iterator->key->as<FunctionSignature>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForFunction(const Vector<Type, 16>& results, const Vector<Type, 16>& args)
+RefPtr<FunctionSignature> TypeInformation::typeDefinitionForFunction(const Vector<Type, 16>& results, const Vector<Type, 16>& args)
 {
     if constexpr (ASSERT_ENABLED) {
         ASSERT(!results.contains(Wasm::Types::Void));
@@ -911,64 +922,62 @@ RefPtr<TypeDefinition> TypeInformation::typeDefinitionForFunction(const Vector<T
     Locker locker { info.m_lock };
 
     auto addResult = info.m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { results, args });
-    return addResult.iterator->key;
+    return addResult.iterator->key->as<FunctionSignature>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForStruct(const Vector<FieldType>& fields)
+RefPtr<StructType> TypeInformation::typeDefinitionForStruct(const Vector<FieldType>& fields)
 {
     TypeInformation& info = singleton();
     Locker locker { info.m_lock };
 
     auto addResult = info.m_typeSet.template add<StructParameterTypes>(StructParameterTypes { fields });
-    return addResult.iterator->key;
+    return addResult.iterator->key->as<StructType>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForArray(FieldType elementType)
+RefPtr<ArrayType> TypeInformation::typeDefinitionForArray(FieldType elementType)
 {
     TypeInformation& info = singleton();
     Locker locker { info.m_lock };
 
     auto addResult = info.m_typeSet.template add<ArrayParameterTypes>(ArrayParameterTypes { elementType });
-    return addResult.iterator->key;
+    return addResult.iterator->key->as<ArrayType>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types)
+RefPtr<RecursionGroup> TypeInformation::typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types)
 {
     TypeInformation& info = singleton();
     Locker locker { info.m_lock };
 
     auto addResult = info.m_typeSet.template add<RecursionGroupParameterTypes>(RecursionGroupParameterTypes { types });
-    return addResult.iterator->key;
+    return addResult.iterator->key->as<RecursionGroup>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForProjection(TypeIndex recursionGroup, ProjectionIndex index)
+RefPtr<Projection> TypeInformation::typeDefinitionForProjection(TypeIndex recursionGroup, ProjectionIndex projectionIndex)
 {
     TypeInformation& info = singleton();
     Locker locker { info.m_lock };
 
-    auto addResult = info.m_typeSet.template add<ProjectionParameterTypes>(ProjectionParameterTypes { recursionGroup, index });
-    return addResult.iterator->key;
+    auto addResult = info.m_typeSet.template add<ProjectionParameterTypes>(ProjectionParameterTypes { recursionGroup, projectionIndex });
+    return addResult.iterator->key->as<Projection>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::typeDefinitionForSubtype(const Vector<TypeIndex>& superTypes, TypeIndex underlyingType, bool isFinal)
+RefPtr<Subtype> TypeInformation::typeDefinitionForSubtype(const Vector<TypeIndex>& superTypes, TypeIndex underlyingType, bool isFinal)
 {
     TypeInformation& info = singleton();
     Locker locker { info.m_lock };
 
     auto addResult = info.m_typeSet.template add<SubtypeParameterTypes>(SubtypeParameterTypes { superTypes, underlyingType, isFinal });
-    return addResult.iterator->key;
+    return addResult.iterator->key->as<Subtype>();
 }
 
-RefPtr<TypeDefinition> TypeInformation::getPlaceholderProjection(ProjectionIndex index)
+RefPtr<Projection> TypeInformation::getPlaceholderProjection(ProjectionIndex projectionIndex)
 {
     TypeInformation& info = singleton();
-    auto projection = typeDefinitionForProjection(Projection::PlaceholderGroup, index);
+    auto projection = typeDefinitionForProjection(Projection::PlaceholderGroup, projectionIndex);
 
     {
         Locker locker { info.m_lock };
-
-        if (!info.m_placeholders.contains(projection))
-            info.m_placeholders.add(projection);
+        info.m_placeholders.add(projection);
     }
 
     return projection;
@@ -1026,7 +1035,7 @@ RefPtr<RTT> TypeInformation::canonicalRTTForType(TypeIndex type)
         ASSERT(superRTT.has_value());
         DisplayCount displaySize = superRTT.value()->displaySize() + 1;
 
-        protector = RTT::tryCreateRTT(kind, displaySize);
+        protector = RTT::tryCreate(kind, displaySize);
         RELEASE_ASSERT(protector);
 
         protector->setDisplayEntry(0, superRTT.value());
@@ -1036,7 +1045,7 @@ RefPtr<RTT> TypeInformation::canonicalRTTForType(TypeIndex type)
         return protector;
     }
 
-    protector = RTT::tryCreateRTT(kind, 0);
+    protector = RTT::tryCreate(kind, 0);
     RELEASE_ASSERT(protector);
     return protector;
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -68,7 +68,7 @@ void JSWebAssemblyException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(cell, visitor);
 
     auto* exception = jsCast<JSWebAssemblyException*>(cell);
-    const auto& tagType = exception->tag().type();
+    SUPPRESS_UNCOUNTED_LOCAL const auto& tagType = exception->tag().type();
     unsigned offset = 0;
     for (unsigned i = 0; i < tagType.argumentCount(); ++i) {
         if (isRefType(tagType.argumentType(i)))
@@ -90,7 +90,7 @@ JSValue JSWebAssemblyException::getArg(JSGlobalObject* globalObject, unsigned i)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    const auto& tagType = tag().type();
+    SUPPRESS_UNCOUNTED_LOCAL const auto& tagType = tag().type();
     ASSERT(i < tagType.argumentCount());
 
     auto argTypeKind = tagType.argumentType(i).kind;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -50,7 +50,7 @@ JSWebAssemblyStruct::JSWebAssemblyStruct(VM& vm, WebAssemblyGCStructure* structu
 
 JSWebAssemblyStruct* JSWebAssemblyStruct::tryCreate(VM& vm, WebAssemblyGCStructure* structure)
 {
-    auto* structType = structure->typeDefinition().as<Wasm::StructType>();
+    SUPPRESS_UNCOUNTED_LOCAL auto* structType = structure->typeDefinition().as<Wasm::StructType>();
     auto* cell = tryAllocateCell<JSWebAssemblyStruct>(vm, TrailingArrayType::allocationSize(structType->instancePayloadSize()));
     if (!cell) [[unlikely]]
         return nullptr;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.cpp
@@ -131,7 +131,7 @@ bool WebAssemblyCompileOptions::validateImportForBuiltinSetNames(const Wasm::Imp
     Ref<const Wasm::TypeDefinition> type = Wasm::TypeInformation::get(typeIndex);
     if (!type->is<Wasm::FunctionSignature>())
         return false;
-    auto* importSig = type->as<Wasm::FunctionSignature>();
+    SUPPRESS_UNCOUNTED_LOCAL auto* importSig = type->as<Wasm::FunctionSignature>();
 
     return builtinSig.check(*importSig);
 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -57,7 +57,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globa
     if (&tag->tag() == &Wasm::Tag::jsExceptionTag()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "WebAssembly.Exception constructor does not accept WebAssembly.JSTag"_s);
 
-    const auto& tagFunctionType = tag->type();
+    SUPPRESS_UNCOUNTED_LOCAL const auto& tagFunctionType = tag->type();
     MarkedArgumentBuffer values;
     values.ensureCapacity(tagFunctionType.argumentCount());
     forEachInIterable(globalObject, tagParameters, [&] (VM&, JSGlobalObject*, JSValue nextValue) {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -121,7 +121,7 @@ static JSObject* createTypeReflectionObject(JSGlobalObject* globalObject, JSWebA
         typeObj = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
 
         Wasm::TypeIndex typeIndex = module->moduleInformation().typeIndexFromFunctionIndexSpace(Wasm::FunctionSpaceIndex(impOrExp.kindIndex));
-        const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
+        SUPPRESS_UNCOUNTED_LOCAL const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
 
         JSArray* functionParametersTypes = constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(throwScope, { });

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp
@@ -49,7 +49,7 @@ WebAssemblyWrapperFunction* WebAssemblyWrapperFunction::create(VM& vm, JSGlobalO
     ASSERT_WITH_MESSAGE(!function->inherits<WebAssemblyWrapperFunction>(), "We should never double wrap a wrapper function.");
 
     String name = emptyString();
-    const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
+    SUPPRESS_UNCOUNTED_LOCAL const auto& signature = Wasm::TypeInformation::getFunctionSignature(typeIndex);
     NativeExecutable* executable = nullptr;
     if (signature.argumentsOrResultsIncludeV128() || signature.argumentsOrResultsIncludeExnref()) [[unlikely]]
         executable = vm.getHostFunction(callWebAssemblyWrapperFunctionIncludingInvalidValues, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, name);


### PR DESCRIPTION
#### dc1ef6a78206884b6ef022cc4e71497e4cb9e8d2
<pre>
[JSC] Do not use Variant for each of TypeDefinition kind
<a href="https://bugs.webkit.org/show_bug.cgi?id=297407">https://bugs.webkit.org/show_bug.cgi?id=297407</a>
<a href="https://rdar.apple.com/158334942">rdar://158334942</a>

Reviewed by Justin Michaud and Keith Miller.

FunctionSignature etc. must be just a derived type of TypeDefinition.
There is no reason having Variant and making code much more unsafe and
complicated. This patch just makes FunctionSignature, StructType etc. as
a derived type of TypeDefinition. We can do further more clean up in
various places. But this patch starts doing this clean up in WasmTypeDefinition.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/runtime/IteratorOperations.h:
(JSC::forEachInFastArray):
(JSC::forEachInIterationRecord):
(JSC::forEachInIterable):
(JSC::forEachInIteratorProtocol):
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::WasmCallingConvention::callInformationFor const):
(JSC::Wasm::JSCallingConvention::callInformationFor const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addArguments):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::dump const):
(JSC::Wasm::FunctionSignature::FunctionSignature):
(JSC::Wasm::StructType::StructType):
(JSC::Wasm::ArrayType::ArrayType):
(JSC::Wasm::RecursionGroup::RecursionGroup):
(JSC::Wasm::Projection::Projection):
(JSC::Wasm::Projection::dump const):
(JSC::Wasm::Subtype::Subtype):
(JSC::Wasm::Subtype::cleanup):
(JSC::Wasm::RecursionGroup::cleanup):
(JSC::Wasm::computeStructTypeHash):
(JSC::Wasm::computeRecursionGroupHash):
(JSC::Wasm::computeProjectionHash):
(JSC::Wasm::computeSubtypeHash):
(JSC::Wasm::TypeDefinition::hash const):
(JSC::Wasm::FunctionSignature::tryCreate):
(JSC::Wasm::StructType::tryCreate):
(JSC::Wasm::ArrayType::tryCreate):
(JSC::Wasm::RecursionGroup::tryCreate):
(JSC::Wasm::Projection::tryCreate):
(JSC::Wasm::Subtype::tryCreate):
(JSC::Wasm::TypeDefinition::substitute):
(JSC::Wasm::substituteParent):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::TypeDefinition::unrollSlow const):
(JSC::Wasm::RTT::tryCreate):
(JSC::Wasm::TypeInformation::signatureForJSException):
(JSC::Wasm::FunctionParameterTypes::translate):
(JSC::Wasm::StructParameterTypes::hash):
(JSC::Wasm::StructParameterTypes::equal):
(JSC::Wasm::StructParameterTypes::translate):
(JSC::Wasm::ArrayParameterTypes::translate):
(JSC::Wasm::RecursionGroupParameterTypes::hash):
(JSC::Wasm::RecursionGroupParameterTypes::translate):
(JSC::Wasm::ProjectionParameterTypes::hash):
(JSC::Wasm::ProjectionParameterTypes::equal):
(JSC::Wasm::ProjectionParameterTypes::translate):
(JSC::Wasm::SubtypeParameterTypes::hash):
(JSC::Wasm::SubtypeParameterTypes::translate):
(JSC::Wasm::TypeInformation::TypeInformation):
(JSC::Wasm::TypeInformation::typeDefinitionForFunction):
(JSC::Wasm::TypeInformation::typeDefinitionForStruct):
(JSC::Wasm::TypeInformation::typeDefinitionForArray):
(JSC::Wasm::TypeInformation::typeDefinitionForRecursionGroup):
(JSC::Wasm::TypeInformation::typeDefinitionForProjection):
(JSC::Wasm::TypeInformation::typeDefinitionForSubtype):
(JSC::Wasm::TypeInformation::getPlaceholderProjection):
(JSC::Wasm::TypeInformation::canonicalRTTForType):
(JSC::Wasm::TypeDefinition::tryCreateFunctionSignature): Deleted.
(JSC::Wasm::TypeDefinition::tryCreateStructType): Deleted.
(JSC::Wasm::TypeDefinition::tryCreateArrayType): Deleted.
(JSC::Wasm::TypeDefinition::tryCreateRecursionGroup): Deleted.
(JSC::Wasm::TypeDefinition::tryCreateProjection): Deleted.
(JSC::Wasm::TypeDefinition::tryCreateSubtype): Deleted.
(JSC::Wasm::RTT::tryCreateRTT): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::TypeDefinition::is const):
(JSC::Wasm::TypeDefinition::as):
(JSC::Wasm::TypeDefinition::as const):
(JSC::Wasm::TypeDefinition::operator== const):
(JSC::Wasm::TypeDefinition::unroll const):
(JSC::Wasm::TypeDefinition::unownedIndex const):
(JSC::Wasm::TypeDefinition::TypeDefinition):
(JSC::Wasm:: const):
(JSC::Wasm::FunctionSignature::argumentCount const): Deleted.
(JSC::Wasm::FunctionSignature::returnCount const): Deleted.
(JSC::Wasm::FunctionSignature::hasRecursiveReference const): Deleted.
(JSC::Wasm::FunctionSignature::setHasRecursiveReference): Deleted.
(JSC::Wasm::FunctionSignature::returnType const): Deleted.
(JSC::Wasm::FunctionSignature::returnsVoid const): Deleted.
(JSC::Wasm::FunctionSignature::argumentType const): Deleted.
(JSC::Wasm::FunctionSignature::argumentsOrResultsIncludeI64 const): Deleted.
(JSC::Wasm::FunctionSignature::setArgumentsOrResultsIncludeI64): Deleted.
(JSC::Wasm::FunctionSignature::argumentsOrResultsIncludeV128 const): Deleted.
(JSC::Wasm::FunctionSignature::setArgumentsOrResultsIncludeV128): Deleted.
(JSC::Wasm::FunctionSignature::argumentsOrResultsIncludeExnref const): Deleted.
(JSC::Wasm::FunctionSignature::setArgumentsOrResultsIncludeExnref): Deleted.
(JSC::Wasm::FunctionSignature::numVectors const): Deleted.
(JSC::Wasm::FunctionSignature::numReturnVectors const): Deleted.
(JSC::Wasm::FunctionSignature::hasReturnVector const): Deleted.
(JSC::Wasm::FunctionSignature::operator== const): Deleted.
(JSC::Wasm::FunctionSignature::getReturnType): Deleted.
(JSC::Wasm::FunctionSignature::getArgumentType): Deleted.
(JSC::Wasm::FunctionSignature::storage): Deleted.
(JSC::Wasm::FunctionSignature::storage const): Deleted.
(JSC::Wasm::StructType::fieldCount const): Deleted.
(JSC::Wasm::StructType::field const): Deleted.
(JSC::Wasm::StructType::hasRefFieldTypes const): Deleted.
(JSC::Wasm::StructType::hasRecursiveReference const): Deleted.
(JSC::Wasm::StructType::setHasRecursiveReference): Deleted.
(JSC::Wasm::StructType::getField): Deleted.
(JSC::Wasm::StructType::storage): Deleted.
(JSC::Wasm::StructType::storage const): Deleted.
(JSC::Wasm::StructType::offsetOfFieldInPayload const): Deleted.
(JSC::Wasm::StructType::instancePayloadSize const): Deleted.
(JSC::Wasm::StructType::fieldOffsetFromInstancePayload): Deleted.
(JSC::Wasm::ArrayType::ArrayType): Deleted.
(JSC::Wasm::ArrayType::elementType const): Deleted.
(JSC::Wasm::ArrayType::hasRecursiveReference const): Deleted.
(JSC::Wasm::ArrayType::setHasRecursiveReference): Deleted.
(JSC::Wasm::ArrayType::getElementType): Deleted.
(JSC::Wasm::ArrayType::storage): Deleted.
(JSC::Wasm::ArrayType::storage const): Deleted.
(JSC::Wasm::RecursionGroup::RecursionGroup): Deleted.
(JSC::Wasm::RecursionGroup::typeCount const): Deleted.
(JSC::Wasm::RecursionGroup::type const): Deleted.
(JSC::Wasm::RecursionGroup::getType): Deleted.
(JSC::Wasm::RecursionGroup::storage): Deleted.
(JSC::Wasm::RecursionGroup::storage const): Deleted.
(JSC::Wasm::Projection::Projection): Deleted.
(JSC::Wasm::Projection::recursionGroup const): Deleted.
(JSC::Wasm::Projection::index const): Deleted.
(JSC::Wasm::Projection::getRecursionGroup): Deleted.
(JSC::Wasm::Projection::getIndex): Deleted.
(JSC::Wasm::Projection::storage): Deleted.
(JSC::Wasm::Projection::storage const): Deleted.
(JSC::Wasm::Projection::isPlaceholder const): Deleted.
(JSC::Wasm::Subtype::Subtype): Deleted.
(JSC::Wasm::Subtype::supertypeCount const): Deleted.
(JSC::Wasm::Subtype::isFinal const): Deleted.
(JSC::Wasm::Subtype::firstSuperType const): Deleted.
(JSC::Wasm::Subtype::superType const): Deleted.
(JSC::Wasm::Subtype::underlyingType const): Deleted.
(JSC::Wasm::Subtype::getSuperType): Deleted.
(JSC::Wasm::Subtype::getUnderlyingType): Deleted.
(JSC::Wasm::Subtype::storage): Deleted.
(JSC::Wasm::Subtype::storage const): Deleted.
(JSC::Wasm::TypeDefinition::payload): Deleted.
(JSC::Wasm::TypeDefinition::allocatedFunctionSize): Deleted.
(JSC::Wasm::TypeDefinition::allocatedStructSize): Deleted.
(JSC::Wasm::TypeDefinition::allocatedArraySize): Deleted.
(JSC::Wasm::TypeDefinition::allocatedRecursionGroupSize): Deleted.
(JSC::Wasm::TypeDefinition::allocatedProjectionSize): Deleted.
(JSC::Wasm::TypeDefinition::allocatedSubtypeSize): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp:
(JSC::JSWebAssemblyException::visitChildrenImpl):
(JSC::JSWebAssemblyException::getArg const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::tryCreate):
* Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.cpp:
(JSC::WebAssemblyCompileOptions::validateImportForBuiltinSetNames const):
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::createTypeReflectionObject):
* Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.cpp:
(JSC::WebAssemblyWrapperFunction::create):

Canonical link: <a href="https://commits.webkit.org/298730@main">https://commits.webkit.org/298730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5904e602803a5542adbc1d9cfb1387cbb3117612

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116502 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122559 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68915 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/22617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66240 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/108612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/98767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22776 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115030 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32586 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43761 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100718 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20177 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18598 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48875 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143728 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37014 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->