### PR TITLE
[GTK] Create WebKitWebExtension

### DIFF
--- a/Source/WebCore/platform/graphics/Icon.h
+++ b/Source/WebCore/platform/graphics/Icon.h
@@ -68,7 +68,7 @@ public:
 #endif
 
 #if PLATFORM(GTK)
-    WEBCORE_EXPORT static RefPtr<Icon> create(GIcon*);
+    WEBCORE_EXPORT static RefPtr<Icon> create(GRefPtr<GIcon>&&);
 
     GIcon* icon() const { return m_icon.get(); };
 #endif
@@ -93,7 +93,7 @@ private:
     Icon(HICON);
     HICON m_hIcon;
 #elif PLATFORM(GTK)
-    explicit Icon(GIcon*);
+    explicit Icon(GRefPtr<GIcon>&&);
     GRefPtr<GIcon> m_icon;
 #endif
 };

--- a/Source/WebCore/platform/graphics/gtk/IconGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/IconGtk.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-Icon::Icon(GIcon* icon)
+Icon::Icon(GRefPtr<GIcon>&& icon)
     : m_icon(icon)
 {
 }
@@ -44,12 +44,12 @@ Icon::~Icon()
 {
 }
 
-RefPtr<Icon> Icon::create(GIcon* icon)
+RefPtr<Icon> Icon::create(GRefPtr<GIcon>&& icon)
 {
     if (!icon)
         return nullptr;
 
-    return adoptRef(new Icon(icon));
+    return adoptRef(new Icon(WTFMove(icon)));
 }
 
 void Icon::paint(GraphicsContext&, const FloatRect&)

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -218,6 +218,15 @@ if (ENABLE_2022_GLIB_API)
     )
 endif ()
 
+if (ENABLE_2022_GLIB_API)
+    list(APPEND WebKitGTK_HEADER_TEMPLATES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebExtension.h.in
+    )
+    list(APPEND WebKit_SOURCES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebExtension.cpp
+    )
+endif ()
+
 set(WebKitGTK_INSTALLED_HEADERS
     ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/WebKitEnumTypes.h
     ${WebKitGTK_DERIVED_SOURCES_DIR}/webkit/WebKitVersion.h

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -214,6 +214,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitUserMediaPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitUserMessage.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebContext.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebExtensionMatchPattern.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebResource.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebView.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebViewSessionState.h.in
@@ -229,6 +230,15 @@ set(WPE_API_HEADER_TEMPLATES
 if (ENABLE_2022_GLIB_API)
     list(APPEND WPE_API_HEADER_TEMPLATES
         ${WEBKIT_DIR}/UIProcess/API/glib/WebKitNetworkSession.h.in
+    )
+endif ()
+
+if (ENABLE_2022_GLIB_API)
+    list(APPEND WPE_API_HEADER_TEMPLATES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebExtension.h.in
+    )
+    list(APPEND WebKit_SOURCES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebExtension.cpp
     )
 endif ()
 

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -34,6 +34,12 @@
 #include <wtf/RetainPtr.h>
 #endif
 
+#if PLATFORM(GTK)
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GSpanExtras.h>
+#include <wtf/glib/WTFGType.h>
+#endif
+
 OBJC_CLASS NSData;
 
 namespace API {
@@ -74,6 +80,14 @@ public:
 
 #if PLATFORM(COCOA)
     static Ref<Data> createWithoutCopying(NSData *);
+#endif
+
+#if PLATFORM(GTK)
+    static Ref<Data> createWithoutCopying(GRefPtr<GBytes>&& bytes)
+    {
+        auto span = WTF::span(bytes);
+        return createWithoutCopying(span, [bytes = WTFMove(bytes)] () { });
+    }
 #endif
 
     ~Data()

--- a/Source/WebKit/Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
+++ b/Source/WebKit/Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Igalia S.L.
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,38 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WebExtensionUtilities.h"
 
-#include "WebKitNavigationAction.h"
-#include "WebMouseEvent.h"
-#include <WebCore/FrameLoaderTypes.h>
+#include <gdk/gdk.h>
 
-unsigned toPlatformModifiers(OptionSet<WebKit::WebEventModifier>);
-WebKitNavigationType toWebKitNavigationType(WebCore::NavigationType);
-unsigned toWebKitMouseButton(WebKit::WebMouseEventButton);
-unsigned toWebKitError(unsigned webCoreError);
 #if ENABLE(WK_WEB_EXTENSIONS)
-#if ENABLE(2022_GLIB_API)
-unsigned toWebKitWebExtensionError(unsigned apiError);
-#endif // ENABLE(2022_GLIB_API)
-unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError);
+
+namespace WebKit {
+
+Vector<double> availableScreenScales()
+{
+    Vector<double> screenScales;
+
+    auto* display = gdk_display_get_default();
+
+#if USE(GTK4)
+    auto* monitors = gdk_display_get_monitors(display);
+    unsigned currentMonitor = 0;
+    while (auto* item = g_list_model_get_item(monitors, currentMonitor++)) {
+        auto* monitor = GDK_MONITOR(item);
+        ASSERT(GDK_IS_MONITOR(monitor));
+        screenScales.append(gdk_monitor_get_scale_factor(monitor));
+    }
+#endif
+
+    if (!screenScales.isEmpty())
+        return screenScales;
+
+    // Assume 1x if we got no results. This can happen on headless devices (bots).
+    return { 1.0 };
+}
+
+} // namespace WebKit
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)
-unsigned toWebCoreError(unsigned webKitError);
-
-enum SnapshotRegion {
-    SnapshotRegionVisible,
-    SnapshotRegionFullDocument
-};
-
-static constexpr auto networkCacheSubdirectory = "WebKitCache"_s;

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -79,6 +79,8 @@ Shared/API/glib/WebKitURIRequest.cpp @no-unify
 Shared/API/glib/WebKitURIResponse.cpp @no-unify
 Shared/API/glib/WebKitUserMessage.cpp @no-unify
 
+Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
+
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp
@@ -226,6 +228,8 @@ UIProcess/Automation/glib/BidiBrowserAgentGlib.cpp @no-unify
 UIProcess/Automation/gtk/WebAutomationSessionGtk.cpp @no-unify
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+
+UIProcess/Extensions/gtk/WebExtensionGtk.cpp
 
 UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp
 UIProcess/Gamepad/manette/UIGamepadProviderManette.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -122,6 +122,8 @@ UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
 
 Shared/API/c/wpe/WKEventWPE.cpp
 
+Shared/Extensions/wpe/WebExtensionUtilitiesWPE.cpp
+
 UIProcess/API/glib/APIContentRuleListStoreGLib.cpp @no-unify
 UIProcess/API/glib/InputMethodFilter.cpp @no-unify
 UIProcess/API/glib/KeyAutoRepeatHandler.cpp @no-unify
@@ -181,6 +183,7 @@ UIProcess/API/glib/WebKitUserContentManager.cpp @no-unify
 UIProcess/API/glib/WebKitUserMediaPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitVersion.cpp @no-unify
 UIProcess/API/glib/WebKitWebContext.cpp @no-unify
+UIProcess/API/glib/WebKitWebExtensionMatchPattern.cpp @no-unify
 UIProcess/API/glib/WebKitWebResource.cpp @no-unify
 UIProcess/API/glib/WebKitWebResourceLoadManager.cpp @no-unify
 UIProcess/API/glib/WebKitWebView.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.cpp
@@ -112,12 +112,30 @@ GQuark webkit_snapshot_error_quark()
     return g_quark_from_static_string("WebKitSnapshotError");
 }
 
+#if ENABLE(2022_GLIB_API)
+/**
+ * webkit_web_extension_error_quark:
+ *
+ * Gets the quark for the domain of Web Extension errors.
+ *
+ * Returns: web extension error domain.
+ * 
+ * Since: 2.52
+ */
+GQuark webkit_web_extension_error_quark()
+{
+    return g_quark_from_static_string("WebKitWebExtensionError");
+}
+#endif
+
 /**
  * webkit_web_extension_match_pattern_error_quark:
  *
  * Gets the quark for the domain of Web Extension Match Pattern errors.
  *
  * Returns: web extension match pattern error domain.
+ * 
+ * Since: 2.48
  */
 GQuark webkit_web_extension_match_pattern_error_quark()
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitError.h.in
@@ -36,7 +36,10 @@ G_BEGIN_DECLS
 #define WEBKIT_JAVASCRIPT_ERROR                  webkit_javascript_error_quark ()
 #define WEBKIT_SNAPSHOT_ERROR                    webkit_snapshot_error_quark ()
 #define WEBKIT_USER_CONTENT_FILTER_ERROR         webkit_user_content_filter_error_quark ()
-#define WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR webkit_web_extension_error_quark ()
+#if ENABLE(2022_GLIB_API)
+#define WEBKIT_WEB_EXTENSION_ERROR               webkit_web_extension_error_quark ()
+#endif
+#define WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR webkit_web_extension_match_pattern_error_quark ()
 
 #if PLATFORM(GTK)
 #define WEBKIT_PRINT_ERROR                       webkit_print_error_quark ()
@@ -158,6 +161,36 @@ typedef enum {
     WEBKIT_SNAPSHOT_ERROR_FAILED_TO_CREATE = 799
 } WebKitSnapshotError;
 
+#if ENABLE(2022_GLIB_API)
+/**
+ * WebKitWebExtensionError:
+ * @WEBKIT_WEB_EXTENSION_ERROR_UNKNOWN: An unknown error occured.
+ * @WEBKIT_WEB_EXTENSION_ERROR_RESOURCE_NOT_FOUND: A specified resource was not found on disk.
+ * @WEBKIT_WEB_EXTENSION_ERROR_INVALID_RESOURCE_CODE_SIGNATURE: A resource failed the bundle's code signature checks.
+ * @WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST: An invalid `manifest.json` was encountered.
+ * @WEBKIT_WEB_EXTENSION_ERROR_UNSUPPORTED_MANIFEST_VERSION: The manifest version is not supported.
+ * @WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY: An invalid manifest entry was encountered.
+ * @WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY: An invalid declarative net request entry was encountered.
+ * @WEBKIT_WEB_EXTENSION_ERROR_INVALID_BACKGROUND_PERSISTENCE: The extension specified background persistence that was not compatible with the platform or features requested.
+ * @WEBKIT_WEB_EXTENSION_ERROR_INVALID_ARCHIVE: The archive file is invalid or corrupt.
+ *
+ * Enum values used to denote errors happening when parsing a #WebKitWebExtension
+ * 
+ * Since: 2.52
+ */
+typedef enum {
+    WEBKIT_WEB_EXTENSION_ERROR_UNKNOWN = 899,
+    WEBKIT_WEB_EXTENSION_ERROR_RESOURCE_NOT_FOUND = 800,
+    WEBKIT_WEB_EXTENSION_ERROR_INVALID_RESOURCE_CODE_SIGNATURE = 801,
+    WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST = 802,
+    WEBKIT_WEB_EXTENSION_ERROR_UNSUPPORTED_MANIFEST_VERSION = 803,
+    WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY = 804,
+    WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY = 805,
+    WEBKIT_WEB_EXTENSION_ERROR_INVALID_BACKGROUND_PERSISTENCE = 806,
+    WEBKIT_WEB_EXTENSION_ERROR_INVALID_ARCHIVE = 807,
+} WebKitWebExtensionError;
+#endif
+
 /**
  * WebKitWebExtensionMatchPatternError:
  * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_UNKNOWN: An unknown error occured.
@@ -166,6 +199,8 @@ typedef enum {
  * @WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_INVALID_PATH: The path component was invalid.
  *
  * Enum values used to denote errors happening when creating a #WebKitWebExtensionMatchPattern
+ * 
+ * Since: 2.52
  */
 typedef enum {
     WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_UNKNOWN = 899,
@@ -226,6 +261,11 @@ webkit_javascript_error_quark                  (void);
 
 WEBKIT_API GQuark
 webkit_snapshot_error_quark                    (void);
+
+#if ENABLE(2022_GLIB_API)
+WEBKIT_API GQuark
+webkit_web_extension_error_quark               (void);
+#endif
 
 WEBKIT_API GQuark
 webkit_web_extension_match_pattern_error_quark (void);

--- a/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp
@@ -31,6 +31,7 @@
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtension.h"
 #include "WebExtensionMatchPattern.h"
 #endif
 
@@ -155,6 +156,35 @@ unsigned toWebKitError(unsigned webCoreError)
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+#if ENABLE(2022_GLIB_API)
+unsigned toWebKitWebExtensionError(unsigned apiError)
+{
+    auto error = static_cast<WebKit::WebExtension::APIError>(apiError);
+
+    switch (error) {
+    case WebKit::WebExtension::APIError::ResourceNotFound:
+        return WEBKIT_WEB_EXTENSION_ERROR_RESOURCE_NOT_FOUND;
+    case WebKit::WebExtension::APIError::InvalidResourceCodeSignature:
+        return WEBKIT_WEB_EXTENSION_ERROR_INVALID_RESOURCE_CODE_SIGNATURE;
+    case WebKit::WebExtension::APIError::InvalidManifest:
+        return WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST;
+    case WebKit::WebExtension::APIError::UnsupportedManifestVersion:
+        return WEBKIT_WEB_EXTENSION_ERROR_UNSUPPORTED_MANIFEST_VERSION;
+    case WebKit::WebExtension::APIError::InvalidManifestEntry:
+        return WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY;
+    case WebKit::WebExtension::APIError::InvalidDeclarativeNetRequestEntry:
+        return WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY;
+    case WebKit::WebExtension::APIError::InvalidBackgroundPersistence:
+        return WEBKIT_WEB_EXTENSION_ERROR_INVALID_BACKGROUND_PERSISTENCE;
+    case WebKit::WebExtension::APIError::InvalidArchive:
+        return WEBKIT_WEB_EXTENSION_ERROR_INVALID_ARCHIVE;
+    case WebKit::WebExtension::APIError::Unknown:
+        return WEBKIT_WEB_EXTENSION_ERROR_UNKNOWN;
+    }
+
+    return WEBKIT_WEB_EXTENSION_ERROR_UNKNOWN;
+}
+#endif // ENABLE(2022_GLIB_API)
 unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError)
 {
     auto error = static_cast<WebKit::WebExtensionMatchPattern::Error>(apiError);
@@ -171,7 +201,7 @@ unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError)
         return WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR_UNKNOWN;
     }
 }
