### PR TITLE
[AutoFill Debugging] Part 4: Add support for `-[WKWebView _debugTextWithConfiguration:completionHandler:]`

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -1,0 +1,48 @@
+container=root,rect=[…]
+    rect=[…],role='banner'
+        rect=[…],aria-label='Main Page Title'
+            text='Welcome to Test Page\n\n',rect=[…]
+    container=navigation,rect=[…],role='navigation',aria-label='Main navigation'
+        container=list,rect=[…]
+            container=list-item,rect=[…]
+                type=link,uid=…,rect=[…],eventListeners=[click],url='mailto:wenson_hsieh@apple.com'
+                    text='Section 1\n',rect=[…]
+            container=list-item,rect=[…]
+                type=link,uid=…,rect=[…],eventListeners=[click],url='https://example.com/'
+                    text='Section 2\n',rect=[…]
+    rect=[…],role='main'
+        container=section,rect=[…],aria-label='Interactive Elements'
+            container=button,uid=…,rect=[…],eventListeners=[click],aria-label='Test button'
+                text='Click Me',rect=[…]
+            text='This button does nothing\n',rect=[…]
+            type=textFormControl,controlType='text',uid=…,rect=[…],placeholder='Enter text here'
+                text='Enter text here\n',rect=[…]
+            uid=…,rect=[…],role='button',eventListeners=[click,keyboard]
+                text='Clickable Div\n',rect=[…]
+        container=section,rect=[…],aria-label='Content with Roles'
+            container=article,rect=[…],role='article'
+                text='Article Title\n\n',rect=[…]
+                text='January 1, 2024',rect=[…]
+                text='This is some article content with ',rect=[…]
+                text='highlighted text',rect=[…]
+                text='.\n\n',rect=[…]
+            rect=[…],role='complementary',aria-label='Related information'
+                text='Related Links\n\n',rect=[…]
+                container=list,rect=[…]
+                    container=list-item,rect=[…]
+                        type=link,uid=…,rect=[…],eventListeners=[hover],url='https://webkit.org/'
+                            text='Example Link\n',rect=[…]
+                    container=list-item,rect=[…]
+                        type=link,uid=…,rect=[…],eventListeners=[hover],url='https://apple.com/'
+                            text='Test Link\n',rect=[…]
+            rect=[…],role='region'
+                rect=[…],role='status'
+                    text='Ready\n',rect=[…]
+                container=button,uid=…,rect=[…],eventListeners=[click]
+                    text='Update Status',rect=[…]
+    rect=[…],role='contentinfo'
+        text='Footer content with ',rect=[…]
+        rect=[…],role='img',aria-label='copyright symbol'
+            text='©',rect=[…]
+        text=' 2024\n\n',rect=[…]
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -1,0 +1,91 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+.clickable {
+    background-color: lightblue;
+    padding: 10px;
+    margin: 5px;
+    cursor: pointer;
+}
+
+.focusable {
+    border: 2px solid green;
+    padding: 5px;
+    margin: 3px;
+}
+
+.interactive {
+    background-color: lightyellow;
+    padding: 8px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div role="banner">
+    <h1 id="main-title" aria-label="Main Page Title">Welcome to Test Page</h1>
+</div>
+<nav role="navigation" aria-label="Main navigation">
+    <ul>
+        <li><a href="mailto:wenson_hsieh@apple.com" onclick="return false;">Section 1</a></li>
+        <li><a href="https://example.com/" onclick="return false;">Section 2</a></li>
+    </ul>
+</nav>
+<main role="main">
+    <section id="section1" aria-label="Interactive Elements">
+        <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
+        <div id="btn-help" aria-hidden="true">This button does nothing</div>
+        <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
+        <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
+    </section>
+    <section id="section2" aria-label="Content with Roles">
+        <article role="article">
+            <header>
+                <h3>Article Title</h3>
+                <time datetime="2024-01-01">January 1, 2024</time>
+            </header>
+            <p>This is some article content with <mark>highlighted text</mark>.</p>
+        </article>
+        <aside role="complementary" aria-label="Related information">
+            <h4>Related Links</h4>
+            <ul>
+                <li><a href="https://webkit.org" onmouseover="this.style.color='red'">Example Link</a></li>
+                <li><a href="https://apple.com" onmouseout="this.style.color=''">Test Link</a></li>
+            </ul>
+        </aside>
+        <div role="region">
+            <div role="status" aria-live="polite" id="status-msg">Ready</div>
+            <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
+        </div>
+    </section>
+</main>
+<footer role="contentinfo">
+    <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
+</footer>
+<div role="dialog" aria-hidden="true" style="display: none;">
+    <p>This dialog is hidden and should not be extracted.</p>
+</div>
+
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({ normalize: true });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2443,6 +2443,26 @@ window.UIHelper = class UIHelper {
             }, eventTarget || document.activeElement, waitForEvent);
         }
     }
