### PR TITLE
Add VMTraps stop-the-world using stack checks [Interpreters only for now]

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1325,6 +1325,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/StableSort.h
     runtime/StackAlignment.h
     runtime/StackFrame.h
+    runtime/StackManager.h
+    runtime/StackManagerInlines.h
     runtime/StringIteratorPrototype.h
     runtime/StringObject.h
     runtime/StringPrototype.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2152,9 +2152,11 @@
 		FE265F202C02D39100997B07 /* AssertInvariants.h in Headers */ = {isa = PBXBuildFile; fileRef = FE265F1E2C02D39100997B07 /* AssertInvariants.h */; };
 		FE287D02252FB2E800D723F9 /* VerifierSlotVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = FE287D01252FB2E800D723F9 /* VerifierSlotVisitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE2A87601F02381600EB31B2 /* MinimumReservedZoneSize.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2A875F1F02381600EB31B2 /* MinimumReservedZoneSize.h */; };
+		FE2BCD5F2E4AF67C005FE224 /* StackManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2BCD5D2E4AF65A005FE224 /* StackManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE2CC9302756B2B9003F5AB8 /* HeapSubspaceTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2CC92F2756B2B9003F5AB8 /* HeapSubspaceTypes.h */; };
 		FE2D0B382AE242B000A071A7 /* SideDataRepository.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2D0B362AE242AF00A071A7 /* SideDataRepository.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE3022D71E42857300BAC493 /* VMInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3022D51E42856700BAC493 /* VMInspector.h */; };
