### PR TITLE
Add character concept to ASCIICType functions

### DIFF
--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <array>
+#include <concepts>
+#include <type_traits>
 #include <wtf/Assertions.h>
 #include <wtf/text/LChar.h>
 
@@ -40,57 +42,60 @@
 
 namespace WTF {
 
-template<typename CharacterType> constexpr bool isASCII(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIAlpha(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIDigit(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIHexDigit(CharacterType);
-template<typename CharacterType> constexpr bool isASCIILower(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIGraphic(CharacterType);
-template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType);
-template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType);
-template<typename CharacterType> constexpr bool isASCIIUpper(CharacterType);
+template<typename T>
+concept Character = std::convertible_to<std::remove_cv_t<T>, char>;
+
+template<Character CharacterType> constexpr bool isASCII(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIAlpha(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIDigit(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIHexDigit(CharacterType);
+template<Character CharacterType> constexpr bool isASCIILower(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIOctalDigit(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIPrintable(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIGraphic(CharacterType);
+template<Character CharacterType> constexpr bool isTabOrSpace(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIWhitespace(CharacterType);
+template<Character CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType);
+template<Character CharacterType> constexpr bool isASCIIUpper(CharacterType);
 
 // Inverse of isASCIIWhitespace for predicates
-template<typename CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType);
+template<Character CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType);
 
-template<typename CharacterType> CharacterType toASCIILower(CharacterType);
-template<typename CharacterType> CharacterType toASCIIUpper(CharacterType);
+template<Character CharacterType> CharacterType toASCIILower(CharacterType);
+template<Character CharacterType> CharacterType toASCIIUpper(CharacterType);
 
-template<typename CharacterType> uint8_t toASCIIHexValue(CharacterType);
-template<typename CharacterType> uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter);
+template<Character CharacterType> uint8_t toASCIIHexValue(CharacterType);
+template<Character CharacterType> uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter);
 
 constexpr char lowerNibbleToASCIIHexDigit(uint8_t);
 constexpr char upperNibbleToASCIIHexDigit(uint8_t);
 constexpr char lowerNibbleToLowercaseASCIIHexDigit(uint8_t);
 constexpr char upperNibbleToLowercaseASCIIHexDigit(uint8_t);
 
-template<typename CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType, char expectedASCIILowercaseLetter);
+template<Character CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType, char expectedASCIILowercaseLetter);
 
 // The toASCIILowerUnchecked function can be used for comparing any input character
 // to a lowercase English character. The isASCIIAlphaCaselessEqual function should
 // be used for regular comparison of ASCII alpha characters, but switch statements
 // in the CSS tokenizer, for example, instead make direct use toASCIILowerUnchecked.
-template<typename CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType);
+template<Character CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType);
 
 extern WTF_EXPORT_PRIVATE const std::array<uint8_t, 256> asciiCaseFoldTable;
 
-template<typename CharacterType> constexpr bool isASCII(CharacterType character)
+template<Character CharacterType> constexpr bool isASCII(CharacterType character)
 {
     return !(character & ~0x7F);
 }
 
-template<typename CharacterType> constexpr bool isASCIILower(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIILower(CharacterType character)
 {
     return character >= 'a' && character <= 'z';
 }
 
-template<typename CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType character)
+template<Character CharacterType> constexpr CharacterType toASCIILowerUnchecked(CharacterType character)
 {
     // This function can be used for comparing any input character
     // to a lowercase English character. The isASCIIAlphaCaselessEqual
@@ -100,58 +105,58 @@ template<typename CharacterType> constexpr CharacterType toASCIILowerUnchecked(C
     return character | 0x20;
 }
 
-template<typename CharacterType> constexpr bool isASCIIAlpha(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIAlpha(CharacterType character)
 {
     return isASCIILower(toASCIILowerUnchecked(character));
 }
 
-template<typename CharacterType> constexpr bool isASCIIDigit(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIDigit(CharacterType character)
 {
     return character >= '0' && character <= '9';
 }
 
-template<typename CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIAlphanumeric(CharacterType character)
 {
     return isASCIIDigit(character) || isASCIIAlpha(character);
 }
 
-template<typename CharacterType> constexpr bool isASCIIHexDigit(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIHexDigit(CharacterType character)
 {
     return isASCIIDigit(character) || (toASCIILowerUnchecked(character) >= 'a' && toASCIILowerUnchecked(character) <= 'f');
 }
 
-template<typename CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIBinaryDigit(CharacterType character)
 {
     return character == '0' || character == '1';
 }
 
-template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIOctalDigit(CharacterType character)
 {
     return character >= '0' && character <= '7';
 }
 
-template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIPrintable(CharacterType character)
 {
     return character >= ' ' && character <= '~';
 }
 
-template<typename CharacterType> constexpr bool isASCIIGraphic(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIGraphic(CharacterType character)
 {
     return character >= '!' && character <= '~';
 }
 
-template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType character)
+template<Character CharacterType> constexpr bool isTabOrSpace(CharacterType character)
 {
     return character == ' ' || character == '\t';
 }
 
 // Infra's "ASCII whitespace" <https://infra.spec.whatwg.org/#ascii-whitespace>
-template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIWhitespace(CharacterType character)
 {
     return character == ' ' || character == '\n' || character == '\t' || character == '\r' || character == '\f';
 }
 
-template<typename CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(CharacterType character)
 {
     // This is different from isASCIIWhitespace: JSON/HTTP/XML do not accept \f as a whitespace.
     // ECMA-404 specifies the following:
@@ -166,22 +171,22 @@ template<typename CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(Chara
     return character == ' ' || character == '\n' || character == '\t' || character == '\r';
 }
 
-template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType character)
+template<Character CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType character)
 {
     return isASCIIWhitespace(character) || character == '\v';
 }
 
-template<typename CharacterType> constexpr bool isASCIIUpper(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIUpper(CharacterType character)
 {
     return character >= 'A' && character <= 'Z';
 }
 
-template<typename CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType character)
+template<Character CharacterType> constexpr bool isNotASCIIWhitespace(CharacterType character)
 {
     return !isASCIIWhitespace(character);
 }
 
-template<typename CharacterType> inline CharacterType toASCIILower(CharacterType character)
+template<Character CharacterType> inline CharacterType toASCIILower(CharacterType character)
 {
     return character | (isASCIIUpper(character) << 5);
 }
@@ -196,18 +201,18 @@ template<> inline LChar toASCIILower(LChar character)
     return asciiCaseFoldTable[character];
 }
 
-template<typename CharacterType> inline CharacterType toASCIIUpper(CharacterType character)
+template<Character CharacterType> inline CharacterType toASCIIUpper(CharacterType character)
 {
     return character & ~(isASCIILower(character) << 5);
 }
 
-template<typename CharacterType> inline uint8_t toASCIIHexValue(CharacterType character)
+template<Character CharacterType> inline uint8_t toASCIIHexValue(CharacterType character)
 {
     ASSERT(isASCIIHexDigit(character));
     return character < 'A' ? character - '0' : (character - 'A' + 10) & 0xF;
 }
 
-template<typename CharacterType> inline uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter)
+template<Character CharacterType> inline uint8_t toASCIIHexValue(CharacterType firstCharacter, CharacterType secondCharacter)
 {
     return toASCIIHexValue(firstCharacter) << 4 | toASCIIHexValue(secondCharacter);
 }
@@ -236,7 +241,7 @@ constexpr char upperNibbleToLowercaseASCIIHexDigit(uint8_t value)
     return nibble + (nibble < 10 ? '0' : 'a' - 10);
 }
 
-template<typename CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType inputCharacter, char expectedASCIILowercaseLetter)
+template<Character CharacterType> constexpr bool isASCIIAlphaCaselessEqual(CharacterType inputCharacter, char expectedASCIILowercaseLetter)
 {
     // Name of this argument says this must be a lowercase letter, but it can actually be:
     //   - a lowercase letter
@@ -255,7 +260,7 @@ template<typename CharacterType> constexpr bool isASCIIAlphaCaselessEqual(Charac
     return false;
 }
 
-template<typename CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType character)
+template<Character CharacterType> constexpr bool isASCIIDigitOrPunctuation(CharacterType character)
 {
     return (character >= '!' && character <= '@') || (character >= '[' && character <= '`') || (character >= '{' && character <= '~');
 }
