### PR TITLE
Reset storage permission after each Storage Access API test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window.js
@@ -79,6 +79,9 @@ promise_test(
 if (!canUseAutogrant) {
   promise_test(
       async t => {
+        t.add_cleanup(async () => {
+          await test_driver.set_permission({name: 'storage-access'}, 'prompt');
+        });
         await SetFirstPartyCookie(location.origin, initialCookie);
         await test_driver.set_permission(
             {name: 'storage-access'}, 'denied');
@@ -92,7 +95,10 @@ if (!canUseAutogrant) {
           '] document.requestStorageAccess() should be rejected with a NotAllowedError with denied permission');
 } else {
   promise_test(
-      async () => {
+      async t => {
+        t.add_cleanup(async () => {
+          await test_driver.set_permission({name: 'storage-access'}, 'prompt');
+        });
         await SetFirstPartyCookie(location.origin, initialCookie);
         await document.requestStorageAccess();
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html
@@ -26,6 +26,9 @@
   // 'prompt' permission state is effectively the same as 'denied' from the
   // perspective of platform tests.
   promise_test(async t => {
+    t.add_cleanup(async () => {
+      await test_driver.set_permission({name: 'storage-access'}, 'prompt');
+    });
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
     await document.requestStorageAccess();
@@ -38,7 +41,10 @@
         'After obtaining storage access, scripts in the frame should be able to access cookies.');
   }, `[${testPrefix}] document.requestStorageAccess() should resolve even without a user gesture when already granted.`);
 
-  promise_test(async () => {
+  promise_test(async t => {
+    t.add_cleanup(async () => {
+      await test_driver.set_permission({name: 'storage-access'}, 'prompt');
+    });
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-no-storage-access.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-no-storage-access.html
@@ -21,6 +21,9 @@
   }, '`allow-storage-access-by-user-activation` sandbox attribute is supported');
   promise_test(
       async t => {
+        t.add_cleanup(async () => {
+          await test_driver.set_permission({name: 'storage-access'}, 'prompt');
+        });
         await test_driver.set_permission({name: 'storage-access'}, 'granted');
         await MaybeSetStorageAccess('*', '*', 'blocked');
         return promise_rejects_dom(
@@ -31,6 +34,9 @@
           '] document.requestStorageAccess() should reject with a NotAllowedError with no user gesture.');
 
   promise_test(async t => {
+    t.add_cleanup(async () => {
+      await test_driver.set_permission({name: 'storage-access'}, 'prompt');
+    });
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window.js
@@ -248,7 +248,7 @@ promise_test(async (t) => {
                                        non_retry_path,
                                        [['script', responder_script]]));
     t.add_cleanup(async () => {
-        SetPermissionInFrame(iframe,
+        await SetPermissionInFrame(iframe,
             [{ name: 'storage-access' }, 'prompt']);
     });
     await SetPermissionInFrame(iframe,


### PR DESCRIPTION
#### 2afd6c04469b0ebecf826d3dbfa551dc41fbcf7a
<pre>
Reset storage permission after each Storage Access API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=297464">https://bugs.webkit.org/show_bug.cgi?id=297464</a>
<a href="https://rdar.apple.com/158417768">rdar://158417768</a>

Reviewed by Tim Nguyen.

I needed to make these changes in <a href="https://github.com/web-platform-tests/wpt/pull/54330">https://github.com/web-platform-tests/wpt/pull/54330</a> to make the tests
pass in Chrome and Firefox after 298703@main.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess.sub.https.window.js:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-no-storage-access.html:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/storage-access-headers.tentative.https.sub.window.js:
(async promise_test):

Canonical link: <a href="https://commits.webkit.org/298772@main">https://commits.webkit.org/298772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2473e833abe9a0ce7b5e126aa0bcbeb40aae2220

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67166 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0679b47-efd3-4ce7-aa7b-095ca59890af) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed3e3991-b042-41d5-8dc3-c138905d2612) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69018 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125805 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32673 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97020 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20267 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39456 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18619 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43380 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42846 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->