### PR TITLE
Parsing text-decoration: grammar-error

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt
@@ -16,5 +16,5 @@ PASS Property text-decoration-line value 'underline line-through blink'
 PASS Property text-decoration-line value 'overline line-through blink'
 PASS Property text-decoration-line value 'underline overline line-through blink'
 PASS Property text-decoration-line value 'spelling-error'
-FAIL Property text-decoration-line value 'grammar-error' assert_true: 'grammar-error' is a supported value for text-decoration-line. expected true got false
+PASS Property text-decoration-line value 'grammar-error'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-valid-expected.txt
@@ -65,5 +65,5 @@ PASS e.style['text-decoration-line'] = "blink overline line-through underline" s
 PASS e.style['text-decoration-line'] = "blink line-through underline overline" should set the property value
 PASS e.style['text-decoration-line'] = "blink line-through overline underline" should set the property value
 PASS e.style['text-decoration-line'] = "spelling-error" should set the property value
-FAIL e.style['text-decoration-line'] = "grammar-error" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['text-decoration-line'] = "grammar-error" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt
@@ -10,7 +10,7 @@ PASS Can set 'text-decoration-line' to the 'overline' keyword: overline
 PASS Can set 'text-decoration-line' to the 'line-through' keyword: line-through
 PASS Can set 'text-decoration-line' to the 'blink' keyword: blink
 PASS Can set 'text-decoration-line' to the 'spelling-error' keyword: spelling-error
-FAIL Can set 'text-decoration-line' to the 'grammar-error' keyword: grammar-error Invalid values
+PASS Can set 'text-decoration-line' to the 'grammar-error' keyword: grammar-error
 PASS Setting 'text-decoration-line' to a length: 0px throws TypeError
 PASS Setting 'text-decoration-line' to a length: -3.14em throws TypeError
 PASS Setting 'text-decoration-line' to a length: 3.14cm throws TypeError

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10794,17 +10794,15 @@
                     "value": "blink",
                     "comment": "The value is parsed and computed but ignored for rendering."
                 },
-                {
-                    "value": "spelling-error",
-                    "settings-flag": "cssTextDecorationLineErrorValues"
-                }
+                "spelling-error",
+                "grammar-error"
             ],
             "codegen-properties": {
                 "style-converter": "StyleType<TextDecorationLine>",
                 "aliases": [
                     "-webkit-text-decoration-line"
                 ],
-                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues)",
+                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues) | grammar-error@(settings-flag=cssTextDecorationLineErrorValues)",
                 "parser-exported": true
             },
             "specification": {

--- a/Source/WebCore/style/StyleExtractorSerializer.h
+++ b/Source/WebCore/style/StyleExtractorSerializer.h
@@ -1058,7 +1058,6 @@ inline void ExtractorSerializer::serializeTextTransform(ExtractorState& state, S
         serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
 }
 
-
 inline void ExtractorSerializer::serializeTextUnderlinePosition(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, OptionSet<TextUnderlinePosition> textUnderlinePosition)
 {
     ASSERT(!((textUnderlinePosition & TextUnderlinePosition::FromFont) && (textUnderlinePosition & TextUnderlinePosition::Under)));


### PR DESCRIPTION
#### 12de0b76a30f761509aea6b842dad57afc298228
<pre>
Parsing text-decoration: grammar-error
<a href="https://rdar.apple.com/158375262">rdar://158375262</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297443">https://bugs.webkit.org/show_bug.cgi?id=297443</a>

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-decoration-line-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/text-decoration-line-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractorSerializer.h:

Canonical link: <a href="https://commits.webkit.org/299531@main">https://commits.webkit.org/299531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93cb194fb1de3dd7f4963155e1ca46a67d866811

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71378 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43ff69c8-9610-4cac-9738-a4ac84690dc8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47576 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90655 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b1a620c-fed1-4789-89f9-bcae4aa65293) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71080 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae19bfec-7764-42ab-9f77-222e30f67408) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/30707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25079 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69195 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/101117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128553 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34969 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/99219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98997 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/25165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44457 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/22473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/42793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46089 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/51789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45554 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48904 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->