### PR TITLE
Replace contents all at once in Node::normalize()

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -729,6 +729,7 @@ ExceptionOr<void> Node::normalize()
 
     Ref document = this->document();
     RefPtr node = this;
+    Vector<Ref<Text>> textNodesToRemove;
     while (RefPtr firstChild = node->firstChild())
         node = WTF::move(firstChild);
     while (node) {
@@ -745,44 +746,73 @@ ExceptionOr<void> Node::normalize()
 
         Ref text = uncheckedDowncast<Text>(*node);
 
-        // Remove empty text nodes.
+        // Case 1: Empty text nodes.
         if (!text->length()) {
-            // Care must be taken to get the next node before removing the current node.
+            // Queue for removal.
+            textNodesToRemove.append(text);
             node = NodeTraversal::nextPostOrder(*node);
-            text->remove();
             continue;
         }
 
-        // Merge text nodes.
-        while (RefPtr nextSibling = node->nextSibling()) {
-            if (nextSibling->nodeType() != TEXT_NODE)
-                break;
-            Ref nextText = uncheckedDowncast<Text>(nextSibling.releaseNonNull());
+        // Case 2: Merge adjacent text nodes.
+        StringBuilder builder;
 
-            // Remove empty text nodes.
+        RefPtr<Node> candidateNode = node->nextSibling();
+        RefPtr<Node> lastProcessedSibling = nullptr;
+
+        while (candidateNode) {
+            if (candidateNode->nodeType() != TEXT_NODE)
+                break;
+
+            Ref nextText = uncheckedDowncast<Text>(candidateNode.releaseNonNull());
+            RefPtr nextCandidate = nextText->nextSibling();
+
+            // Handle empty sibling
             if (!nextText->length()) {
-                nextText->remove();
+                textNodesToRemove.append(nextText);
+                lastProcessedSibling = candidateNode;
+                candidateNode = nextCandidate;
                 continue;
             }
 
-            // Both non-empty text nodes. Merge them.
-            unsigned offset = text->length();
+            // Check if merging would cause overflow
+            unsigned offset = text->length() + builder.length();
 
             if (nextText->length() > StringImpl::MaxLength - offset) {
+                if (!builder.isEmpty()) {
+                    text->appendData(builder.toString());
+                    // We just deallocated a ~2GB string, plus one or two ~2GB temporary buffers
+                    // Let's explicitly try and release that memory to minimize disruption
+                    builder.clear();
+                    WTF::releaseFastMallocFreeMemory();
+                }
+
                 return Exception { ExceptionCode::InvalidModificationError,
                     "Normalized Node String representation exceeds implementation maximum length."_s };
             }
 
-            // Update start/end for any affected Ranges before appendData since modifying contents might trigger mutation events that modify ordering.
+            // Both non-empty text nodes. Merge them.
+            builder.append(nextText->data());
+            // Update start/end for any affected Ranges before setData since modifying contents might trigger mutation events that modify ordering.
             document->textNodesMerged(nextText, offset);
+            textNodesToRemove.append(nextText);
 
-            // FIXME: DOM spec requires contents to be replaced all at once (see https://dom.spec.whatwg.org/#dom-node-normalize).
-            // Appending once per sibling may trigger mutation events too many times.
-            text->appendData(nextText->data());            
-            nextText->remove();
+            lastProcessedSibling = candidateNode;
+            candidateNode = nextCandidate;
         }
 
+        if (!builder.isEmpty())
+            text->appendData(builder.toString());
+
+        if (lastProcessedSibling)
+            node = lastProcessedSibling;
+
         node = NodeTraversal::nextPostOrder(*node);
+    }
+
+    for (auto& textNode : textNodesToRemove) {
+        if (textNode->parentNode())
+            textNode->remove();
     }
 
     return { };


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=297458

Reviewed by NOBODY (OOPS!).

Aligns closer to the spec, and allows us to reduce allocations of temporary buffers.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/388558e15021f7ee457ca093d63af301e2291fd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/138420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/10785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/49830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/146504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/91395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/140294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/11489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/10939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/105909 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77260 "4 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/141367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/8625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/124089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/86757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/8212 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/5984 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/6797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/117632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/42288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/149222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/10467 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/42845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/114303 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/10484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/8852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/114646 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/8283 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/120375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/65342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/10515 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/38308 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/10249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/74111 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/10454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/10305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->