### PR TITLE
[WebXR][OpenXR] Add API to get consent required/optional features of WebKitXRPermissionRequest

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -376,9 +376,9 @@ private:
     }
 
 #if ENABLE(WEBXR) && USE(OPENXR)
-    void requestPermissionOnXRSessionFeatures(WebKit::WebPageProxy&, const WebCore::SecurityOriginData& origin, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler) final
+    void requestPermissionOnXRSessionFeatures(WebKit::WebPageProxy&, const WebCore::SecurityOriginData& origin, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& consentRequired, const PlatformXR::Device::FeatureList& consentOptional, const PlatformXR::Device::FeatureList& requiredFeaturesRequested, const PlatformXR::Device::FeatureList& optionalFeaturesRequested, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler) final
     {
-        GRefPtr<WebKitXRPermissionRequest> request = webkitXRPermissionRequestCreate(origin, mode, granted, WTFMove(completionHandler));
+        GRefPtr<WebKitXRPermissionRequest> request = webkitXRPermissionRequestCreate(origin, mode, granted, consentRequired, consentOptional, requiredFeaturesRequested, optionalFeaturesRequested, WTFMove(completionHandler));
         webkitWebViewMakePermissionRequest(m_webView, WEBKIT_PERMISSION_REQUEST(request.get()));
     }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
@@ -59,11 +59,52 @@ typedef enum {
     WEBKIT_XR_SESSION_MODE_IMMERSIVE_AR,
 } WebKitXRSessionMode;
 
+/**
+ * WebKitXRSessionFeatures:
+ * @WEBKIT_XR_SESSION_FEATURES_VIEWER: viewer feature.
+ * @WEBKIT_XR_SESSION_FEATURES_LOCAL: local feature.
+ * @WEBKIT_XR_SESSION_FEATURES_LOCAL_FLOOR: local-floor feature.
+ * @WEBKIT_XR_SESSION_FEATURES_BOUNDED_FLOOR: bounded-floor feature.
+ * @WEBKIT_XR_SESSION_FEATURES_UNBOUNDED: unbounded feature.
+ * @WEBKIT_XR_SESSION_FEATURES_HAND_TRACKING: hand tracking feature.
+ *
+ * Enum values representing the XR session features.
+ *
+ * Since: 2.52
+ */
+typedef enum {
+    WEBKIT_XR_SESSION_FEATURES_VIEWER        = 1 << 0,
+    WEBKIT_XR_SESSION_FEATURES_LOCAL         = 1 << 1,
+    WEBKIT_XR_SESSION_FEATURES_LOCAL_FLOOR   = 1 << 2,
+    WEBKIT_XR_SESSION_FEATURES_BOUNDED_FLOOR = 1 << 3,
+    WEBKIT_XR_SESSION_FEATURES_UNBOUNDED     = 1 << 4,
+    WEBKIT_XR_SESSION_FEATURES_HAND_TRACKING = 1 << 5,
+} WebKitXRSessionFeatures;
+
 WEBKIT_API WebKitSecurityOrigin *
 webkit_xr_permission_request_get_security_origin             (WebKitXRPermissionRequest *request);
 
 WEBKIT_API WebKitXRSessionMode
 webkit_xr_permission_request_get_session_mode                (WebKitXRPermissionRequest *request);
+
+WEBKIT_API WebKitXRSessionFeatures
+webkit_xr_permission_request_get_granted_features            (WebKitXRPermissionRequest *request);
+
+WEBKIT_API WebKitXRSessionFeatures
+webkit_xr_permission_request_get_consent_required_features   (WebKitXRPermissionRequest *request);
+
+WEBKIT_API WebKitXRSessionFeatures
+webkit_xr_permission_request_get_consent_optional_features   (WebKitXRPermissionRequest *request);
+
+WEBKIT_API WebKitXRSessionFeatures
+webkit_xr_permission_request_get_required_features_requested (WebKitXRPermissionRequest *request);
+
+WEBKIT_API WebKitXRSessionFeatures
+webkit_xr_permission_request_get_optional_features_requested (WebKitXRPermissionRequest *request);
+
+WEBKIT_API void
+webkit_xr_permission_request_set_granted_features            (WebKitXRPermissionRequest *request,
+                                                              WebKitXRSessionFeatures    granted);
 
 G_END_DECLS
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequestPrivate.h
@@ -25,6 +25,6 @@
 
 #if ENABLE(WEBXR)
 
-WebKitXRPermissionRequest* webkitXRPermissionRequestCreate(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& granted, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
+WebKitXRPermissionRequest* webkitXRPermissionRequestCreate(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList& consentRequired, const PlatformXR::Device::FeatureList& consentOptional, const PlatformXR::Device::FeatureList& requiredFeaturesRequested, const PlatformXR::Device::FeatureList& optionalFeaturesRequested, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
 
 #endif // ENABLE(WEBXR)

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -266,6 +266,13 @@ static void webViewTitleChanged(WebKitWebView* webView, GParamSpec*, WPEView* vi
 static gboolean decidePermissionRequest(WebKitWebView *, WebKitPermissionRequest *request, gpointer)
 {
     g_print("Accepting %s request\n", G_OBJECT_TYPE_NAME(request));
+
+    if (WEBKIT_IS_XR_PERMISSION_REQUEST(request)) {
+        WebKitXRPermissionRequest* xrRequest = WEBKIT_XR_PERMISSION_REQUEST(request);
+        /* Grant all optional features */
+        webkit_xr_permission_request_set_granted_features(xrRequest, webkit_xr_permission_request_get_consent_optional_features(xrRequest));
+    }
+
     webkit_permission_request_allow(request);
 
     return TRUE;


### PR DESCRIPTION
#### 91c148a27b2ec626f3f235606bf8164e1d81d42f
<pre>
[WebXR][OpenXR] Add API to get consent required/optional features of WebKitXRPermissionRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=298178">https://bugs.webkit.org/show_bug.cgi?id=298178</a>

Reviewed by Adrian Perez de Castro.

MiniBrowser grant all optional features at the moment. GTK MiniBrowser
should have a UI to select optional features to grant.

Needs to add API tests.

* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp:
(toFeatureList):
(webkitXRPermissionRequestAllow):
(webkit_xr_permission_request_get_granted_features):
(webkit_xr_permission_request_get_consent_required_features):
(webkit_xr_permission_request_get_consent_optional_features):
(webkit_xr_permission_request_get_required_features_requested):
(webkit_xr_permission_request_get_optional_features_requested):
(webkit_xr_permission_request_set_granted_features):
(toWebKitXRSessionFeatures):
(webkitXRPermissionRequestCreate):
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequestPrivate.h:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(WebKitXRSessionFeaturesToString):
(decidePermissionRequest):
* Tools/MiniBrowser/wpe/main.cpp:
(decidePermissionRequest):

Canonical link: <a href="https://commits.webkit.org/299591@main">https://commits.webkit.org/299591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66dedc7ad4234426a3c6d9e3cf51c75b375c6787

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68826 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/111091 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98952 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/118397 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98732 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44191 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42449 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/19016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51428 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/146185 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45216 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/146185 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->