### PR TITLE
AX: AXNotifications enum and AXComputedObjectAttributeCache can be extracted from AXObjectCache

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -831,10 +831,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Scripts/generate-log-declarations.py
 
     accessibility/AXAttributeCacheScope.h
+    accessibility/AXComputedObjectAttributeCache.h
     accessibility/AXCoreObject.h
     accessibility/AXGeometryManager.h
     accessibility/AXLogger.h
     accessibility/AXLoggerBase.h
+    accessibility/AXNotifications.h
     accessibility/AXObjectCache.h
     accessibility/AXObjectCacheInlines.h
     accessibility/AXSearchManager.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -553,6 +553,7 @@ Modules/webxr/XRSubImage.cpp
 Modules/webxr/XRWebGLBinding.cpp
 Modules/webxr/XRWebGLSubImage.cpp
 accessibility/AXAttributeCacheScope.cpp
+accessibility/AXComputedObjectAttributeCache.cpp
 accessibility/AXCoreObject.cpp
 accessibility/AXGeometryManager.cpp
 accessibility/AXLogger.cpp

--- a/Source/WebCore/accessibility/AXComputedObjectAttributeCache.cpp
+++ b/Source/WebCore/accessibility/AXComputedObjectAttributeCache.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXComputedObjectAttributeCache.h"
+
+namespace WebCore {
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache);
+
+AccessibilityObjectInclusion AXComputedObjectAttributeCache::getIgnored(AXID id) const
+{
+    auto it = m_idMapping.find(id);
+    return it != m_idMapping.end() ? it->value.ignored : AccessibilityObjectInclusion::DefaultBehavior;
+}
+
+void AXComputedObjectAttributeCache::setIgnored(AXID id, AccessibilityObjectInclusion inclusion)
+{
+    HashMap<AXID, CachedAXObjectAttributes>::iterator it = m_idMapping.find(id);
+    if (it != m_idMapping.end())
+        it->value.ignored = inclusion;
+    else {
+        CachedAXObjectAttributes attributes;
+        attributes.ignored = inclusion;
+        m_idMapping.set(id, attributes);
+    }
+}
+
+} // WebCore

--- a/Source/WebCore/accessibility/AXComputedObjectAttributeCache.h
+++ b/Source/WebCore/accessibility/AXComputedObjectAttributeCache.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/AXCoreObject.h>
+#include <wtf/DebugHeap.h>
+
+namespace WebCore {
+
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache);
+class AXComputedObjectAttributeCache {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache, AXComputedObjectAttributeCache);
+public:
+    AccessibilityObjectInclusion getIgnored(AXID) const;
+    void setIgnored(AXID, AccessibilityObjectInclusion);
+
+private:
+    struct CachedAXObjectAttributes {
+        CachedAXObjectAttributes()
+            : ignored(AccessibilityObjectInclusion::DefaultBehavior)
+        { }
+
+        AccessibilityObjectInclusion ignored;
+    };
+
+    HashMap<AXID, CachedAXObjectAttributes> m_idMapping;
+};
+
+} // WebCore
+

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -32,6 +32,7 @@
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 #include "AXIsolatedObject.h"
 #endif
+#include "AXNotifications.h"
 #include "AXObjectCache.h"
 #include "AXSearchManager.h"
 #include "AXTextRun.h"

