### PR TITLE
[WPE] Favicon database support

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -228,6 +228,7 @@ set(WPE_API_HEADER_TEMPLATES
 
 if (ENABLE_2022_GLIB_API)
     list(APPEND WPE_API_HEADER_TEMPLATES
+        ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFaviconDatabase.h.in
         ${WEBKIT_DIR}/UIProcess/API/glib/WebKitNetworkSession.h.in
     )
 endif ()

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -123,6 +123,7 @@ UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
 Shared/API/c/wpe/WKEventWPE.cpp
 
 UIProcess/API/glib/APIContentRuleListStoreGLib.cpp @no-unify
+UIProcess/API/glib/IconDatabase.cpp @no-unify
 UIProcess/API/glib/InputMethodFilter.cpp @no-unify
 UIProcess/API/glib/KeyAutoRepeatHandler.cpp @no-unify
 UIProcess/API/glib/WebKitApplicationInfo.cpp @no-unify
@@ -138,6 +139,7 @@ UIProcess/API/glib/WebKitDownload.cpp @no-unify
 UIProcess/API/glib/WebKitDownloadClient.cpp @no-unify
 UIProcess/API/glib/WebKitEditorState.cpp @no-unify
 UIProcess/API/glib/WebKitError.cpp @no-unify
+UIProcess/API/glib/WebKitFaviconDatabase.cpp @no-unify
 UIProcess/API/glib/WebKitFeature.cpp @no-unify
 UIProcess/API/glib/WebKitFileChooserRequest.cpp @no-unify
 UIProcess/API/glib/WebKitFindController.cpp @no-unify
@@ -145,6 +147,7 @@ UIProcess/API/glib/WebKitFormClient.cpp @no-unify
 UIProcess/API/glib/WebKitFormSubmissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationManager.cpp @no-unify
 UIProcess/API/glib/WebKitGeolocationPermissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitIconLoadingClient.cpp @no-unify
 UIProcess/API/glib/WebKitInitialize.cpp @no-unify
 UIProcess/API/glib/WebKitInjectedBundleClient.cpp @no-unify
 UIProcess/API/glib/WebKitInputMethodContext.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "IconDatabase.h"
 
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))
+
 #include "Logging.h"
 #include <WebCore/BitmapImage.h>
 #include <WebCore/Image.h>
@@ -694,3 +696,5 @@ void IconDatabase::clear(CompletionHandler<void()>&& completionHandler)
 }
 
 } // namespace WebKit
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2017 Igalia S.L.
+ * Copyright (C) 2012, 2017, 2025 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,32 @@
 #endif
 
 G_BEGIN_DECLS
+
+#if PLATFORM(WPE) && ENABLE(2022_GLIB_API)
+#define WEBKIT_TYPE_FAVICON (webkit_favicon_get_type())
+typedef struct _WebKitFavicon WebKitFavicon;
+
+WEBKIT_API GType
+webkit_favicon_get_type   (void);
+
+WEBKIT_API WebKitFavicon *
+webkit_favicon_ref        (WebKitFavicon *favicon);
+
+WEBKIT_API void
+webkit_favicon_unref      (WebKitFavicon *favicon);
+
+WEBKIT_API guint
+webkit_favicon_get_width  (WebKitFavicon *favicon);
+
+WEBKIT_API guint
+webkit_favicon_get_height (WebKitFavicon *favicon);
+
+WEBKIT_API guint
+webkit_favicon_get_stride (WebKitFavicon *favicon);
+
+WEBKIT_API GBytes *
+webkit_favicon_get_bytes  (WebKitFavicon *favicon);
+#endif
 
 #define WEBKIT_FAVICON_DATABASE_ERROR           (webkit_favicon_database_error_quark())
 #define WEBKIT_TYPE_FAVICON_DATABASE            (webkit_favicon_database_get_type())
@@ -75,14 +101,16 @@ typedef enum {
 WEBKIT_API GQuark
 webkit_favicon_database_error_quark        (void);
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))
 WEBKIT_API void
 webkit_favicon_database_get_favicon        (WebKitFaviconDatabase *database,
                                             const gchar           *page_uri,
                                             GCancellable          *cancellable,
                                             GAsyncReadyCallback    callback,
                                             gpointer               user_data);
+#endif
 
