### PR TITLE
[AutoFill Debugging] Part 3: Add support for new text extraction item types and metadata

### DIFF
--- a/LayoutTests/fast/text-extraction/avoid-extracting-password-fields.html
+++ b/LayoutTests/fast/text-extraction/avoid-extracting-password-fields.html
@@ -24,7 +24,10 @@ addEventListener("load", async () => {
 
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
-    document.body.textContent = await UIHelper.requestTextExtraction();
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true
+    });
     testRunner.notifyDone();
 });
 </script>

--- a/LayoutTests/fast/text-extraction/basic-text-extraction.html
+++ b/LayoutTests/fast/text-extraction/basic-text-extraction.html
@@ -33,7 +33,10 @@ addEventListener("load", async () => {
 
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
-    document.body.textContent = await UIHelper.requestTextExtraction();
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true
+    });
     testRunner.notifyDone();
 });
 </script>

--- a/LayoutTests/fast/text-extraction/text-extraction-display-contents.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-display-contents.html
@@ -26,7 +26,10 @@ div.transparent {
 addEventListener("load", async () => {
     jsTestIsAsync = true;
 
-    document.body.textContent = await UIHelper.requestTextExtraction();
+    document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true
+    });
     finishJSTest();
 });
 </script>

--- a/LayoutTests/fast/text-extraction/text-extraction-visible-overflow-expected.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-visible-overflow-expected.html
@@ -42,6 +42,8 @@ addEventListener("load", async () => {
     window.testRunner?.waitUntilDone();
 
     document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true,
         clipToBounds: true,
         includeRects: true
     });

--- a/LayoutTests/fast/text-extraction/text-extraction-visible-overflow.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-visible-overflow.html
@@ -43,6 +43,8 @@ addEventListener("load", async () => {
     window.testRunner?.waitUntilDone();
 
     document.body.textContent = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true,
         clipToBounds: true,
         includeRects: true
     });

