### PR TITLE
[RenderReplaced][Interop] Coerce block sizing for degenerate aspect ratio SVGs.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1776,8 +1776,6 @@ imported/w3c/web-platform-tests/css/css-grid/abspos/orthogonal-positioned-grid-d
 
 webkit.org/b/216146 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-baseline-align-001.html [ ImageOnlyFailure ]
 webkit.org/b/216146 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-baseline-justify-001.html [ ImageOnlyFailure ]
-webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-aspect-ratio-stretch-3.html [ ImageOnlyFailure ]
-webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-4.html [ ImageOnlyFailure ]
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-5.html [ ImageOnlyFailure ]
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-6.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-content-distribution-029.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.tentative-expected.txt
@@ -42,7 +42,7 @@ PASS SVG image, with natural width, and aspect ratio from viewBox
 FAIL SVG image, with natural width, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 600
 PASS SVG image, with natural height, and aspect ratio from viewBox
 FAIL SVG image, with natural height, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 180 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 720
+FAIL SVG image, with natural width of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 600
 FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
 FAIL SVG image, with natural height of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 720
 FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
@@ -72,7 +72,7 @@ PASS SVG image, with natural width and height
 PASS SVG image, with natural width and height (when not rendered)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (when not rendered)
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 720
+FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 300
 FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
 FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox assert_equals: naturalWidth expected 0 but got 720
 FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
@@ -118,7 +118,7 @@ PASS SVG image, with natural width, and aspect ratio from viewBox (with srcset/1
 FAIL SVG image, with natural width, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 60 but got 600
 PASS SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x)
 FAIL SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 180 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 720
+FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 600
 FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
 FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 720
 FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
@@ -148,7 +148,7 @@ PASS SVG image, with natural width and height (with srcset/1x)
 PASS SVG image, with natural width and height (with srcset/1x) (when not rendered)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/1x)
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/1x) (when not rendered)
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 720
+FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 300
 FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
 FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x) assert_equals: naturalWidth expected 0 but got 720
 FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
