### PR TITLE
Data race on LogIdentifier setter/use on LocalSampleBufferDisplayLayer can lead to UAF

### DIFF
--- a/LayoutTests/ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf-expected.txt
+++ b/LayoutTests/ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf.html
+++ b/LayoutTests/ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    window.onerror = (e) => {
+        $vm.print(e);
+    };
+
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    if (window.IPC) {
+        import('./coreipc.js').then(({
+            CoreIPC
+        }) => {
+            const identifier = 10;
+            CoreIPC.GPU.RemoteSampleBufferDisplayLayerManager.CreateLayer(0, {
+                id: identifier,
+                hideRootLayer: false,
+                size: {
+                    width: 100,
+                    height: 100
+                },
+                shouldMaintainAspectRatio: false,
+                canShowWhileLocked: true
+            }, (r) => {
+                let d = 0;
+                for (let z = 0; z < 5; z++) {
+                    setTimeout(() => {
+                        for (let x = 0; x < 32 * 25; x++) {
+                            CoreIPC.GPU.RemoteSampleBufferDisplayLayer.EnqueueVideoFrame(identifier, {
+                                frame: {
+                                    time: {
+                                        timeValue: 0x100000000,
+                                        timeScale: 1,
+                                        timeFlags: 0
+                                    },
+                                    mirrored: true,
+                                    rotation: 0,
+                                    buffer: {
+                                        alias: {
+                                            variantType: 'WebCore::IntSize',
+                                            variant: {
+                                                width: 100,
+                                                height: 100
+                                            }
+                                        }
+                                    }
+                                }
+                            });
+                            CoreIPC.GPU.RemoteSampleBufferDisplayLayer.SetLogIdentifier(identifier, {
+                                logIdentifier: "A".repeat(8192*64)
+                            });
+                        }
+                    }, 500);
+                }
+                setTimeout(() => { window.testRunner?.notifyDone() }, 3000);
+            });
+        });
+    } else {
+        window.testRunner?.notifyDone();
+    }
+</script>
+<body>
+    <p>This test passes if WebKit does not crash.</p>
+</body>
+

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -64,7 +64,7 @@ public:
 
     virtual void initialize(bool hideRootLayer, IntSize, bool shouldMaintainAspectRatio, CompletionHandler<void(bool didSucceed)>&&) = 0;
 #if !RELEASE_LOG_DISABLED
-    virtual void setLogIdentifier(String&&) = 0;
+    virtual void setLogIdentifier(uint64_t) = 0;
 #endif
     virtual bool didFail() const = 0;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -69,7 +69,7 @@ public:
     PlatformLayer* rootLayer() final;
     void initialize(bool hideRootLayer, IntSize, bool shouldMaintainAspectRatio, CompletionHandler<void(bool didSucceed)>&&) final;
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(String&& logIdentifier) final { m_logIdentifier = WTFMove(logIdentifier); }
+    void setLogIdentifier(uint64_t) final;
 #endif
     bool didFail() const final;
 
@@ -117,7 +117,7 @@ private:
     bool m_paused { false };
     bool m_didFail { false };
 #if !RELEASE_LOG_DISABLED
-    String m_logIdentifier;
+    uint64_t m_logIdentifier;
     FrameRateMonitor m_frameRateMonitor WTF_GUARDED_BY_CAPABILITY(workQueue());
 #endif
 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -192,6 +192,11 @@ void LocalSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size,
     callback(true);
 }
 