+
+    static async requestDebugText(options = { })
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve("");
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(() => {
+                uiController.requestDebugText(result => uiController.uiScriptComplete(result));
+            })()`, debugText => {
+                if (options.normalize) {
+                    debugText = debugText
+                        .replace(/uid=\d+/g, "uid=…")
+                        .replace(/rect=\[[^\]]+\]/g, "rect=[…]")
+                        .replace(/\t/g, "    ");
+                }
+                resolve(debugText);
+            });
+        });
+    }
 }
 
 UIHelper.EventStreamBuilder = class {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6343,6 +6343,13 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 }
 #endif // PLATFORM(MAC)
 
+- (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(void(^)(NSString *))completionHandler
+{
+    [self _requestTextExtraction:configuration completionHandler:makeBlockPtr([completionHandler = makeBlockPtr(completionHandler)](WKTextExtractionResult *result) {
+        completionHandler(result.textRepresentation);
+    }).get()];
+}
+
 @end
 
 @implementation WKWebView (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -636,6 +636,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (NSUInteger)accessibilityUIProcessLocalTokenHash;
 #endif
 
+- (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -28,14 +28,12 @@
 
 @implementation _WKTextExtractionConfiguration
 
-@synthesize mergeParagraphs = _mergeParagraphs;
-@synthesize skipNearlyTransparentContent = _skipNearlyTransparentContent;
-
 - (instancetype)init
 {
     if (!(self = [super init]))
         return nil;
 
+    _canIncludeIdentifiers = YES;
     _targetRect = CGRectNull;
     return self;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  Whether to include unique identifiers, for each interactive element.
- Defaults to `NO`.
+ Defaults to `YES`.
  */
 @property (nonatomic) BOOL canIncludeIdentifiers;
 
@@ -166,6 +166,7 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 - (instancetype)initWithRootItem:(WKTextExtractionItem *)rootItem popupMenu:(nullable WKTextExtractionPopupMenu *)popupMenu;
 @property (nonatomic, readonly) WKTextExtractionItem *rootItem;
 @property (nonatomic, readonly, nullable) WKTextExtractionPopupMenu *popupMenu;
+@property (nonatomic, readonly) NSString *textRepresentation;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -111,6 +111,7 @@ extension WKWebView {
             configuration.targetRect = visibleRect
             configuration.mergeParagraphs = true
             configuration.skipNearlyTransparentContent = true
+            configuration.canIncludeIdentifiers = false
             if let result = await _requestTextExtraction(configuration) {
                 collector.collect(createIntelligenceElement(item: result.rootItem))
             }

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -430,6 +430,7 @@ interface UIScriptController {
     undefined acceptInlinePrediction();
 
     undefined requestTextExtraction(object callback, TextExtractionOptions options);
+    undefined requestDebugText(object callback);
 
     undefined requestRenderedTextForFrontmostTarget(long x, long y, object callback);
     undefined adjustVisibilityForFrontmostTarget(long x, long y, object callback);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -436,6 +436,7 @@ public:
 
     // Text Extraction
     virtual void requestTextExtraction(JSValueRef, TextExtractionOptions*) { notImplemented(); }
+    virtual void requestDebugText(JSValueRef) { notImplemented(); }
 
     // Element Targeting
     virtual void requestRenderedTextForFrontmostTarget(int, int, JSValueRef) { notImplemented(); }

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -90,6 +90,7 @@ private:
     void setSpellCheckerResults(JSValueRef) final;
 
     void requestTextExtraction(JSValueRef callback, TextExtractionOptions*) final;
+    void requestDebugText(JSValueRef callback) final;
 
     void requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback) final;
     void adjustVisibilityForFrontmostTarget(int x, int y, JSValueRef callback) final;

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -356,6 +356,19 @@ void UIScriptControllerCocoa::requestTextExtraction(JSValueRef callback, TextExt
     }];
 }
 
+void UIScriptControllerCocoa::requestDebugText(JSValueRef callback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+    RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+    [webView() _debugTextWithConfiguration:configuration.get() completionHandler:^(NSString *text) {
+        if (!m_context)
+            return;
+
+        auto description = adopt(JSStringCreateWithCFString((__bridge CFStringRef)text));
+        m_context->asyncTaskComplete(callbackID, { JSValueMakeString(m_context->jsContext(), description.get()) });
+    }];
+}
+
 void UIScriptControllerCocoa::requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);


### PR DESCRIPTION
#### 4dce17fe3a12a5d312dc280ef1ff35f9b48bfcd7
<pre>
[AutoFill Debugging] Part 4: Add support for `-[WKWebView _debugTextWithConfiguration:completionHandler:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297474">https://bugs.webkit.org/show_bug.cgi?id=297474</a>
<a href="https://rdar.apple.com/158431432">rdar://158431432</a>

Reviewed by Richard Robinson and Patrick Angle.

Add support for a new SPI method on `WKWebView` that uses text extraction to provide a textual
representation of the current page, for debugging purposes. See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html: Added.

Add a basic layout test that exercises most aspects of the debug text extraction workflow, including
event listeners, DOM/ARIA attributes, and special element types.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async requestDebugText):
(window.UIHelper.prototype.async requestDebugText):
(window.UIHelper):

