### PR TITLE
Navigation isRequestFromClientOrUserInput is incorrectly true for window.open call with web archive

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2037,7 +2037,7 @@ Ref<WebProcessProxy> WebPageProxy::ensureProtectedRunningProcess()
     return ensureRunningProcess();
 }
 
-RefPtr<API::Navigation> WebPageProxy::loadRequest(WebCore::ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, IsPerformingHTTPFallback isPerformingHTTPFallback, std::unique_ptr<NavigationActionData>&& lastNavigationAction, API::Object* userData)
+RefPtr<API::Navigation> WebPageProxy::loadRequest(WebCore::ResourceRequest&& request, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, IsPerformingHTTPFallback isPerformingHTTPFallback, std::unique_ptr<NavigationActionData>&& lastNavigationAction, API::Object* userData, bool isRequestFromClientOrUserInput)
 {
     if (m_isClosed)
         return nullptr;
@@ -2057,7 +2057,8 @@ RefPtr<API::Navigation> WebPageProxy::loadRequest(WebCore::ResourceRequest&& req
     if (lastNavigationAction)
         navigation->setLastNavigationAction(*lastNavigationAction);
 
-    navigation->markRequestAsFromClientInput();
+    if (isRequestFromClientOrUserInput)
+        navigation->markRequestAsFromClientInput();
 
     if (shouldForceForegroundPriorityForClientNavigation())
         navigation->setClientNavigationActivity(legacyMainFrameProcess().protectedThrottler()->foregroundActivity("Client navigation"_s));
@@ -8718,8 +8719,10 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
             newPage->internals().privateClickMeasurement = { { WTFMove(*privateClickMeasurement), { }, { } } };
 
         if (navigationDataForNewProcess && !openedBlobURL) {
+            bool isRequestFromClientOrUserInput = navigationDataForNewProcess->isRequestFromClientOrUserInput;
+
             reply(std::nullopt, std::nullopt);
-            newPage->loadRequest(WTFMove(request), shouldOpenExternalURLsPolicy, IsPerformingHTTPFallback::No, WTFMove(navigationDataForNewProcess));
+            newPage->loadRequest(WTFMove(request), shouldOpenExternalURLsPolicy, IsPerformingHTTPFallback::No, WTFMove(navigationDataForNewProcess), nullptr, isRequestFromClientOrUserInput);
             return;
         }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -917,7 +917,7 @@ public:
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&);
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy);
     RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback);
-    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, std::unique_ptr<NavigationActionData>&&, API::Object* userData = nullptr);
+    RefPtr<API::Navigation> loadRequest(WebCore::ResourceRequest&&, WebCore::ShouldOpenExternalURLsPolicy, WebCore::IsPerformingHTTPFallback, std::unique_ptr<NavigationActionData>&&, API::Object* userData = nullptr, bool isRequestFromClientOrUserInput = true);
 
     RefPtr<API::Navigation> loadFile(const String& fileURL, const String& resourceDirectoryURL, bool isAppInitiated = true, API::Object* userData = nullptr);
     RefPtr<API::Navigation> loadData(Ref<WebCore::SharedBuffer>&&, const String& MIMEType, const String& encoding, const String& baseURL, API::Object* userData = nullptr);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -3266,16 +3266,13 @@ TEST(WKDownload, OriginatingFrameWhenConvertingNavigationInNewWindow)
         EXPECT_EQ(a.webView, b.webView);
     };
 
-    __block bool isClientOrUserInitiated = false;
     __block bool checkedDownload { false };
 
     auto tryOpenerInitiatedDownloads = ^{
         checkedDownload = false;
-        isClientOrUserInitiated = true;
         [webView evaluateJavaScript:@"a = document.createElement('a'); a.href = 'https://webkit.org/download'; a.target = '_blank'; document.body.appendChild(a); a.click()" completionHandler:nil];
         Util::run(&checkedDownload);
 
-        isClientOrUserInitiated = false;
         checkedDownload = false;
         [webView evaluateJavaScript:@"w = window.open('https://webkit.org/download')" completionHandler:nil];
         Util::run(&checkedDownload);
@@ -3295,14 +3292,7 @@ TEST(WKDownload, OriginatingFrameWhenConvertingNavigationInNewWindow)
     };
     navigationDelegate.get().navigationResponseDidBecomeDownload = ^(WKNavigationResponse *response, WKDownload *download) {
         frameInfoShouldBeEqual(response._navigationInitiatingFrame, openerMainFrame.get());
-
-        if (isClientOrUserInitiated) {
-            EXPECT_WK_STREQ(download.originatingFrame.request.URL.absoluteString, "about:blank");
-            EXPECT_WK_STREQ(download.originatingFrame.securityOrigin.host, "");
-
-            isClientOrUserInitiated = false;
-        } else
-            frameInfoShouldBeEqual(download.originatingFrame, openerMainFrame.get());
+        frameInfoShouldBeEqual(download.originatingFrame, openerMainFrame.get());
 
         checkedDownload = true;
     };