@@ -176,7 +176,7 @@ FAIL SVG image, with natural width (with srcset/2x) assert_equals: height expect
 FAIL SVG image, with natural width (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 300
 FAIL SVG image, with natural height (with srcset/2x) assert_equals: width expected 300 but got 150
 FAIL SVG image, with natural height (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 150 but got 300
-FAIL SVG image, with natural width of 0 (with srcset/2x) assert_equals: naturalWidth expected 0 but got 150
+FAIL SVG image, with natural width of 0 (with srcset/2x) assert_equals: naturalWidth expected 0 but got 300
 FAIL SVG image, with natural width of 0 (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
 FAIL SVG image, with natural height of 0 (with srcset/2x) assert_equals: naturalHeight expected 0 but got 75
 FAIL SVG image, with natural height of 0 (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 150 but got 300
@@ -194,7 +194,7 @@ PASS SVG image, with natural width, and aspect ratio from viewBox (with srcset/2
 FAIL SVG image, with natural width, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 600
 PASS SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x)
 FAIL SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 90 but got 600
-FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 720
+FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 600
 FAIL SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
 FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 720
 FAIL SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600
@@ -224,7 +224,7 @@ PASS SVG image, with natural width and height (with srcset/2x)
 FAIL SVG image, with natural width and height (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 60
 PASS SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x)
 FAIL SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 30 but got 60
-FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 720
+FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 300
 FAIL SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 300
 FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x) assert_equals: naturalWidth expected 0 but got 720
 FAIL SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x) (when not rendered) assert_equals: naturalWidth when not rendered expected 0 but got 600

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -79,6 +79,7 @@ public:
     bool isShowingAltText() const;
 
     virtual bool shouldDisplayBrokenImageIcon() const;
+    bool shouldRespectZeroIntrinsicWidth() const override;
 
     String accessibilityDescription() const { return imageResource().image()->accessibilityDescription(); }
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -100,6 +100,14 @@ RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& styl
 
 RenderReplaced::~RenderReplaced() = default;
 
+bool RenderReplaced::shouldRespectZeroIntrinsicWidth() const
+{
+    // Per CSSWG resolution, 0px intrinsic width should be respected for SVG
+    // items and coerce the intrinsic height to 0px as well. Note that this is
+    // not the case for 0px intrinsic height SVGs or for other RenderReplaced items.
+    return false;
+}
+
 void RenderReplaced::willBeDestroyed()
 {
     if (!renderTreeBeingDestroyed() && parent())
@@ -664,7 +672,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
 
     if (style.logicalWidth().isAuto()) {
         bool computedHeightIsAuto = style.logicalHeight().isAuto();
-        bool hasIntrinsicWidth = constrainedSize.width() > 0 || shouldApplySizeOrInlineSizeContainment();
+        bool hasIntrinsicWidth = constrainedSize.width() > 0 || (!constrainedSize.width() && shouldRespectZeroIntrinsicWidth()) || shouldApplySizeOrInlineSizeContainment();
         bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
 
         // For flex or grid items where the logical height has been overriden then we should use that size to compute the replaced width as long as the flex or
@@ -746,8 +754,8 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit
     computeIntrinsicSizesConstrainedByTransferredMinMaxSizes(contentRenderer, constrainedSize, intrinsicRatio);
 
     bool widthIsAuto = style().logicalWidth().isAuto();
+    bool hasIntrinsicWidth = constrainedSize.width() > 0 || (!constrainedSize.width() && shouldRespectZeroIntrinsicWidth()) || shouldApplySizeOrInlineSizeContainment();
     bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
-    bool hasIntrinsicWidth = constrainedSize.width() > 0 || shouldApplySizeOrInlineSizeContainment();
 
     // See computeReplacedLogicalHeight() for a similar check for heights.
     if (auto overridinglogicalWidth = (!intrinsicRatio.isEmpty() && (isFlexItem() || isGridItem()) && hasIntrinsicSize(contentRenderer, hasIntrinsicWidth, hasIntrinsicHeight) ? overridingBorderBoxLogicalWidth() : std::nullopt))

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -31,6 +31,8 @@ class RenderReplaced : public RenderBox {
 public:
     virtual ~RenderReplaced();
 
+    virtual bool shouldRespectZeroIntrinsicWidth() const;
+
     LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred = ShouldComputePreferred::ComputeActual) const override;
     LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const override;
 


### PR DESCRIPTION
#### 2a8e0a3b3b2c6ffdd9c12c876b14bfa8ad105977
<pre>
[RenderReplaced][Interop] Coerce block sizing for degenerate aspect ratio SVGs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297457">https://bugs.webkit.org/show_bug.cgi?id=297457</a>
&lt;<a href="https://rdar.apple.com/156339128">rdar://156339128</a>&gt;

Reviewed by Sammy Gill.

This PR fixes an issue where SVGs with 0px inline intrinsic size (width) were
being ignored in:

RenderReplaced::computeReplacedLogicalWidth()

This is incorrect as 0px is a valid intrinsic width for SVGs and has implications
for sizing the RenderReplaced block. Mishandeling this eventually resulted in
a failure to override the SVG&apos;s block direction intrinsic size (height) to 0px.

Per CSSWG resolution, degenerate aspect ratios derived from SVGs&apos;
width and height (from 0px, or -Npx) should fall back to the viewbox
aspect ratio.
See: <a href="https://github.com/w3c/csswg-drafts/issues/6286#issuecomment-866986544%5C">https://github.com/w3c/csswg-drafts/issues/6286#issuecomment-866986544%5C</a>

Per CSSWG resolution, we should then use the aforementioned aspect ratio
to set the *block* size to match a valid *inline* size.

This means that degenerate aspect ratios resulting from a valid inline
size of 0px should result in a computed block size of 0px.

Note that degenerate aspect ratios from a valid block size of 0px
will instead be computed to respect the viewbox aspect ratio relative to
an explicit inline size.

Note that degenerate aspect ratios from invalid block sizes
(e.g. -1px) will not be respected.
See: <a href="https://github.com/w3c/csswg-drafts/issues/11236#issuecomment-2718502765">https://github.com/w3c/csswg-drafts/issues/11236#issuecomment-2718502765</a>

This PR introduces

shouldRespectZeroIntrinsicWidth()
shouldRespectZeroIntrinsicHeight()

to document this behavior.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.tentative-expected.txt:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::shouldRespectZeroIntrinsicWidth const):
(WebCore::RenderImage::paint):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::shouldRespectZeroIntrinsicWidth const):
(WebCore::RenderReplaced::shouldRespectZeroIntrinsicHeight const):
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/RenderReplaced.h:

Canonical link: <a href="https://commits.webkit.org/299085@main">https://commits.webkit.org/299085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7684a59093bf68f6185a5bf687f4ec6027b7650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69767 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c06f4153-152d-4b69-80b5-82c277c898a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89369 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/56976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1c1b88a-7f98-4335-9f78-6eaa8c543616) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69862 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9bbb1fb7-0934-4e41-87f4-8fa916e879d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23695 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99767 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126980 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98024 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97812 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24889 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21160 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50202 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43986 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45677 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->