--- a/Source/WebCore/accessibility/AXNotifications.h
+++ b/Source/WebCore/accessibility/AXNotifications.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+#define WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro) \
+    macro(AbbreviationChanged) \
+    macro(AccessKeyChanged) \
+    macro(ActiveDescendantChanged) \
+    macro(AnnouncementRequested) \
+    macro(AutocorrectionOccured) \
+    macro(AutofillTypeChanged) \
+    macro(ARIAColumnIndexChanged) \
+    macro(ARIAColumnIndexTextChanged) \
+    macro(ARIARoleDescriptionChanged) \
+    macro(ARIARowIndexChanged) \
+    macro(ARIARowIndexTextChanged) \
+    macro(BrailleLabelChanged) \
+    macro(BrailleRoleDescriptionChanged) \
+    macro(CellSlotsChanged) \
+    macro(CheckedStateChanged) \
+    macro(ChildrenChanged) \
+    macro(ColumnCountChanged) \
+    macro(ColumnIndexChanged) \
+    macro(ColumnSpanChanged) \
+    macro(CommandChanged) \
+    macro(CommandForChanged) \
+    macro(ContentEditableAttributeChanged) \
+    macro(ControlledObjectsChanged) \
+    macro(CurrentStateChanged) \
+    macro(DatetimeChanged) \
+    macro(DescribedByChanged) \
+    macro(DisabledStateChanged) \
+    macro(DraggableStateChanged) \
+    macro(DropEffectChanged) \
+    macro(ExtendedDescriptionChanged) \
+    macro(FlowToChanged) \
+    macro(FocusableStateChanged) \
+    macro(FocusedUIElementChanged) \
+    macro(FontChanged) \
+    macro(FrameLoadComplete) \
+    macro(GrabbedStateChanged) \
+    macro(HasPopupChanged) \
+    macro(IdAttributeChanged) \
+    macro(ImageOverlayChanged) \
+    macro(InertOrVisibilityChanged) \
+    macro(InputTypeChanged) \
+    macro(IsAtomicChanged) \
+    macro(IsEditableWebAreaChanged) \
+    macro(KeyShortcutsChanged) \
+    macro(LabelChanged) \
+    macro(LanguageChanged) \
+    macro(LayoutComplete) \
+    macro(LevelChanged) \
+    macro(LoadComplete) \
+    macro(NameChanged) \
+    macro(NewDocumentLoadComplete) \
+    macro(PageScrolled) \
+    macro(PlaceholderChanged) \
+    macro(PopoverTargetChanged) \
+    macro(PositionInSetChanged) \
+    macro(RoleChanged) \
+    macro(RowIndexChanged) \
+    macro(RowSpanChanged) \
+    macro(CellScopeChanged) \
+    macro(SelectedChildrenChanged) \
+    macro(SelectedCellsChanged) \
+    macro(SelectedStateChanged) \
+    macro(SelectedTextChanged) \
+    macro(SetSizeChanged) \
+    macro(TextColorChanged) \
+    macro(TextCompositionBegan) \
+    macro(TextCompositionEnded) \
+    macro(URLChanged) \
+    macro(ValueChanged) \
+    macro(VisibilityChanged) \
+    macro(VisitedStateChanged) \
+    macro(ScrolledToAnchor) \
+    macro(LiveRegionCreated) \
+    macro(LiveRegionChanged) \
+    macro(LiveRegionRelevantChanged) \
+    macro(LiveRegionStatusChanged) \
+    macro(MaximumValueChanged) \
+    macro(MenuListItemSelected) \
+    macro(MenuListValueChanged) \
+    macro(MenuClosed) \
+    macro(MenuOpened) \
+    macro(MinimumValueChanged) \
+    macro(MultiSelectableStateChanged) \
+    macro(OrientationChanged) \
+    macro(RowCountChanged) \
+    macro(RowCollapsed) \
+    macro(RowExpanded) \
+    macro(ExpandedChanged) \
+    macro(InvalidStatusChanged) \
+    macro(PressDidSucceed) \
+    macro(PressDidFail) \
+    macro(PressedStateChanged) \
+    macro(ReadOnlyStatusChanged) \
+    macro(RequiredStatusChanged) \
+    macro(SortDirectionChanged) \
+    macro(SpeakAsChanged) \
+    macro(TextChanged) \
+    macro(TextCompositionChanged) \
+    macro(TextUnderElementChanged) \
+    macro(TextSecurityChanged) \
+    macro(ElementBusyChanged) \
+    macro(DraggingStarted) \
+    macro(DraggingEnded) \
+    macro(DraggingEnteredDropZone) \
+    macro(DraggingDropped) \
+    macro(DraggingExitedDropZone) \
+
+
+#if ENABLE(AX_THREAD_TEXT_APIS)
+#define WEBCORE_AXNOTIFICATION_KEYS(macro) \
+    WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro) \
+    macro(TextRunsChanged)
+#else
+#define WEBCORE_AXNOTIFICATION_KEYS(macro) \
+    WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro)
+#endif
+
+enum class AXNotification : uint8_t {
+#define WEBCORE_DEFINE_AXNOTIFICATION_ENUM(name) name,
+WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_DEFINE_AXNOTIFICATION_ENUM)
+#undef WEBCORE_DEFINE_AXNOTIFICATION_ENUM
+};
+
+} // WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -30,10 +30,12 @@
 #include "AXObjectCache.h"
 
 #include "AXAttributeCacheScope.h"
