### PR TITLE
[import-w3c-tests] Support WPT working copy not called "web-platform-tests"

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/filesystem.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem.py
@@ -231,6 +231,9 @@ class FileSystem(object):
     def normpath(self, path):
         return os.path.normpath(path)
 
+    def symlink(self, src, dst):
+        return os.symlink(src, dst)
+
     def open_binary_tempfile(self, suffix):
         """Create, open, and return a binary temp file. Returns a tuple of the file and the name."""
         temp_fd, temp_name = tempfile.mkstemp(suffix)

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -116,6 +116,24 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue(host.filesystem.exists("/mock-checkout/LayoutTests/w3c/web-platform-tests/test2/__init__.py"))
         self.assertTrue(host.filesystem.getsize("/mock-checkout/LayoutTests/w3c/web-platform-tests/test1/__init__.py") > 0)
 
+    def test_import_dir_not_web_platform_tests(self):
+        # This is a horrible hack so we don't actually need to support symlinks in the MockFileSystem.
+        MockFileSystem.symlink = lambda self, src, dst: self.copytree(src, dst)
+        self.addCleanup(lambda: delattr(MockFileSystem, "symlink"))
+
+        FAKE_FILES = {}
+        FAKE_FILES.update(FAKE_RESOURCES)
+        FAKE_FILES.update({
+            '/t/wpt/test1/test.html': MINIMAL_TESTHARNESS,
+            '/t/wpt/wpt': '',
+            '/t/wpt/resources/testharness.js': '',
+        })
+
+        fs = self.import_downloaded_tests(['--no-fetch', '-s', '/t/wpt', '-d', 'w3c'], FAKE_FILES)
+        print(fs.files_under("/mock-checkout/LayoutTests/w3c/web-platform-tests"))
+
+        self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/test1/test.html'))
+
     def import_directory(self, args, files, test_paths):
         return self.import_downloaded_tests(args + test_paths, files)
 


### PR DESCRIPTION
#### a5576777af890db59e372bd099aee01d331284c6
<pre>
[import-w3c-tests] Support WPT working copy not called &quot;web-platform-tests&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=257730">https://bugs.webkit.org/show_bug.cgi?id=257730</a>
<a href="https://rdar.apple.com/problem/110278828">rdar://problem/110278828</a>

Reviewed by Brianna Fan.

The GitHub repo w3c/web-platform-tests was renamed to
web-platform-tests/wpt back in May 2018. Since then, `git clone &lt;url&gt;`
has created a directory called &quot;wpt&quot; from which we could not import.

This fix is, arguably, an inelegant solution to the problem: we simply
create a temporary directory, and create a symlink within it called
&quot;web-platform-tests&quot; pointing at the existing working copy.

This is done because we assume we&apos;re getting paths relative to
`LayoutTests/imported/w3c` all over the place and trying to
disentangle this has proven to be more work than its worth.

Longer term we should disentangle all of that, as part of furthering
the modern assumption that WPT is the only repo which we are importing
from, but fixing this usability bug is more urgent than that.

* Tools/Scripts/webkitpy/common/system/filesystem.py:
(FileSystem.symlink):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(parse_args):
(TestImporter.do_import):
(TestImporter._get_wpt_directory):
(TestImporter.should_skip_path):
These are all PurePath, because we (for now) require everything to go via the Filesystem object.
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(TestImporterTest.test_import_dir_not_web_platform_tests):

Canonical link: <a href="https://commits.webkit.org/298861@main">https://commits.webkit.org/298861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f01604922b4b25b616917f3f7c42b8158c680ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67130 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88468 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42958 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68912 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/115877 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22618 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125709 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97177 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96972 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42268 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39351 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18664 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43285 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42751 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->