+#if PLATFORM(GTK)
 #if USE(GTK4)
 WEBKIT_API GdkTexture *
 webkit_favicon_database_get_favicon_finish (WebKitFaviconDatabase *database,
@@ -94,6 +122,13 @@ webkit_favicon_database_get_favicon_finish (WebKitFaviconDatabase *database,
                                             GAsyncResult          *result,
                                             GError               **error);
 #endif
+#endif
+
+#if PLATFORM(WPE) && ENABLE(2022_GLIB_API)
+WEBKIT_API WebKitFavicon *
+webkit_favicon_database_get_favicon_finish (WebKitFaviconDatabase *database,
+                                            GAsyncResult          *result,
+                                            GError               **error);
 #endif
 
 WEBKIT_API gchar *

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabasePrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabasePrivate.h
@@ -23,10 +23,17 @@
 #include "WebKitFaviconDatabase.h"
 #include <WebCore/LinkIcon.h>
 
+#if PLATFORM(WPE) && ENABLE(2022_GLIB_API)
+#include <wtf/glib/GRefPtr.h>
+namespace WTF {
+WTF_DEFINE_GREF_TRAITS_INLINE(WebKitFavicon, webkit_favicon_ref, webkit_favicon_unref)
+}
+#endif
+
 WebKitFaviconDatabase* webkitFaviconDatabaseCreate();
 void webkitFaviconDatabaseOpen(WebKitFaviconDatabase*, const String& path, bool isEphemeral);
 void webkitFaviconDatabaseClose(WebKitFaviconDatabase*);
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))
 void webkitFaviconDatabaseGetLoadDecisionForIcon(WebKitFaviconDatabase*, const WebCore::LinkIcon&, const String&, bool isEphemeral, Function<void(bool)>&&);
 void webkitFaviconDatabaseSetIconForPageURL(WebKitFaviconDatabase*, const WebCore::LinkIcon&, API::Data&, const String&, bool isEphemeral);
 void webkitFaviconDatabaseGetFaviconInternal(WebKitFaviconDatabase*, const gchar* pageURI, bool isEphemeral, GCancellable*, GAsyncReadyCallback, gpointer);

--- a/Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "WebKitIconLoadingClient.h"
 
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))
+
 #include "APIIconLoadingClient.h"
 #include "WebKitWebViewPrivate.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -66,3 +68,5 @@ void attachIconLoadingClientToView(WebKitWebView* webView)
 {
     webkitWebViewGetPage(webView).setIconLoadingClient(makeUnique<IconLoadingClient>(webView));
 }
+
+#endif // PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -96,6 +96,10 @@ WEBKIT_DECLARE_DERIVABLE_TYPE (WebKitWebView, webkit_web_view, WEBKIT, WEB_VIEW,
 
 typedef struct _WebKitPrintOperation WebKitPrintOperation;
 
