### PR TITLE
[interactive-widget] Implement logic to support overlays-content

### DIFF
--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt
@@ -1,0 +1,18 @@
+Scrolled to 40, 1048
+PASS document.scrollingElement.scrollTop is 1048
+PASS document.scrollingElement.scrollLeft is 40
+PASS window.visualViewport.pageTop is not 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 797
+Scrolled to 0, 0
+PASS document.scrollingElement.scrollTop is 0
+PASS document.scrollingElement.scrollLeft is 0
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 797
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        body {
+            height: 2000px;
+            width: 2000px;
+        }
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            window.scrollTo(40, 1048);
+            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+
+            shouldBe('document.scrollingElement.scrollTop', '1048');
+            shouldBe('document.scrollingElement.scrollLeft', '40');
+            shouldNotBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            window.scrollTo(0, 0);
+            debug('Scrolled to ' + window.scrollX + ', ' + window.scrollY);
+
+            shouldBe('document.scrollingElement.scrollTop', '0');
+            shouldBe('document.scrollingElement.scrollLeft', '0');
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt
@@ -1,0 +1,22 @@
+layoutViewport: {"x":0,"y":0,"width":390,"height":747,"top":0,"right":390,"bottom":747,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":747,"top":0,"right":390,"bottom":747,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 747
+layoutViewport: {"x":0,"y":0,"width":390,"height":697,"top":0,"right":390,"bottom":697,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":697,"top":0,"right":390,"bottom":697,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 697
+layoutViewport: {"x":0,"y":0,"width":390,"height":729,"top":0,"right":390,"bottom":729,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":729,"top":0,"right":390,"bottom":729,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 729
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+        body { 
+            background-color: pink;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+
+            // Test the bottom inset being smaller than the input accessory view.
+            await UIHelper.setObscuredInsets(0, 0, 50, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            // Test the bottom inset being bigger than the input accessory view.
+            await UIHelper.setObscuredInsets(0, 0, 100, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            // Test the bottom inset being equal to the input accessory view.
+            await UIHelper.setObscuredInsets(0, 0, 68, 0);
+            await UIHelper.renderingUpdate();
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            finishJSTest();
+        });
+    </script>
+</body>
+</html> 

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt
@@ -1,0 +1,10 @@
+layoutViewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is 1
+PASS window.visualViewport.width is 390
+PASS window.visualViewport.height is 797
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldBe('window.visualViewport.scale', '1');
+            shouldBe('window.visualViewport.width', JSON.stringify(internals.layoutViewportRect().width));
+            shouldBe('window.visualViewport.height', JSON.stringify(internals.layoutViewportRect().height));
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt
@@ -1,0 +1,11 @@
+layoutViewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+visualViewportRect: {"x":0,"y":0,"width":268,"height":548,"top":0,"right":268,"bottom":548,"left":0}
+PASS window.visualViewport.pageTop is 0
+PASS window.visualViewport.scale is not 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Layout viewport: {"x":0,"y":0,"width":390,"height":797,"top":0,"right":390,"bottom":797,"left":0}
+Visual viewport: {"x":0,"y":0,"width":268,"height":548,"top":0,"right":268,"bottom":548,"left":0}
+
+

--- a/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html
+++ b/LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=overlays-content"/>
+    <style>
+        input {
+            width: 400px;
+            height: 50px;
+        }
+    </style>
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <p id="results"></p>
+    <input id="input" type="text">
+
+    <script>
+        jsTestIsAsync = true;
+        addEventListener("load", async () => {
+            let textField = document.querySelector("input");
+            await UIHelper.activateElement(textField);
+            await UIHelper.waitForKeyboardToShow();
+
+            debug('layoutViewport: ' + JSON.stringify(internals.layoutViewportRect()));
+            debug('visualViewportRect: ' + JSON.stringify(internals.visualViewportRect()));
+
+            shouldBe('window.visualViewport.pageTop', '0');
+            shouldNotBe('window.visualViewport.scale', '1');
+            var output = 'Layout viewport: ' + JSON.stringify(internals.layoutViewportRect()) + '\nVisual viewport: ' + JSON.stringify(internals.visualViewportRect()) + '\n';
+            document.getElementById('results').innerText = output;
+
+            finishJSTest();
+        });
+    </script>
+</body>
+
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3399,6 +3399,9 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
         if (UIPeripheralHost.sharedInstance.isUndocked)
             return CGRectZero;
 
+        if (_perProcessState.viewportMetaTagInteractiveWidget == WebCore::InteractiveWidget::OverlaysContent)
+            return _inputViewBoundsInWindow;
+
         auto keyboardFrameInScreen = endFrameValue.CGRectValue;
         // The keyboard rect is always in screen coordinates. In the view services case the window does not
         // have the interface orientation rotation transformation; its host does. So, it makes no sense to


### PR DESCRIPTION
#### 8d1e4b35f7b280a333e20e975e05c8b051c71792
<pre>
[interactive-widget] Implement logic to support overlays-content
<a href="https://bugs.webkit.org/show_bug.cgi?id=297473">https://bugs.webkit.org/show_bug.cgi?id=297473</a>
<a href="https://rdar.apple.com/158431078">rdar://158431078</a>

Reviewed by NOBODY (OOPS!).

Add support for the overlays-content value for interactive-widgets.
In this case, we don&apos;t want to account for `_inputViewBoundsInWindow`, which
typically represents views bounds such as the bounds for the area above a
virtual keyboard. By doing so, we prevent interactive UI widgets on screen
to change the initial or visual viewport.

Created layout tests that utilize this overlays-content value and ensured
these tests fail with the default resizes-visual behavior.

* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-keyboard-scroll.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-obscured-insets.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-disabled.html: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled-expected.txt: Added.
* LayoutTests/fast/visual-viewport/ios/interactive-widget-overlays-content-zoom-enabled.html: Added.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _keyboardChangedWithInfo:adjustScrollView:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d1e4b35f7b280a333e20e975e05c8b051c71792

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67461 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41d1d7d3-fbed-4f8e-9e3f-ffb9594dea12) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88756 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43512 "5 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69213 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66611 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126082 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97220 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42543 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40177 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49251 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43122 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44827 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->