### PR TITLE
Safari use-after-free crash at com.apple.AppKit:  -[NSScrollerImp knobLayer]

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -29,12 +29,15 @@
 
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/UserInterfaceLayoutDirection.h>
+#include <wtf/RecursiveLockAdapter.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS CALayer;
 OBJC_CLASS NSColor;
 OBJC_CLASS NSScrollerImp;
 OBJC_CLASS WebScrollerImpDelegateMac;
+
+enum class FeatureToAnimate;
 
 namespace WebCore {
 
@@ -61,8 +64,7 @@ public:
     CALayer *hostLayer() const { return m_hostLayer.get(); }
     void setHostLayer(CALayer *);
 
-    RetainPtr<NSScrollerImp> takeScrollerImp() { return std::exchange(m_scrollerImp, { }); }
-    NSScrollerImp *scrollerImp() { return m_scrollerImp.get(); }
+    RetainPtr<NSScrollerImp> takeScrollerImp();
     void setScrollerImp(NSScrollerImp *imp);
     void updateScrollbarStyle();
     void updatePairScrollerImps();
@@ -83,8 +85,15 @@ public:
     void setEnabled(bool flag) { m_isEnabled = flag; }
     void setScrollbarLayoutDirection(UserInterfaceLayoutDirection);
     void scrollbarColorChanged(const std::optional<ScrollbarColor>&);
+    void setUsePresentationValue(bool inMomentumPhase);
 
     void setNeedsDisplay();
+
+    void updateProgress(FeatureToAnimate, double);
+    bool isScrollerFor(NSScrollerImp*);
+    double knobAlpha();
+    double trackAlpha();
+    bool hasScrollerImp();
 
 private:
     int m_minimumKnobLength { 0 };
@@ -101,6 +110,7 @@ private:
     RetainPtr<NSColor> m_thumbColor;
 
     RetainPtr<CALayer> m_hostLayer;
+    mutable RecursiveLock m_scrollerImpLock;
     RetainPtr<NSScrollerImp> m_scrollerImp;
     RetainPtr<WebScrollerImpDelegateMac> m_scrollerImpDelegate;
 };

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -128,9 +128,6 @@ public:
 private:
     ScrollerPairMac(ScrollingTreeScrollingNode&);
 
-    NSScrollerImp *scrollerImpHorizontal() { return horizontalScroller().scrollerImp(); }
-    NSScrollerImp *scrollerImpVertical() { return verticalScroller().scrollerImp(); }
-
     ThreadSafeWeakPtr<ScrollingTreeScrollingNode> m_scrollingNode;
 
     ScrollbarHoverState m_scrollbarHoverState;

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -110,7 +110,7 @@
     else
         scroller = &scrollerPair->verticalScroller();
 
-    ASSERT(scrollerImp == scroller->scrollerImp());
+    ASSERT(scroller->isScrollerFor(scrollerImp));
 
     return scroller->lastKnownMousePositionInScrollbar();
 }
@@ -233,18 +233,18 @@ void ScrollerPairMac::contentsSizeChanged()
 void ScrollerPairMac::setUsePresentationValues(bool inMomentumPhase)
 {
     m_usingPresentationValues = inMomentumPhase;
-    [scrollerImpHorizontal() setUsePresentationValue:m_usingPresentationValues];
-    [scrollerImpVertical() setUsePresentationValue:m_usingPresentationValues];
+    m_horizontalScroller.setUsePresentationValue(m_usingPresentationValues);
+    m_verticalScroller.setUsePresentationValue(m_usingPresentationValues);
 }
 
 void ScrollerPairMac::setHorizontalScrollbarPresentationValue(float scrollbValue)
 {
-    [scrollerImpHorizontal() setPresentationValue:scrollbValue];
+    m_horizontalScroller.setUsePresentationValue(scrollbValue);
 }
 
 void ScrollerPairMac::setVerticalScrollbarPresentationValue(float scrollbValue)
 {
-    [scrollerImpVertical() setPresentationValue:scrollbValue];
+    m_verticalScroller.setUsePresentationValue(scrollbValue);
 }
 
 void ScrollerPairMac::updateValues()
@@ -317,7 +317,7 @@ ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientati
 
 bool ScrollerPairMac::hasScrollerImp()
 {
-    return verticalScroller().scrollerImp() || horizontalScroller().scrollerImp();
+    return verticalScroller().hasScrollerImp() || horizontalScroller().hasScrollerImp();
 }
 
 void ScrollerPairMac::releaseReferencesToScrollerImpsOnTheMainThread()