+#if PLATFORM(WPE) && ENABLE(2022_GLIB_API)
+typedef struct _WebKitFavicon WebKitFavicon;
+#endif
+
 /**
  * WebKitPolicyDecisionType:
  * @WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION: This type of policy decision
@@ -592,8 +596,11 @@ webkit_web_view_go_to_back_forward_list_item         (WebKitWebView             
 WEBKIT_API const gchar *
 webkit_web_view_get_uri                              (WebKitWebView             *web_view);
 
-#if PLATFORM(GTK)
-#if USE(GTK4)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))
+#if PLATFORM(WPE)
+WEBKIT_API WebKitFavicon *
+webkit_web_view_get_favicon                          (WebKitWebView             *web_view);
+#elif USE(GTK4)
 WEBKIT_API GdkTexture *
 webkit_web_view_get_favicon                          (WebKitWebView             *web_view);
 #else

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -52,7 +52,7 @@ void webkitWebViewWillStartLoad(WebKitWebView*);
 void webkitWebViewLoadChanged(WebKitWebView*, WebKitLoadEvent);
 void webkitWebViewLoadFailed(WebKitWebView*, WebKitLoadEvent, const char* failingURI, GError*);
 void webkitWebViewLoadFailedWithTLSErrors(WebKitWebView*, const char* failingURI, GError*, GTlsCertificateFlags, GTlsCertificate*);
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(2022_GLIB_API))
 void webkitWebViewGetLoadDecisionForIcon(WebKitWebView*, const WebCore::LinkIcon&, Function<void(bool)>&&);
 void webkitWebViewSetIcon(WebKitWebView*, const WebCore::LinkIcon&, API::Data&);
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -39,7 +39,7 @@
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
 #include "WebKitFaviconDatabasePrivate.h"
 #endif
 
@@ -95,7 +95,7 @@ struct _WebKitWebsiteDataManagerPrivate {
     CString baseDataDirectory;
     CString baseCacheDirectory;
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
     GRefPtr<WebKitFaviconDatabase> faviconDatabase;
 #endif
 
@@ -1077,7 +1077,7 @@ void webkit_website_data_manager_set_network_proxy_settings(WebKitWebsiteDataMan
 }
 #endif
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
 static String webkitWebsiteDataManagerGetFaviconDatabasePath(WebKitWebsiteDataManager* manager)
 {
     if (webkit_website_data_manager_is_ephemeral(manager))

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
@@ -25,7 +25,7 @@
 #include <gio/gio.h>
 #include <@API_INCLUDE_PREFIX@/WebKitCookieManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitMemoryPressureSettings.h>
@@ -87,7 +87,7 @@ webkit_website_data_manager_get_base_data_directory                   (WebKitWeb
 WEBKIT_API const gchar *
 webkit_website_data_manager_get_base_cache_directory                  (WebKitWebsiteDataManager *manager);
 
-#if PLATFORM(GTK) && ENABLE(2022_GLIB_API)
+#if ENABLE(2022_GLIB_API)
 WEBKIT_API void
 webkit_website_data_manager_set_favicons_enabled                      (WebKitWebsiteDataManager *manager,
                                                                        gboolean                  enabled);

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -61,7 +61,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitEditorState.h>
 #include <@API_INCLUDE_PREFIX@/WebKitEnumTypes.h>
 #include <@API_INCLUDE_PREFIX@/WebKitError.h>
-#if PLATFORM(GTK) || (PLATFORM(WPE) && !ENABLE(2022_GLIB_API))
+#if PLATFORM(GTK) || PLATFORM(WPE)
 #include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
 #endif
 #include <@API_INCLUDE_PREFIX@/WebKitFeature.h>

--- a/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformWPE.cmake
@@ -29,3 +29,7 @@ list(APPEND WebKitGLibAPITest_LIBRARIES
 if (ENABLE_WPE_PLATFORM)
     add_subdirectory(WPEPlatform)
 endif ()
+
+if (ENABLE_2022_GLIB_API)
+    ADD_WK2_TEST(TestWebKitFaviconDatabase ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp)
+endif ()


### PR DESCRIPTION
#### a79ea53815c4f69982c3eab9a3d97c797dcd5b13
<pre>
[WPE] Favicon database support
<a href="https://bugs.webkit.org/show_bug.cgi?id=296927">https://bugs.webkit.org/show_bug.cgi?id=296927</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Tests: Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/IconDatabase.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(_WebKitFavicon::width const):
(_WebKitFavicon::height const):
(_WebKitFavicon::ensureBytes const):
(_WebKitFavicon::stride const):
(_WebKitFavicon::ensureBytes):
(_WebKitFavicon::create):
(_WebKitFavicon::_WebKitFavicon):
(webkit_favicon_ref):
(webkit_favicon_unref):
(webkit_favicon_get_width):
(webkit_favicon_get_height):
(webkit_favicon_get_stride):
(webkit_favicon_get_bytes):
(webkit_favicon_database_get_favicon_finish):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabasePrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitIconLoadingClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(gotFaviconCallback):
(webkitWebViewConstructed):
(webkitWebViewGetProperty):
(webkitWebViewDispose):
(webkit_web_view_class_init):
(webkitWebViewLoadChanged):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.h.in:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFaviconDatabase.cpp:
(testFaviconDatabaseGetFavicon):
(afterAll):
* Tools/TestWebKitAPI/glib/PlatformWPE.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a79ea53815c4f69982c3eab9a3d97c797dcd5b13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/123800 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/130579 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/75950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/125677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94163 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62482 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/126753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/110753 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/74754 "Found 1 new API test failure: WPE/TestWebKitFaviconDatabase:/webkit/WebKitFaviconDatabase/get-favicon (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28913 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74062 "Hash a79ea538 for PR 49452 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/104969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133275 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/50752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102624 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/106972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102454 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/47800 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/47602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/50606 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/51754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->