### PR TITLE
OrderedHashTable addImpl should only increment the alive entry count if no exception takes place

### DIFF
--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -439,18 +439,18 @@ public:
         Storage* candidate = expandIfNeeded(globalObject, owner, base);
         RETURN_IF_EXCEPTION(scope, void());
 
-        Storage& candidateRef = *candidate;
-        TableSize capacity = Helper::capacity(candidateRef);
-        Entry newEntry = usedCapacity(candidateRef);
-        TableIndex newEntryKeyIndex = entryDataStartIndex(dataTableStartIndex(capacity), newEntry);
-        incrementAliveEntryCount(candidateRef);
-
         bool firstAliveEntry = result.normalizedKey.isEmpty();
         if (firstAliveEntry) [[unlikely]] {
             result.normalizedKey = normalizeMapKey(key);
             result.hash = jsMapHash(globalObject, vm, result.normalizedKey);
             RETURN_IF_EXCEPTION(scope, void());
         }
+
+        Storage& candidateRef = *candidate;
+        TableSize capacity = Helper::capacity(candidateRef);
+        Entry newEntry = usedCapacity(candidateRef);
+        TableIndex newEntryKeyIndex = entryDataStartIndex(dataTableStartIndex(capacity), newEntry);
+        incrementAliveEntryCount(candidateRef);
 
         bool rehashed = &base != candidate;
         if (rehashed || firstAliveEntry) [[unlikely]]


### PR DESCRIPTION
#### a05032c6961001c252d02445bd513060f09b360b
<pre>
OrderedHashTable addImpl should only increment the alive entry count if no exception takes place
<a href="https://bugs.webkit.org/show_bug.cgi?id=293579">https://bugs.webkit.org/show_bug.cgi?id=293579</a>
<a href="https://rdar.apple.com/152034907">rdar://152034907</a>

Reviewed by Yusuke Suzuki.

If an exception is thrown while we are calculating the normalized key, we
will end up in a state where we have incremented aliveEntryCount, but the
map will not actually have an element added. We should only increment the
aliveEntryCount if we successfully add an element to the map.

* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::addImpl):

Originally-landed-as: 289651.538@safari-7621-branch (44dd2c945c05). <a href="https://rdar.apple.com/157790926">rdar://157790926</a>
Canonical link: <a href="https://commits.webkit.org/298709@main">https://commits.webkit.org/298709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d58f697149782ce8cd94c66e62133dc0eb132c60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122440 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66944 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88395 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68829 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22515 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66121 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108493 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125589 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114911 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97105 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96900 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20087 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39231 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43165 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48756 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143609 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42631 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36990 "Found 1 new JSC stress test failure: wasm.yaml/wasm/v8/import-function.js.wasm-bbq-no-consts (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->