Add a testing hook to request `debugText`.

(async UIHelper.EventStreamBuilder.prototype._reset): Deleted.
(async UIHelper.EventStreamBuilder.prototype.begin): Deleted.
(async UIHelper.EventStreamBuilder.prototype.wait): Deleted.
(async UIHelper.EventStreamBuilder.prototype.move): Deleted.
(async UIHelper.EventStreamBuilder.prototype.end): Deleted.
(async UIHelper.EventStreamBuilder.prototype.takeResult): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _debugTextWithConfiguration:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration init]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(String.escaped):
(WKTextExtractionItem.textRepresentationRecursive(_:)):
(WKTextExtractionItem.textRepresentationParts):
(WKTextExtractionContainerItem.textRepresentationParts):
(WKTextExtractionContentEditableItem.textRepresentationParts):
(WKTextExtractionTextFormControlItem.textRepresentationParts):
(WKTextExtractionLinkItem.textRepresentationParts):
(WKTextExtractionTextItem.textRepresentationParts):
(WKTextExtractionScrollableItem.textRepresentationParts):
(WKTextExtractionSelectItem.textRepresentationParts):
(WKTextExtractionImageItem.textRepresentationParts):

Add support for a `fileprivate` method to return an array of text representation parts (e.g.
`url=…`, `aria-label=&apos;…&apos;`, etc.) that&apos;s used to assemble the one-line text representation. Each
subclass adds additional, item-specific information on top of the default information added by
`WKTextExtractionItem`.

(WKTextExtractionPopupMenu.textRepresentation):
(WKTextExtractionResult.textRepresentation):

Add support for `-[WKTextExtractionResult textRepresentation]`. This returns a textual
representation of the extraction result, with 1 element per line.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::requestDebugText):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::requestDebugText):

Canonical link: <a href="https://commits.webkit.org/298782@main">https://commits.webkit.org/298782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e0c2ffdb30d487d23b53f3ac1f0e9ec5cd32449

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67207 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ed38536-b374-452f-9ce9-f4144f1913ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/36997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88582 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b136e45-6753-474c-ae0d-07cbf8b7ab33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69048 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66376 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98887 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/22897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125845 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43534 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97043 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42365 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39496 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49015 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42886 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->