### PR TITLE
[Win] Use DiscardVirtualMemory in libpas

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_monotonic_time.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_monotonic_time.c
@@ -106,8 +106,8 @@ uint64_t pas_get_current_monotonic_time_nanoseconds(void)
         return -1;
 
     /* Convert to seconds and nanoseconds */
-    long sec = counter.QuadPart / frequency.QuadPart;
-    long nsec = (long)((counter.QuadPart % frequency.QuadPart) * 1000000000LL / frequency.QuadPart);
+    uint64_t sec = counter.QuadPart / frequency.QuadPart;
+    uint64_t nsec = (uint64_t)((counter.QuadPart % frequency.QuadPart) * 1000000000ULL / frequency.QuadPart);
 
     return sec * 1.0e9 + nsec;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_thread.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread.c
@@ -186,7 +186,7 @@ int pthread_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex)
 
 int pthread_cond_timedwait(pthread_cond_t* cond, pthread_mutex_t* mutex, const struct timespec* abstime)
 {
-    uint64_t wait_ms = abstime->tv_sec * 1000 + abstime->tv_nsec / 1000;
+    uint64_t wait_ms = abstime->tv_sec * 1000 + abstime->tv_nsec / 1000000;
     return SleepConditionVariableSRW(cond, mutex, wait_ms, 0);
 }
 


### PR DESCRIPTION
#### 71474d040dcbd34614cabeed78cdfbbb9bff133d
<pre>
[Win] Use DiscardVirtualMemory in libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=297094">https://bugs.webkit.org/show_bug.cgi?id=297094</a>

Reviewed by Yusuke Suzuki.

Using DiscardVirtualMemory with a VirtualAlloc fallback; it seems that
DiscardVirtualMemory is better at returning memory to the OS faster.

Also avoiding committing and decommitting outside the requested range
due to the returned memInfo.

Fix a bug in pthread_cond_timedwait which might make the scavenger
thread run less frequently than it should.

Canonical link: <a href="https://commits.webkit.org/298752@main">https://commits.webkit.org/298752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8ef930f6b86372def2988d12fc113ac9f96acb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66979 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68854 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66154 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108526 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125622 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114944 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97123 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96918 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24691 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43198 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143642 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42664 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/36997 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->