### PR TITLE
The Storage Access API should grant access per frame

### DIFF
--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html
@@ -82,6 +82,7 @@
                     });
                     break;
                 case "#step4":
+                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
                     document.location.hash = "step5";
                     let iframeElement = document.createElement("iframe");
                     iframeElement.onload = function() {
@@ -97,6 +98,7 @@
                     openIframe(thirdPartyBaseUrl + subPathToGetCookies + "&message=Should receive cookies even though it's not the requesting frame.", runTest);
                     break;
                 case "#step6":
+                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(false);
                     testRunner.setStatisticsShouldBlockThirdPartyCookies(false, function() {
                         setEnableFeature(false, finishJSTest);
                     });

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt
@@ -3,6 +3,6 @@ Blocked access to external URL https://www.localhost:9443/storage-access-api/res
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Grants have per-frame scope assert_false: frame2 should still not have storage access. expected false got true
+PASS Grants have per-frame scope
 TIMEOUT Cross-site sibling iframes should not be able to take advantage of the existing permission grant requested by others. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt
@@ -8,7 +8,7 @@ FAIL 'Activate-Storage-Access: retry' is a no-op on a request without an `allowe
 FAIL 'Activate-Storage-Access: retry' is a no-op on a request from an origin that does not match its `allowed-origin` value. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `retry` is a no-op on a request with a `none` Storage Access status. assert_array_equals: value is undefined, expected array
 FAIL Activate-Storage-Access `load` header grants storage access to frame. assert_true: frame should have storage access because of the `load` header expected true got false
-PASS Activate-Storage-Access `load` is honored for `active` cases.
+FAIL Activate-Storage-Access `load` is honored for `active` cases. assert_true: expected true got false
 PASS Activate-Storage-Access `load` header is a no-op for requests without storage access.
 FAIL Sec-Fetch-Storage-Access is `inactive` for ABA case. assert_array_equals: value is undefined, expected array
 FAIL Storage Access can be activated for ABA cases by retrying. assert_array_equals: value is undefined, expected array

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -390,7 +390,7 @@ StorageAccessAPIPerPageScopeEnabled:
   type: bool
   defaultValue:
     WebCore:
-      default: true
+      default: false
 
 StorageBlockingPolicy:
   type: uint32_t


### PR DESCRIPTION
#### 04fe24390c9ffdbcba3d96932e09831dbb8d64ac
<pre>
The Storage Access API should grant access per frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=297421">https://bugs.webkit.org/show_bug.cgi?id=297421</a>
<a href="https://rdar.apple.com/158353881">rdar://158353881</a>

Reviewed by Matthew Finkel.

This aligns Safari with the current specification, which grants storage to frames rather than pages.

<a href="https://privacycg.github.io/storage-access/#the-document-object">https://privacycg.github.io/storage-access/#the-document-object</a>

* LayoutTests/http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html:
This test is expecting a per page scope, so explicitly set the setting.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-site-sibling-iframes.sub.https.window-expected.txt:

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window-expected.txt:
This was previously passing by chance. `Activate-Storage-Access` is not implemented.

* Source/WebCore/page/Settings.yaml:

Canonical link: <a href="https://commits.webkit.org/298743@main">https://commits.webkit.org/298743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f05393b4d6a0320b375ffe7352b492647ef252

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66998 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88429 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42905 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104455 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68868 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28425 "Found 1 new test failure: imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.html (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22560 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66173 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98719 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22722 "Found 1 new test failure: imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125641 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43329 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32538 "Found 1 new test failure: imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97136 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96931 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42223 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20126 "Found 1 new test failure: imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-web-socket.sub.https.window.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39283 "Hash 67f05393 for PR 49415 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18605 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48808 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44388 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->