--- a/LayoutTests/fast/text-extraction/text-extraction-when-scrolled.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-when-scrolled.html
@@ -32,6 +32,8 @@ addEventListener("load", async () => {
     await UIHelper.renderingUpdate();
 
     const extractionResult = await UIHelper.requestTextExtraction({
+        mergeParagraphs: true,
+        skipNearlyTransparentContent: true,
         clipToBounds: true,
         includeRects: true
     });

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -38,7 +38,7 @@ enum class ExceptionCode : uint8_t;
 
 namespace TextExtraction {
 
-WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
+WEBCORE_EXPORT Item extractItem(Request&&, Page&);
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 
 struct RenderedText {

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -28,23 +28,26 @@
 #include "CharacterRange.h"
 #include "FloatRect.h"
 #include "FloatSize.h"
+#include "NodeIdentifier.h"
 #include <wtf/Forward.h>
 #include <wtf/URL.h>
 
 namespace WebCore {
 namespace TextExtraction {
 
-enum class EventListenerCategory : uint16_t {
+enum class EventListenerCategory : uint8_t {
     Click       = 1 << 0,
     Hover       = 1 << 1,
     Touch       = 1 << 2,
     Wheel       = 1 << 3,
-    Gesture     = 1 << 4,
-    Pointer     = 1 << 5,
-    Keyboard    = 1 << 6,
-    Focus       = 1 << 7,
-    Form        = 1 << 8,
-    Media       = 1 << 9,
+    Keyboard    = 1 << 4,
+};
+
+struct Request {
+    std::optional<WebCore::FloatRect> collectionRectInRootView;
+    bool mergeParagraphs { false };
+    bool skipNearlyTransparentContent { false };
+    bool canIncludeIdentifiers { false };
 };
 
 struct Editable {
@@ -70,6 +73,30 @@ struct ImageItemData {
     String altText;
 };
 
+struct LinkItemData {
+    String target;
+    URL completedURL;
+};
+
+struct ContentEditableData {
+    bool isPlainTextOnly { false };
+    bool isFocused { false };
+};
+
+struct TextFormControlData {
+    Editable editable;
+    String controlType;
+    String autocomplete;
+    bool isReadonly { false };
+    bool isDisabled { false };
+    bool isChecked { false };
+};
+
+struct SelectData {
+    Vector<String> selectedValues;
+    bool isMultiple { false };
+};
+
 enum class ContainerType : uint8_t {
     Root,
     ViewportConstrained,
@@ -80,14 +107,19 @@ enum class ContainerType : uint8_t {
     Section,
     Nav,
     Button,
+    Generic,
 };
 
-using ItemData = Variant<ContainerType, TextItemData, ScrollableItemData, ImageItemData>;
+using ItemData = Variant<ContainerType, TextItemData, ScrollableItemData, ImageItemData, SelectData, ContentEditableData, TextFormControlData, LinkItemData>;
 
 struct Item {
     ItemData data;
     FloatRect rectInRootView;
     Vector<Item> children;
+    std::optional<NodeIdentifier> nodeIdentifier;
+    OptionSet<EventListenerCategory> eventListeners;
+    HashMap<String, String> ariaAttributes;
+    String accessibilityRole;
 };
 
 } // namespace TextExtraction

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7041,6 +7041,14 @@ header: <WebCore/LayerTreeAsTextOptions.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::Request {
+    std::optional<WebCore::FloatRect> collectionRectInRootView;
+    bool mergeParagraphs;
+    bool skipNearlyTransparentContent;
+    bool canIncludeIdentifiers;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Editable {
     String label;
     String placeholder;
@@ -7068,6 +7076,34 @@ header: <WebCore/TextExtractionTypes.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::LinkItemData {
+    String target;
+    URL completedURL;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::ContentEditableData {
+    bool isPlainTextOnly;
+    bool isFocused;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::TextFormControlData {
+    WebCore::TextExtraction::Editable editable;
+    String controlType;
+    String autocomplete;
+    bool isReadonly;
+    bool isDisabled;
+    bool isChecked;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::SelectData {
+    Vector<String> selectedValues;
+    bool isMultiple;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] enum class WebCore::TextExtraction::ContainerType : uint8_t {
     Root,
     ViewportConstrained,
@@ -7077,14 +7113,28 @@ header: <WebCore/TextExtractionTypes.h>
     Article,
     Section,
     Nav,
-    Button
+    Button,
+    Generic
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader, OptionSet] enum class WebCore::TextExtraction::EventListenerCategory : uint8_t {
+    Click,
+    Hover,
+    Touch,
+    Wheel,
+    Keyboard,
 };
 
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Item {
-    Variant<WebCore::TextExtraction::ContainerType, WebCore::TextExtraction::TextItemData, WebCore::TextExtraction::ScrollableItemData, WebCore::TextExtraction::ImageItemData> data;
+    Variant<WebCore::TextExtraction::ContainerType, WebCore::TextExtraction::TextItemData, WebCore::TextExtraction::ScrollableItemData, WebCore::TextExtraction::ImageItemData, WebCore::TextExtraction::SelectData, WebCore::TextExtraction::ContentEditableData, WebCore::TextExtraction::TextFormControlData, WebCore::TextExtraction::LinkItemData> data;
     WebCore::FloatRect rectInRootView;
     Vector<WebCore::TextExtraction::Item> children;
+    std::optional<WebCore::NodeIdentifier> nodeIdentifier;
+    OptionSet<WebCore::TextExtraction::EventListenerCategory> eventListeners;
+    HashMap<String, String> ariaAttributes;
+    String accessibilityRole;
 };
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -29,7 +29,7 @@
 @implementation _WKTextExtractionConfiguration
 
 @synthesize mergeParagraphs = _mergeParagraphs;
-@synthesize ignoreTransparency = _ignoreTransparency;
+@synthesize skipNearlyTransparentContent = _skipNearlyTransparentContent;
 
 - (instancetype)init
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -35,7 +35,7 @@ internal import WebKit_Internal
 
 extension WKTextExtractionEventListenerTypes {
     static let all: [WKTextExtractionEventListenerTypes] = [
-        .click, .hover, .touch, .wheel, .gesture, .pointer, .keyboard, .focus, .form, .media,
+        .click, .hover, .touch, .wheel, .keyboard,
     ]
 
     fileprivate var description: String {
@@ -48,18 +48,8 @@ extension WKTextExtractionEventListenerTypes {
             "touch"
         case .wheel:
             "wheel"
-        case .gesture:
-            "gesture"
-        case .pointer:
-            "pointer"
         case .keyboard:
             "keyboard"
-        case .focus:
-            "focus"
-        case .form:
-            "form"
-        case .media:
-            "media"
         default:
             "unknown"
         }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -34,15 +34,21 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  Whether to merge adjacent runs of text into paragraphs.
  This also combines links and editable containers into a single text item.
- Defaults to `false`.
+ Defaults to `NO`.
  */
 @property (nonatomic) BOOL mergeParagraphs;
 
 /*!
  Ignores transparent (or nearly-transparent) subtrees.
- Defaults to `false`.
+ Defaults to `NO`.
  */
-@property (nonatomic) BOOL ignoreTransparency;
+@property (nonatomic) BOOL skipNearlyTransparentContent;
+
+/*!
+ Whether to include unique identifiers, for each interactive element.
+ Defaults to `NO`.
+ */
+@property (nonatomic) BOOL canIncludeIdentifiers;
 
 @end
 
@@ -65,12 +71,7 @@ typedef NS_OPTIONS(NSUInteger, WKTextExtractionEventListenerTypes) {
     WKTextExtractionEventListenerTypeHover     = 1 << 1,
     WKTextExtractionEventListenerTypeTouch     = 1 << 2,
     WKTextExtractionEventListenerTypeWheel     = 1 << 3,
-    WKTextExtractionEventListenerTypeGesture   = 1 << 4,
-    WKTextExtractionEventListenerTypePointer   = 1 << 5,
-    WKTextExtractionEventListenerTypeKeyboard  = 1 << 6,
-    WKTextExtractionEventListenerTypeFocus     = 1 << 7,
-    WKTextExtractionEventListenerTypeForm      = 1 << 8,
-    WKTextExtractionEventListenerTypeMedia     = 1 << 9,
+    WKTextExtractionEventListenerTypeKeyboard  = 1 << 4,
 };
 
 typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -110,7 +110,7 @@ extension WKWebView {
             let configuration = _WKTextExtractionConfiguration()
             configuration.targetRect = visibleRect
             configuration.mergeParagraphs = true
-            configuration.ignoreTransparency = true
+            configuration.skipNearlyTransparentContent = true
             if let result = await _requestTextExtraction(configuration) {
                 collector.collect(createIntelligenceElement(item: result.rootItem))
             }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16477,11 +16477,11 @@ void WebPageProxy::takeSnapshotForTargetedElement(const API::TargetedElementInfo
     sendWithAsyncReply(Messages::WebPage::TakeSnapshotForTargetedElement(info.nodeIdentifier(), info.documentIdentifier()), WTFMove(completion));
 }
 
-void WebPageProxy::requestTextExtraction(std::optional<FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&& completion)
+void WebPageProxy::requestTextExtraction(WebCore::TextExtraction::Request&& request, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&& completion)
 {
     if (!hasRunningProcess())
         return completion({ });
-    sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(WTFMove(collectionRectInRootView)), WTFMove(completion));
+    sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(WTFMove(request)), WTFMove(completion));
 }
 
 void WebPageProxy::addConsoleMessage(FrameIdentifier frameID, MessageSource messageSource, MessageLevel messageLevel, const String& message, std::optional<ResourceLoaderIdentifier> coreIdentifier)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -339,6 +339,7 @@ struct OpenID4VPRequest;
 
 namespace TextExtraction {
 struct Item;
+struct Request;
 }
 
 #if ENABLE(WRITING_TOOLS)
@@ -2619,7 +2620,7 @@ public:
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<Ref<API::TargetedElementInfo>>>&&)>&&);
     void takeSnapshotForTargetedElement(const API::TargetedElementInfo&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
-    void requestTextExtraction(std::optional<WebCore::FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
 
     void hasVideoInPictureInPictureDidChange(bool);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10050,9 +10050,9 @@ void WebPage::requestAllTargetableElements(float hitTestInterval, CompletionHand
     completion(page->checkedElementTargetingController()->findAllTargets(hitTestInterval));
 }
 
-void WebPage::requestTextExtraction(std::optional<FloatRect>&& collectionRectInRootView, CompletionHandler<void(TextExtraction::Item&&)>&& completion)
+void WebPage::requestTextExtraction(TextExtraction::Request&& request, CompletionHandler<void(TextExtraction::Item&&)>&& completion)
 {
-    completion(TextExtraction::extractItem(WTFMove(collectionRectInRootView), Ref { *corePage() }));
+    completion(TextExtraction::extractItem(WTFMove(request), Ref { *corePage() }));
 }
 
 template<typename T> T WebPage::contentsToRootView(WebCore::FrameIdentifier frameID, T geometry)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -350,6 +350,7 @@ using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierTy
 
 namespace TextExtraction {
 struct Item;
+struct Request;
 }
 
 namespace WritingTools {
@@ -2581,7 +2582,7 @@ private:
     void requestTargetedElement(WebCore::TargetedElementRequest&&, CompletionHandler<void(Vector<WebCore::TargetedElementInfo>&&)>&&);
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<WebCore::TargetedElementInfo>>&&)>&&);
 
-    void requestTextExtraction(std::optional<WebCore::FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     static void setHasLaunchedWebContentProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -809,7 +809,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     RequestAllTargetableElements(float hitTestInterval) -> (Vector<Vector<WebCore::TargetedElementInfo>> elements)
 
-    RequestTextExtraction(std::optional<WebCore::FloatRect> collectionRectInRootView) -> (struct WebCore::TextExtraction::Item item)
+    RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
 
 #if PLATFORM(IOS_FAMILY)
     ShouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint point) -> (bool shouldDismiss)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -45,6 +45,8 @@ dictionary ScrollToOptions {
 dictionary TextExtractionOptions {
     boolean clipToBounds = false;
     boolean includeRects = false;
+    boolean mergeParagraphs = false;
+    boolean skipNearlyTransparentContent = false;
 };
 
 interface UIScriptController {

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -60,6 +60,9 @@ ScrollToOptions* toScrollToOptions(JSContextRef, JSValueRef);
 struct TextExtractionOptions {
     bool clipToBounds { false };
     bool includeRects { false };
+    bool mergeParagraphs { false };
+    bool skipNearlyTransparentContent { false };
+    bool canIncludeIdentifiers { false };
 };
 
 TextExtractionOptions* toTextExtractionOptions(JSContextRef, JSValueRef);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -72,6 +72,9 @@ TextExtractionOptions* toTextExtractionOptions(JSContextRef context, JSValueRef 
     static TextExtractionOptions options;
     options.clipToBounds = booleanProperty(context, (JSObjectRef)argument, "clipToBounds", false);
     options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
+    options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
+    options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);
+    options.canIncludeIdentifiers = booleanProperty(context, (JSObjectRef)argument, "canIncludeIdentifiers", false);
     return &options;
 }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -345,8 +345,8 @@ void UIScriptControllerCocoa::requestTextExtraction(JSValueRef callback, TextExt
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
     RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
     [configuration setTargetRect:extractionRect];
-    [configuration setMergeParagraphs:YES];
-    [configuration setIgnoreTransparency:YES];
+    [configuration setMergeParagraphs:options && options->mergeParagraphs];
+    [configuration setSkipNearlyTransparentContent:options && options->skipNearlyTransparentContent];
     [webView() _requestTextExtraction:configuration.get() completionHandler:^(WKTextExtractionResult *result) {
         if (!m_context)
             return;


### PR DESCRIPTION
#### 20c66472f87c18ac32c6b2dc06b789c80b8b0ca1
<pre>
[AutoFill Debugging] Part 3: Add support for new text extraction item types and metadata
<a href="https://bugs.webkit.org/show_bug.cgi?id=297419">https://bugs.webkit.org/show_bug.cgi?id=297419</a>
<a href="https://rdar.apple.com/158352832">rdar://158352832</a>

Reviewed by Abrar Rahman Protyasha.

Add support for new text extraction item types:

• LinkItemData
• ContentEditableData
• TextFormControlData
• SelectData

...as well as additional metadata per item:

• `role` DOM attribute
• Various `aria-*` DOM attributes
• Event listeners
• Unique node IDs (only if needed)

There should be no change in behavior yet, since these items aren&apos;t surfaced through any WebKit API.

* LayoutTests/fast/text-extraction/avoid-extracting-password-fields.html:
* LayoutTests/fast/text-extraction/basic-text-extraction.html:
* LayoutTests/fast/text-extraction/text-extraction-display-contents.html:
* LayoutTests/fast/text-extraction/text-extraction-visible-overflow-expected.html:
* LayoutTests/fast/text-extraction/text-extraction-visible-overflow.html:
* LayoutTests/fast/text-extraction/text-extraction-when-scrolled.html:

Adjust existing tests to continue exercising existing text extraction behaviors by setting the
`mergeParagraphs` and `skipNearlyTransparentContent` configuration flags.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(WKTextExtractionEventListenerTypes.description):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::containerType):
(WebKit::eventListenerTypes):
(WebKit::createItemWithChildren):
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestTextExtraction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestTextExtraction):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::requestTextExtraction):

Canonical link: <a href="https://commits.webkit.org/298726@main">https://commits.webkit.org/298726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32adb7fd1732849787308ca06bdb1e26cb119c37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67031 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68888 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22593 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66206 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125674 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97151 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96946 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42238 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20154 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48841 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42716 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->