### PR TITLE
4X fast/forms/switch/zoom-approximates-transform layout tests are constant ImageOnlyFailures

### DIFF
--- a/LayoutTests/fast/forms/switch/zoom-approximates-transform-rtl.html
+++ b/LayoutTests/fast/forms/switch/zoom-approximates-transform-rtl.html
@@ -1,1 +1,2 @@
+<meta name="fuzzy" content="maxDifference=37; totalPixels=2540" />
 <input type=checkbox switch style=zoom:5 dir=rtl>

--- a/LayoutTests/fast/forms/switch/zoom-approximates-transform-vertical-lr.html
+++ b/LayoutTests/fast/forms/switch/zoom-approximates-transform-vertical-lr.html
@@ -1,1 +1,2 @@
+<meta name="fuzzy" content="maxDifference=35; totalPixels=2252" />
 <input type=checkbox switch style="zoom:5; writing-mode:vertical-lr">

--- a/LayoutTests/fast/forms/switch/zoom-approximates-transform-vertical-rl.html
+++ b/LayoutTests/fast/forms/switch/zoom-approximates-transform-vertical-rl.html
@@ -1,1 +1,2 @@
+<meta name="fuzzy" content="maxDifference=35; totalPixels=2252" />
 <input type=checkbox switch style="zoom:5; writing-mode:vertical-rl">

--- a/LayoutTests/fast/forms/switch/zoom-approximates-transform.html
+++ b/LayoutTests/fast/forms/switch/zoom-approximates-transform.html
@@ -1,1 +1,2 @@
+<meta name="fuzzy" content="maxDifference=35; totalPixels=2215" />
 <input type=checkbox switch style=zoom:5>

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -23,12 +23,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-p
 # rdar://154889639 (REGRESSION(Liquid Glass): [ OS 26 ] fast/forms/datalist/datalist-fallback-content.html is a constant ImageOnlyFailure)
 fast/forms/datalist/datalist-fallback-content.html [ Pass ]
 
-# rdar://154990654 (REGRESSION(Liquid Glass): [ Tahoe ] 4X fast/forms/switch/zoom-approximates-transform (layout-tests) are constant ImageOnlyFailures)
-fast/forms/switch/zoom-approximates-transform-rtl.html [ Pass ]
-fast/forms/switch/zoom-approximates-transform-vertical-lr.html [ Pass ] 
-fast/forms/switch/zoom-approximates-transform-vertical-rl.html [ Pass ] 
-fast/forms/switch/zoom-approximates-transform.html [ Pass ] 
-
 # Tests which pass only with form control refresh enabled (support added in Tahoe)
 fast/forms/appearance-default-button.html  [ Skip ]
 fast/forms/form-control-refresh [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2476,12 +2476,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/new-content-transform-p
 # rdar://154889639 (REGRESSION(Liquid Glass): [ OS 26 ] fast/forms/datalist/datalist-fallback-content.html is a constant ImageOnlyFailure)
 fast/forms/datalist/datalist-fallback-content.html [ ImageOnlyFailure ]
 
-# rdar://154990654 (REGRESSION(Liquid Glass): [ Tahoe ] 4X fast/forms/switch/zoom-approximates-transform (layout-tests) are constant ImageOnlyFailures)
-fast/forms/switch/zoom-approximates-transform-rtl.html [ ImageOnlyFailure ]
-fast/forms/switch/zoom-approximates-transform-vertical-lr.html [ ImageOnlyFailure ] 
-fast/forms/switch/zoom-approximates-transform-vertical-rl.html [ ImageOnlyFailure ] 
-fast/forms/switch/zoom-approximates-transform.html [ ImageOnlyFailure ] 
-
 # Tests which pass only with form control refresh enabled
 fast/forms/appearance-default-button.html  [ Pass ]
 fast/forms/form-control-refresh [ Pass ]


### PR DESCRIPTION
#### b0e74e85f3215089d0067cb074c36d7b37467178
<pre>
4X fast/forms/switch/zoom-approximates-transform layout tests are constant ImageOnlyFailures
<a href="https://bugs.webkit.org/show_bug.cgi?id=297426">https://bugs.webkit.org/show_bug.cgi?id=297426</a>
<a href="https://rdar.apple.com/154990654">rdar://154990654</a>

Reviewed by Tim Horton.

Scale and zoom are unique operations which are not strictly required to look
identical to one another. Similar behavior exists for other controls besides
switch controls, and such behavior is not unique to WebKit. Add pixel tolerance
to each of the failing tests to account for this.

* LayoutTests/fast/forms/switch/zoom-approximates-transform-rtl.html:
* LayoutTests/fast/forms/switch/zoom-approximates-transform-vertical-lr.html:
* LayoutTests/fast/forms/switch/zoom-approximates-transform-vertical-rl.html:
* LayoutTests/fast/forms/switch/zoom-approximates-transform.html:
* LayoutTests/platform/mac-sequoia/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298714@main">https://commits.webkit.org/298714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35301330ff966ee4d041028b981f2d4d9bf88b19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116467 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/36128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/26679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/44716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/122524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119416 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/26679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/122524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/26679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/66205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/43361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/44716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/125673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/43726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/26679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/125673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/26679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18592 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/43249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/42715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->