### PR TITLE
com.apple.WebKit.WebContent use-after-free crash at libwebrtc.dylib:  dcsctp::TransmissionControlBlock::SendBufferedPackets

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/tx/outstanding_data.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/tx/outstanding_data.cc
@@ -286,6 +286,17 @@ bool OutstandingData::NackItem(UnwrappedTSN tsn,
   return true;
 }
 
+auto OutstandingData::enqueueItem(std::deque<Item>& deque, const Item& item) -> Item&
+{
+    Data message_end(item.data().stream_id, item.data().ssn, item.data().mid,
+                     item.data().fsn, item.data().ppid, std::vector<uint8_t>(),
+                     Data::IsBeginning(false), Data::IsEnd(true),
+                     item.data().is_unordered);
+    return deque.emplace_back(
+        item.message_id(), std::move(message_end), Timestamp::Zero(),
+        MaxRetransmits(0), Timestamp::PlusInfinity(), LifecycleId::NotSet());
+}
+
 void OutstandingData::AbandonAllFor(const Item& item) {
   // Erase all remaining chunks from the producer, if any.
   if (discard_from_send_queue_(item.data().stream_id, item.message_id())) {
@@ -297,14 +308,8 @@ void OutstandingData::AbandonAllFor(const Item& item) {
     // skipped over). So create a new fragment, representing the end, that the
     // received will never see as it is abandoned immediately and used as cum
     // TSN in the sent FORWARD-TSN.
-    Data message_end(item.data().stream_id, item.data().ssn, item.data().mid,
-                     item.data().fsn, item.data().ppid, std::vector<uint8_t>(),
-                     Data::IsBeginning(false), Data::IsEnd(true),
-                     item.data().is_unordered);
     UnwrappedTSN tsn = next_tsn();
-    Item& added_item = outstanding_data_.emplace_back(
-        item.message_id(), std::move(message_end), Timestamp::Zero(),
-        MaxRetransmits(0), Timestamp::PlusInfinity(), LifecycleId::NotSet());
+    Item& added_item = enqueueItem(outstanding_data_, item);
 
     // The added chunk shouldn't be included in `unacked_bytes`, so set it
     // as acked.
@@ -393,6 +398,7 @@ std::vector<std::pair<TSN, Data>> OutstandingData::GetChunksToBeRetransmitted(
 
 void OutstandingData::ExpireOutstandingChunks(Timestamp now) {
   UnwrappedTSN tsn = last_cumulative_tsn_ack_;
+  std::deque<Item> to_be_abandoned;
   for (const Item& item : outstanding_data_) {
     tsn.Increment();
     // Chunks that are nacked can be expired. Care should be taken not to expire
@@ -401,15 +407,19 @@ void OutstandingData::ExpireOutstandingChunks(Timestamp now) {
     if (item.is_abandoned()) {
       // Already abandoned.
     } else if (item.is_nacked() && item.has_expired(now)) {
-      RTC_DLOG(LS_VERBOSE) << "Marking nacked chunk " << *tsn.Wrap()
-                           << " and message " << *item.data().mid
-                           << " as expired";
-      AbandonAllFor(item);
+      RTC_DLOG(LS_VERBOSE) << "Will mark nacked chunk " << *tsn.Wrap()
+                             << " and message " << *item.data().mid
+                             << " as expired";
+      enqueueItem(to_be_abandoned, item);
     } else {
       // A non-expired chunk. No need to iterate any further.
       break;
     }
   }
+  for (const Item& item : to_be_abandoned) {
+    AbandonAllFor(item);
+  }
+
   RTC_DCHECK(IsConsistent());
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/tx/outstanding_data.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/tx/outstanding_data.h
@@ -352,6 +352,8 @@ class OutstandingData {
 
   bool IsConsistent() const;
 
+  static Item& enqueueItem(std::deque<Item>&, const Item&);
+
   // The size of the data chunk (DATA/I-DATA) header that is used.
   const size_t data_chunk_header_size_;
   // The last cumulative TSN ack number.


### PR DESCRIPTION
#### 96745ccf6bd5864a129ca805c99acbad073f07e3
<pre>
com.apple.WebKit.WebContent use-after-free crash at libwebrtc.dylib:  dcsctp::TransmissionControlBlock::SendBufferedPackets
<a href="https://rdar.apple.com/150587630">rdar://150587630</a>

Reviewed by David Kilzer.

Instead of modifying outstanding_data_ while iterating it, we iterate outstanding_data_ and put copies of its Items to be processed in a separate deque.
We then iterate through the vector to do the processing.
We add an enqueue routine to share code between the two places where outstanding_data_ is iterated/modified.

* Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/tx/outstanding_data.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/net/dcsctp/tx/outstanding_data.h:

Originally-landed-as: 289651.536@safari-7621-branch (c609e634bb2f). <a href="https://rdar.apple.com/157791161">rdar://157791161</a>
Canonical link: <a href="https://commits.webkit.org/298910@main">https://commits.webkit.org/298910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1207f345457ae308a2188a1bf80db2f0f89045b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66955 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44643 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42872 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69401 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22520 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66132 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125600 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97107 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96902 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20092 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43176 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42642 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->