+void LocalSampleBufferDisplayLayer::setLogIdentifier(uint64_t logIdentifier)
+{
+    m_logIdentifier = logIdentifier;
+}
+
 LocalSampleBufferDisplayLayer::~LocalSampleBufferDisplayLayer()
 {
     ASSERT(isMainThread());
@@ -229,7 +234,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RefPtr client = m_client.get();
     if (client && m_sampleBufferDisplayLayer.get().status == AVQueuedSampleBufferRenderingStatusFailed) {
 ALLOW_DEPRECATED_DECLARATIONS_END
-        RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerStatusDidChange going to failed status (%{public}s) ", m_logIdentifier.utf8().data());
+    RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerStatusDidChange going to failed status (%llu) ", m_logIdentifier);
         if (!m_didFail) {
             m_didFail = true;
             client->sampleBufferDisplayLayerStatusDidFail();
@@ -240,7 +245,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 void LocalSampleBufferDisplayLayer::layerErrorDidChange()
 {
     ASSERT(isMainThread());
-    RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerErrorDidChange (%{public}s) ", m_logIdentifier.utf8().data());
+    RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerErrorDidChange (%llu) ", m_logIdentifier);
     RefPtr client = m_client.get();
     if (!client || m_didFail)
         return;
@@ -416,7 +421,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     constexpr size_t frameCountPerLog = 1800; // log every minute at 30 fps
     if (!(m_frameRateMonitor.frameCount() % frameCountPerLog)) {
         if (auto* metrics = [m_sampleBufferDisplayLayer videoPerformanceMetrics])
-            RELEASE_LOG(WebRTC, "LocalSampleBufferDisplayLayer (%{public}s) metrics, total=%lu, dropped=%lu, corrupted=%lu, display-composited=%lu, non-display-composited=%lu (pending=%lu)", m_logIdentifier.utf8().data(), metrics.totalNumberOfVideoFrames, metrics.numberOfDroppedVideoFrames, metrics.numberOfCorruptedVideoFrames, metrics.numberOfDisplayCompositedVideoFrames, metrics.numberOfNonDisplayCompositedVideoFrames, m_pendingVideoFrameQueue.size());
+            RELEASE_LOG(WebRTC, "LocalSampleBufferDisplayLayer (%llu) metrics, total=%lu, dropped=%lu, corrupted=%lu, display-composited=%lu, non-display-composited=%lu (pending=%lu)", m_logIdentifier, metrics.totalNumberOfVideoFrames, metrics.numberOfDroppedVideoFrames, metrics.numberOfCorruptedVideoFrames, metrics.numberOfDisplayCompositedVideoFrames, metrics.numberOfNonDisplayCompositedVideoFrames, m_pendingVideoFrameQueue.size());
     }
     m_frameRateMonitor.update();
 #endif
@@ -432,7 +437,7 @@ void LocalSampleBufferDisplayLayer::onIrregularFrameRateNotification(MonotonicTi
         if (!protectedThis)
             return;
 
-        RELEASE_LOG(WebRTC, "LocalSampleBufferDisplayLayer::enqueueVideoFrame (%{public}s) at %f, previous frame was at %f, observed frame rate is %f, delay since last frame is %f ms, frame count is %lu", protectedThis->m_logIdentifier.utf8().data(), frameTime, lastFrameTime, observedFrameRate, (frameTime - lastFrameTime) * 1000, frameCount);
+        RELEASE_LOG(WebRTC, "LocalSampleBufferDisplayLayer::enqueueVideoFrame (%llu) at %f, previous frame was at %f, observed frame rate is %f, delay since last frame is %f ms, frame count is %lu", protectedThis->m_logIdentifier, frameTime, lastFrameTime, observedFrameRate, (frameTime - lastFrameTime) * 1000, frameCount);
     });
 }
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -437,7 +437,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
     scheduleRenderingModeChanged();
 
     RefPtr sampleBufferDisplayLayer = m_sampleBufferDisplayLayer;
-    sampleBufferDisplayLayer->setLogIdentifier(makeString(hex(logIdentifier())));
+    sampleBufferDisplayLayer->setLogIdentifier(logIdentifier());
     if (m_storedBounds)
         sampleBufferDisplayLayer->updateBoundsAndPosition(*m_storedBounds);
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -79,7 +79,7 @@ private:
     RefPtr<WebCore::LocalSampleBufferDisplayLayer> protectedSampleBufferDisplayLayer() const;
 
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(String&&);
+    void setLogIdentifier(uint64_t);
 #endif
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer);
     void flush();

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
@@ -30,7 +30,7 @@
 ]
 messages -> RemoteSampleBufferDisplayLayer {
 #if !RELEASE_LOG_DISABLED
-    SetLogIdentifier(String logIdentifier)
+    SetLogIdentifier(uint64_t logIdentifier)
 #endif
     UpdateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)
     Flush()

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -90,9 +90,9 @@ void RemoteSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size
 }
 
 #if !RELEASE_LOG_DISABLED
-void RemoteSampleBufferDisplayLayer::setLogIdentifier(String&& identifier)
+void RemoteSampleBufferDisplayLayer::setLogIdentifier(uint64_t identifier)
 {
-    m_sampleBufferDisplayLayer->setLogIdentifier(WTFMove(identifier));
+    m_sampleBufferDisplayLayer->setLogIdentifier(identifier);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -69,7 +69,7 @@ void SampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size, bool
 }
 
 #if !RELEASE_LOG_DISABLED
-void SampleBufferDisplayLayer::setLogIdentifier(String&& logIdentifier)
+void SampleBufferDisplayLayer::setLogIdentifier(uint64_t logIdentifier)
 {
     ASSERT(m_hostingContext->contextID);
     m_connection->send(Messages::RemoteSampleBufferDisplayLayer::SetLogIdentifier { logIdentifier }, identifier());

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -60,7 +60,7 @@ private:
     // WebCore::SampleBufferDisplayLayer
     void initialize(bool hideRootLayer, WebCore::IntSize, bool shouldMaintainAspectRatio, CompletionHandler<void(bool)>&&) final;
 #if !RELEASE_LOG_DISABLED
-    void setLogIdentifier(String&&) final;
+    void setLogIdentifier(uint64_t) final;
 #endif
     bool didFail() const final;
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;


### PR DESCRIPTION
#### 880a52f6ce5945d71dc6b8190f388f22f18cc006
<pre>
Data race on LogIdentifier setter/use on LocalSampleBufferDisplayLayer can lead to UAF
<a href="https://rdar.apple.com/152079992">rdar://152079992</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=293986">https://bugs.webkit.org/show_bug.cgi?id=293986</a>

Reviewed by Chris Dumez.

This fixes the bug by using an integer instead of a string as the log identifier

* LayoutTests/ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf-expected.txt: Added.
* LayoutTests/ipc/LocalSampleBufferDisplayLayer-LogIdentifier-data-race-uaf.html: Added.
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::layerStatusDidChange):
(WebCore::LocalSampleBufferDisplayLayer::layerErrorDidChange):
(WebCore::LocalSampleBufferDisplayLayer::enqueueBufferInternal):
(WebCore::LocalSampleBufferDisplayLayer::onIrregularFrameRateNotification):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
(WebKit::RemoteSampleBufferDisplayLayer::setLogIdentifier):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::setLogIdentifier):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:

Originally-landed-as: 289651.577@safari-7621-branch (87cbcc71660c). <a href="https://rdar.apple.com/157789662">rdar://157789662</a>
Canonical link: <a href="https://commits.webkit.org/298771@main">https://commits.webkit.org/298771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e838fba465cc4a0199495dd89584e6bf45fe0af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67008 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68877 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22571 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66183 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125651 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/114973 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97144 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96939 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39293 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18618 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43227 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48818 "Found 1 new failure in GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->