+#include "AXComputedObjectAttributeCache.h"
 #include "AXIsolatedObject.h"
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
+#include "AXNotifications.h"
 #include "AXObjectCacheInlines.h"
 #include "AXRemoteFrame.h"
 #include "AXTextMarker.h"
@@ -142,7 +144,6 @@
 
 namespace WebCore {
 
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXObjectCache);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AXObjectCache);
 
@@ -176,24 +177,6 @@ static bool nodeRendererIsValid(Node& node)
 static bool nodeAndRendererAreValid(Node* node)
 {
     return node ? nodeRendererIsValid(*node) : false;
-}
-
-AccessibilityObjectInclusion AXComputedObjectAttributeCache::getIgnored(AXID id) const
-{
-    auto it = m_idMapping.find(id);
-    return it != m_idMapping.end() ? it->value.ignored : AccessibilityObjectInclusion::DefaultBehavior;
-}
-
-void AXComputedObjectAttributeCache::setIgnored(AXID id, AccessibilityObjectInclusion inclusion)
-{
-    HashMap<AXID, CachedAXObjectAttributes>::iterator it = m_idMapping.find(id);
-    if (it != m_idMapping.end())
-        it->value.ignored = inclusion;
-    else {
-        CachedAXObjectAttributes attributes;
-        attributes.ignored = inclusion;
-        m_idMapping.set(id, attributes);
-    }
 }
 
 AccessibilityReplacedText::AccessibilityReplacedText(const VisibleSelection& selection)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <WebCore/AXTextMarker.h>
-#include <WebCore/AXTextStateChangeIntent.h>
 #include <WebCore/AXTreeStore.h>
 #include <WebCore/SimpleRange.h>
 #include <WebCore/StyleChange.h>
@@ -39,7 +38,6 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
-#include <wtf/text/MakeString.h>
 
 OBJC_CLASS NSMutableArray;
 