+		FE3040882E43E58D00E5087B /* StackManagerInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3040872E43E58D00E5087B /* StackManagerInlines.h */; };
 		FE336B5325DB497D0098F034 /* MarkingConstraintExecutorPair.h in Headers */ = {isa = PBXBuildFile; fileRef = FE336B5225DB497D0098F034 /* MarkingConstraintExecutorPair.h */; };
 		FE3422121D6B81C30032BE88 /* ThrowScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3422111D6B818C0032BE88 /* ThrowScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE34EE2124398AAE00AA2E7C /* EnsureStillAliveHere.h in Headers */ = {isa = PBXBuildFile; fileRef = FE34EE2024398A9A00AA2E7C /* EnsureStillAliveHere.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6047,6 +6049,8 @@
 		FE265F1F2C02D39100997B07 /* AssertInvariants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AssertInvariants.cpp; sourceTree = "<group>"; };
 		FE287D01252FB2E800D723F9 /* VerifierSlotVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VerifierSlotVisitor.h; sourceTree = "<group>"; };
 		FE2A875F1F02381600EB31B2 /* MinimumReservedZoneSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MinimumReservedZoneSize.h; sourceTree = "<group>"; };
+		FE2BCD5D2E4AF65A005FE224 /* StackManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StackManager.h; sourceTree = "<group>"; };
+		FE2BCD5E2E4AF65A005FE224 /* StackManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StackManager.cpp; sourceTree = "<group>"; };
 		FE2BD66E25C0DC8200999D3B /* VerifierSlotVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VerifierSlotVisitor.cpp; sourceTree = "<group>"; };
 		FE2CC92F2756B2B9003F5AB8 /* HeapSubspaceTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeapSubspaceTypes.h; sourceTree = "<group>"; };
 		FE2D0B352AE242AF00A071A7 /* SideDataRepository.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SideDataRepository.cpp; sourceTree = "<group>"; };
@@ -6054,6 +6058,7 @@
 		FE2E6A7A1D6EA5FE0060F896 /* ThrowScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThrowScope.cpp; sourceTree = "<group>"; };
 		FE3022D41E42856700BAC493 /* VMInspector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VMInspector.cpp; sourceTree = "<group>"; };
 		FE3022D51E42856700BAC493 /* VMInspector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMInspector.h; sourceTree = "<group>"; };
+		FE3040872E43E58D00E5087B /* StackManagerInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StackManagerInlines.h; sourceTree = "<group>"; };
 		FE336B5225DB497D0098F034 /* MarkingConstraintExecutorPair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarkingConstraintExecutorPair.h; sourceTree = "<group>"; };
 		FE3422111D6B818C0032BE88 /* ThrowScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThrowScope.h; sourceTree = "<group>"; };
 		FE34EE2024398A9A00AA2E7C /* EnsureStillAliveHere.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnsureStillAliveHere.h; sourceTree = "<group>"; };
@@ -8949,6 +8954,9 @@
 				0F3AC751183EA1040032029F /* StackAlignment.h */,
 				0F6DB7E71D6124B200CDBF8E /* StackFrame.cpp */,
 				0F6DB7E81D6124B200CDBF8E /* StackFrame.h */,
+				FE2BCD5E2E4AF65A005FE224 /* StackManager.cpp */,
+				FE2BCD5D2E4AF65A005FE224 /* StackManager.h */,
+				FE3040872E43E58D00E5087B /* StackManagerInlines.h */,
 				A730B6111250068F009D25B1 /* StrictEvalActivation.cpp */,
 				A730B6101250068F009D25B1 /* StrictEvalActivation.h */,
 				276B388C2A71D18700252F4E /* StrictEvalActivationInlines.h */,
@@ -11925,6 +11933,8 @@
 				E32EF01E2BD72AEF001675BA /* StableSort.h in Headers */,
 				0F3AC752183EA1040032029F /* StackAlignment.h in Headers */,
 				0F6DB7E91D6124B500CDBF8E /* StackFrame.h in Headers */,
+				FE2BCD5F2E4AF67C005FE224 /* StackManager.h in Headers */,
+				FE3040882E43E58D00E5087B /* StackManagerInlines.h in Headers */,
 				A7C1EAF217987AB600299DB2 /* StackVisitor.h in Headers */,
 				14DF04DA16B3996D0016A513 /* StaticPropertyAnalysis.h in Headers */,
 				14CA958B16AB50DE00938A06 /* StaticPropertyAnalyzer.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1041,6 +1041,7 @@ runtime/SimpleTypedArrayController.cpp
 runtime/SmallStrings.cpp
 runtime/SparseArrayValueMap.cpp
 runtime/StackFrame.cpp
+runtime/StackManager.cpp
 runtime/StrictEvalActivation.cpp
 runtime/StringConstructor.cpp
 runtime/StringIteratorPrototype.cpp

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -880,7 +880,7 @@ void Heap::gatherStackRoots(ConservativeRoots& roots)
 {
     m_machineThreads->gatherConservativeRoots(roots, *m_jitStubRoutines, *m_codeBlocks, m_currentThreadState, m_currentThread);
 #if ENABLE(C_LOOP)
-    vm().interpreter.cloopStack().gatherConservativeRoots(roots, *m_jitStubRoutines, *m_codeBlocks);
+    vm().cloopStack().gatherConservativeRoots(roots, *m_jitStubRoutines, *m_codeBlocks);
 #endif
 }
 

--- a/Source/JavaScriptCore/interpreter/CLoopStack.h
+++ b/Source/JavaScriptCore/interpreter/CLoopStack.h
@@ -39,6 +39,7 @@ namespace JSC {
     class CodeBlockSet;
     class ConservativeRoots;
     class JITStubRoutineSet;
+    class StackManager;
     class VM;
     class LLIntOffsetsExtractor;
 
@@ -76,6 +77,7 @@ namespace JSC {
         bool isSafeToRecurse() const;
 
     private:
+        StackManager& stackManager() const;
         VM& vm() const;
 
         Register* lowAddress() const

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Research In Motion Limited. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,10 +36,6 @@
 #include <JavaScriptCore/Opcode.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
-
-#if ENABLE(C_LOOP)
-#include <JavaScriptCore/CLoopStack.h>
-#endif
 
 
 namespace JSC {
@@ -134,11 +130,6 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
         Interpreter();
         ~Interpreter();
 
-#if ENABLE(C_LOOP)
-        CLoopStack& cloopStack() { return m_cloopStack; }
-        const CLoopStack& cloopStack() const { return m_cloopStack; }
-#endif
-        
         static inline JSC::Opcode getOpcode(OpcodeID);
 
         static inline OpcodeID getOpcodeID(JSC::Opcode);
@@ -179,10 +170,6 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
 #endif
 
         inline VM& vm();
-#if ENABLE(C_LOOP)
-        CLoopStack m_cloopStack;
-        friend class CLoopStack; // Only needed to enable CLoopStack::vm()'s implementation.
-#endif
         
 #if ENABLE(COMPUTED_GOTO_OPCODES)
 #if !ENABLE(LLINT_EMBEDDED_OPCODE_ID) || ASSERT_ENABLED

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -62,7 +62,6 @@ LLINT_SLOW_PATH_HIDDEN_DECL(entry_osr_function_for_call_arityCheck);
 LLINT_SLOW_PATH_HIDDEN_DECL(entry_osr_function_for_construct_arityCheck);
 LLINT_SLOW_PATH_HIDDEN_DECL(loop_osr);
 LLINT_SLOW_PATH_HIDDEN_DECL(replace);
-LLINT_SLOW_PATH_HIDDEN_DECL(stack_check);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_new_object);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_new_array);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_new_array_with_size);
@@ -160,9 +159,11 @@ LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_log_shadow_chicken_tail);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_out_of_line_jump_target);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_arityCheck);
 LLINT_SLOW_PATH_HIDDEN_DECL(slow_path_instanceof);
+
+extern "C" UGPRPair SYSV_ABI llint_check_stack_and_vm_traps(CallFrame*, const JSInstruction* pc, void* newStackPointer) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair SYSV_ABI llint_throw_stack_overflow_error(VM*, ProtoCallFrame*) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit(CallFrame* callFrame, EncodedJSValue unused) REFERENCED_FROM_ASM WTF_INTERNAL;
-extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame* callFrame, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit(CallFrame*, EncodedJSValue unused) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_slow_path_checkpoint_osr_exit_from_inlined_call(CallFrame*, EncodedJSValue callResult) REFERENCED_FROM_ASM WTF_INTERNAL;
 #if ENABLE(C_LOOP)
 extern "C" UGPRPair SYSV_ABI llint_stack_check_at_vm_entry(VM*, Register*) REFERENCED_FROM_ASM WTF_INTERNAL;
 #endif

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -271,6 +271,11 @@ const NoPtrTag = constexpr NoPtrTag
 # VMTraps data
 const VMTrapsAsyncEvents = constexpr VMTraps::AsyncEvents
 
+# VM offsets
+const VMTrapAwareSoftStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_trapAwareSoftStackLimit
+const VMCLoopStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_cloopStackLimit
+const VMSoftStackLimitOffset = VM::m_traps + VMTraps::m_stack + StackManager::m_softStackLimit
+
 # Some register conventions.
 # - We use a pair of registers to represent the PC: one register for the
 #   base of the bytecodes, and one register for the index.
@@ -1545,17 +1550,21 @@ if not ADDRESS64
     bpa t0, cfr, .needStackCheck
 end
     loadp CodeBlock::m_vm[t1], t2
-    if C_LOOP
-        bplteq VM::m_cloopStackLimit[t2], t0, .stackHeightOK
-    else
-        bplteq VM::m_softStackLimit[t2], t0, .stackHeightOK
-    end
+    bpbeq VMTrapAwareSoftStackLimitOffset[t2], t0, .stackHeightOK
 
 .needStackCheck:
     # Stack height check failed - need to call a slow_path.
     # Set up temporary stack pointer for call including callee saves
     subp maxFrameExtentForSlowPathCall, sp
-    callSlowPath(_llint_stack_check)
+
+    # Do the equivalent of callSlowPath() except with 3 arguments.
+    prepareStateForCCall()
+    move t0, a2
+    move cfr, a0
+    move PC, a1
+    cCall3(_llint_check_stack_and_vm_traps)
+    restoreStateAfterCCall()
+
     bpeq r1, 0, .stackHeightOKGetCodeBlock
 
     # We're throwing before the frame is fully set up. This frame will be

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -170,6 +170,7 @@ public:
     operator Register*() { return std::bit_cast<Register*>(m_value); }
     operator VM*() { return std::bit_cast<VM*>(m_value); }
     operator CallLinkInfo*() { return std::bit_cast<CallLinkInfo*>(m_value); }
+    operator void*() { return reinterpret_cast<void*>(m_value); }
 
     template<typename T, typename = std::enable_if_t<sizeof(T) == sizeof(uintptr_t)>>
     ALWAYS_INLINE void operator=(T value) { m_value = std::bit_cast<uintptr_t>(value); }
@@ -359,7 +360,7 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm, 
         void* m_originalStackPointer;
     };
 
-    CLoopStack& cloopStack = vm->interpreter.cloopStack();
+    CLoopStack& cloopStack = vm->cloopStack();
     StackPointerScope stackPointerScope(cloopStack);
 
     lr = getOpcode(llint_return_to_host);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -228,7 +228,7 @@ macro doVMEntry(makeCall)
     # and the frame for the JS code we're executing. We need to do this check
     # before we start copying the args from the protoCallFrame below.
     if C_LOOP
-        bpaeq t3, VM::m_cloopStackLimit[vm], .stackHeightOK
+        bpaeq t3, VMCLoopStackLimitOffset[vm], .stackHeightOK
         move entry, t4
         move vm, t5
         cloopCallSlowPath _llint_stack_check_at_vm_entry, vm, t3
@@ -242,7 +242,7 @@ macro doVMEntry(makeCall)
         move t5, vm
         jmp _llint_throw_stack_overflow_error_from_vm_entry
     else
-        bplteq t3, VM::m_softStackLimit[vm], _llint_throw_stack_overflow_error_from_vm_entry
+        bpbeq t3, VMSoftStackLimitOffset[vm], _llint_throw_stack_overflow_error_from_vm_entry
     end
 
 .stackHeightOK:
@@ -712,9 +712,9 @@ macro functionArityCheck(opcodeName, doneLabel)
     subp cfr, t3, t5
     loadp CodeBlock::m_vm[t1], t0
     if C_LOOP
-        bplteq VM::m_cloopStackLimit[t0], t5, .stackHeightOK
+        bpbeq VMCLoopStackLimitOffset[t0], t5, .stackHeightOK
     else
-        bplteq VM::m_softStackLimit[t0], t5, .stackHeightOK
+        bpbeq VMSoftStackLimitOffset[t0], t5, .stackHeightOK
     end
 
     prepareStateForCCall()

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2011-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -191,7 +191,7 @@ macro doVMEntry(makeCall)
     # and the frame for the JS code we're executing. We need to do this check
     # before we start copying the args from the protoCallFrame below.
     if C_LOOP
-        bpaeq t3, VM::m_cloopStackLimit[vm], .stackHeightOK
+        bpaeq t3, VMCLoopStackLimitOffset[vm], .stackHeightOK
         move entry, t4
         move vm, t5
         cloopCallSlowPath _llint_stack_check_at_vm_entry, vm, t3
@@ -207,7 +207,7 @@ macro doVMEntry(makeCall)
 .stackHeightOK:
         move t3, sp
     else
-        bplteq t3, VM::m_softStackLimit[vm],  _llint_throw_stack_overflow_error_from_vm_entry
+        bpbeq t3, VMSoftStackLimitOffset[vm],  _llint_throw_stack_overflow_error_from_vm_entry
         move t3, sp
     end
 
@@ -710,9 +710,9 @@ macro functionArityCheck(opcodeName, doneLabel)
     subp cfr, t3, t5
     loadp CodeBlock::m_vm[t1], t0
     if C_LOOP
-        bplteq VM::m_cloopStackLimit[t0], t5, .stackHeightOK
+        bpbeq VMCLoopStackLimitOffset[t0], t5, .stackHeightOK
     else
-        bplteq VM::m_softStackLimit[t0], t5, .stackHeightOK
+        bpbeq VMSoftStackLimitOffset[t0], t5, .stackHeightOK
     end
 
     prepareStateForCCall()

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -508,6 +508,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Unsigned, watchdog, 0, Normal, "watchdog timeout (0 = Disabled, N = a timeout period of N milliseconds)"_s) \
     v(Bool, usePollingTraps, false, Normal, "use polling (instead of signalling) VM traps"_s) \
+    v(Bool, forceTrapAwareStackChecks, false, Normal, "force trap ware stack checks to be taken for testing"_s) \
     \
     v(Bool, useMachForExceptions, true, Normal, "Use mach exceptions rather than signals to handle faults and pass thread messages. (This does nothing on platforms without mach)"_s) \
     v(Bool, allowNonSPTagging, true, Normal, "allow use of the pacib instruction instead of just pacibsp (This can break lldb/posix signals as it puts live data below SP)"_s) \

--- a/Source/JavaScriptCore/runtime/StackManager.cpp
+++ b/Source/JavaScriptCore/runtime/StackManager.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StackManager.h"
+
+#include "StackManagerInlines.h"
+
+namespace JSC {
+
+void StackManager::requestStop()
+{
+    Locker lock { m_mirrorLock };
+    m_trapAwareSoftStackLimit.storeRelaxed(stopRequestMarker());
+    for (auto& mirror : m_mirrors)
+        mirror.m_trapAwareSoftStackLimit.storeRelaxed(stopRequestMarker());
+}
+
+void StackManager::cancelStop()
+{
+    if (Options::forceTrapAwareStackChecks()) [[unlikely]]
+        return;
+
+    Locker lock { m_mirrorLock };
+    m_trapAwareSoftStackLimit.storeRelaxed(m_softStackLimit);
+    for (auto& mirror : m_mirrors)
+        mirror.m_trapAwareSoftStackLimit.storeRelaxed(m_softStackLimit);
+}
+
+void StackManager::setStackSoftLimit(void* newStackLimit)
+{
+    m_softStackLimit = newStackLimit;
+
+    Locker lock { m_mirrorLock };
+#if !ENABLE(C_LOOP)
+    if (!hasStopRequest())
+        m_trapAwareSoftStackLimit.storeRelaxed(newStackLimit);
+    void* newTrapAwareSoftStackLimit = trapAwareSoftStackLimit();
+#endif
+    for (auto& mirror : m_mirrors) {
+#if !ENABLE(C_LOOP)
+        mirror.m_trapAwareSoftStackLimit.storeRelaxed(newTrapAwareSoftStackLimit);
+#endif
+        mirror.m_softStackLimit = newStackLimit;
+    }
+}
+
+#if ENABLE(C_LOOP)
+void StackManager::setCLoopStackLimit(void* newStackLimit)
+{
+    m_cloopStackLimit = newStackLimit;
+
+    Locker lock { m_mirrorLock };
+    if (!hasStopRequest())
+        m_trapAwareSoftStackLimit.storeRelaxed(newStackLimit);
+
+    void* newTrapAwareSoftStackLimit = trapAwareSoftStackLimit();
+    for (auto& mirror : m_mirrors) {
+        mirror.m_trapAwareSoftStackLimit.storeRelaxed(newTrapAwareSoftStackLimit);
+        mirror.m_softStackLimit = newStackLimit;
+    }
+}
+#endif
+
+void StackManager::registerMirror(StackManager::Mirror& mirror)
+{
+    Locker lock { m_mirrorLock };
+    mirror.m_trapAwareSoftStackLimit.storeRelaxed(trapAwareSoftStackLimit());
+    mirror.m_softStackLimit = m_softStackLimit;
+    m_mirrors.append(&mirror);
+}
+
+void StackManager::unregisterMirror(StackManager::Mirror& mirror)
+{
+    Locker lock { m_mirrorLock };
+    m_mirrors.remove(&mirror);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/StackManager.h
+++ b/Source/JavaScriptCore/runtime/StackManager.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Atomics.h>
+#include <wtf/Lock.h>
+#include <wtf/SentinelLinkedList.h>
+
+#if ENABLE(C_LOOP)
+#include "CLoopStack.h"
+#endif
+
+namespace JSC {
+
+class StackManager {
+public:
+    class Mirror : public BasicRawSentinelNode<Mirror> {
+    public:
+        void* softStackLimit() const { return m_softStackLimit; }
+        void* trapAwareSoftStackLimit() const { return m_trapAwareSoftStackLimit.loadRelaxed(); }
+
+        static constexpr ptrdiff_t offsetOfSoftStackLimit()
+        {
+            return OBJECT_OFFSETOF(Mirror, m_softStackLimit);
+        }
+
+    private:
+        Atomic<void*> m_trapAwareSoftStackLimit { nullptr };
+        void* m_softStackLimit { nullptr };
+
+        friend class LLIntOffsetsExtractor;
+        friend class StackManager;
+    };
+
+    void registerMirror(Mirror&);
+    void unregisterMirror(Mirror&);
+
+    bool hasStopRequest() { return trapAwareSoftStackLimit() == stopRequestMarker(); }
+    void requestStop();
+    void cancelStop();
+
+    void* softStackLimit() const { return m_softStackLimit; }
+    void* trapAwareSoftStackLimit() const { return m_trapAwareSoftStackLimit.loadRelaxed(); }
+
+    void setStackSoftLimit(void* newLimit);
+
+    static constexpr ptrdiff_t offsetOfSoftStackLimit()
+    {
+        return OBJECT_OFFSETOF(StackManager, m_softStackLimit);
+    }
+
+    void** addressOfSoftStackLimit() { return &m_softStackLimit; }
+
+#if ENABLE(C_LOOP)
+    void* cloopStackLimit() { return m_cloopStackLimit; }
+    void setCLoopStackLimit(void* newStackLimit);
+    ALWAYS_INLINE void* currentCLoopStackPointer() const { return m_cloopStack.currentStackPointer(); }
+
+    CLoopStack& cloopStack() { return m_cloopStack; }
+    const CLoopStack& cloopStack() const { return m_cloopStack; }
+
+    static constexpr ptrdiff_t offsetOfCLoopStack()
+    {
+        return OBJECT_OFFSETOF(StackManager, m_cloopStack);
+    }
+#endif
+
+    VM& vm();
+
+private:
+    static ALWAYS_INLINE void* stopRequestMarker() { return reinterpret_cast<void*>(std::numeric_limits<uintptr_t>::max()); }
+
+    Atomic<void*> m_trapAwareSoftStackLimit { nullptr };
+    void* m_softStackLimit { nullptr };
+
+    Lock m_mirrorLock;
+    SentinelLinkedList<Mirror, BasicRawSentinelNode<Mirror>> m_mirrors WTF_GUARDED_BY_LOCK(m_mirrorLock);
+
+#if ENABLE(C_LOOP)
+    void* m_cloopStackLimit { nullptr };
+
+    // m_cloopStack must be declared after the m_mirrors list because CLoopStack
+    // initialization requires calling setCLoopStackLimit() which relies on
+    // m_mirrors (above) being already initialized.
+    CLoopStack m_cloopStack;
+#endif
+    friend class LLIntOffsetsExtractor;
+};
+
+static_assert(sizeof(Atomic<void*>) == sizeof(void*), "m_trapAwareSoftStackLimit relies on this invariant");
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/StackManagerInlines.h
+++ b/Source/JavaScriptCore/runtime/StackManagerInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,44 +20,21 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
-#if ENABLE(C_LOOP)
-
-#include "CLoopStack.h"
-#include "CallFrame.h"
-#include "CodeBlock.h"
-#include "StackManagerInlines.h"
+#include "StackManager.h"
 #include "VM.h"
+#include "VMTrapsInlines.h"
 
 namespace JSC {
 
-ALWAYS_INLINE VM& CLoopStack::vm() const
+ALWAYS_INLINE VM& StackManager::vm()
 {
-    return stackManager().vm();
-}
-
-inline void CLoopStack::setCLoopStackLimit(Register* newTopOfStack)
-{
-    m_end = newTopOfStack;
-    stackManager().setCLoopStackLimit(newTopOfStack);
-}
-
-inline bool CLoopStack::ensureCapacityFor(Register* newTopOfStack)
-{
-    if (newTopOfStack >= m_end)
-        return true;
-    return grow(newTopOfStack);
-}
-
-ALWAYS_INLINE StackManager& CLoopStack::stackManager() const
-{
-    return *std::bit_cast<StackManager*>(std::bit_cast<uintptr_t>(this) - StackManager::offsetOfCLoopStack());
+    VMTraps& traps = *std::bit_cast<VMTraps*>(std::bit_cast<uintptr_t>(this) - VMTraps::offsetOfStackManager());
+    return traps.vm();
 }
 
 } // namespace JSC
-
-#endif // ENABLE(C_LOOP)

--- a/Source/JavaScriptCore/runtime/VMInlines.h
+++ b/Source/JavaScriptCore/runtime/VMInlines.h
@@ -33,6 +33,10 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/Watchdog.h>
 
+#if ENABLE(C_LOOP)
+#include "CLoopStackInlines.h"
+#endif
+
 namespace JSC {
 
 inline ActiveScratchBufferScope::ActiveScratchBufferScope(ScratchBuffer* buffer, size_t activeScratchBufferSizeInJSValues)
@@ -53,18 +57,18 @@ inline ActiveScratchBufferScope::~ActiveScratchBufferScope()
 bool VM::ensureJSStackCapacityFor(Register* newTopOfStack)
 {
 #if !ENABLE(C_LOOP)
-    return newTopOfStack >= m_softStackLimit;
+    return newTopOfStack >= softStackLimit();
 #else
-    return ensureJSStackCapacityForCLoop(newTopOfStack);
+    return cloopStack().ensureCapacityFor(newTopOfStack);
 #endif
     
 }
 
 bool VM::isSafeToRecurseSoft() const
 {
-    bool safe = isSafeToRecurse(m_softStackLimit);
+    bool safe = isSafeToRecurse(softStackLimit());
 #if ENABLE(C_LOOP)
-    safe = safe && isSafeToRecurseSoftCLoop();
+    safe = safe && cloopStack().isSafeToRecurse();
 #endif
     return safe;
 }

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -74,8 +74,9 @@ namespace Wasm {
     macro(CastFailure, "ref.cast failed to cast reference to target heap type"_s) \
     macro(OutOfBoundsDataSegmentAccess, "Offset + array length would exceed the size of a data segment"_s) \
     macro(OutOfBoundsElementSegmentAccess, "Offset + array length would exceed the length of an element segment"_s) \
-    macro(OutOfMemory,  "Out of memory"_s) \
+    macro(OutOfMemory, "Out of memory"_s) \
     macro(IllegalArgument, "Illegal argument"_s) \
+    macro(Termination, "Termination"_s)
 
 enum class ExceptionType : uint32_t {
 #define MAKE_ENUM(enumName, error) enumName,
@@ -142,6 +143,7 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::CastFailure:
     case ExceptionType::OutOfMemory:
     case ExceptionType::IllegalArgument:
+    case ExceptionType::Termination:
         return false;
     case ExceptionType::InvalidGCTypeUse:
     case ExceptionType::TypeErrorInvalidValueUse:

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -134,6 +134,7 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
 
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer);
 
 } } // namespace JSC::IPInt
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -68,7 +68,6 @@ JSWebAssemblyInstance::JSWebAssemblyInstance(VM& vm, Structure* structure, JSWeb
     , m_jsModule(module, WriteBarrierEarlyInit)
     , m_moduleRecord(moduleRecord, WriteBarrierEarlyInit)
     , m_tables(module->module().moduleInformation().tableCount())
-    , m_softStackLimit(vm.softStackLimit())
     , m_module(module->module())
     , m_sourceProvider(sourceProvider)
     , m_globalsToMark(m_module.get().moduleInformation().globalCount())
@@ -139,10 +138,13 @@ void JSWebAssemblyInstance::finishCreation(VM& vm)
     }
     if (moduleInformation.typeCount())
         vm.writeBarrier(this);
+
+    m_vm->traps().registerMirror(m_stackMirror);
 }
 
 JSWebAssemblyInstance::~JSWebAssemblyInstance()
 {
+    m_vm->traps().unregisterMirror(m_stackMirror);
     clearJSCallICs(*m_vm);
     for (unsigned i = 0; i < m_numImportFunctions; ++i)
         importFunctionInfo(i)->~WasmOrJSImportableFunctionCallLinkInfo();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -32,6 +32,7 @@
 #include "JSWebAssemblyGlobal.h"
 #include "JSWebAssemblyMemory.h"
 #include "JSWebAssemblyTable.h"
+#include "StackManager.h"
 #include "WasmCalleeGroup.h"
 #include "WasmCreationMode.h"
 #include "WasmFormat.h"
@@ -130,9 +131,7 @@ public:
 
     using FunctionWrapperMap = UncheckedKeyHashMap<uint32_t, WriteBarrier<Unknown>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
-    static constexpr ptrdiff_t offsetOfSoftStackLimit() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_softStackLimit); }
-
-    void updateSoftStackLimit(void* softStackLimit) { m_softStackLimit = softStackLimit; }
+    static constexpr ptrdiff_t offsetOfSoftStackLimit() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_stackMirror) + StackManager::Mirror::offsetOfSoftStackLimit(); }
 
     Wasm::Module& module() const { return m_module.get(); }
     SourceTaintedOrigin taintedness() const { return m_sourceProvider->sourceTaintedOrigin(); }
@@ -299,7 +298,7 @@ public:
         m_temporaryCallFrame = callFrame;
     }
 
-    void* softStackLimit() const { return m_softStackLimit; }
+    void* softStackLimit() const { return m_stackMirror.softStackLimit(); }
 
     void setFaultPC(void* pc) { m_faultPC = pc; };
     void* faultPC() const { return m_faultPC; }
@@ -317,7 +316,7 @@ private:
     WriteBarrier<WebAssemblyModuleRecord> m_moduleRecord;
     WriteBarrier<JSWebAssemblyMemory> m_memory;
     FixedVector<WriteBarrier<JSWebAssemblyTable>> m_tables;
-    void* m_softStackLimit { nullptr };
+    StackManager::Mirror m_stackMirror;
     CagedPtr<Gigacage::Primitive, void> m_cachedMemory;
     size_t m_cachedBoundsCheckingSize { 0 };
     const Ref<Wasm::Module> m_module;


### PR DESCRIPTION
#### 37f1943f82ff13c2934249c191c8b7e1d31119bd
<pre>
Add VMTraps stop-the-world using stack checks [Interpreters only for now]
<a href="https://bugs.webkit.org/show_bug.cgi?id=297402">https://bugs.webkit.org/show_bug.cgi?id=297402</a>
<a href="https://rdar.apple.com/158326517">rdar://158326517</a>

Reviewed by Yijia Huang.

We already do stack checks on every function entry.  We can piggy back on this check to signal
if we need to go down a slow path to check for VM traps in addition to an actual stack check.

For this first implementation, we&apos;ll only be implementing this for interpreters only for now.
We&apos;ll have to work on JIT support in a future patch.

Specific changes:

1. Introducing StackManager
   ========================
   Move VM::m_softStackLimit into a new StackManager class, which is embedded in VMTraps.
   VMTraps will now manage this limit value via its StackManager.

   Also move Interpreter::m_cloopStack and VM::m_cloopStackLimit into the StackManager.
   VMTraps will now manage them via StackManager as well.

2. Stack checks and m_trapAwareSoftStackLimit
   ==========================================
   Stack checks at the various interpreter entry points now check StackManager::m_trapAwareSoftStackLimit
   instead of m_softStackLimit.  m_trapAwareSoftStackLimit normally will have the same value as
   m_softStackLimit.  However, when VMTraps wants to request a stop, it will set
   m_trapAwareSoftStackLimit to StackManager::stopRequestMarker(), which is the largest (highest)
   possible pointer value.  As a result, all the stack checks that check m_trapAwareSoftStackLimit
   will &quot;fail&quot; and take the slow path to investigate more (more details on what &quot;investigate&quot; mean
   below).

   m_softStackLimit will retain the actual stack limit value.  When VMTraps no longer need to
   stop-the-world, StackManager will set m_trapAwareSoftStackLimit back to m_softStackLimit.

   It is important to note that not all stack checks need switch to checking m_trapAwareSoftStackLimit.
   We only need to do so at strategic control flow points.  For example, js_to_wasm_wrapper_entry
   continues to check m_softStackLimit directly.  This is OK because control flow will shortly
   flow into the target Wasm function, where the stack check will check m_trapAwareSoftStackLimit.

   For now, none of the stack checks in JIT generated code are changed to check m_trapAwareSoftStackLimit.
   That will require additional work.

3. JSWebAssemblyInstance and StackManager::Mirror
   ==============================================
   JSWebAssemblyInstance has its own copy of m_softStackLimit.  This is done as a performance
   optimization.  JSWebAssemblyInstance is not changed to embed a StackManager::Mirror instead.
   The StackManager::Mirror will manage the m_softStackLimit and a m_trapAwareSoftStackLimit
   Value.  Relevant Wasm entry points will now do their stack check against
   StackManager::Mirror::m_trapAwareSoftStackLimit.

   JSWebAssemblyInstance&apos;s constructor and destructor will register and unregister its
   StackManager::Mirror with VMTraps&apos; StackManager.

   With this, VM::updateStackLimits() no longer needs to iterate all Wasm instances to update their
   m_softStackLimit (and m_trapAwareSoftStackLimit).  Instead, the StackManager will take care of
   updating all the Mirrors that are registered with it.  This update operation is synchronized
   using StackManager::m_mirrorLock.

   Synchronizing on StackManager::m_mirrorLock also enables us to iterate all Mirrors to set
   their m_trapAwareSoftStackLimit to StackManager::stopRequestMarker() while the mutator
   Threads are still running.  The previous scheme which iterate JSWebAssemblyInstances
   requires the VMs&apos; apiLocks.  That does not work because the mutators will be holding that
   lock while executing scripts, and hence, the stop request can never be made that way while
   the mutator is busy.  Using StackManager::m_mirrorLock instead solves this issue.

4. Stack Checks and their slow path to investigate stack limit comparison failures
   ===============================================================================
   m_trapAwareSoftStackLimit stack check sites will no longer assume that it is encountering a
   StackOverflow every time its stack limit comparison fails.  As such, it cannot just dispatch
   to a StackOverflow handler as before.

   Instead, if the stack limit comparison fails, we&apos;ll now call a runtime function in a slow path.
   That runtime function will check VMTraps::handleTrapsIfNeeded(), which will be responsible for
   servicing any stop-the-world request if applicable.

   VMTraps::handleTrapsIfNeeded() will return a boolean indicating if it did service any such
   request.  If so, a TerminationException may have been thrown, and the runtime function needs
   to handle that accordingly.  In the future, other conditions and cases may be added, but this
   is the only one for now.

   If there&apos;s no TerminationException, the runtime function will proceed will doing the actual
   stack limit check using m_softStackLimit instead.  If we still fail the comparison check there,
   the function will trigger the code path for throwing a StackOverflow error.

5. VMTraps and Stop-the-World requests
   ===================================
   VMTraps::requestThreadStopIfNeeded() and VMTraps:cancelThreadStopIfNeeded() now call
   StackManager::requestStop() and StackManager::cancelStop() respectively to use the stack
   checks as a stop-the-world mechanism.  This is in addition to the current signal based
   stopping mechanism.

   StackManager::requestStop() will replace m_trapAwareSoftStackLimit with
   StackManager::stopRequestMarker() in all the right places (as described above).

   StackManager::cancelStop() will set m_trapAwareSoftStackLimit back to m_softStackLimit.

   Currently, clients calling VMTraps::fireTrap() is the channel for triggering stop-the-world
   (if applicable).  VMTraps::handleTraps() will cancel stop-the-world once the relevant traps
   have been handled.  In the future, we may change where we cancel stop-the-world as we learn
   more about how it can be used.

6. Fixed a stack check bug in offlineasm asm code.  The stack checks were being done with bplteq
   (signed compare and branch).  Instead, they should be done with bpbeq (unsigned compare and
   branch).  This is needed because pointers are unsigned, and because StackManager::stopRequestMarker()
   will never trigger the slow path otherwise.  StackManager::stopRequestMarker() is the MAX value,
   but will be wrongly interpreted by bplteq as -1.  Using bpbeq instead fixes this.

7. Fixed a bug in the operationCallMayThrow() macro at the point where it dispatches to the stack
   overflow handler.  The code there is failing to pop saved registers off the stack before jumping
   out, thereby resulting in a stack leak.  At present, this bug is benign because it&apos;s jumping to
   a stack overflow handler that will just throw a StackOverflow error, leading to the stack being
   unwound ... which fixes the leak.  At present, there is also no code in the code path that relies
   on the stackPointer being correct.  However, this is fragile.

   So, in this patch, we fix the stackPointer (by popping off the unused saved values) before taking
   the jump.

   Do the same in the new operationCallMayThrowPreservingRegisters().

8. The IPInt checkStackOverflow() macro currently uses operationCallMayThrowPreservingRegisters(),
   which preserves Wasm argument registers using preserveWasmArgumentRegisters().  This is not safe
   for SIMD which needs to preserve more bits for the vector FPRs.  This will need to be addressed
   when we add SIMD support to IPInt in the future.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::gatherStackRoots):
* Source/JavaScriptCore/interpreter/CLoopStack.h:
* Source/JavaScriptCore/interpreter/CLoopStackInlines.h:
(JSC::CLoopStack::stackManager const):
(JSC::CLoopStack::vm const):
(JSC::CLoopStack::setCLoopStackLimit):
* Source/JavaScriptCore/interpreter/Interpreter.h:
(JSC::Interpreter::cloopStack): Deleted.
(JSC::Interpreter::cloopStack const): Deleted.
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_check_stack_and_vm_traps):
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
(JSC::CLoopRegister::operator void*):
(JSC::CLoop::execute):
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/StackManager.cpp: Added.
(JSC::StackManager::requestStop):
(JSC::StackManager::cancelStop):
(JSC::StackManager::setStackSoftLimit):
(JSC::StackManager::setCLoopStackLimit):
(JSC::StackManager::registerMirror):
(JSC::StackManager::unregisterMirror):
* Source/JavaScriptCore/runtime/StackManager.h: Added.
(JSC::StackManager::Mirror::softStackLimit const):
(JSC::StackManager::Mirror::trapAwareSoftStackLimit const):
(JSC::StackManager::Mirror::offsetOfSoftStackLimit):
(JSC::StackManager::hasStopRequest):
(JSC::StackManager::softStackLimit const):
(JSC::StackManager::trapAwareSoftStackLimit const):
(JSC::StackManager::offsetOfSoftStackLimit):
(JSC::StackManager::addressOfSoftStackLimit):
(JSC::StackManager::cloopStackLimit):
(JSC::StackManager::currentCLoopStackPointer const):
(JSC::StackManager::cloopStack):
(JSC::StackManager::cloopStack const):
(JSC::StackManager::offsetOfCLoopStack):
(JSC::StackManager::stopRequestMarker):
* Source/JavaScriptCore/runtime/StackManagerInlines.h: Copied from Source/JavaScriptCore/interpreter/CLoopStackInlines.h.
(JSC::StackManager::vm):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::updateSoftReservedZoneSize):
(JSC::VM::updateStackLimits):
(JSC::sanitizeStackForVM):
(JSC::VM::ensureJSStackCapacityForCLoop): Deleted.
(JSC::VM::isSafeToRecurseSoftCLoop const): Deleted.
(JSC::VM::currentCLoopStackPointer const): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::offsetOfTraps):
(JSC::VM::offsetOfTrapsBits):
(JSC::VM::offsetOfSoftStackLimit):
(JSC::VM::addressOfSoftStackLimit):
(JSC::VM::cloopStack):
(JSC::VM::cloopStack const):
(JSC::VM::cloopStackLimit):
(JSC::VM::currentCLoopStackPointer const):
(JSC::VM::softStackLimit): Deleted.
(JSC::VM::setCLoopStackLimit): Deleted.
* Source/JavaScriptCore/runtime/VMInlines.h:
(JSC::VM::ensureJSStackCapacityFor):
(JSC::VM::isSafeToRecurseSoft const):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
(JSC::VMTraps::cancelThreadStopIfNeeded):
(JSC::VMTraps::requestThreadStopIfNeeded):
(JSC::VMTraps::handleTraps):
(JSC::VMTraps::handleTrapsIfNeeded):
(JSC::VMTraps::VMTraps):
* Source/JavaScriptCore/runtime/VMTraps.h:
(JSC::VMTraps::clearTrap):
(JSC::VMTraps::cloopStack):
(JSC::VMTraps::cloopStack const):
(JSC::VMTraps::cloopStackLimit):
(JSC::VMTraps::currentCLoopStackPointer const):
(JSC::VMTraps::softStackLimit const):
(JSC::VMTraps::setStackSoftLimit):
(JSC::VMTraps::addressOfSoftStackLimit):
(JSC::VMTraps::offsetOfStackManager):
(JSC::VMTraps::offsetOfSoftStackLimit):
(JSC::VMTraps::registerMirror):
(JSC::VMTraps::unregisterMirror):
* Source/JavaScriptCore/wasm/WasmExceptionType.h:
(JSC::Wasm::isTypeErrorExceptionType):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::throwWasmToJSException):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::finishCreation):
(JSC::JSWebAssemblyInstance::~JSWebAssemblyInstance):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:

Canonical link: <a href="https://commits.webkit.org/298805@main">https://commits.webkit.org/298805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc036608918c160e385174acfefcda74593135c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67218 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37008 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43008 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c08c90e9-b4c0-4eee-9ab6-ef04e24057fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69057 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22751 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66387 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108760 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125856 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115174 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43545 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32713 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97055 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39507 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18637 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49026 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143872 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42902 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37037 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46237 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->