### PR TITLE
Fix -Wpreferred-type-bitfield-enum-conversion warnings in WebCore

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -224,7 +224,7 @@ bool SelectorChecker::match(const CSSSelector& selector, const Element& element,
         return false;
 
     if (checkingContext.pseudoId == PseudoId::None && pseudoIdSet) {
-        PseudoIdSet publicPseudoIdSet = pseudoIdSet & PseudoIdSet::fromMask(static_cast<unsigned>(PseudoId::PublicPseudoIdMask));
+        PseudoIdSet publicPseudoIdSet = pseudoIdSet & PseudoIdSet::fromMask(PublicPseudoIdMask);
         if (checkingContext.resolvingMode == Mode::ResolvingStyle && publicPseudoIdSet)
             checkingContext.pseudoIDSet = publicPseudoIdSet;
 

--- a/Source/WebCore/rendering/style/FillLayer.h
+++ b/Source/WebCore/rendering/style/FillLayer.h
@@ -196,9 +196,11 @@ private:
     LengthSize m_sizeLength;
     FillRepeatXY m_repeat;
 
+    static constexpr unsigned FillBoxBitWidth = 3;
+
     PREFERRED_TYPE(FillAttachment) unsigned m_attachment : 2;
-    PREFERRED_TYPE(FillBox) unsigned m_clip : 3;
-    PREFERRED_TYPE(FillBox) unsigned m_origin : 2;
+    PREFERRED_TYPE(FillBox) unsigned m_clip : FillBoxBitWidth;
+    PREFERRED_TYPE(FillBox) unsigned m_origin : FillBoxBitWidth;
     PREFERRED_TYPE(CompositeOperator) unsigned m_composite : 4;
     PREFERRED_TYPE(FillSizeType) unsigned m_sizeType : 2;
     PREFERRED_TYPE(BlendMode) unsigned m_blendMode : 5;
@@ -217,7 +219,7 @@ private:
 
     PREFERRED_TYPE(FillLayerType) unsigned m_type : 1;
 
-    PREFERRED_TYPE(FillBox) mutable unsigned m_clipMax : 2; // maximum m_clip value from this to bottom layer
+    PREFERRED_TYPE(FillBox) mutable unsigned m_clipMax : FillBoxBitWidth; // maximum m_clip value from this to bottom layer
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, FillSize);

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -28,6 +28,7 @@
 #include <initializer_list>
 #include <limits>
 #include <optional>
+#include <wtf/EnumTraits.h>
 
 namespace WTF {
 class TextStream;
@@ -118,8 +119,9 @@ enum class PseudoId : uint32_t {
 
     FirstPublicPseudoId = FirstLine,
     FirstInternalPseudoId = WebKitScrollbarThumb,
-    PublicPseudoIdMask = ((1 << FirstInternalPseudoId) - 1) & ~((1 << FirstPublicPseudoId) - 1)
 };
+
+constexpr auto PublicPseudoIdMask = static_cast<std::underlying_type_t<PseudoId>>(((1U << enumToUnderlyingType(PseudoId::FirstInternalPseudoId)) - 1U) & ~((1U << enumToUnderlyingType(PseudoId::FirstPublicPseudoId)) - 1U));
 
 inline std::optional<PseudoId> parentPseudoElement(PseudoId pseudoId)
 {

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -911,7 +911,7 @@ inline bool RenderStyle::NonInheritedFlags::hasPseudoStyle(PseudoId pseudo) cons
 
 inline bool RenderStyle::NonInheritedFlags::hasAnyPublicPseudoStyles() const
 {
-    return static_cast<unsigned>(PseudoId::PublicPseudoIdMask) & pseudoBits;
+    return PublicPseudoIdMask & pseudoBits;
 }
 
 inline bool RenderStyle::breakOnlyAfterWhiteSpace() const

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -405,7 +405,7 @@ inline void RenderStyle::setInsideSubmitButton(bool value) { SET(m_rareInherited
 inline void RenderStyle::NonInheritedFlags::setHasPseudoStyles(PseudoIdSet pseudoIdSet)
 {
     ASSERT(pseudoIdSet);
-    ASSERT((pseudoIdSet.data() & static_cast<unsigned>(PseudoId::PublicPseudoIdMask)) == pseudoIdSet.data());
+    ASSERT((pseudoIdSet.data() & PublicPseudoIdMask) == pseudoIdSet.data());
     pseudoBits |= pseudoIdSet.data() >> 1; // Shift down as we do not store a bit for PseudoId::None.
 }
 


### PR DESCRIPTION
#### 5a74e184fd2204750d9870b60555fb2f7fb987c8
<pre>
Fix -Wpreferred-type-bitfield-enum-conversion warnings in WebCore
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=297439">https://bugs.webkit.org/show_bug.cgi?id=297439</a>&gt;
&lt;<a href="https://rdar.apple.com/158245532">rdar://158245532</a>&gt;

Reviewed by Brent Fulgham.

Warnings found by -Wpreferred-type-bitfield-enum-conversion indicate
that a bitfield used to store an enum type are too small to hold one or
more values defined in the enum.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::match const):
- Switch to use new definition of PublicPseudoIdMask.
* Source/WebCore/rendering/style/FillLayer.h:
(WebCore::FillLayer::FillBoxBitWidth): Add.
(WebCore::FillLayer::m_clip):
(WebCore::FillLayer::m_origin):
(WebCore::FillLayer::m_clipMax):
- Define FillBoxBitWidth constant for bitwidth of FillBox enum, then
  use it when definining bitfileds of type FillBox.  This fixes the
  warning and a real bug where m_origin and m_clipMax could not hold all
  values of FillBox.
* Source/WebCore/rendering/style/RenderStyleConstants.h:
(WebCore::PseudoId::PublicPseudoIdMask): Remove.
(WebCore::PublicPseudoIdMask): Add.
- Define PublicPseudoIdMask outside enum class PseudoId since it&apos;s too
  large to be held by the RenderStyle::pseudoElementType bitfield.  This
  was not a bug in practice, but fixes the warning by moving the mask
  value outside of the enum itself.
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::NonInheritedFlags::hasAnyPublicPseudoStyles const):
- Switch to use new definition of PublicPseudoIdMask.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::NonInheritedFlags::setHasPseudoStyles):
- Switch to use new definition of PublicPseudoIdMask.

Canonical link: <a href="https://commits.webkit.org/298737@main">https://commits.webkit.org/298737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e9051bf9511c6f2c72302019fab5b73c9cf0e18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122556 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/67062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44748 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/67062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68911 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22612 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66237 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125705 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32582 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100714 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/96966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42264 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20173 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18602 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48872 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42747 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->