@@ -49,6 +47,7 @@ class TextStream;
 
 namespace WebCore {
 
+class AXComputedObjectAttributeCache;
 class AXGeometryManager;
 class AXIsolatedTree;
 class AXRemoteFrame;
@@ -75,6 +74,9 @@ class ScrollView;
 class VisiblePosition;
 class Widget;
 
+struct AXTextStateChangeIntent;
+
+enum class AXNotification : uint8_t;
 enum class AXStreamOptions : uint16_t;
 enum class AXProperty : uint16_t;
 
@@ -93,36 +95,8 @@ struct CharacterOffset {
 
     int remaining() const { return remainingOffset; }
     bool isNull() const { return !node; }
-    bool isEqual(const CharacterOffset& other) const
-    {
-        if (isNull() || other.isNull())
-            return false;
-        return node == other.node && startIndex == other.startIndex && offset == other.offset;
-    }
-
-    String debugDescription()
-    {
-        return makeString("CharacterOffset {node: "_s, node ? node->debugDescription() : "null"_s, ", startIndex: "_s, startIndex, ", offset: "_s, offset, ", remainingOffset: "_s, remainingOffset, '}');
-    }
-};
-
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache);
-class AXComputedObjectAttributeCache {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXComputedObjectAttributeCache, AXComputedObjectAttributeCache);
-public:
-    AccessibilityObjectInclusion getIgnored(AXID) const;
-    void setIgnored(AXID, AccessibilityObjectInclusion);
-
-private:
-    struct CachedAXObjectAttributes {
-        CachedAXObjectAttributes()
-            : ignored(AccessibilityObjectInclusion::DefaultBehavior)
-        { }
-
-        AccessibilityObjectInclusion ignored;
-    };
-
-    HashMap<AXID, CachedAXObjectAttributes> m_idMapping;
+    inline bool isEqual(const CharacterOffset& other) const;
+    inline String debugDescription();
 };
 
 struct VisiblePositionIndex {
@@ -169,129 +143,6 @@ public:
 protected:
     String m_replacedText;
     VisiblePositionIndexRange m_replacedRange;
-};
-
-#define WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro) \
-    macro(AbbreviationChanged) \
-    macro(AccessKeyChanged) \
-    macro(ActiveDescendantChanged) \
-    macro(AnnouncementRequested) \
-    macro(AutocorrectionOccured) \
-    macro(AutofillTypeChanged) \
-    macro(ARIAColumnIndexChanged) \
-    macro(ARIAColumnIndexTextChanged) \
-    macro(ARIARoleDescriptionChanged) \
-    macro(ARIARowIndexChanged) \
-    macro(ARIARowIndexTextChanged) \
-    macro(BrailleLabelChanged) \
-    macro(BrailleRoleDescriptionChanged) \
-    macro(CellSlotsChanged) \
-    macro(CheckedStateChanged) \
-    macro(ChildrenChanged) \
-    macro(ColumnCountChanged) \
-    macro(ColumnIndexChanged) \
-    macro(ColumnSpanChanged) \
-    macro(CommandChanged) \
-    macro(CommandForChanged) \
-    macro(ContentEditableAttributeChanged) \
-    macro(ControlledObjectsChanged) \
-    macro(CurrentStateChanged) \
-    macro(DatetimeChanged) \
-    macro(DescribedByChanged) \
-    macro(DisabledStateChanged) \
-    macro(DraggableStateChanged) \
-    macro(DropEffectChanged) \
-    macro(ExtendedDescriptionChanged) \
-    macro(FlowToChanged) \
-    macro(FocusableStateChanged) \
-    macro(FocusedUIElementChanged) \
-    macro(FontChanged) \
-    macro(FrameLoadComplete) \
-    macro(GrabbedStateChanged) \
-    macro(HasPopupChanged) \
-    macro(IdAttributeChanged) \
-    macro(ImageOverlayChanged) \
-    macro(InertOrVisibilityChanged) \
-    macro(InputTypeChanged) \
-    macro(IsAtomicChanged) \
-    macro(IsEditableWebAreaChanged) \
-    macro(KeyShortcutsChanged) \
-    macro(LabelChanged) \
-    macro(LanguageChanged) \
-    macro(LayoutComplete) \
-    macro(LevelChanged) \
-    macro(LoadComplete) \
-    macro(NameChanged) \
-    macro(NewDocumentLoadComplete) \
-    macro(PageScrolled) \
-    macro(PlaceholderChanged) \
-    macro(PopoverTargetChanged) \
-    macro(PositionInSetChanged) \
-    macro(RoleChanged) \
-    macro(RowIndexChanged) \
-    macro(RowSpanChanged) \
-    macro(CellScopeChanged) \
-    macro(SelectedChildrenChanged) \
-    macro(SelectedCellsChanged) \
-    macro(SelectedStateChanged) \
-    macro(SelectedTextChanged) \
-    macro(SetSizeChanged) \
-    macro(TextColorChanged) \
-    macro(TextCompositionBegan) \
-    macro(TextCompositionEnded) \
-    macro(URLChanged) \
-    macro(ValueChanged) \
-    macro(VisibilityChanged) \
-    macro(VisitedStateChanged) \
-    macro(ScrolledToAnchor) \
-    macro(LiveRegionCreated) \
-    macro(LiveRegionChanged) \
-    macro(LiveRegionRelevantChanged) \
-    macro(LiveRegionStatusChanged) \
-    macro(MaximumValueChanged) \
-    macro(MenuListItemSelected) \
-    macro(MenuListValueChanged) \
-    macro(MenuClosed) \
-    macro(MenuOpened) \
-    macro(MinimumValueChanged) \
-    macro(MultiSelectableStateChanged) \
-    macro(OrientationChanged) \
-    macro(RowCountChanged) \
-    macro(RowCollapsed) \
-    macro(RowExpanded) \
-    macro(ExpandedChanged) \
-    macro(InvalidStatusChanged) \
-    macro(PressDidSucceed) \
-    macro(PressDidFail) \
-    macro(PressedStateChanged) \
-    macro(ReadOnlyStatusChanged) \
-    macro(RequiredStatusChanged) \
-    macro(SortDirectionChanged) \
-    macro(SpeakAsChanged) \
-    macro(TextChanged) \
-    macro(TextCompositionChanged) \
-    macro(TextUnderElementChanged) \
-    macro(TextSecurityChanged) \
-    macro(ElementBusyChanged) \
-    macro(DraggingStarted) \
-    macro(DraggingEnded) \
-    macro(DraggingEnteredDropZone) \
-    macro(DraggingDropped) \
-    macro(DraggingExitedDropZone) \
-
-#if ENABLE(AX_THREAD_TEXT_APIS)
-#define WEBCORE_AXNOTIFICATION_KEYS(macro) \
-    WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro) \
-    macro(TextRunsChanged)
-#else
-#define WEBCORE_AXNOTIFICATION_KEYS(macro) \
-    WEBCORE_AXNOTIFICATION_KEYS_DEFAULT(macro)
-#endif
-
-enum class AXNotification {
-#define WEBCORE_DEFINE_AXNOTIFICATION_ENUM(name) name,
-WEBCORE_AXNOTIFICATION_KEYS(WEBCORE_DEFINE_AXNOTIFICATION_ENUM)
-#undef WEBCORE_DEFINE_AXNOTIFICATION_ENUM
 };
 
 enum class AXLoadingEvent : uint8_t {

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -29,8 +29,22 @@
 #pragma once
 
 #include "AXGeometryManager.h"
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
+
+inline String CharacterOffset::debugDescription()
+{
+    auto nodeDescription = node ? CheckedPtr { node.get() }->debugDescription() : "null"_s;
+    return makeString("CharacterOffset {node: "_s, nodeDescription, ", startIndex: "_s, startIndex, ", offset: "_s, offset, ", remainingOffset: "_s, remainingOffset, '}');
+}
+
+inline bool CharacterOffset::isEqual(const CharacterOffset& other) const
+{
+    if (isNull() || other.isNull())
+        return false;
+    return node == other.node && startIndex == other.startIndex && offset == other.offset;
+}
 
 template<typename U>
 inline Vector<Ref<AXCoreObject>> AXObjectCache::objectsForIDs(const U& axIDs) const

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AccessibilityMenuList.h"
 
+#include "AXNotifications.h"
 #include "AXObjectCache.h"
 #include "AccessibilityMenuListPopup.h"
 #include "RenderMenuList.h"

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AccessibilityMenuListPopup.h"
 
+#include "AXNotifications.h"
 #include "AXObjectCache.h"
 #include "AccessibilityMenuList.h"
 #include "AccessibilityMenuListOption.h"

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -32,6 +32,7 @@
 #include "AXAttachmentHelpers.h"
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
+#include "AXNotifications.h"
 #include "AXObjectCache.h"
 #include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -30,9 +30,11 @@
 #include "AccessibilityObject.h"
 
 #include "AXAttributeCacheScope.h"
+#include "AXComputedObjectAttributeCache.h"
 #include "AXIsolatedTree.h"
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
+#include "AXNotifications.h"
 #include "AXObjectCache.h"
 #include "AXObjectCacheInlines.h"
 #include "AXRemoteFrame.h"

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -31,6 +31,7 @@
 
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
+#include "AXNotifications.h"
 #include "AXObjectCache.h"
 #include "AXUtilities.h"
 #include "AccessibilityImageMapLink.h"

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -21,6 +21,7 @@
 #include "AXObjectCache.h"
 
 #if USE(ATSPI)
+#include "AXNotifications.h"
 #include "AXTextStateChangeIntent.h"
 #include "AccessibilityObject.h"
 #include "AccessibilityObjectAtspi.h"

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "AXNotifications.h"
 #import "AccessibilityObject.h"
 #import "Chrome.h"
 #import "RenderObject.h"

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -30,6 +30,7 @@
 
 #import "AXAttributeCacheScope.h"
 #import "AXLogger.h"
+#import "AXNotifications.h"
 #import "AXObjectCache.h"
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -31,6 +31,7 @@
 #include "AXAttributeCacheScope.h"
 #include "AXIsolatedObject.h"
 #include "AXLogger.h"
+#include "AXNotifications.h"
 #include "AXTreeStore.h"
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC)
 
 #import "AXIsolatedObject.h"