-#endif
+#endif // ENABLE(WK_WEB_EXTENSIONS)
 
 unsigned toWebCoreError(unsigned webKitError)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp
@@ -1,0 +1,1298 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#if ENABLE(2022_GLIB_API)
+
+#include "config.h"
+#include "WebKitWebExtension.h"
+
+#include "WebExtension.h"
+#include "WebKitError.h"
+#include "WebKitPrivate.h"
+#include "WebKitWebExtensionInternal.h"
+#include "WebKitWebExtensionMatchPatternPrivate.h"
+#include <WebCore/Icon.h>
+#include <wtf/RefPtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
+
+using namespace WebKit;
+
+/**
+ * WebKitWebExtension:
+ *
+ * Represents a [WebExtension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions).
+ * 
+ * A #WebKitWebExtension object encapsulates a web extension’s
+ * resources that are defined by a [`manifest.json` file](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json).
+ * 
+ * This class handles the reading and parsing of the manifest file
+ * along with the supporting resources like icons and localizations.
+ *
+ * Since: 2.52
+ */
+
+static void gInitableInterfaceInit(GInitableIface*);
+
+struct _WebKitWebExtensionPrivate {
+#if ENABLE(WK_WEB_EXTENSIONS)
+    GRefPtr<GFile> path;
+    RefPtr<WebExtension> extension;
+    CString defaultLocale;
+    CString displayName;
+    CString displayShortName;
+    CString displayVersion;
+    CString displayDescription;
+    CString displayActionLabel;
+    CString version;
+    GRefPtr<GPtrArray> requestedPermissions;
+    GRefPtr<GPtrArray> optionalPermissions;
+#endif
+};
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitWebExtension, webkit_web_extension, G_TYPE_OBJECT, GObject,
+    G_IMPLEMENT_INTERFACE(G_TYPE_INITABLE, gInitableInterfaceInit))
+
+static void webkitWebExtensionSetPath(WebKitWebExtension*, GFile*);
+
+enum {
+    PROP_0,
+    PROP_PATH,
+    PROP_MANIFEST_VERSION,
+    PROP_DEFAULT_LOCALE,
+    PROP_DISPLAY_NAME,
+    PROP_DISPLAY_SHORT_NAME,
+    PROP_DISPLAY_VERSION,
+    PROP_DISPLAY_DESCRIPTION,
+    PROP_DISPLAY_ACTION_LABEL,
+    PROP_VERSION,
+    PROP_REQUESTED_PERMISSIONS,
+    PROP_OPTIONAL_PERMISSIONS,
+    PROP_HAS_BACKGROUND_CONTENT,
+    PROP_HAS_PERSISTENT_BACKGROUND_CONTENT,
+    PROP_HAS_INJECTED_CONTENT,
+    PROP_HAS_OPTIONS_PAGE,
+    PROP_HAS_OVERRIDE_NEW_TAB_PAGE,
+    PROP_HAS_COMMANDS,
+    PROP_HAS_CONTENT_MODIFICATION_RULES,
+    N_PROPERTIES,
+};
+
+static std::array<GParamSpec*, N_PROPERTIES> properties;
+
+static void webkitWebExtensionGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    WebKitWebExtension* extension = WEBKIT_WEB_EXTENSION(object);
+
+    switch (propId) {
+    case PROP_PATH:
+        g_value_set_object(value, webkit_web_extension_get_path(extension));
+        break;
+    case PROP_MANIFEST_VERSION:
+        g_value_set_double(value, webkit_web_extension_get_manifest_version(extension));
+        break;
+    case PROP_DEFAULT_LOCALE:
+        g_value_set_string(value, webkit_web_extension_get_default_locale(extension));
+        break;
+    case PROP_DISPLAY_NAME:
+        g_value_set_string(value, webkit_web_extension_get_display_name(extension));
+        break;
+    case PROP_DISPLAY_SHORT_NAME:
+        g_value_set_string(value, webkit_web_extension_get_display_short_name(extension));
+        break;
+    case PROP_DISPLAY_VERSION:
+        g_value_set_string(value, webkit_web_extension_get_display_version(extension));
+        break;
+    case PROP_DISPLAY_DESCRIPTION:
+        g_value_set_string(value, webkit_web_extension_get_display_description(extension));
+        break;
+    case PROP_DISPLAY_ACTION_LABEL:
+        g_value_set_string(value, webkit_web_extension_get_display_action_label(extension));
+        break;
+    case PROP_VERSION:
+        g_value_set_string(value, webkit_web_extension_get_version(extension));
+        break;
+    case PROP_REQUESTED_PERMISSIONS:
+        g_value_set_boxed(value, webkit_web_extension_get_requested_permissions(extension));
+        break;
+    case PROP_OPTIONAL_PERMISSIONS:
+        g_value_set_boxed(value, webkit_web_extension_get_optional_permissions(extension));
+        break;
+    case PROP_HAS_BACKGROUND_CONTENT:
+        g_value_set_boolean(value, webkit_web_extension_get_has_background_content(extension));
+        break;
+    case PROP_HAS_PERSISTENT_BACKGROUND_CONTENT:
+        g_value_set_boolean(value, webkit_web_extension_get_has_persistent_background_content(extension));
+        break;
+    case PROP_HAS_INJECTED_CONTENT:
+        g_value_set_boolean(value, webkit_web_extension_get_has_injected_content(extension));
+        break;
+    case PROP_HAS_OPTIONS_PAGE:
+        g_value_set_boolean(value, webkit_web_extension_get_has_options_page(extension));
+        break;
+    case PROP_HAS_OVERRIDE_NEW_TAB_PAGE:
+        g_value_set_boolean(value, webkit_web_extension_get_has_override_new_tab_page(extension));
+        break;
+    case PROP_HAS_COMMANDS:
+        g_value_set_boolean(value, webkit_web_extension_get_has_commands(extension));
+        break;
+    case PROP_HAS_CONTENT_MODIFICATION_RULES:
+        g_value_set_boolean(value, webkit_web_extension_get_has_content_modification_rules(extension));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void webkitWebExtensionSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
+{
+    WebKitWebExtension* extension = WEBKIT_WEB_EXTENSION(object);
+
+    switch (propId) {
+    case PROP_PATH:
+        webkitWebExtensionSetPath(extension, G_FILE(g_value_get_object(value)));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void webkit_web_extension_class_init(WebKitWebExtensionClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->get_property = webkitWebExtensionGetProperty;
+    objectClass->set_property = webkitWebExtensionSetProperty;
+
+    /**
+     * WebKitWebExtension:path:
+     * 
+     * A #GFile pointing to the folder containing the extension manifest and resources.
+     * See webkit_web_extension_get_path() for more details.
+     *
+     * Since: 2.52
+     */
+    properties[PROP_PATH] =
+        g_param_spec_object(
+            "path",
+            nullptr, nullptr,
+            G_TYPE_FILE,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WebKitWebExtension:manifest-version:
+     * 
+     * The parsed manifest version of the #WebKitWebExtension.
+     * See webkit_web_extension_get_manifest_version() for more details.
+     *
+     * Since: 2.52
+     */
+    properties[PROP_MANIFEST_VERSION] =
+        g_param_spec_string(
+            "manifest-version",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:default-locale:
+     * 
+     * The default locale for the #WebKitWebExtension.
+     * See webkit_web_extension_get_default_locale() for more details.
+     *
+     * Since: 2.52
+     */
+    properties[PROP_DEFAULT_LOCALE] =
+        g_param_spec_string(
+            "default-locale",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:display-name:
+     * 
+     * The localized name of the #WebKitWebExtension.
+     * See webkit_web_extension_get_display_name() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_DISPLAY_NAME] =
+        g_param_spec_string(
+            "display-name",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:display-short-name:
+     * 
+     * The localized short name of the #WebKitWebExtension.
+     * See webkit_web_extension_get_display_short_name() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_DISPLAY_SHORT_NAME] =
+        g_param_spec_string(
+            "display-short-name",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:display-version:
+     * 
+     * The localized display version of the #WebKitWebExtension.
+     * See webkit_web_extension_get_display_version() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_DISPLAY_VERSION] =
+        g_param_spec_string(
+            "display-version",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:display-description:
+     * 
+     * The localized description of the #WebKitWebExtension.
+     * See webkit_web_extension_get_display_description() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_DISPLAY_DESCRIPTION] =
+        g_param_spec_string(
+            "display-description",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:display-action-label:
+     * 
+     * The localized extension action label of the #WebKitWebExtension.
+     * See webkit_web_extension_get_display_action_label() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_DISPLAY_ACTION_LABEL] =
+        g_param_spec_string(
+            "display-action-label",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:version:
+     * 
+     * The version of the #WebKitWebExtension.
+     * See webkit_web_extension_get_version() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_VERSION] =
+        g_param_spec_string(
+            "version",
+            nullptr, nullptr,
+            nullptr,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:requested-permissions:
+     * 
+     * The set of permissions that the #WebKitWebExtension requires for its base functionality.
+     * See webkit_web_extension_get_requested_permissions() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_REQUESTED_PERMISSIONS] =
+        g_param_spec_boxed(
+            "requested-permissions",
+            nullptr, nullptr,
+            G_TYPE_STRV,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:optional-permissions:
+     * 
+     * The set of permissions that the #WebKitWebExtension may need for optional functionality.
+     * See webkit_web_extension_get_optional_permissions() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_OPTIONAL_PERMISSIONS] =
+        g_param_spec_boxed(
+            "optional-permissions",
+            nullptr, nullptr,
+            G_TYPE_STRV,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-background-content:
+     * 
+     * Whether the #WebKitWebExtension has background content that can run when needed.
+     * See webkit_web_extension_get_has_background_content() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_BACKGROUND_CONTENT] =
+        g_param_spec_boolean(
+            "has-background-content",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-persistent-background-content:
+     * 
+     * Whether the #WebKitWebExtension has background content that stays in memory as long as the extension is loaded.
+     * See webkit_web_extension_get_has_persistent_background_content() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_PERSISTENT_BACKGROUND_CONTENT] =
+        g_param_spec_boolean(
+            "has-persistent-background-content",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-injected-content:
+     * 
+     * Whether the #WebKitWebExtension has script or stylesheet content that can be injected into webpages.
+     * See webkit_web_extension_get_has_injected_content() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_INJECTED_CONTENT] =
+        g_param_spec_boolean(
+            "has-injected-content",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-options-page:
+     * 
+     * Whether the #WebKitWebExtension has an options page.
+     * See webkit_web_extension_get_has_options_page() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_OPTIONS_PAGE] =
+        g_param_spec_boolean(
+            "has-options-page",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-override-new-tab-page:
+     * 
+     * Whether the #WebKitWebExtension provides an alternative to the default new tab page.
+     * See webkit_web_extension_get_has_override_new_tab_page() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_OVERRIDE_NEW_TAB_PAGE] =
+        g_param_spec_boolean(
+            "has-override-new-tab-page",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-commands:
+     * 
+     * Whether the #WebKitWebExtension includes commands that users can invoke.
+     * See webkit_web_extension_get_has_commands() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_COMMANDS] =
+        g_param_spec_boolean(
+            "has-commands",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    /**
+     * WebKitWebExtension:has-content-modification-rules:
+     * 
+     * Whether the #WebKitWebExtension includes rules used for content modification or blocking.
+     * See webkit_web_extension_get_content_modification_rules() for more details.
+     * 
+     * Since: 2.52
+     */
+    properties[PROP_HAS_CONTENT_MODIFICATION_RULES] =
+        g_param_spec_boolean(
+            "has-content-modification-rules",
+            nullptr, nullptr,
+            FALSE,
+            WEBKIT_PARAM_READABLE);
+
+    g_object_class_install_properties(objectClass, properties.size(), properties.data());
+}
+
+static gboolean webkitWebExtensionInitableInit(GInitable* initable, GCancellable* cancellable, GError** error)
+{
+#if ENABLE(WK_WEB_EXTENSIONS)
+    WebKitWebExtension* self = WEBKIT_WEB_EXTENSION(initable);
+    GRefPtr<GFile> extensionPath = self->priv->path;
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(self), FALSE);
+    g_return_val_if_fail(extensionPath && G_IS_FILE(extensionPath.get()), FALSE);
+    g_return_val_if_fail(g_file_query_file_type(extensionPath.get(), G_FILE_QUERY_INFO_NONE, nullptr) == G_FILE_TYPE_DIRECTORY, FALSE);
+
+    RefPtr<API::Error> internalError;
+    Ref extension = WebKit::WebExtension::create(extensionPath.get(), internalError);
+    if (internalError) {
+        g_set_error(error, webkit_web_extension_error_quark(),
+            toWebKitWebExtensionError(internalError->errorCode()), internalError->localizedDescription().utf8().data(), nullptr);
+        return FALSE;
+    }
+
+    self->priv->extension = WTFMove(extension);
+
+    return TRUE;
+#else
+    return FALSE;
+#endif
+}
+
+static void gInitableInterfaceInit(GInitableIface* iface)
+{
+    iface->init = webkitWebExtensionInitableInit;
+}
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+WebKitWebExtension* webkitWebExtensionCreate(HashMap<String, GRefPtr<GBytes>>&& resources, GError** error)
+{
+    WebExtension::Resources newResources;
+    for (auto& it : resources)
+        newResources.add(it.key, API::Data::createWithoutCopying(WTFMove(it.value)));
+
+    Ref extension = WebKit::WebExtension::create(WTFMove(newResources));
+
+    if (!extension->errors().isEmpty()) {
+        Ref internalError = extension->errors().last();
+        g_set_error(error, webkit_web_extension_error_quark(),
+            toWebKitWebExtensionError(internalError->errorCode()), internalError->localizedDescription().utf8().data(), nullptr);
+    }
+
+    WebKitWebExtension* object = WEBKIT_WEB_EXTENSION(g_object_new(WEBKIT_TYPE_WEB_EXTENSION, nullptr));
+    object->priv->extension = WTFMove(extension);
+    return object;
+}
+
+/**
+ * webkit_web_extension_new:
+ * @extension_path: A #GFile pointing to the folder containing the extension manifest and resources
+ * @error: return location for error or %NULL to ignore
+ * 
+ * Creates a new WebKitWebExtension from a folder containing the extension contents. The folder must
+ * contain a `manifest.json` file. If the manifest is invalid or missing, an error will be returned.
+ * 
+ * Returns: (nullable): the new #WebKitWebExtension, or %NULL if the extension failed to be created
+ * 
+ * Since: 2.52
+ */
+WebKitWebExtension* webkit_web_extension_new(GFile *extensionPath, GError **error)
+{
+    g_return_val_if_fail(G_IS_FILE(extensionPath), nullptr);
+    g_return_val_if_fail(g_file_query_file_type(extensionPath, G_FILE_QUERY_INFO_NONE, nullptr) == G_FILE_TYPE_DIRECTORY, nullptr);
+
+    return WEBKIT_WEB_EXTENSION(g_initable_new (WEBKIT_TYPE_WEB_EXTENSION, nullptr, error, "path", extensionPath, nullptr));
+}
+
+void webkitWebExtensionSetPath(WebKitWebExtension* extension, GFile* file)
+{
+    g_return_if_fail(WEBKIT_IS_WEB_EXTENSION(extension));
+
+    extension->priv->path = file;
+}
+
+/**
+ * webkit_web_extension_get_path:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the #GFile pointing to the folder containing the extension manifest and resources
+ * 
+ * Returns: (transfer none): a #GFile pointing to the folder
+ * 
+ * Since: 2.52
+ */
+GFile* webkit_web_extension_get_path(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), 0);
+
+    return extension->priv->path.get();
+}
+
+/**
+ * webkit_web_extension_get_manifest_version:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the parsed manifest version, or `0` if there is no
+ * version specified in the manifest.
+ *
+ * An ``WKWebExtensionErrorUnsupportedManifestVersion`` error will be
+ * reported if the manifest version isn't specified.
+ * 
+ * Returns: the parsed manifest version.
+ * 
+ * Since: 2.52
+ */
+gdouble webkit_web_extension_get_manifest_version(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), 0);
+
+    return extension->priv->extension->manifestVersion();
+}
+
+/**
+ * webkit_web_extension_supports_manifest_version:
+ * @extension: a #WebKitWebExtension
+ * @manifest_version: the version number to check
+ * 
+ * Checks if a manifest version is supported by the extension.
+ * 
+ * Returns: `TRUE` if the extension specified a manifest version
+ * that is greater than or equal to @manifest_version.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_supports_manifest_version(WebKitWebExtension* extension, gdouble manifestVersion)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->supportsManifestVersion(manifestVersion);
+}
+
+/**
+ * webkit_web_extension_get_default_locale:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the default locale for the extension.
+ * 
+ * Returns: (nullable): the default locale, or %NULL if there was no default
+ * locale specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_default_locale(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->defaultLocale.isNull())
+        return priv->defaultLocale.data();
+
+    auto defaultLocale = priv->extension->defaultLocale();
+    if (defaultLocale.isEmpty())
+        return nullptr;
+
+    priv->defaultLocale = defaultLocale.utf8();
+    return priv->defaultLocale.data();
+}
+
+/**
+ * webkit_web_extension_get_display_name:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the localized name for the extension.
+ * 
+ * Returns: (nullable): the localized name, or %NULL if there was no
+ * name specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_display_name(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->displayName.isNull())
+        return priv->displayName.data();
+
+    auto displayName = priv->extension->displayName();
+    if (displayName.isEmpty())
+        return nullptr;
+
+    priv->displayName = displayName.utf8();
+    return priv->displayName.data();
+}
+
+/**
+ * webkit_web_extension_get_display_short_name:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the localized short name for the extension.
+ * 
+ * Returns: (nullable): the localized name, or %NULL if there was no
+ * short name specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_display_short_name(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->displayShortName.isNull())
+        return priv->displayShortName.data();
+
+    auto displayShortName = priv->extension->displayShortName();
+    if (displayShortName.isEmpty())
+        return nullptr;
+
+    priv->displayShortName = displayShortName.utf8();
+    return priv->displayShortName.data();
+}
+
+/**
+ * webkit_web_extension_get_display_version:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the localized display version for the extension.
+ * 
+ * Returns: (nullable): the localized display version, or %NULL if there was no
+ * display version specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_display_version(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->displayVersion.isNull())
+        return priv->displayVersion.data();
+
+    auto displayVersion = priv->extension->displayVersion();
+    if (displayVersion.isEmpty())
+        return nullptr;
+
+    priv->displayVersion = displayVersion.utf8();
+    return priv->displayVersion.data();
+}
+
+/**
+ * webkit_web_extension_get_display_description:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the localized display description for the extension.
+ * 
+ * Returns: (nullable): the localized display description, or %NULL if there
+ * was no display description specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_display_description(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->displayDescription.isNull())
+        return priv->displayDescription.data();
+
+    auto displayDescription = priv->extension->displayDescription();
+    if (displayDescription.isEmpty())
+        return nullptr;
+
+    priv->displayDescription = displayDescription.utf8();
+    return priv->displayDescription.data();
+}
+
+/**
+ * webkit_web_extension_get_display_action_label:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the localized display action label for the extension.
+ * 
+ * This label serves as a default and should be used to represent the extension in contexts like action sheets or toolbars prior to 
+ * the extension being loaded into an extension context.
+ * Once the extension is loaded, use the ``actionForTab:`` API to get the tab-specific label.
+ * 
+ * Returns: (nullable): the localized display action label, or %NULL if there
+ * was no display action label specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_display_action_label(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->displayActionLabel.isNull())
+        return priv->displayActionLabel.data();
+
+    auto displayActionLabel = priv->extension->displayActionLabel();
+    if (displayActionLabel.isEmpty())
+        return nullptr;
+
+    priv->displayActionLabel = displayActionLabel.utf8();
+    return priv->displayActionLabel.data();
+}
+
+/**
+ * webkit_web_extension_get_icon:
+ * @extension: a #WebKitWebExtension
+ * @width: The width to use when looking up the icon.
+ * @height: The height to use when looking up the icon.
+ *
+ * Returns the extension's icon image for the specified size.
+ * This icon should represent the extension in settings or other areas that show the extension.
+ * The returned image will be the best match for the specified size that is available in the extension's
+ * icon set. If no matching icon can be found, the method will return %NULL.
+ * 
+ * Returns: (nullable) (transfer none): the icon image, or %NULL if no icon could be loaded.
+ * 
+ * Since: 2.52
+ */
+GIcon* webkit_web_extension_get_icon(WebKitWebExtension* extension, gdouble width, gdouble height)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    auto icon = priv->extension->icon(WebCore::FloatSize(width, height));
+    if (!icon)
+        return nullptr;
+    return icon->icon();
+}
+
+/**
+ * webkit_web_extension_get_action_icon:
+ * @extension: a #WebKitWebExtension
+ * @width: The width to use when looking up the icon.
+ * @height: The height to use when looking up the icon.
+ *
+ * Returns the extension's default action icon image for the specified size.
+ * This icon serves as a default and should be used to represent the extension in contexts like action sheets or toolbars prior to 
+ * the extension being loaded into an extension context. Once the extension is loaded, use the
+ * ``actionForTab:`` API to get the tab-specific icon.
+ * The returned image will be the best match for the specified size that is available in the extension's action icon set. If no matching icon is available,
+ * the method will fall back to the extension's icon.
+ * 
+ * Returns: (nullable) (transfer none): the icon image, or %NULL if no icon could be loaded.
+ * 
+ * Since: 2.52
+ */
+GIcon* webkit_web_extension_get_action_icon(WebKitWebExtension* extension, gdouble width, gdouble height)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    auto icon = priv->extension->actionIcon(WebCore::FloatSize(width, height));
+    if (!icon)
+        return nullptr;
+    return icon->icon();
+}
+
+/**
+ * webkit_web_extension_get_version:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the version for the extension.
+ * 
+ * Returns: (nullable): the version, or %NULL if there was no
+ * version specified.
+ * 
+ * Since: 2.52
+ */
+const gchar* webkit_web_extension_get_version(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (!priv->version.isNull())
+        return priv->version.data();
+
+    auto version = priv->extension->version();
+    if (version.isEmpty())
+        return nullptr;
+
+    priv->version = version.utf8();
+    return priv->version.data();
+}
+
+/**
+ * webkit_web_extension_get_requested_permissions:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the set of permissions that the extension requires
+ * for its base functionality.
+ * 
+ * Returns: (nullable) (array zero-terminated=1) (transfer none): a
+ * %NULL-terminated array of strings containing permission names,
+ * or %NULL otherwise. This array and its contents are owned by
+ * WebKit and should not be modified or freed.
+ * 
+ * Since: 2.52
+ */
+const gchar* const * webkit_web_extension_get_requested_permissions(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (priv->requestedPermissions)
+        return reinterpret_cast<gchar**>(priv->requestedPermissions->pdata);
+
+    auto requestedPermissions = priv->extension->requestedPermissions();
+    if (!requestedPermissions.size())
+        return nullptr;
+
+    priv->requestedPermissions = adoptGRef(g_ptr_array_new_with_free_func(g_free));
+    for (auto permission : requestedPermissions)
+        g_ptr_array_add(priv->requestedPermissions.get(), g_strdup(permission.utf8().data()));
+    g_ptr_array_add(priv->requestedPermissions.get(), nullptr);
+
+    return reinterpret_cast<gchar**>(priv->requestedPermissions->pdata);
+}
+
+/**
+ * webkit_web_extension_get_optional_permissions:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the set of permissions that the extension may need for
+ * optional functionality. These permissions can be requested
+ * by the extension at a later time.
+ * 
+ * Returns: (nullable) (array zero-terminated=1) (transfer none): a
+ * %NULL-terminated array of strings containing permission names,
+ * or %NULL otherwise. This array and its contents are owned by
+ * WebKit and should not be modified or freed.
+ * 
+ * Since: 2.52
+ */
+const gchar* const * webkit_web_extension_get_optional_permissions(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    WebKitWebExtensionPrivate* priv = extension->priv;
+    if (priv->optionalPermissions)
+        return reinterpret_cast<gchar**>(priv->optionalPermissions->pdata);
+
+    auto optionalPermissions = priv->extension->optionalPermissions();
+    if (!optionalPermissions.size())
+        return nullptr;
+
+    priv->optionalPermissions = adoptGRef(g_ptr_array_new_with_free_func(g_free));
+    for (auto permission : optionalPermissions)
+        g_ptr_array_add(priv->optionalPermissions.get(), g_strdup(permission.utf8().data()));
+    g_ptr_array_add(priv->optionalPermissions.get(), nullptr);
+
+    return reinterpret_cast<gchar**>(priv->optionalPermissions->pdata);
+}
+
+/**
+ * webkit_web_extension_get_requested_permission_match_patterns:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the set of websites that the extension requires access to for its base functionality.
+ *
+ * Returns: (array zero-terminated=1) (element-type WebKitWebExtensionMatchPattern) (transfer full): a
+ *    %NULL-terminated array of match patterns matching the required websites.
+ * 
+ * Since: 2.52
+ */
+WebKitWebExtensionMatchPattern** webkit_web_extension_get_requested_permission_match_patterns(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    auto matchPatternSet = extension->priv->extension->requestedPermissionMatchPatterns();
+    if (!matchPatternSet.size())
+        return nullptr;
+
+    GPtrArray* returnValue = g_ptr_array_new_with_free_func(g_free);
+    for (Ref pattern : matchPatternSet)
+        g_ptr_array_add(returnValue, webkitWebExtensionMatchPatternCreate(pattern));
+    g_ptr_array_add(returnValue, nullptr);
+
+    return reinterpret_cast<WebKitWebExtensionMatchPattern**>(g_ptr_array_free(returnValue, FALSE));
+}
+
+/**
+ * webkit_web_extension_get_optional_permission_match_patterns:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the set of websites that the extension may need access to for optional functionality.
+ * These match patterns can be requested by the extension at a later time.
+ *
+ * Returns: (array zero-terminated=1) (element-type WebKitWebExtensionMatchPattern) (transfer full): a
+ *    %NULL-terminated array of match patterns matching the optional websites.
+ * 
+ * Since: 2.52
+ */
+WebKitWebExtensionMatchPattern** webkit_web_extension_get_optional_permission_match_patterns(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    auto matchPatternSet = extension->priv->extension->optionalPermissionMatchPatterns();
+    if (!matchPatternSet.size())
+        return nullptr;
+
+    GPtrArray* returnValue = g_ptr_array_new_with_free_func(g_free);
+    for (Ref pattern : matchPatternSet)
+        g_ptr_array_add(returnValue, webkitWebExtensionMatchPatternCreate(pattern));
+    g_ptr_array_add(returnValue, nullptr);
+
+    return reinterpret_cast<WebKitWebExtensionMatchPattern**>(g_ptr_array_free(returnValue, FALSE));
+}
+
+/**
+ * webkit_web_extension_get_all_requested_match_patterns:
+ * @extension: a #WebKitWebExtension
+ *
+ * Get the set of websites that the extension requires access to for injected content
+ * and for receiving messages from websites.
+ *
+ * Returns: (array zero-terminated=1) (element-type WebKitWebExtensionMatchPattern) (transfer full): a
+ *    %NULL-terminated array of match patterns matching all requested websites.
+ * 
+ * Since: 2.52
+ */
+WebKitWebExtensionMatchPattern** webkit_web_extension_get_all_requested_match_patterns(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), nullptr);
+
+    auto matchPatternSet = extension->priv->extension->allRequestedMatchPatterns();
+    if (!matchPatternSet.size())
+        return nullptr;
+
+    GPtrArray* returnValue = g_ptr_array_new_with_free_func(g_free);
+    for (Ref pattern : matchPatternSet)
+        g_ptr_array_add(returnValue, webkitWebExtensionMatchPatternCreate(pattern));
+    g_ptr_array_add(returnValue, nullptr);
+
+    return reinterpret_cast<WebKitWebExtensionMatchPattern**>(g_ptr_array_free(returnValue, FALSE));
+}
+
+/**
+ * webkit_web_extension_get_has_background_content:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension has background content that can run when needed.
+ * 
+ * Returns: `TRUE` if the extension can run in the background even when no
+ * webpages are open.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_background_content(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->hasBackgroundContent();
+}
+
+gboolean webkit_web_extension_get_has_service_worker_background_content(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->backgroundContentIsServiceWorker();
+}
+
+gboolean webkit_web_extension_get_has_modular_background_content(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->backgroundContentUsesModules();
+}
+
+/**
+ * webkit_web_extension_get_has_persistent_background_content:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension has background content that stays in memory as long
+ * as the extension is loaded.
+ * 
+ * Returns: `TRUE` if the extension can run in the background.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_persistent_background_content(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->backgroundContentIsPersistent();
+}
+
+/**
+ * webkit_web_extension_get_has_injected_content:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension has script or stylesheet content
+ * that can be injected into webpages.
+ * 
+ * Once the extension is loaded, use the ``hasInjectedContent``
+ * property on an extension context, as the injectable content
+ * can change after the extension is loaded.
+ * 
+ * Returns: `TRUE` if the extension has content that can be
+ * injected by matching against the extension's
+ * requested match patterns.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_injected_content(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->hasStaticInjectedContent();
+}
+
+/**
+ * webkit_web_extension_get_has_options_page:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension has an options page.
+ * 
+ * The app should provide access to this page through a
+ * user interface element, which can be accessed via
+ * ``optionsPageURL`` on an extension context.
+ * 
+ * Returns: `TRUE` if the extension includes a dedicated options
+ * page where users can customize settings.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_options_page(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->hasOptionsPage();
+}
+
+/**
+ * webkit_web_extension_get_has_override_new_tab_page:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension provides an alternative to
+ * the default new tab page.
+ * 
+ * The app should prompt the user for permission to use
+ * the extension's new tab page as the default, which can
+ * be accessed via ``overrideNewTabPageURL``
+ * on an extension context.
+ * 
+ * Returns: `TRUE` if the extension can specify a custom page
+ * that can be displayed when a new tab is opened in the app,
+ * instead of the default new tab page.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_override_new_tab_page(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->hasOverrideNewTabPage();
+}
+
+/**
+ * webkit_web_extension_get_has_commands:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension includes commands that users can invoke.
+ * 
+ * These commands should be accessible via keyboard shortcuts,
+ * menu items, or other user interface elements provided
+ * by the app. The list of commands can be accessed
+ * via ``commands`` on an extension context, and
+ * invoked via ``performCommand:``.
+ * 
+ * Returns: `TRUE` if the extension contains one or more commands
+ * that can be performed by the user.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_commands(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->hasCommands();
+}
+
+/**
+ * webkit_web_extension_get_has_content_modification_rules:
+ * @extension: a #WebKitWebExtension
+ * 
+ * Get whether the extension includes rules used for
+ * content modification or blocking.
+ * 
+ * Returns: `TRUE` if the extension contains one or more rules
+ * for content modification.
+ * 
+ * Since: 2.52
+ */
+gboolean webkit_web_extension_get_has_content_modification_rules(WebKitWebExtension* extension)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEB_EXTENSION(extension), FALSE);
+
+    return extension->priv->extension->hasContentModificationRules();
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
+WebKitWebExtension* webkit_web_extension_new(GFile *extension, GError **error)
+{
+    return nullptr;
+}
+
+void webkitWebExtensionSetPath(WebKitWebExtension* extension, GFile* file)
+{
+    return;
+}
+
+GFile* webkit_web_extension_get_path(WebKitWebExtension* extension)
+{
+    return nullptr;
+}
+
+gdouble webkit_web_extension_get_manifest_version(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_supports_manifest_version(WebKitWebExtension* extension, gdouble manifestVersion)
+{
+    return 0;
+}
+
+const gchar* webkit_web_extension_get_default_locale(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_get_display_name(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_get_display_short_name(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_get_display_version(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_get_display_description(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+const gchar* webkit_web_extension_get_display_action_label(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+GIcon* webkit_web_extension_get_icon(WebKitWebExtension* extension, gdouble width, gdouble height)
+{
+    return nullptr;
+}
+
+GIcon* webkit_web_extension_get_action_icon(WebKitWebExtension* extension, gdouble width, gdouble height)
+{
+    return nullptr;
+}
+
+const gchar* webkit_web_extension_get_version(WebKitWebExtension* extension)
+{
+    return "";
+}
+
+const gchar* const * webkit_web_extension_get_requested_permissions(WebKitWebExtension* extension)
+{
+    return nullptr;
+}
+
+const gchar* const * webkit_web_extension_get_optional_permissions(WebKitWebExtension* extension)
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern** webkit_web_extension_get_requested_permission_match_patterns(WebKitWebExtension* extension)
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern** webkit_web_extension_get_optional_permission_match_patterns(WebKitWebExtension* extension)
+{
+    return nullptr;
+}
+
+WebKitWebExtensionMatchPattern** webkit_web_extension_get_all_requested_match_patterns(WebKitWebExtension* extension)
+{
+    return nullptr;
+}
+
+gboolean webkit_web_extension_get_has_background_content(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_service_worker_background_content(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_modular_background_content(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_persistent_background_content(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_injected_content(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_options_page(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_override_new_tab_page(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_commands(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+gboolean webkit_web_extension_get_has_content_modification_rules(WebKitWebExtension* extension)
+{
+    return 0;
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+#endif // ENABLE(2022_GLIB_API)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtension.h.in
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitWebExtension_h
+#define WebKitWebExtension_h
+
+#if ENABLE(2022_GLIB_API)
+
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+#include "WebKitWebExtensionMatchPattern.h"
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_WEB_EXTENSION                            (webkit_web_extension_get_type ())
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitWebExtension, webkit_web_extension, WEBKIT, WEB_EXTENSION, GObject)
+
+WEBKIT_API WebKitWebExtension *
+webkit_web_extension_new                                     (GFile   *extension_path,
+                                                              GError **error);
+
+WEBKIT_API GFile *
+webkit_web_extension_get_path                                (WebKitWebExtension* extension);
+
+WEBKIT_API gdouble
+webkit_web_extension_get_manifest_version                    (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_supports_manifest_version               (WebKitWebExtension *extension,
+                                                              gdouble             manifest_version);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_default_locale                      (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_display_name                        (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_display_short_name                  (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_display_version                     (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_display_description                 (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_display_action_label                (WebKitWebExtension *extension);
+
+WEBKIT_API GIcon *
+webkit_web_extension_get_icon                                (WebKitWebExtension *extension,
+                                                              gdouble             width,
+                                                              gdouble             height);
+
+WEBKIT_API GIcon *
+webkit_web_extension_get_action_icon                         (WebKitWebExtension *extension,
+                                                              gdouble             width,
+                                                              gdouble             height);
+
+WEBKIT_API const gchar *
+webkit_web_extension_get_version                             (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar * const *
+webkit_web_extension_get_requested_permissions               (WebKitWebExtension *extension);
+
+WEBKIT_API const gchar * const *
+webkit_web_extension_get_optional_permissions                (WebKitWebExtension *extension);
+
+WEBKIT_API WebKitWebExtensionMatchPattern **
+webkit_web_extension_get_requested_permission_match_patterns (WebKitWebExtension *extension);
+
+WEBKIT_API WebKitWebExtensionMatchPattern **
+webkit_web_extension_get_optional_permission_match_patterns  (WebKitWebExtension *extension);
+
+WEBKIT_API WebKitWebExtensionMatchPattern **
+webkit_web_extension_get_all_requested_match_patterns        (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_background_content              (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_persistent_background_content   (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_injected_content                (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_options_page                    (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_override_new_tab_page           (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_commands                        (WebKitWebExtension *extension);
+
+WEBKIT_API gboolean
+webkit_web_extension_get_has_content_modification_rules      (WebKitWebExtension *extension);
+
+G_END_DECLS
+
+#endif // ENABLE(2022_GLIB_API)
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionInternal.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebExtensionInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -19,15 +19,19 @@
 
 #pragma once
 
-#include "WebExtensionMatchPattern.h"
-#include "WebKitWebExtensionMatchPattern.h"
-#include <wtf/RefPtr.h>
-
-typedef struct _WebKitWebExtensionMatchPattern WebKitWebExtensionMatchPattern;
-
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(Ref<WebKit::WebExtensionMatchPattern>&);
-WebKitWebExtensionMatchPattern* webkitWebExtensionMatchPatternCreate(const RefPtr<WebKit::WebExtensionMatchPattern>&);
+#include "WebKitWebExtension.h"
+#include <WebKit/WKBase.h>
+#include <wtf/HashMap.h>
+#include <wtf/text/WTFString.h>
 
-#endif
+// Private API required by the unit tests
+
+typedef struct _WebKitWebExtension WebKitWebExtension;
+
+WK_EXPORT WebKitWebExtension* webkitWebExtensionCreate(HashMap<String, GRefPtr<GBytes>>&& resources, GError**);
+WK_EXPORT gboolean webkit_web_extension_get_has_service_worker_background_content(WebKitWebExtension*);
+WK_EXPORT gboolean webkit_web_extension_get_has_modular_background_content(WebKitWebExtension*);
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -122,7 +122,8 @@
 #include <@API_INCLUDE_PREFIX@/WebKitUserMessage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitVersion.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebContext.h>
-#if PLATFORM(GTK)
+#if ENABLE(2022_GLIB_API)
+#include <@API_INCLUDE_PREFIX@/WebKitWebExtension.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebExtensionMatchPattern.h>
 #endif
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -73,6 +73,9 @@ public:
 #if PLATFORM(COCOA)
     explicit WebExtension(NSBundle *appExtensionBundle, NSURL *resourceURL, RefPtr<API::Error>&);
     explicit WebExtension(NSDictionary *manifest, Resources&& = { });
+#else
+    explicit WebExtension(GFile *resourcesFile, RefPtr<API::Error>&);
+    explicit WebExtension(const JSON::Value& manifest, Resources&& = { });
 #endif
 
     explicit WebExtension(Resources&& = { });

--- a/Source/WebKit/UIProcess/Extensions/gtk/WebExtensionGtk.cpp
+++ b/Source/WebKit/UIProcess/Extensions/gtk/WebExtensionGtk.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebExtension.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "Logging.h"
+#include "WebExtensionLocalization.h"
+#include "WebExtensionUtilities.h"
+#include <WebCore/DataURLDecoder.h>
+#include <WebCore/LocalizedStrings.h>
+#include <gtk/gtk.h>
+#include <wtf/FileSystem.h>
+#include <wtf/Language.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/text/Base64.h>
+
+namespace WebKit {
+
+static constexpr auto generatedBackgroundPageFilename = "_generated_background_page.html"_s;
+static constexpr auto generatedBackgroundServiceWorkerFilename = "_generated_service_worker.js"_s;
+
+WebExtension::WebExtension(GFile* resourcesFile, RefPtr<API::Error>& outError)
+    : m_manifestJSON(JSON::Value::null())
+{
+    RELEASE_ASSERT(resourcesFile);
+
+    outError = nullptr;
+
+    GUniquePtr<char> baseURL(g_file_get_path(resourcesFile));
+    if (!g_str_has_prefix(baseURL.get(), "file"))
+        baseURL.reset(g_strconcat("file:", baseURL.get(), nullptr));
+
+    // While there is a check below to make sure that the directory has a path suffix, it can sometimes remove the full path
+    // and leave only the protocol.
+    if (!g_str_has_suffix(baseURL.get(), "/"))
+        baseURL.reset(g_strconcat(baseURL.get(), "/", nullptr));
+    m_resourceBaseURL = URL { String::fromUTF8(baseURL.get()) };
+
+    if (m_resourceBaseURL.isValid()) {
+        auto isDirectory = g_file_query_file_type(resourcesFile, G_FILE_QUERY_INFO_NONE, nullptr) == G_FILE_TYPE_DIRECTORY;
+
+        if (!isDirectory) {
+            outError = createError(Error::Unknown);
+            return;
+        }
+    }
+
+    RELEASE_ASSERT(m_resourceBaseURL.protocolIsFile());
+    RELEASE_ASSERT(m_resourceBaseURL.hasPath());
+
+    if (m_resourceBaseURL.path().right(1) != "/"_s)
+        m_resourceBaseURL = URL::fileURLWithFileSystemPath(FileSystem::pathByAppendingComponent(m_resourceBaseURL.path(), "/"_s));
+
+    if (!manifestParsedSuccessfully()) {
+        ASSERT(!m_errors.isEmpty());
+        outError = m_errors.last().ptr();
+    }
+}
+
+WebExtension::WebExtension(const JSON::Value& manifest, Resources&& resources)
+    : m_manifestJSON(manifest)
+    , m_resources(WTFMove(resources))
+{
+    auto manifestString = manifest.toJSONString();
+    RELEASE_ASSERT(manifestString);
+
+    m_resources.set("manifest.json"_s, manifestString);
+}
+
+Expected<Ref<API::Data>, RefPtr<API::Error>> WebExtension::resourceDataForPath(const String& originalPath, CacheResult cacheResult, SuppressNotFoundErrors suppressErrors)
+{
+    ASSERT(originalPath);
+
+    String path = originalPath;
+
+    // Remove leading slash to normalize the path for lookup/storage in the cache dictionary.
+    if (path.startsWith('/'))
+        path = path.substring(1);
+
+    if (path.startsWith("data:"_s)) {
+        if (auto decodedURL = WebCore::DataURLDecoder::decode(URL { path }))
+            return API::Data::create(decodedURL.value().data);
+        ASSERT(path == "data:"_s);
+        return API::Data::create(std::span<const uint8_t> { });
+    }
+
+    if (path == generatedBackgroundPageFilename || path  == generatedBackgroundServiceWorkerFilename)
+        return API::Data::create(generatedBackgroundContent().utf8().span());
+
+    if (auto entry = m_resources.find(path); entry != m_resources.end()) {
+        return WTF::switchOn(entry->value,
+            [](const Ref<API::Data>& data) {
+                return data;
+            },
+            [](const String& string) {
+                return API::Data::create(string.utf8().span());
+            });
+    }
+
+    auto resourceURL = resourceFileURLForPath(path);
+    if (resourceURL.isEmpty()) {
+        if (suppressErrors == SuppressNotFoundErrors::No)
+            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find \"%s\" in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", path.utf8().data())));
+        return makeUnexpected(nullptr);
+    }
+
+    auto rawData = FileSystem::readEntireFile(resourceURL.fileSystemPath());
+    if (!rawData.has_value()) {
+        if (suppressErrors == SuppressNotFoundErrors::No)
+            return makeUnexpected(createError(Error::ResourceNotFound, WEB_UI_FORMAT_STRING("Unable to find \"%s\" in the extension’s resources.", "WKWebExtensionErrorResourceNotFound description with file name", path.utf8().data())));
+        return makeUnexpected(nullptr);
+    }
+
+    Ref data = API::Data::create(*rawData);
+    if (cacheResult == CacheResult::Yes)
+        m_resources.set(path, data);
+
+    return data;
+}
+
+void WebExtension::recordError(Ref<API::Error> error)
+{
+    RELEASE_LOG_ERROR(Extensions, "Error recorded: %s", error->platformError());
+
+    // Only the first occurrence of each error is recorded in the array. This prevents duplicate errors,
+    // such as repeated "resource not found" errors, from being included multiple times.
+    if (m_errors.contains(error))
+        return;
+
+    m_errors.append(error);
+}
+
+Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> WebExtension::iconForPath(const String& path, WebCore::FloatSize sizeForResizing, std::optional<double> idealDisplayScale)
+{
+    ASSERT(path);
+
+    auto dataResult = resourceDataForPath(path);
+    if (!dataResult)
+        return makeUnexpected(dataResult.error());
+
+    Ref imageData = dataResult.value();
+    auto gimageBytes = adoptGRef(g_bytes_new(imageData->span().data(), imageData->size()));
+
+    if (!sizeForResizing.isZero()) {
+        GUniqueOutPtr<GError> error;
+
+        auto loader = adoptGRef(gdk_pixbuf_loader_new());
+        gdk_pixbuf_loader_write_bytes(loader.get(), gimageBytes.get(), &error.outPtr());
+        if (error) {
+            RELEASE_LOG_ERROR(Extensions, "Unknown error when loading an icon: %s", error.get()->message);
+            return makeUnexpected(createError(Error::Unknown));
+        }
+        if (!gdk_pixbuf_loader_close(loader.get(), &error.outPtr()) && error) {
+            RELEASE_LOG_ERROR(Extensions, "Unknown error when loading an icon: %s", error.get()->message);
+            return makeUnexpected(createError(Error::Unknown));
+        }
+        auto pixbuf = adoptGRef(gdk_pixbuf_copy(gdk_pixbuf_loader_get_pixbuf(loader.get())));
+        if (!pixbuf)
+            return makeUnexpected(nullptr);
+
+        // Proportionally scale the size
+        auto originalWidth = gdk_pixbuf_get_width(pixbuf.get());
+        auto originalHeight = gdk_pixbuf_get_height(pixbuf.get());
+        auto aspectWidth = originalWidth ? (sizeForResizing.width() / originalWidth) : 0;
+        auto aspectHeight = originalHeight ? (sizeForResizing.height() / originalHeight) : 0;
+        auto aspectRatio = std::min(aspectWidth, aspectHeight);
+
+        gdk_pixbuf_scale_simple(pixbuf.get(), originalWidth * aspectRatio, originalHeight * aspectRatio, GDK_INTERP_BILINEAR);
+
+        gchar* buffer;
+        gsize bufferSize;
+        if (!gdk_pixbuf_save_to_buffer(pixbuf.get(), &buffer, &bufferSize, "png", &error.outPtr(), nullptr) && error) {
+            RELEASE_LOG_ERROR(Extensions, "Unknown error when loading an icon: %s", error.get()->message);
+            return makeUnexpected(createError(Error::Unknown));
+        }
+
+        gimageBytes = adoptGRef(g_bytes_new_take(buffer, bufferSize));
+    }
+
+    GRefPtr<GIcon> image = adoptGRef(g_bytes_icon_new(gimageBytes.get()));
+
+    if (RefPtr iconResult = WebCore::Icon::create(WTFMove(image)))
+        return iconResult.releaseNonNull();
+    return makeUnexpected(nullptr);
+}
+
+RefPtr<WebCore::Icon> WebExtension::bestIcon(RefPtr<JSON::Object> icons, WebCore::FloatSize idealSize, const Function<void(Ref<API::Error>)>& reportError)
+{
+    if (!icons)
+        return nullptr;
+
+    auto idealPointSize = idealSize.width() > idealSize.height() ? idealSize.width() : idealSize.height();
+    auto bestScale = largestDisplayScale();
+
+    auto pixelSize = idealPointSize * bestScale;
+    auto iconPath = pathForBestImage(*icons, pixelSize);
+    if (iconPath.isEmpty())
+        return nullptr;
+
+    auto imageValue = iconForPath(iconPath, idealSize);
+    if (imageValue)
+        return imageValue.value().get();
+
+    if (reportError && !imageValue && imageValue.error())
+        reportError(imageValue.error().releaseNonNull());
+
+    return nullptr;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
@@ -1,0 +1,1188 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "TestMain.h"
+#include "WebExtensionUtilities.h"
+#include <WebKitWebExtensionInternal.h>
+#include <wtf/HashMap.h>
+#include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+using namespace TestWebKitAPI;
+
+static GRefPtr<GBytes> createGBytes(const gchar* string)
+{
+    return adoptGRef(g_bytes_new_static(string, strlen(string)));
+}
+
+static void testExtensionCreationFromDirectory(Test*, gconstpointer)
+{
+    static const char* extensionManifest = "{ \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }";
+
+    GUniqueOutPtr<GError> error;
+    GUniquePtr<char> filePath(g_build_filename(Test::dataDirectory(), "manifest.json", nullptr));
+    g_assert_true(g_file_set_contents(filePath.get(), extensionManifest, strlen(extensionManifest), &error.outPtr()));
+    g_assert_no_error(error.get());
+
+    GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(Test::dataDirectory()));
+    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkit_web_extension_new(file.get(), &error.outPtr()));
+    g_assert_no_error(error.get());
+
+    g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_version(extension.get()), ==,  "1.0");
+    g_assert_cmpstr(webkit_web_extension_get_display_description(extension.get()), ==,  "Test description");
+    g_assert_cmpstr(webkit_web_extension_get_version(extension.get()), ==,  "1.0");
+    g_assert_cmpint(webkit_web_extension_get_manifest_version(extension.get()), ==, 2);
+}
+
+static void testDisplayStringParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 2 }");
+
+    g_assert_null(webkit_web_extension_get_display_name(extension.get()));
+    g_assert_null(webkit_web_extension_get_display_short_name(extension.get()));
+    g_assert_null(webkit_web_extension_get_display_version(extension.get()));
+    g_assert_null(webkit_web_extension_get_display_description(extension.get()));
+    g_assert_null(webkit_web_extension_get_version(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+
+    g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_version(extension.get()), ==,  "1.0");
+    g_assert_cmpstr(webkit_web_extension_get_display_description(extension.get()), ==,  "Test description");
+    g_assert_cmpstr(webkit_web_extension_get_version(extension.get()), ==,  "1.0");
+    g_assert_cmpint(webkit_web_extension_get_manifest_version(extension.get()), ==, 2);
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+
+    g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_version(extension.get()), ==,  "1.0");
+    g_assert_cmpstr(webkit_web_extension_get_display_description(extension.get()), ==,  "Test description");
+    g_assert_cmpstr(webkit_web_extension_get_version(extension.get()), ==,  "1.0");
+    g_assert_cmpint(webkit_web_extension_get_manifest_version(extension.get()), ==, 3);
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"name\": \"Test\", \"short_name\": \"Tst\", \"version\": \"1.0\", \"version_name\": \"1.0 Final\", \"description\": \"Test description\" }");
+
+    g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Test");
+    g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Tst");
+    g_assert_cmpstr(webkit_web_extension_get_display_version(extension.get()), ==,  "1.0 Final");
+    g_assert_cmpstr(webkit_web_extension_get_display_description(extension.get()), ==,  "Test description");
+    g_assert_cmpstr(webkit_web_extension_get_version(extension.get()), ==,  "1.0");
+    g_assert_no_error(error.get());
+}
+
+static void testDefaultLocaleParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString, const gchar* localeFile) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) }, { String::fromUTF8(localeFile), createGBytes("{}") } }, &error.outPtr()));
+    };
+
+    // Test no default locale
+    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes("{ \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }") } }, &error.outPtr()));
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_default_locale(extension.get()));
+
+    // Test with language locale file existing
+    extension = parse("{ \"manifest_version\": 2, \"default_locale\": \"en\", \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", "_locales/en/messages.json");
+    auto* defaultLocale = webkit_web_extension_get_default_locale(extension.get());
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_default_locale(extension.get()), ==, "en");
+
+    // Test with language locale file existing
+    extension = parse("{ \"manifest_version\": 2, \"default_locale\": \"en_US\", \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", "_locales/en_US/messages.json");
+    defaultLocale = webkit_web_extension_get_default_locale(extension.get());
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_default_locale(extension.get()), ==, "en_US");
+
+    // Test with less specific locale file existing
+    extension = parse("{ \"manifest_version\": 2, \"default_locale\": \"en_US\", \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", "_locales/en/messages.json");
+    defaultLocale = webkit_web_extension_get_default_locale(extension.get());
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_null(defaultLocale);
+
+    // Test with wrong locale file existing
+    extension = parse("{ \"manifest_version\": 2, \"default_locale\": \"en_US\", \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", "_locales/zh_CN/messages.json");
+    defaultLocale = webkit_web_extension_get_default_locale(extension.get());
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_null(defaultLocale);
+
+    // Test with no locale file existing
+    extension = parse("{ \"manifest_version\": 2, \"default_locale\": \"en_US\", \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", "");
+    defaultLocale = webkit_web_extension_get_default_locale(extension.get());
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_null(defaultLocale);
+}
+
+static void testDisplayStringParsingWithLocalization(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+
+    const gchar* manifest =
+        "{"
+        "\"manifest_version\": 2,"
+        "\"default_locale\": \"en_US\","
+        "\"name\": \"__MSG_default_name__\","
+        "\"short_name\": \"__MSG_regional_name__\","
+        "\"version\": \"1.0\","
+        "\"description\": \"__MSG_default_description__\""
+        "}";
+
+    const gchar* defaultMessages =
+        "{"
+        "\"default_name\": {"
+        "\"message\": \"Default String\","
+        "\"description\": \"The test name.\""
+        "},"
+        "\"default_description\": {"
+        "\"message\": \"Default Description\","
+        "\"description\": \"The test description.\""
+        "}"
+        "}";
+
+    const gchar* regionalMessages =
+        "{"
+        "\"regional_name\": {"
+        "\"message\": \"Regional String\","
+        "\"description\": \"The regional name.\""
+        "}"
+        "}";
+
+    HashMap<String, GRefPtr<GBytes>> resources = {
+        { "manifest.json"_s, createGBytes(manifest) },
+        { "_locales/en/messages.json"_s, createGBytes(defaultMessages) },
+        { "_locales/en_US/messages.json"_s, createGBytes(regionalMessages) }
+    };
+
+    GRefPtr<WebKitWebExtension> extension = adoptGRef(webkitWebExtensionCreate(WTFMove(resources), &error.outPtr()));
+
+    g_assert_cmpstr(webkit_web_extension_get_display_name(extension.get()), ==, "Default String");
+    g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Regional String");
+    g_assert_cmpstr(webkit_web_extension_get_display_version(extension.get()), ==,  "1.0");
+    g_assert_cmpstr(webkit_web_extension_get_display_description(extension.get()), ==,  "Default Description");
+    g_assert_cmpstr(webkit_web_extension_get_version(extension.get()), ==,  "1.0");
+    g_assert_no_error(error.get());
+
+    manifest =
+        "{"
+        "\"manifest_version\": 2,"
+        "\"default_locale\": \"en_US\","
+        "\"name\": \"__MSG_default_name__\","
+        "\"short_name\": \"__MSG_default_name__\","
+        "\"version\": \"1.0\","
+        "\"description\": \"__MSG_default_description__\""
+        "}";
+    resources = {
+        { "manifest.json"_s, createGBytes(manifest) },
+        { "_locales/en/messages.json"_s, createGBytes(defaultMessages) },
+        { "_locales/en_US/messages.json"_s, createGBytes(regionalMessages) }
+    };
+
+    extension = adoptGRef(webkitWebExtensionCreate(WTFMove(resources), &error.outPtr()));
+
+    g_assert_cmpstr(webkit_web_extension_get_display_short_name(extension.get()), ==,  "Default String");
+    g_assert_no_error(error.get());
+}
+
+static void testActionParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+    auto parseWithIcon = [&](const gchar* manifestString, GRefPtr<GBytes> imageData) {
+        return adoptGRef(webkitWebExtensionCreate({
+            { "manifest.json"_s, createGBytes(manifestString) },
+            { "test.png"_s, imageData }
+        }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parse("{ \"manifest_version\": 2, \"browser_action\": {}, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parse("{ \"manifest_version\": 2, \"page_action\": {}, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parse("{ \"manifest_version\": 2, \"browser_action\": {}, \"page_action\": {}, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parse("{ \"manifest_version\": 2, \"browser_action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_display_action_label(extension.get()), ==, "Button Title");
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parse("{ \"manifest_version\": 2, \"page_action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_display_action_label(extension.get()), ==, "Button Title");
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    // `action` should be ignored in manifest v2
+    extension = parse("{ \"manifest_version\": 2, \"action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    // manifest v3 should look for an `action` key
+    extension = parse("{ \"manifest_version\": 3, \"action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_display_action_label(extension.get()), ==, "Button Title");
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    // Manifest v3 should never find a browser_action.
+    extension = parse("{ \"manifest_version\": 3, \"browser_action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    // Or a page action
+    extension = parse("{ \"manifest_version\": 3, \"page_action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parse("{ \"manifest_version\": 3, \"action\": { }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_no_error(error.get());
+    g_assert_null(webkit_web_extension_get_display_action_label(extension.get()));
+    g_assert_null(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    GRefPtr<GBytes> imageData = Util::makePNGData(16, 16, 0x008000);
+
+    extension = parseWithIcon("{ \"manifest_version\": 3, \"action\": { \"default_icon\": \"test.png\", \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", imageData);
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_display_action_label(extension.get()), ==, "Button Title");
+    g_assert_nonnull(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parseWithIcon("{ \"manifest_version\": 3, \"action\": { \"default_icon\": { \"16\": \"test.png\" }, \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", imageData);
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_display_action_label(extension.get()), ==, "Button Title");
+    g_assert_nonnull(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+
+    extension = parseWithIcon("{ \"manifest_version\": 3, \"icons\": { \"16\": \"test.png\" }, \"action\": { \"default_title\": \"Button Title\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }", imageData);
+    g_assert_no_error(error.get());
+    g_assert_cmpstr(webkit_web_extension_get_display_action_label(extension.get()), ==, "Button Title");
+    g_assert_nonnull(webkit_web_extension_get_action_icon(extension.get(), 16, 16));
+}
+
+static void testContentScriptsParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"content_scripts\": [{ \"js\": [\"\test.js\", 1, \"\"], \"css\": [false, \"test.css\", \"\"], \"matches\": [\"*://*/\"] }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"js\": [\"\test.js\", 1, \"\"], \"css\": [false, \"test.css\", \"\"], \"matches\": [\"*://*/\"], \"exclude_matches\": [\"*://*.example.com/\"] }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"js\": [\"\test.js\", 1, \"\"], \"css\": [false, \"test.css\", \"\"], \"matches\": [\"*://*.example.com/\"] }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"js\": [\"\test.js\"], \"matches\": [\"*://*.example.com/\"], \"world\": \"MAIN\" }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"css\": [false, \"test.css\", \"\"], \"matches\": [\"*://*.example.com/\"], \"css_origin\": \"user\" }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"css\": [false, \"test.css\", \"\"], \"matches\": [\"*://*.example.com/\"], \"css_origin\": \"author\" }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    // Invalid cases
+
+    extension = parse("{ \"content_scripts\": [], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": { \"invalid\": true }, \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"js\": [ \"test.js\" ], \"matches\": [] }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    // Non-critical invalid cases
+
+    extension = parse("{ \"content_scripts\": [{ \"js\": [ \"test.js\" ], \"matches\": [\"*://*.example.com/\"], \"run_at\": \"invalid\" }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"js\": [ \"test.js\" ], \"matches\": [\"*://*.example.com/\"], \"world\": \"INVALID\" }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+
+    extension = parse("{ \"content_scripts\": [{ \"css\": [false, \"test.css\", \"\"], \"matches\": [\"*://*.example.com/\"], \"css_origin\": \"bad\" }], \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_true(webkit_web_extension_get_has_injected_content(extension.get()));
+}
+
+static void testPermissionsParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    // Failure Testing
+
+    // Neither of the "permissions" and "optional_permissions" keys are defined.
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 2, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    const gchar* const* requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    const gchar* const* optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // The "permissions" key alone is defined and empty
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // The "optional_permissions" key alone is defined and empty
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // The "permissions" and "optional_permissions" keys are defined as invalid types
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": 2, \"optional_permissions\": \"foo\", \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // The "permissions" keys is defined with an invalid permission.
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"invalid\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // The "permissions" key is defined with a valid permission
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"tabs\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(requestedPermissions[0], ==, "tabs");
+    g_assert_null(requestedPermissions[1]);
+
+    // The "permissions" key is defined with a valid & invalid permission
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"tabs\", \"invalid\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(requestedPermissions[0], ==, "tabs");
+    g_assert_null(requestedPermissions[1]);
+
+    // The "permissions" key is defined with a valid permission & origin
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"tabs\", \"http://www.webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(requestedPermissions);
+    guint patternLength = 0;
+    auto matchPatterns = webkit_web_extension_get_requested_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_requested_permission_match_patterns(extension.get())[0]), ==, "http://www.webkit.org/");
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(requestedPermissions[0], ==, "tabs");
+    g_assert_null(requestedPermissions[1]);
+
+    // The "permissions" key is defined with a valid permission & invalid origin
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"tabs\", \"foo://www.webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(requestedPermissions[0], ==, "tabs");
+    g_assert_null(requestedPermissions[1]);
+
+    // The "optional_permissions" keys is defined with an invalid permission.
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [ \"invalid\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+
+    // The "optional_permissions" key is defined with a valid permission
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [ \"tabs\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(optionalPermissions[0], ==, "tabs");
+    g_assert_null(optionalPermissions[1]);
+
+    // The "optional_permissions" key is defined with a valid & invalid permission
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [ \"tabs\", \"invalid\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(optionalPermissions[0], ==, "tabs");
+    g_assert_null(optionalPermissions[1]);
+
+    // The "optional_permissions" key is defined with a valid permission & origin
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [ \"tabs\", \"http://www.webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_nonnull(optionalPermissions);
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_optional_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_optional_permission_match_patterns(extension.get())[0]), ==, "http://www.webkit.org/");
+    g_assert_cmpstr(optionalPermissions[0], ==, "tabs");
+    g_assert_null(optionalPermissions[1]);
+
+    // The "optional_permissions" key is defined with a valid permission & invalid origin
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [ \"tabs\", \"foo://www.webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_nonnull(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(optionalPermissions[0], ==, "tabs");
+    g_assert_null(optionalPermissions[1]);
+
+    // The "optional_permissions" key is defined with a valid & forbidden invalid permission
+
+    extension = parse("{ \"manifest_version\": 2, \"optional_permissions\": [ \"tabs\", \"geolocation\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_null(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(optionalPermissions[0], ==, "tabs");
+    g_assert_null(optionalPermissions[1]);
+
+    // The "optional_permissions" key is defined in "permissions"
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"tabs\", \"geolocation\" ], \"optional_permissions\": [ \"tabs\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    requestedPermissions = webkit_web_extension_get_requested_permissions(extension.get());
+    optionalPermissions = webkit_web_extension_get_optional_permissions(extension.get());
+    g_assert_nonnull(requestedPermissions);
+    g_assert_null(webkit_web_extension_get_requested_permission_match_patterns(extension.get()));
+    g_assert_null(optionalPermissions);
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+    g_assert_cmpstr(requestedPermissions[0], ==, "tabs");
+    g_assert_null(requestedPermissions[1]);
+
+    // The "optional_permissions" key contains an origin defined in "permissions"
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"http://www.webkit.org/\" ], \"optional_permissions\": [ \"http://www.webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_requested_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_requested_permission_match_patterns(extension.get())[0]), ==, "http://www.webkit.org/");
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // Make sure manifest v2 extensions ignore hosts from host_permissions (this should only be checked for manifest v3).
+
+    extension = parse("{ \"manifest_version\": 2, \"permissions\": [ \"http://www.webkit.org/\" ], \"optional_permissions\": [ \"http://www.example.com/\" ], \"host_permissions\": [ \"https://webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_requested_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_requested_permission_match_patterns(extension.get())[0]), ==, "http://www.webkit.org/");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_optional_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_optional_permission_match_patterns(extension.get())[0]), ==, "http://www.example.com/");
+
+    // Make sure manifest v3 parses hosts from host_permissions, and ignores hosts in permissions and optional_permissions.
+
+    extension = parse("{ \"manifest_version\": 3, \"permissions\": [ \"http://www.webkit.org/\" ], \"optional_permissions\": [ \"http://www.example.com/\" ], \"host_permissions\": [ \"https://webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_requested_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_requested_permission_match_patterns(extension.get())[0]), ==, "https://webkit.org/");
+    g_assert_null(webkit_web_extension_get_optional_permission_match_patterns(extension.get()));
+
+    // Make sure manifest v3 parses optional_host_permissions.
+
+    extension = parse("{ \"manifest_version\": 3, \"optional_host_permissions\": [ \"http://www.example.com/\" ], \"host_permissions\": [ \"https://webkit.org/\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_requested_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_requested_permission_match_patterns(extension.get())[0]), ==, "https://webkit.org/");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_optional_permission_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_cmpstr(webkit_web_extension_match_pattern_get_string(webkit_web_extension_get_optional_permission_match_patterns(extension.get())[0]), ==, "http://www.example.com/");
+}
+
+static void testBackgroundParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [ \"test.js\" ] }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{\"manifest_version\":2,\"background\":{\"page\":\"test.html\",\"persistent\":false},\"name\":\"Test\",\"version\":\"1.0\",\"description\":\"Test\"}");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [ \"test-1.js\", \"\", \"test-2.js\" ], \"persistent\": true }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"service_worker\": \"test.js\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [ \"test-1.js\", \"test-2.js\" ], \"service_worker\": \"test.js\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"page\": \"test.html\", \"service_worker\": \"test.js\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [ \"test-1.js\", \"test-2.js\" ], \"page\": \"test.html\", \"service_worker\": \"test.js\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"service_worker\": \"test.js\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"service_worker\": \"test.js\", \"type\": \"module\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [ \"test-1.js\", \"test-2.js\" ], \"type\": \"module\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    // Invalid cases
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"page\": \"test.html\", \"persistent\": true }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_BACKGROUND_PERSISTENCE);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"service_worker\": \"test.js\", \"persistent\": true }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_modular_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_BACKGROUND_PERSISTENCE);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": [ \"invalid\" ], \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [], \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"page\": \"\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"page\": [ \"test.html\" ], \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"scripts\": [ [ \"test.js\" ] ], \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"service_worker\": \"\", \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 2, \"background\": { \"service_worker\": [ \"test.js\" ], \"persistent\": false }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_persistent_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+}
+
+static void testBackgroundPreferredEnvironmentParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"service_worker\", \"document\" ], \"service_worker\": \"background.js\", \"scripts\": [ \"background.js\" ], \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"document\", \"service_worker\" ], \"service_worker\": \"background.js\", \"scripts\": [ \"background.js\" ], \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": \"service_worker\", \"service_worker\": \"background.js\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"document\" ], \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": \"document\", \"scripts\": [ \"background.js\" ] }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"document\", \"service_worker\" ], \"scripts\": [ \"background.js\" ] }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"document\", 42, \"unknown\" ], \"scripts\": [ \"background.js\" ] }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"unknown\", 42 ], \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": \"unknown\", \"service_worker\": \"background.js\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"unknown\", \"document\" ], \"service_worker\": \"background.js\", \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_no_error(error.get());
+
+    // Invalid cases
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [], \"service_worker\": \"background.js\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_true(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": 42, \"service_worker\": \"background.js\", \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_true(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_false(webkit_web_extension_get_has_service_worker_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": [ \"service_worker\", \"document\" ] }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": \"document\", \"service_worker\": \"background.js\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"manifest_version\": 3, \"background\": { \"preferred_environment\": \"service_worker\", \"page\": \"background.html\" }, \"name\": \"Test\", \"version\": \"1.0\", \"description\": \"Test description\" }");
+    g_assert_false(webkit_web_extension_get_has_background_content(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+}
+
+static void testOptionsPageParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 3, \"options_page\": \"options.html\", \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_page\": \"\", \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_page\": 123, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_ui\": { \"page\": \"options.html\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_ui\": { \"bad\": \"options.html\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_ui\": { \"page\": 123 }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_ui\": { }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_options_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"options_ui\": { \"page\": \"\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_options_page(extension.get()));
+}
+
+static void testURLOverridesParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"manifest_version\": 3, \"browser_url_overrides\": { \"newtab\": \"newtab.html\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"browser_url_overrides\": { \"bad\": \"newtab.html\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"browser_url_overrides\": { \"newtab\": 123 }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"browser_url_overrides\": { }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"browser_url_overrides\": { \"newtab\": \"\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"chrome_url_overrides\": { \"newtab\": \"newtab.html\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"chrome_url_overrides\": { \"bad\": \"newtab.html\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"chrome_url_overrides\": { \"newtab\": 123 }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"chrome_url_overrides\": { }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+
+    extension = parse("{ \"manifest_version\": 3, \"chrome_url_overrides\": { \"newtab\": \"\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+    g_assert_false(webkit_web_extension_get_has_override_new_tab_page(extension.get()));
+}
+
+static void testContentSecurityPolicyParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    // Manifest V3
+    parse("{ \"manifest_version\": 3, \"content_security_policy\": { \"extension_pages\": \"script-src 'self'; object-src 'self'\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"manifest_version\": 3, \"content_security_policy\": { \"sandbox\": \"sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self'\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"manifest_version\": 3, \"content_security_policy\": { }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"manifest_version\": 2, \"content_security_policy\": { \"extension_pages\": 123 }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    // Manifest V2
+    parse("{ \"manifest_version\": 2, \"content_security_policy\": \"script-src 'self'; object-src 'self'\", \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"manifest_version\": 2, \"content_security_policy\": [ \"invalid\", \"type\" ], \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"manifest_version\": 2, \"content_security_policy\": 123, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"manifest_version\": 2, \"content_security_policy\": { \"extension_pages\": \"script-src 'self'; object-src 'self'\" }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+}
+
+static void testWebAccessibleResourcesV2(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    parse("{ \"manifest_version\": 2, \"web_accessible_resources\": [ \"images/*.png\", \"styles/*.css\" ], \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"manifest_version\": 2, \"web_accessible_resources\": [ ], \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"manifest_version\": 2, \"web_accessible_resources\": \"bad\", \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"manifest_version\": 2, \"web_accessible_resources\": { }, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+}
+
+static void testWebAccessibleResourcesV3(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    parse("{ \"web_accessible_resources\": [ { \"resources\": [ \"images/*.png\", \"styles/*.css\" ], \"matches\": [ \"<all_urls>\" ] }, { \"resources\": [ \"scripts/*.js\" ], \"matches\": [ \"*://localhost/*\" ] } ], \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"web_accessible_resources\": [ { \"resources\": [], \"matches\": [] } ], \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_no_error(error.get());
+
+    parse("{ \"web_accessible_resources\": [ { \"resources\": \"bad\", \"matches\": [ \"<all_urls>\" ] } ], \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"web_accessible_resources\": [ { \"resources\": [ \"images/*.png\" ], \"matches\": \"bad\" } ], \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"web_accessible_resources\": [ { \"matches\": [ \"<all_urls>\" ] } ], \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    parse("{ \"web_accessible_resources\": [ { \"resources\": [] } ], \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+}
+
+static void testCommandsParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"commands\": { \"show-popup\": { \"suggested_key\": { \"default\": \"Ctrl+Shift+P\", \"linux\": \"Ctrl+Shift+A\" }, \"description\": \"Show the popup\" } }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"commands\": { }, \"action\": { \"default_title\": \"Test Action\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"commands\": { }, \"browser_action\": { \"default_title\": \"Test Action\" }, \"manifest_version\": 2, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"commands\": { }, \"page_action\": { \"default_title\": \"Test Action\" }, \"manifest_version\": 2, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_false(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"action\": { \"default_title\": \"Test Action\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"browser_action\": { \"default_title\": \"Test Action\" }, \"manifest_version\": 2, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"page_action\": { \"default_title\": \"Test Action\" }, \"manifest_version\": 2, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_true(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"commands\": { \"show-popup\": \"Invalid\" }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_false(webkit_web_extension_get_has_commands(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+}
+
+static void testDeclarativeNetRequestParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [{ \"id\": \"test\", \"enabled\": true, \"path\": \"rules.json\" }] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    g_assert_true(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    g_assert_no_error(error.get());
+
+    // Missing id
+    extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [{ \"enabled\": true, \"path\": \"rules.json\" }] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    g_assert_false(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY);
+
+    // Missing enabled
+    extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [{ \"id\": \"test\", \"path\": \"rules.json\" }] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    g_assert_false(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY);
+
+    // Missing path
+    extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [{ \"id\": \"test\", \"enabled\": true }] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    g_assert_false(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY);
+
+    // Duplicate names
+    extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [{ \"id\": \"test\", \"enabled\": true, \"path\": \"rules.json\" }, { \"id\": \"test\", \"enabled\": true, \"path\": \"rules2.json\" }] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    // The first rule should be loaded
+    g_assert_true(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    // But an error should still be emitted
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY);
+
+    // One valid rule, one invalid rule
+    extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [{ \"id\": \"test\", \"enabled\": true, \"path\": \"rules.json\" }, { \"enabled\": true, \"path\": \"rules2.json\" }] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    // The first rule should be loaded
+    g_assert_true(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    // But an error should still be emitted
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_DECLARATIVE_NET_REQUEST_ENTRY);
+
+    // No rules
+    extension = parse("{ \"declarative_net_request\": { \"rule_resources\": [] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\", \"permissions\": [ \"declarativeNetRequest\"] }");
+    g_assert_false(webkit_web_extension_get_has_content_modification_rules(extension.get()));
+    g_assert_no_error(error.get());
+}
+
+static void testExternallyConnectableParsing(Test*, gconstpointer)
+{
+    GUniqueOutPtr<GError> error;
+    auto parse = [&](const gchar* manifestString) {
+        return adoptGRef(webkitWebExtensionCreate({ { "manifest.json"_s, createGBytes(manifestString) } }, &error.outPtr()));
+    };
+
+    GRefPtr<WebKitWebExtension> extension = parse("{ \"externally_connectable\": {}, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    // Expect an error since 'externally_connectable' is specified, but there are no valid match patterns or extension ids.
+    extension = parse("{ \"externally_connectable\": { \"matches\": [] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    extension = parse("{ \"externally_connectable\": { \"matches\": [], \"ids\": [ \"\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    // Expect an error if <all_urls> is specified.
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"<all_urls>\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    // Still expect the errork, but have a valid match pattern
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"*://*.example.com/\", \"<all_urls>\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    guint patternLength = 0;
+    auto matchPatterns = webkit_web_extension_get_all_requested_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    // Expect an error for not having a second level domain.
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"*://*.com/\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_error(error.get(), WEBKIT_WEB_EXTENSION_ERROR, WEBKIT_WEB_EXTENSION_ERROR_INVALID_MANIFEST_ENTRY);
+
+    // Match for *://*.example.com/*
+    auto* matchingPattern = webkit_web_extension_match_pattern_new_with_string("*://*.example.com/", nullptr);
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"*://*.example.com/\" ] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_all_requested_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_no_error(error.get());
+    g_assert_true(webkit_web_extension_match_pattern_matches_pattern(webkit_web_extension_get_all_requested_match_patterns(extension.get())[0], matchingPattern, WEBKIT_WEB_EXTENSION_MATCH_PATTERN_OPTIONS_NONE));
+
+    extension = parse("{ \"externally_connectable\": { \"matches\": [ \"*://*.example.com/\" ], \"ids\": [ \"*\"] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    patternLength = 0;
+    matchPatterns = webkit_web_extension_get_all_requested_match_patterns(extension.get());
+    for (; *matchPatterns != nullptr; matchPatterns++)
+        patternLength++;
+    g_assert_cmpint(patternLength, ==, 1);
+    g_assert_no_error(error.get());
+
+    extension = parse("{ \"externally_connectable\": { \"ids\": [ \"*\"] }, \"manifest_version\": 3, \"name\": \"Test\", \"description\": \"Test\", \"version\": \"1.0\" }");
+    g_assert_null(webkit_web_extension_get_all_requested_match_patterns(extension.get()));
+    g_assert_no_error(error.get());
+
+    // FIXME: <https://webkit.org/b/269299> Add more tests for externally_connectable "ids" keys.
+}
+
+void beforeAll()
+{
+    Test::add("WebKitWebExtension", "creation-from-directory", testExtensionCreationFromDirectory);
+    Test::add("WebKitWebExtension", "display-string-parsing", testDisplayStringParsing);
+    Test::add("WebKitWebExtension", "default-locale-parsing", testDefaultLocaleParsing);
+    Test::add("WebKitWebExtension", "display-string-parsing-with-localization", testDisplayStringParsingWithLocalization);
+    Test::add("WebKitWebExtension", "action-parsing", testActionParsing);
+    Test::add("WebKitWebExtension", "content-scripts-parsing", testContentScriptsParsing);
+    Test::add("WebKitWebExtension", "permissions-parsing", testPermissionsParsing);
+    Test::add("WebKitWebExtension", "background-parsing", testBackgroundParsing);
+    Test::add("WebKitWebExtension", "background-preferred-environment-parsing", testBackgroundPreferredEnvironmentParsing);
+    Test::add("WebKitWebExtension", "options-page-parsing", testOptionsPageParsing);
+    Test::add("WebKitWebExtension", "url-overrides-parsing", testURLOverridesParsing);
+    Test::add("WebKitWebExtension", "content-security-policy-parsing", testContentSecurityPolicyParsing);
+    Test::add("WebKitWebExtension", "web-accessible-resources-v2", testWebAccessibleResourcesV2);
+    Test::add("WebKitWebExtension", "web-accessible-resources-v3", testWebAccessibleResourcesV3);
+    Test::add("WebKitWebExtension", "commands", testCommandsParsing);
+    Test::add("WebKitWebExtension", "declarative-net-request", testDeclarativeNetRequestParsing);
+    Test::add("WebKitWebExtension", "externally-connectable", testExternallyConnectableParsing);
+}
+
+void afterAll()
+{
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(WebKitGLibAPITests_SOURCES
     ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/LoadTrackingTest.cpp
     ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+    ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.cpp
     ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/WebKitTestServer.cpp
     ${TOOLS_DIR}/TestWebKitAPI/glib/WebKitGLib/WebViewTest.cpp
 )
@@ -169,6 +170,7 @@ if (ENABLE_WEBXR AND USE_OPENXR)
 endif ()
 
 if (ENABLE_WK_WEB_EXTENSIONS)
+    ADD_WK2_TEST(TestWebKitWebExtension ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp)
     ADD_WK2_TEST(TestWebKitWebExtensionMatchPattern ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtensionMatchPattern.cpp)
 endif ()
 

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "WebExtensionUtilities.h"
 
-#include "WebKitNavigationAction.h"
-#include "WebMouseEvent.h"
-#include <WebCore/FrameLoaderTypes.h>
-
-unsigned toPlatformModifiers(OptionSet<WebKit::WebEventModifier>);
-WebKitNavigationType toWebKitNavigationType(WebCore::NavigationType);
-unsigned toWebKitMouseButton(WebKit::WebMouseEventButton);
-unsigned toWebKitError(unsigned webCoreError);
 #if ENABLE(WK_WEB_EXTENSIONS)
-#if ENABLE(2022_GLIB_API)
-unsigned toWebKitWebExtensionError(unsigned apiError);
-#endif // ENABLE(2022_GLIB_API)
-unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError);
+
+#include <gtk/gtk.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
+
+namespace TestWebKitAPI {
+namespace Util {
+
+GRefPtr<GBytes> makePNGData(int width, int height, int color)
+{
+    GRefPtr<GdkPixbuf> pixbuf = adoptGRef(gdk_pixbuf_new(GDK_COLORSPACE_RGB, FALSE, 8, width, height));
+
+    if (!pixbuf)
+        return { };
+
+    gdk_pixbuf_fill(pixbuf.get(), color);
+
+    GUniqueOutPtr<GError> error;
+    gchar* buffer;
+    gsize bufferSize;
+    if (!gdk_pixbuf_save_to_buffer(pixbuf.get(), &buffer, &bufferSize, "png", &error.outPtr(), nullptr))
+        return { };
+
+    return adoptGRef(g_bytes_new_take(buffer, bufferSize));
+}
+
+} // namespace Util
+} // namespace TestWebKitAPI
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)
-unsigned toWebCoreError(unsigned webKitError);
-
-enum SnapshotRegion {
-    SnapshotRegionVisible,
-    SnapshotRegionFullDocument
-};
-
-static constexpr auto networkCacheSubdirectory = "WebKitCache"_s;

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,25 +25,22 @@
 
 #pragma once
 
-#include "WebKitNavigationAction.h"
-#include "WebMouseEvent.h"
-#include <WebCore/FrameLoaderTypes.h>
+#include "Utilities.h"
+#include "WTFTestUtilities.h"
 
-unsigned toPlatformModifiers(OptionSet<WebKit::WebEventModifier>);
-WebKitNavigationType toWebKitNavigationType(WebCore::NavigationType);
-unsigned toWebKitMouseButton(WebKit::WebMouseEventButton);
-unsigned toWebKitError(unsigned webCoreError);
+#include <wtf/Vector.h>
+#include <wtf/glib/GRefPtr.h>
+
 #if ENABLE(WK_WEB_EXTENSIONS)
-#if ENABLE(2022_GLIB_API)
-unsigned toWebKitWebExtensionError(unsigned apiError);
-#endif // ENABLE(2022_GLIB_API)
-unsigned toWebKitWebExtensionMatchPatternError(unsigned apiError);
+
+namespace TestWebKitAPI {
+
+namespace Util {
+
+GRefPtr<GBytes> makePNGData(int width, int height, int color);
+
+} // namespace Util
+
+} // namespace TestWebKitAPI
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)
-unsigned toWebCoreError(unsigned webKitError);
-
-enum SnapshotRegion {
-    SnapshotRegionVisible,
-    SnapshotRegionFullDocument
-};
-
-static constexpr auto networkCacheSubdirectory = "WebKitCache"_s;


### PR DESCRIPTION
#### 68f61154cacb9920c6c79f3d0e4de23d1f6d3270
<pre>
[GTK] Create WebKitWebExtension
<a href="https://webkit.org/b/285379">https://webkit.org/b/285379</a>

Reviewed by Adrian Perez de Castro and Patrick Griffis.

This creates a GLib API of WebExtension, along with some utility functions needed for Linux-specific pathways. This new API is only built when ENABLE_2022_GLIB_API is enabled,
preventing a conflict with the older WebKitWebExtension API that was renamed.

As well, this fixes WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR as it originally pointed to webkit_web_extension_error_quark(). Both WEBKIT_WEB_EXTENSION_MATCH_PATTERN_ERROR and WEBKIT_WEB_EXTENSION_ERROR now are properly defined with their respective quarks.

Tests: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp
       Tools/TestWebKitAPI/glib/CMakeLists.txt
       Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.cpp
       Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.h
* Source/WebCore/platform/graphics/Icon.h:
* Source/WebCore/platform/graphics/gtk/IconGtk.cpp:
(WebCore::Icon::Icon):
(WebCore::Icon::create):
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/API/APIData.h:
(API::Data::createWithoutCopying):
* Source/WebKit/Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp: Copied from Source/WebKit/UIProcess/API/glib/WebKitPrivate.h.
(WebKit::availableScreenScales):
* Source/WebKit/Shared/Extensions/wpe/WebExtensionUtilitiesWPE.cpp: Copied from Source/WebKit/UIProcess/API/glib/WebKitPrivate.h.
(WebKit::availableScreenScales):
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitError.cpp:
(webkit_web_extension_error_quark):
* Source/WebKit/UIProcess/API/glib/WebKitError.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.cpp:
(toWebKitWebExtensionError):
* Source/WebKit/UIProcess/API/glib/WebKitPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebExtension.cpp: Added.
(webkitWebExtensionGetProperty):
(webkit_web_extension_class_init):
(webkitWebExtensionCreate):
(webkit_web_extension_new):
(webkit_web_extension_get_manifest_version):
(webkit_web_extension_supports_manifest_version):
(webkit_web_extension_get_default_locale):
(webkit_web_extension_get_display_name):
(webkit_web_extension_get_display_short_name):
(webkit_web_extension_get_display_version):
(webkit_web_extension_get_display_description):
(webkit_web_extension_get_display_action_label):
(webkit_web_extension_get_icon):
(webkit_web_extension_get_action_icon):
(webkit_web_extension_get_version):
(webkit_web_extension_get_requested_permissions):
(webkit_web_extension_get_optional_permissions):
(webkit_web_extension_get_requested_permission_match_patterns):
(webkit_web_extension_get_optional_permission_match_patterns):
(webkit_web_extension_get_all_requested_match_patterns):
(webkit_web_extension_get_has_background_content):
(webkit_web_extension_get_has_service_worker_background_content):
(webkit_web_extension_get_has_modular_background_content):
(webkit_web_extension_get_has_persistent_background_content):
(webkit_web_extension_get_has_injected_content):
(webkit_web_extension_get_has_options_page):
(webkit_web_extension_get_has_override_new_tab_page):
(webkit_web_extension_get_has_commands):
(webkit_web_extension_get_has_content_modification_rules):
* Source/WebKit/UIProcess/API/glib/WebKitWebExtension.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionInternal.h: Copied from Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPatternPrivate.h.
* Source/WebKit/UIProcess/API/glib/WebKitWebExtensionMatchPatternPrivate.h:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::WebExtension):
* Source/WebKit/UIProcess/Extensions/gtk/WebExtensionGtk.cpp: Added.
(WebKit::WebExtension::WebExtension):
(WebKit::WebExtension::resourceDataForPath):
(WebKit::WebExtension::recordError):
(WebKit::WebExtension::iconForPath):
(WebKit::WebExtension::bestIcon):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebExtension.cpp: Added.
(createGBytes):
(testExtensionCreationFromDirectory):
(testDisplayStringParsing):
(testDefaultLocaleParsing):
(testDisplayStringParsingWithLocalization):
(testActionParsing):
(testContentScriptsParsing):
(testPermissionsParsing):
(testBackgroundParsing):
(testBackgroundPreferredEnvironmentParsing):
(testOptionsPageParsing):
(testURLOverridesParsing):
(testContentSecurityPolicyParsing):
(testWebAccessibleResourcesV2):
(testWebAccessibleResourcesV3):
(testCommandsParsing):
(testDeclarativeNetRequestParsing):
(testExternallyConnectableParsing):
(beforeAll):
(afterAll):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.cpp: Copied from Source/WebKit/UIProcess/API/glib/WebKitPrivate.h.
(TestWebKitAPI::Util::makePNGData):
* Tools/TestWebKitAPI/glib/WebKitGLib/WebExtensionUtilities.h: Copied from Source/WebKit/UIProcess/API/glib/WebKitPrivate.h.

Canonical link: <a href="https://commits.webkit.org/301078@main">https://commits.webkit.org/301078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f1b090102a201e4271d53d3fdd4b17e62908efa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/44177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76479 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/126376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52758 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94707 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62813 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/29500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/134002 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/39195 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/103186 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48332 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26594 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/48313 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/57030 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->