### PR TITLE
<button> elements with no explicit type are displaying as submit buttons

### DIFF
--- a/LayoutTests/fast/forms/button-explicit-types-match-input-types-expected.html
+++ b/LayoutTests/fast/forms/button-explicit-types-match-input-types-expected.html
@@ -1,0 +1,4 @@
+<input type="button" value="Button">
+<input type="button" value="Button">
+<input type="button" value="Button">
+<input type="submit" value="Button">

--- a/LayoutTests/fast/forms/button-explicit-types-match-input-types.html
+++ b/LayoutTests/fast/forms/button-explicit-types-match-input-types.html
@@ -1,0 +1,4 @@
+<button>Button</button>
+<button type="button">Button</button>
+<button type="reset">Button</button>
+<button type="submit">Button</button>

--- a/LayoutTests/fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button-expected-mismatch.html
+++ b/LayoutTests/fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button-expected-mismatch.html
@@ -1,0 +1,1 @@
+<button>Button</button>

--- a/LayoutTests/fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button.html
+++ b/LayoutTests/fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button.html
@@ -1,0 +1,1 @@
+<input type="submit" value="Button">

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1224,12 +1224,6 @@ bool RenderTheme::isIndeterminate(const RenderObject& renderer) const
     return input && input->isCheckbox() && input->matchesIndeterminatePseudoClass();
 }
 