### PR DESCRIPTION
#### c6f4d9a1c0615dffc995046a164de231cc40756f
<pre>
Navigation isRequestFromClientOrUserInput is incorrectly true for window.open call with web archive
<a href="https://bugs.webkit.org/show_bug.cgi?id=295655">https://bugs.webkit.org/show_bug.cgi?id=295655</a>
<a href="https://rdar.apple.com/154084804">rdar://154084804</a>

Reviewed by Youenn Fablet.

When a web archive is navigated to from a `window.open` call, it&apos;s not
client or user initiated--it&apos;s programmatically initiated from JavaScript.
But currently, the navigation is incorrectly being marked as client or
user initiated.

So when the request loads, and DocumentLoader checks if it&apos;s allowed to
load the web archive:

bool allowsWebArchiveForMainFrame() const { return m_isRequestFromClientOrUserInput; }

it assumes that it can, and it wrongly loads. We can verify that this
happens in MiniBrowser.

The issue is that WebPageProxy::loadRequest() always marks the navigation
as client or user initiated. Now this is fine in cases where the call to
WebPageProxy::loadRequest() comes from the client via the client making
an API call to WKWebView::loadRequest. But in this case, the client isn&apos;t
making an API call. Rather, WebPageProxy::loadRequest() is being called
by WebKit internally. `window.open` leads to WebPageProxy::createNewPage(),
which leads to WebPageProxy::loadRequest().

In this case, we want to tell WebPageProxy::loadRequest() that this is
not client or user initiated. This information is contained in the
`NavigationActionData navigationDataForNewProcess`. So we pass this on
from WebPageProxy::createNewPage() to WebPageProxy::loadRequest().

In all other cases, we keep the current behavior of the navigation being
marked as client or user initiated.

This is tested by a new API test.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadRequest):

This will mark the navigation as client or user initiated based on the
new flag being passed in (isRequestFromClientOrUserInput). To ensure
existing behavior doesn&apos;t change for other cases, this is true by default.

(WebKit::WebPageProxy::createNewPage):

Since WebKit is internally calling loadRequest from here, we explicitly
pass in navigationDataForNewProcess-&gt;isRequestFromClientOrUserInput.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::OriginatingFrameWhenConvertingNavigationInNewWindow)):

The first navigation in this test comes from &quot;a.href&quot; (programmatically
initiated by Javascript). On this call, WebKit is internally calling
WebPageProxy::loadRequest. Before this patch here, this was being marked
as client or user input.

In the fix for <a href="https://bugs.webkit.org/show_bug.cgi?id=293994">https://bugs.webkit.org/show_bug.cgi?id=293994</a>, we changed
WebPageProxy::receivedNavigationResponsePolicyDecision such that if the
navigation was from a client or user input, then the information about the
originating frame would be set to empty. At that time, this first navigation
was going down that code path, so we had to alter the test accordingly.

Now, with this patch, that navigation is correctly being marked as NOT
client or user input. So it&apos;s no longer going down the code path introduced
in that previous patch, and we can now remove those changes to the test.

* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::TEST(LoadWebArchive, FailNavigationFromNonClientOrUserInitiatedWindowOpen)):

New API test.

Originally-landed-as: 289651.603@safari-7621-branch (52189fdc734f). <a href="https://rdar.apple.com/157788008">rdar://157788008</a>
Canonical link: <a href="https://commits.webkit.org/298780@main">https://commits.webkit.org/298780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfac3bfb34423daf6c8f8ce34f52e11d67528a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67190 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d6c957b-3a6c-4cc7-b143-edf3617780c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/42996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19da62b3-0df6-4399-a9bb-f74a324a39f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69033 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125828 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97240 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42348 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39479 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/48998 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42869 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->