### PR TITLE
Paint text-decoration-line: spelling-error

### DIFF
--- a/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-1-expected.html
+++ b/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-1-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html lang="en">
+<meta charset="UTF-8">
+<style>
+div {
+  font-size: 300%;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+if (window.internals)
+  internals.setContinuousSpellCheckingEnabled(true);
+
+function runTest()
+{
+  const target = document.getElementById("target");
+  const misspelledText = "A txet sample";
+  target.focus();
+  document.execCommand("insertText", false, misspelledText);
+  // Add a word separator so that both spelling and grammar markers will appear.
+  document.execCommand("InsertText", false, " ");
+  document.execCommand("Delete", false);
+  target.blur();
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+</script>
+<body>
+<div contenteditable="true" id="target"></div>
+<script>
+UIHelper.setSpellCheckerResults({
+  "A txet sample" : [
+    { type: "spelling", from: 2, to : 6}
+  ]
+}).then(runTest);
+</script>
+</body>

--- a/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-1.html
+++ b/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-1.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="UTF-8">
+<meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-114" />
+<style>
+div {
+  font-size: 300%;
+}
+
+.spelling-error {
+  text-decoration: spelling-error;
+}
+</style>
+
+</script>
+<body>
+<div>A <span class="spelling-error">txet</span> sample</div>
+</body>

--- a/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-2-expected.html
+++ b/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-2-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html lang="en">
+<meta charset="UTF-8">
+<style>
+div {
+  font-size: 300%;
+}
+#target {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-color: blue;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+if (window.internals)
+  internals.setContinuousSpellCheckingEnabled(true);
+
+function runTest()
+{
+  const target = document.getElementById("target");
+  const misspelledText = "txet";
+  target.focus();
+  document.execCommand("InsertText", false, misspelledText);
+  // Add a word separator so that spelling markers will appear.
+  document.execCommand("InsertText", false, " ");
+  document.execCommand("Delete", false);
+  target.blur();
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+</script>
+<body>
+<div contenteditable="true" id="target"></div>
+<script>runTest()</script>
+</body>

--- a/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-2.html
+++ b/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-2.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html lang="en">
+<meta charset="UTF-8">
+<style>
+div {
+  font-size: 300%;
+}
+#target {
+  text-decoration-line: spelling-error;
+  text-decoration-style: wavy;
+  text-decoration-color: red;
+}
+div::spelling-error {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-color: blue;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+if (window.internals)
+  internals.setContinuousSpellCheckingEnabled(true);
+
+function runTest()
+{
+  const target = document.getElementById("target");
+  const misspelledText = "txet";
+  target.focus();
+  document.execCommand("InsertText", false, misspelledText);
+  // Add a word separator so that spelling markers will appear.
+  document.execCommand("InsertText", false, " ");
+  document.execCommand("Delete", false);
+  target.blur();
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+</script>
+<body>
+<div contenteditable="true" id="target"></div>
+<script>runTest()</script>
+</body>

--- a/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-3-expected.html
+++ b/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-3-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html lang="en">
+<meta charset="UTF-8">
+<style>
+div {
+  font-size: 300%;
+}
+#target {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-color: green;
+}
+</style>
+
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+if (window.internals)
+  internals.setContinuousSpellCheckingEnabled(true);
+
+function runTest()
+{
+  const target = document.getElementById("target");
+  const misspelledText = "A txet sample";
+  target.focus();
+  document.execCommand("insertText", false, misspelledText);
+  // Add a word separator so that spelling markers will appear.
+  document.execCommand("InsertText", false, " ");
+  document.execCommand("Delete", false);
+  target.blur();
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+</script>
+<body>
+<div contenteditable="true" id="target"></div>
+<script>runTest()</script>
+</body>

--- a/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-3.html
+++ b/LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-3.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="UTF-8">
+<meta name="fuzzy" content="maxDifference=0-90; totalPixels=0-96" />
+<style>
+div {
+  font-size: 300%;
+}
+
+.spelling-error {
+  text-decoration: spelling-error;
+}
+div::first-line {
+  text-decoration: underline green;
+}
+</style>
+
+</script>
+<body>
+<div>A <span class="spelling-error">txet</span> sample</div>
+</body>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4567,3 +4567,7 @@ imported/w3c/web-platform-tests/css/css-mixins/function-attr.html [ Failure ]
 webgl/2.0.y/conformance2/wasm/teximage2d-2gb-in-4gb-wasm-memory.html [ Skip ]
 # Flaky crash due to running out of commit space
 workers/btoa-oom.html [ Skip ]
+
+webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-1.html [ Skip ]
+webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-2.html [ Skip ]
+webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-3.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1386,3 +1386,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/start-view-transtion-sk
 
 # Not supported on this platform.
 security/contentSecurityPolicy/plugins-types-allows-youtube-plugin-replacement.html [ Skip ]
+
+webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-1.html [ Skip ]
+webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-2.html [ Skip ]
+webkit.org/b/298727 css3/text-decoration/text-decoration-line-spelling-error-3.html [ Skip ]

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1414,3 +1414,7 @@ ins, del {
 :root:lang(zh), [lang|=zh] {
     text-underline-position: left;
 }
+
+:root::spelling-error {
+    text-decoration-line: spelling-error;
+}


### PR DESCRIPTION
#### adddeadab02a659a7217801e5095fc08d994a4b0
<pre>
Paint text-decoration-line: spelling-error
<a href="https://bugs.webkit.org/show_bug.cgi?id=297412">https://bugs.webkit.org/show_bug.cgi?id=297412</a>
<a href="https://rdar.apple.com/158343332">rdar://158343332</a>

Reviewed by Aditya Keerthi.

- Paint spelling-error decoration for an element which effective text-decoration-line
(textDecorationLineInEffect) style is set to &apos;spelling-error&apos;

- SpellingError marked text that is styled via ::spelling-error is removed from being
painted as a marker, such that it is painted as regular text-decoration (TextDecorationPainter),
honoring the style set,  unless its text-decoration-line is spelling-error itself.
In the latter case we should paint decoration with our native spelling error markers.

* LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-1-expected.html: Added.
* LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-1.html: Added.
* LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-2-expected.html: Added.
* LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-2.html: Added.
* LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-3-expected.html: Added.
* LayoutTests/css3/text-decoration/text-decoration-line-spelling-error-3.html: Added.
* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/css/html.css:
(:root::spelling-error):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::removeMarkersPaintedByTextDecorationPainter):
(WebCore::markedTextForTextDecorationLine):
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers):

Canonical link: <a href="https://commits.webkit.org/299864@main">https://commits.webkit.org/299864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11cfc5eaceeb025d2d8eba656f0c8fd30abd0478

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/120469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/40163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72544 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5727dcdc-5aae-4f32-b152-68264537baf1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/122345 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ac5f096-b44b-43d9-ae84-8d8359733ca4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/123421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/72044 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0fcef8f-3899-4afb-ba4d-6ccf2e362a0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26091 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/70461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/102114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/26272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/47390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/100113 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/104166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/44038 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/47252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52957 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46720 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/50067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/48407 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->