@@ -273,12 +278,12 @@ using WTF::isASCIIHexDigit;
 using WTF::isASCIILower;
 using WTF::isASCIIOctalDigit;
 using WTF::isASCIIPrintable;
-using WTF::isTabOrSpace;
+using WTF::isASCIIUpper;
 using WTF::isASCIIWhitespace;
 using WTF::isASCIIWhitespaceWithoutFF;
-using WTF::isUnicodeCompatibleASCIIWhitespace;
-using WTF::isASCIIUpper;
 using WTF::isNotASCIIWhitespace;
+using WTF::isTabOrSpace;
+using WTF::isUnicodeCompatibleASCIIWhitespace;
 using WTF::lowerNibbleToASCIIHexDigit;
 using WTF::lowerNibbleToLowercaseASCIIHexDigit;
 using WTF::toASCIIHexValue;


### PR DESCRIPTION
#### 0263caacc7951bc72672eceedc97476798d5cc24
<pre>
Add character concept to ASCIICType functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=297085">https://bugs.webkit.org/show_bug.cgi?id=297085</a>
<a href="https://rdar.apple.com/157789937">rdar://157789937</a>

Reviewed by Ryan Reno.

This patch adds the concept of a character to ASCIICType.h. This will create better error messages for the developer when passing the wrong type. The functions will now accept only types that are convertible to a character.

* Source/WTF/wtf/ASCIICType.h:
(WTF::isASCII):
(WTF::isASCIILower):
(WTF::toASCIILowerUnchecked):
(WTF::isASCIIAlpha):
(WTF::isASCIIDigit):
(WTF::isASCIIAlphanumeric):
(WTF::isASCIIHexDigit):
(WTF::isASCIIBinaryDigit):
(WTF::isASCIIOctalDigit):
(WTF::isASCIIPrintable):
(WTF::isASCIIGraphic):
(WTF::isTabOrSpace):
(WTF::isASCIIWhitespace):
(WTF::isASCIIWhitespaceWithoutFF):
(WTF::isUnicodeCompatibleASCIIWhitespace):
(WTF::isASCIIUpper):
(WTF::isNotASCIIWhitespace):
(WTF::toASCIILower):
(WTF::toASCIIUpper):
(WTF::toASCIIHexValue):
(WTF::isASCIIAlphaCaselessEqual):
(WTF::isASCIIDigitOrPunctuation):

Canonical link: <a href="https://commits.webkit.org/298753@main">https://commits.webkit.org/298753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05263edf046c8c505a300e3656095b2452999f48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67049 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88463 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42927 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22607 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66224 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108596 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125692 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115014 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97163 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96958 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24692 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20168 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39334 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43268 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48859 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/143712 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42734 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37009 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->