### PR TITLE
[masonry] Update MasonryEnabled to ItemPackCollapseDisplayGridEnabled

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3996,6 +3996,20 @@ IsThirdPartyCookieBlockingDisabled:
     WebCore:
       default: false
 
+ItemPackCollapseDisplayGridEnabled:
+  type: bool
+  status: preview
+  category: css
+  humanReadableName: "CSS Item Pack Collapse (display: grid)"
+  humanReadableDescription: "Enable CSS Item Pack Collapse for CSS Grid"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ItpDebugModeEnabled:
   type: bool
@@ -4609,20 +4623,6 @@ ManagedMediaSourceNeedsAirPlay:
       default: false
     WebKit:
       default: WebKit::defaultManagedMediaSourceNeedsAirPlay()
-    WebCore:
-      default: false
-
-MasonryEnabled:
-  type: bool
-  status: preview
-  category: css
-  humanReadableName: "CSS Masonry Layout"
-  humanReadableDescription: "Enable Masonry Layout for CSS Grid"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
     WebCore:
       default: false
 

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -87,7 +87,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     , cssTransformStyleSeparatedEnabled { document.settings().cssTransformStyleSeparatedEnabled() }
 #endif
-    , masonryEnabled { document.settings().masonryEnabled() }
+    , itemPackCollapseDisplayGridEnabled { document.settings().itemPackCollapseDisplayGridEnabled() }
     , cssAppearanceBaseEnabled { document.settings().cssAppearanceBaseEnabled() }
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
     , cssShapeFunctionEnabled { document.settings().cssShapeFunctionEnabled() }
@@ -129,7 +129,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         | context.cssTransformStyleSeparatedEnabled         << 5
 #endif
-        | context.masonryEnabled                            << 6
+        | context.itemPackCollapseDisplayGridEnabled        << 6
         | context.cssAppearanceBaseEnabled                  << 7
         | context.cssPaintingAPIEnabled                     << 8
         | context.cssShapeFunctionEnabled                   << 9

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -60,7 +60,7 @@ struct CSSParserContext {
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool cssTransformStyleSeparatedEnabled : 1 { false };
 #endif
-    bool masonryEnabled : 1 { false };
+    bool itemPackCollapseDisplayGridEnabled : 1 { false };
     bool cssAppearanceBaseEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssShapeFunctionEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -340,7 +340,7 @@ static bool consumeSubgridNameRepeatFunction(CSSParserTokenRange& range, CSS::Pr
 
 RefPtr<CSSValue> consumeGridTrackList(CSSParserTokenRange& range, CSS::PropertyParserState& state, TrackListType trackListType)
 {
-    if (state.context.masonryEnabled && range.peek().id() == CSSValueMasonry)
+    if (state.context.itemPackCollapseDisplayGridEnabled && range.peek().id() == CSSValueMasonry)
         return consumeIdent(range);
 
     bool seenAutoRepeat = false;
@@ -405,7 +405,7 @@ RefPtr<CSSValue> consumeGridTemplatesRowsOrColumns(CSSParserTokenRange& range, C
 
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
-    if (state.context.masonryEnabled && range.peek().id() == CSSValueMasonry)
+    if (state.context.itemPackCollapseDisplayGridEnabled && range.peek().id() == CSSValueMasonry)
         return consumeIdent(range);
     return consumeGridTrackList(range, state, GridTemplate);
 }


### PR DESCRIPTION
#### e2416175cc20a1229e914af2d9545045de61c43c
<pre>
[masonry] Update MasonryEnabled to ItemPackCollapseDisplayGridEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=297413">https://bugs.webkit.org/show_bug.cgi?id=297413</a>
<a href="https://rdar.apple.com/157690167">rdar://157690167</a>

Reviewed by Sammy Gill.

The masonry feature is now known as item-pack: collapse.
<a href="https://webkit.org/blog/16587/item-flow-part-1-a-new-unified-concept-for-layout/">https://webkit.org/blog/16587/item-flow-part-1-a-new-unified-concept-for-layout/</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
(WebCore::CSSPropertyParserHelpers::consumeGridTrackList):
(WebCore::CSSPropertyParserHelpers::consumeGridTemplatesRowsOrColumns):

Canonical link: <a href="https://commits.webkit.org/298738@main">https://commits.webkit.org/298738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b46c2d731f98837acc0c359ccaa05f180d6b45e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67044 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88453 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42923 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68896 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66219 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108591 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125687 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115009 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97160 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20159 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39329 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48854 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143707 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42729 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37007 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->