### PR DESCRIPTION
#### 9861733b659d85270bcecdf43e5544a104dfc07e
<pre>
Safari use-after-free crash at com.apple.AppKit:  -[NSScrollerImp knobLayer]
<a href="https://bugs.webkit.org/show_bug.cgi?id=293144">https://bugs.webkit.org/show_bug.cgi?id=293144</a>
<a href="https://rdar.apple.com/148851492">rdar://148851492</a>

Reviewed by Simon Fraser.

The stack trace in <a href="https://rdar.apple.com/148851492">rdar://148851492</a> makes this look like the scroller imp being
used on the scrolling thread is being destructed in the main thread, so add a lock
around the scroller imp to prevent this from happening.

Combined changes:
* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(-[WebScrollbarPartAnimationMac setCurrentProgress:]):
(-[WebScrollerImpDelegateMac mouseLocationInScrollerForScrollerImp:]):
(-[WebScrollerImpDelegateMac setUpAlphaAnimation:featureToAnimate:animateAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateKnobAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateTrackAlphaTo:duration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateUIStateTransitionWithDuration:]):
(-[WebScrollerImpDelegateMac scrollerImp:animateExpansionTransitionWithDuration:]):
(WebCore::ScrollerMac::attach):
(WebCore::ScrollerMac::detach):
(WebCore::ScrollerMac::setHostLayer):
(WebCore::ScrollerMac::setHiddenByStyle):
(WebCore::ScrollerMac::updateValues):
(WebCore::ScrollerMac::updateScrollbarStyle):
(WebCore::ScrollerMac::setScrollerImp):
(WebCore::ScrollerMac::setScrollbarLayoutDirection):
(WebCore::ScrollerMac::setNeedsDisplay):
(WebCore::ScrollerMac::takeScrollerImp):
(WebCore::ScrollerMac::setUsePresentationValue):
(WebCore::ScrollerMac::updateProgress):
(WebCore::ScrollerMac::isScroller):
(WebCore::ScrollerMac::knobAlpha):
(WebCore::ScrollerMac::trackAlpha):
(WebCore::ScrollerMac::hasScrollerImp):
(WebCore::ScrollerMac::scrollbarState const):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
(WebCore::ScrollerPairMac::scrollerImpHorizontal): Deleted.
(WebCore::ScrollerPairMac::scrollerImpVertical): Deleted.
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(-[WebScrollerImpPairDelegateMac scrollerImpPair:convertContentPoint:toScrollerImp:]):
(WebCore::ScrollerPairMac::setUsePresentationValues):
(WebCore::ScrollerPairMac::setHorizontalScrollbarPresentationValue):
(WebCore::ScrollerPairMac::setVerticalScrollbarPresentationValue):
(WebCore::ScrollerPairMac::hasScrollerImp):

Originally-landed-as: 289651.583@safari-7621-branch (e2f4cdc8895f). <a href="https://rdar.apple.com/157789309">rdar://157789309</a>
Canonical link: <a href="https://commits.webkit.org/298807@main">https://commits.webkit.org/298807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30f23c2729d8f72790607bd66fbc074c399c1231

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67243 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52dbf81e-f070-4181-a6b1-1ac0a5c1cb5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37033 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88607 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43021 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, storage/indexeddb/delete-in-upgradeneeded-close-in-versionchange.html, storage/indexeddb/factory-cmp.html, storage/indexeddb/factory-deletedatabase-private.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-rgb565-rgb-unsigned_short_5_6_5.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-3d-rgb16f-rgb-float.html, webgl/2.0.0/conformance2/textures/image/tex-2d-rgba16f-rgba-half_float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-3d-rg32f-rg-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-3d-rgb5_a1-rgba-unsigned_byte.html, webgl/2.0.y/conformance/glsl/matrices/glsl-mat3-construction.html, webgl/2.0.y/conformance/ogles/GL/functions/functions_113_to_120.html, webgl/2.0.y/conformance/ogles/GL/struct/struct_017_to_024.html, webgl/2.0.y/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html, webgl/2.0.y/conformance/ogles/GL/vec/vec_009_to_016.html, webgl/2.0.y/conformance/ogles/GL/vec3/vec3_001_to_008.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0c68ad1-2bd8-4cb6-ba1f-c4b8fdf968cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69074 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28591 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22762 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66412 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125881 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43570 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32726 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97068 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20313 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39532 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18640 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43456 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49051 "Found 5 new failures in page/scrolling/mac/ScrollerPairMac.mm, page/scrolling/mac/ScrollerMac.mm and found 1 fixed file: page/scrolling/mac/ScrollerPairMac.mm") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42923 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44628 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->