### PR TITLE
[Liquid Glass] [iOS] Opening a cnn.com article in the background results in inverted toolbar colors

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -56,6 +56,7 @@
 
 #if HAVE(LIQUID_GLASS)
 @property (nonatomic, readonly) BOOL _usesHardTopScrollEdgeEffect;
+- (void)_didChangeTopScrollEdgeEffectStyle;
 - (void)_setInternalTopPocketColor:(UIColor *)color;
 - (WKUIScrollEdgeEffect *)_wk_topEdgeEffect;
 - (WKUIScrollEdgeEffect *)_wk_leftEdgeEffect;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -614,7 +614,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         if (!originalEffect)
             return nil;
 
-        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Top]);
+        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Top]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Top, wrapper);
     }
     return wrapper.get();
@@ -628,7 +628,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         if (!originalEffect)
             return nil;
 
-        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Left]);
+        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Left]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Left, wrapper);
     }
     return wrapper.get();
@@ -642,7 +642,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         if (!originalEffect)
             return nil;
 
-        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Right]);
+        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Right]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Right, wrapper);
     }
     return wrapper.get();
@@ -656,7 +656,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         if (!originalEffect)
             return nil;
 
-        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Bottom]);
+        wrapper = adoptNS([[WKUIScrollEdgeEffect alloc] initWithScrollView:self scrollEdgeEffect:originalEffect.get() boxSide:WebCore::BoxSide::Bottom]);
         _edgeEffectWrappers.setAt(WebCore::BoxSide::Bottom, wrapper);
     }
     return wrapper.get();
@@ -690,6 +690,16 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 - (BOOL)_usesHardTopScrollEdgeEffect
 {
     return [[self _wk_topEdgeEffect] usesHardStyle];
+}
+
+- (void)_didChangeTopScrollEdgeEffectStyle
+{
+    RetainPtr webView = _internalDelegate;
+    if (!webView)
+        return;
+
+    [webView _updateTopScrollPocketCaptureColor];
+    [webView _updatePrefersSolidColorHardPocket];
 }
 
 #endif // HAVE(LIQUID_GLASS)

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h
@@ -31,10 +31,11 @@
 #import <WebCore/BoxSides.h>
 
 @class UIScrollEdgeEffect;
+@class WKScrollView;
 
 @interface WKUIScrollEdgeEffect : NSObject
 
-- (instancetype)initWithScrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)side;
+- (instancetype)initWithScrollView:(WKScrollView *)scrollView scrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)side;
 
 @property (nonatomic, getter=isInternallyHidden) BOOL internallyHidden;
 @property (nonatomic) BOOL usesHardStyle;

--- a/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
+++ b/Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY) && HAVE(LIQUID_GLASS)
 
+#import "WKScrollView.h"
 #import <UIKit/UIKit.h>
 #import <wtf/OptionSet.h>
 
@@ -41,17 +42,19 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
 } // namespace WebKit
 
 @implementation WKUIScrollEdgeEffect {
+    __weak WKScrollView *_scrollView;
     __weak UIScrollEdgeEffect *_effect;
     OptionSet<WebKit::HiddenScrollEdgeEffectSource> _hiddenSources;
     WebCore::BoxSide _boxSide;
     BOOL _usesHardStyle;
 }
 
-- (instancetype)initWithScrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)boxSide
+- (instancetype)initWithScrollView:(WKScrollView *)scrollView scrollEdgeEffect:(UIScrollEdgeEffect *)effect boxSide:(WebCore::BoxSide)boxSide
 {
     if (!(self = [super init]))
         return nil;
 
+    _scrollView = scrollView;
     _boxSide = boxSide;
     _effect = effect;
     _hiddenSources = { };
@@ -105,9 +108,13 @@ enum class HiddenScrollEdgeEffectSource : uint8_t {
 
 - (void)setStyle:(UIScrollEdgeEffectStyle *)style
 {
+    BOOL wasUsingHardStyle = _usesHardStyle;
     _usesHardStyle = [style isEqual:UIScrollEdgeEffectStyle.hardStyle];
 
     _effect.style = style;
+
+    if (_boxSide == WebCore::BoxSide::Top && wasUsingHardStyle != _usesHardStyle)
+        [_scrollView _didChangeTopScrollEdgeEffectStyle];
 }
 
 - (NSString *)description


### PR DESCRIPTION
#### 1a16e315eb638ea271fb3ada1a8e8670ab622f9d
<pre>
[Liquid Glass] [iOS] Opening a cnn.com article in the background results in inverted toolbar colors
<a href="https://bugs.webkit.org/show_bug.cgi?id=297461">https://bugs.webkit.org/show_bug.cgi?id=297461</a>
<a href="https://rdar.apple.com/158367323">rdar://158367323</a>

Reviewed by Timothy Hatcher and Abrar Rahman Protyasha.

When a top fixed-position header element is present, we currently sample the element&apos;s background
color and fill the top scroll pocket&apos;s background color with it, in addition to placing a solid
background color extension view inside the obscured inset area. On iPad, where Safari uses the hard
scroll edge effect style, we additionally:

1. Set the top scroll pocket to prefer solid (opaque) colors.
2. Set the top scroll pocket&apos;s capture color to the fixed position element&apos;s background color.

...only if the top scroll pocket uses the `.hard` pocket style. However, in the case where the
scroll pocket changes from `.soft` to `.hard` after the color has already been sampled, nothing
causes us to recompute and set the capture color. On websites like cnn.com where the top sampled
color differs from the page background color, this causes us to end up with a solid-color pocket
that matches the background of the page (white), but Safari expects a dark top pocket color (since
the top sampled color is black), and sets the interface style on the favorites bar and tab bar
accordingly; the end result is white text on a white background.

To fix this, we add plumbing to recompute and change the capture color as well as the &quot;prefers solid
color hard pocket&quot; flag when the style of the pocket changes.

* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _wk_topEdgeEffect]):
(-[WKScrollView _wk_leftEdgeEffect]):
(-[WKScrollView _wk_rightEdgeEffect]):
(-[WKScrollView _wk_bottomEdgeEffect]):
(-[WKScrollView _didChangeTopScrollEdgeEffectStyle]):
* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.h:
* Source/WebKit/UIProcess/ios/WKUIScrollEdgeEffect.mm:
(-[WKUIScrollEdgeEffect initWithScrollView:scrollEdgeEffect:boxSide:]):

Plumb the `WKScrollView` into the scroll edge effect wrapper.

(-[WKUIScrollEdgeEffect setStyle:]):

Call back to `WKScrollView` when the edge effect style changes.

(-[WKUIScrollEdgeEffect initWithScrollEdgeEffect:boxSide:]): Deleted.
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, TopScrollPocketCaptureColorAfterSettingHardStyle)):

Add an API test that dynamically changes the top scroll edge effect style and verifies that:

1. The capture color of the top scroll edge effect matches the top fixed element.
2. The top scroll edge effect prefers solid colors.

Canonical link: <a href="https://commits.webkit.org/298764@main">https://commits.webkit.org/298764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef2ee4c7935cf24583360821ec2ba7b8e0c504dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36251 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/26855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67156 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/61da71ff-fba3-4651-a826-99966a2c156a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88546 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69006 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22695 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66324 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98849 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22855 "Exiting early after 60 failures. 56943 tests run. 60 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125795 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97220 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100792 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97012 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24702 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39445 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48971 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->