### PR TITLE
ASAN_ILL | WebCore::ElementAnimationRareData::setLastStyleChangeEventStyle; Style::TreeResolver::createAnimatedElementUpdate; Style::TreeResolver::resolveElement

### DIFF
--- a/LayoutTests/webanimations/reparent-element-with-animation-crash-expected.txt
+++ b/LayoutTests/webanimations/reparent-element-with-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webanimations/reparent-element-with-animation-crash.html
+++ b/LayoutTests/webanimations/reparent-element-with-animation-crash.html
@@ -1,0 +1,16 @@
+<style>
+ div { animation: a0 forwards}
+ @keyframes a0 {}
+</style>
+<div id="div">This test passes if it does not crash.</div>
+<script>
+ div.attributeStyleMap.set('animation-timeline', 'none');
+ (async () => {
+     await new Promise (resolve=>setTimeout(resolve, 50));
+     document.documentElement.append(div);
+     window.testRunner?.notifyDone();
+ })();
+
+ window.testRunner?.dumpAsText();
+ window.testRunner?.waitUntilDone();
+</script>

--- a/Source/WebCore/animation/ElementAnimationRareData.cpp
+++ b/Source/WebCore/animation/ElementAnimationRareData.cpp
@@ -52,6 +52,13 @@ KeyframeEffectStack& ElementAnimationRareData::ensureKeyframeEffectStack()
 
 void ElementAnimationRareData::setAnimationsCreatedByMarkup(CSSAnimationCollection&& animations)
 {
+    if (m_keyframeEffectStack) {
+        for (auto& animation : m_animationsCreatedByMarkup) {
+            if (RefPtr keyframeEffect = dynamicDowncast<KeyframeEffect>(animation->effect()))
+                m_keyframeEffectStack->removeEffect(*keyframeEffect);
+        }
+    }
+
     m_animationsCreatedByMarkup = WTFMove(animations);
 }
 


### PR DESCRIPTION
#### 0a0cd3fd2cc0cc7d6a8589d5524bae1687440eb3
<pre>
ASAN_ILL | WebCore::ElementAnimationRareData::setLastStyleChangeEventStyle; Style::TreeResolver::createAnimatedElementUpdate; Style::TreeResolver::resolveElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=293018">https://bugs.webkit.org/show_bug.cgi?id=293018</a>

Reviewed by Antoine Quint.

When an element with an animation and keyframe effect associated is reparented,
style originated animations are cancelled for its styleable. This causes the
animation rare data&apos;s animations to be destroyed, which in turn also destroys
the keyframe effects for those animations that have them. The issue is that
keyframe effects are also weak referenced from animation rare data&apos;s keyframe
effect stack, and these weak references become null and are at risk of being
null-dereferenced later on.

This can be fixed by removing keyframe effects for every animation created by
markup from the keyframe stack, before removing the animations.

A similar fix was landed in <a href="https://commits.webkit.org/292328@main">https://commits.webkit.org/292328@main</a>, but that only
addressed the case when an animation is removed from a timeline.

* LayoutTests/webanimations/reparent-element-with-animation-crash-expected.txt: Added.
* LayoutTests/webanimations/reparent-element-with-animation-crash.html: Added.
* Source/WebCore/animation/ElementAnimationRareData.cpp:
(WebCore::ElementAnimationRareData::setAnimationsCreatedByMarkup):

Originally-landed-as: 292955.14@webkit-2025.4-embargoed (d79e4c2037ff). <a href="https://rdar.apple.com/157788971">rdar://157788971</a>
Canonical link: <a href="https://commits.webkit.org/298748@main">https://commits.webkit.org/298748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef7f2f80f95ad41578547d613944a52dd72964f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66994 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88494 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42904 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68865 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66169 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125637 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97134 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42220 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39279 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43213 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48804 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42679 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46019 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->