+#import "AXNotifications.h"
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
 #import "AccessibilityObject.h"

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AXObjectCache.h"
 
+#include "AXNotifications.h"
 #include "AccessibilityObject.h"
 #include "Chrome.h"
 #include "ChromeClient.h"

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "AXObjectCache.h"
 
+#include "AXNotifications.h"
 #include "AccessibilityObject.h"
 #include "Chrome.h"
 #include "ChromeClient.h"

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -163,7 +163,7 @@ struct WindowFeatures;
 
 enum class ActivityStateForCPUSampling : uint8_t;
 enum class AXLoadingEvent : uint8_t;
-enum class AXNotification;
+enum class AXNotification : uint8_t;
 enum class AXTextChange : uint8_t;
 enum class CookieConsentDecisionResult : uint8_t;
 enum class DidFilterLinkDecoration : bool { No, Yes };


### PR DESCRIPTION
#### e79ade1b9f553c410b3e7858adea567357296f9c
<pre>
AX: AXNotifications enum and AXComputedObjectAttributeCache can be extracted from AXObjectCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=297469">https://bugs.webkit.org/show_bug.cgi?id=297469</a>
<a href="https://rdar.apple.com/158425759">rdar://158425759</a>

Reviewed by Joshua Hoffman.

AXObjectCache.h is included from a lot of places, we should remove definitions that aren&apos;t needed everywhere

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXComputedObjectAttributeCache.cpp: Copied from Source/WebCore/accessibility/AXObjectCacheInlines.h.
(WebCore::AXComputedObjectAttributeCache::getIgnored const):
(WebCore::AXComputedObjectAttributeCache::setIgnored):
* Source/WebCore/accessibility/AXComputedObjectAttributeCache.h: Added.
* Source/WebCore/accessibility/AXLogger.cpp:
* Source/WebCore/accessibility/AXNotifications.h: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXComputedObjectAttributeCache::getIgnored const): Deleted.
(WebCore::AXComputedObjectAttributeCache::setIgnored): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::CharacterOffset::isEqual const): Deleted.
(WebCore::CharacterOffset::debugDescription): Deleted.
(WebCore::AXComputedObjectAttributeCache::CachedAXObjectAttributes::CachedAXObjectAttributes): Deleted.
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::CharacterOffset::debugDescription):
(WebCore::CharacterOffset::isEqual const):
* Source/WebCore/accessibility/AXSearchManager.cpp:
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
* Source/WebCore/page/ChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/298796@main">https://commits.webkit.org/298796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb113840980887e9e954b41dedbf3063629e641c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88593 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22749 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125861 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97263 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97056 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24722 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49031 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->