-bool RenderTheme::isSubmitButton(const Node* node) const
-{
-    RefPtr element = dynamicDowncast<HTMLFormControlElement>(node);
-    return element && element->isSubmitButton();
-}
-
 bool RenderTheme::isEnabled(const RenderObject& renderer) const
 {
     RefPtr element = dynamicDowncast<Element>(renderer.node());

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -414,7 +414,6 @@ public:
     bool isWindowActive(const RenderObject&) const;
     bool isChecked(const RenderObject&) const;
     bool isIndeterminate(const RenderObject&) const;
-    bool isSubmitButton(const Node*) const;
     bool isEnabled(const RenderObject&) const;
     bool isFocused(const RenderObject&) const;
     bool isPressed(const RenderObject&) const;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -272,6 +272,8 @@ protected:
     float adjustedMaximumLogicalWidthForControl(const RenderStyle&, const Element&, float) const final;
 #endif
 
+    bool isSubmitStyleButton(const Node*) const;
+
 private:
     void purgeCaches() override;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -559,7 +559,7 @@ bool RenderThemeCocoa::controlSupportsTints(const RenderObject& box) const
 #if PLATFORM(MAC)
     switch (box.style().usedAppearance()) {
     case StyleAppearance::Button:
-        return isSubmitButton(box.node());
+        return isSubmitStyleButton(box.node());
     case StyleAppearance::Checkbox:
     case StyleAppearance::Radio:
         return isChecked(box) || isIndeterminate(box);
@@ -1273,7 +1273,7 @@ bool RenderThemeCocoa::paintButtonForVectorBasedControls(const RenderObject& box
 #if PLATFORM(MAC)
         isWindowActive = states.contains(ControlStyle::State::WindowActive);
 #endif
-        if (isSubmitButton(box.node()) && isWindowActive)
+        if (isSubmitStyleButton(box.node()) && isWindowActive)
             backgroundColor = controlTintColorWithContrast(box.style(), styleColorOptions);
         else
             backgroundColor = colorCompositedOverCanvasColor(CSSValueAppleSystemOpaqueSecondaryFill, styleColorOptions);
@@ -2402,7 +2402,7 @@ bool RenderThemeCocoa::adjustButtonStyleForVectorBasedControls(RenderStyle& styl
     };
 
     if (!style.hasExplicitlySetColor()) {
-        if (isSubmitButton(element))
+        if (isSubmitStyleButton(element))
             adjustStyleForSubmitButton();
         else
             style.setColor(buttonTextColor(styleColorOptions, isEnabled));
@@ -4471,6 +4471,17 @@ void RenderThemeCocoa::adjustTextControlInnerTextStyle(RenderStyle& style, const
 #endif
 
     RenderTheme::adjustTextControlInnerTextStyle(style, shadowHostStyle, shadowHost);
+}
+
+bool RenderThemeCocoa::isSubmitStyleButton(const Node* node) const
+{
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(node))
+        return input->isSubmitButton();
+
+    if (RefPtr button = dynamicDowncast<HTMLButtonElement>(node))
+        return button->isExplicitlySetSubmitButton();
+
+    return false;
 }
 
 }

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -172,8 +172,6 @@ private:
     String extraDefaultStyleSheet() final;
 #endif
 
-    bool isSubmitStyleButton(const Element&) const;
-
     void adjustButtonLikeControlStyle(RenderStyle&, const Element&) const;
 
     Color systemColor(CSSValueID, OptionSet<StyleColorOptions>) const override;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -899,17 +899,6 @@ void RenderThemeIOS::paintSearchFieldDecorations(const RenderBox& box, const Pai
 // This value matches the opacity applied to UIKit controls.
 constexpr auto pressedStateOpacity = 0.75f;
 
-bool RenderThemeIOS::isSubmitStyleButton(const Element& element) const
-{
-    if (RefPtr input = dynamicDowncast<HTMLInputElement>(element))
-        return input->isSubmitButton();
-
-    if (RefPtr button = dynamicDowncast<HTMLButtonElement>(element))
-        return button->isExplicitlySetSubmitButton();
-
-    return false;
-}
-
 void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Element& element) const
 {
     if (PAL::currentUserInterfaceIdiomIsVision())
@@ -920,7 +909,7 @@ void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Elem
 
     if (!style.hasAutoAccentColor()) {
         auto tintColor = style.usedAccentColor(element.document().styleColorOptions(&style));
-        if (isSubmitStyleButton(element))
+        if (isSubmitStyleButton(&element))
             style.setBackgroundColor(WTFMove(tintColor));
         else
             style.setColor(WTFMove(tintColor));


### PR DESCRIPTION
#### f18f19148f92e687817feedc04eb7f7532159b21
<pre>
&lt;button&gt; elements with no explicit type are displaying as submit buttons
<a href="https://bugs.webkit.org/show_bug.cgi?id=297416">https://bugs.webkit.org/show_bug.cgi?id=297416</a>
<a href="https://rdar.apple.com/158331127">rdar://158331127</a>

Reviewed by Tim Horton and Aditya Keerthi.

Move `isSubmitStyleButton` from RenderThemeIOS into RenderThemeCocoa and use it
to detect input elements with type &quot;submit&quot;, and button elements with explicit type
&quot;submit&quot;. Button elements with no specified type will now display the same as inputs
and button elements with type &quot;button&quot;.

* LayoutTests/fast/forms/button-explicit-types-match-input-types-expected.html: Added.
* LayoutTests/fast/forms/button-explicit-types-match-input-types.html: Added.
* LayoutTests/fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button-expected-mismatch.html: Added.
* LayoutTests/fast/forms/form-control-refresh/button-without-explicit-type-does-not-display-as-submit-button.html: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::isSubmitButton const): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::controlSupportsTints const):
(WebCore::RenderThemeCocoa::paintButtonForVectorBasedControls):
(WebCore::RenderThemeCocoa::adjustButtonStyleForVectorBasedControls const):
(WebCore::RenderThemeCocoa::isSubmitStyleButton const):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustButtonLikeControlStyle const):
(WebCore::RenderThemeIOS::isSubmitStyleButton const): Deleted.

Canonical link: <a href="https://commits.webkit.org/298721@main">https://commits.webkit.org/298721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7bb2526e54de34736cfe10ed53f814215c91756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66986 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88423 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68862 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66161 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125629 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97128 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42211 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39271 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42671 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44376 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->