### PR TITLE
In some cases, we can't follow file:// links from a local file

### DIFF
--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -127,6 +127,11 @@ SandboxExtensionHandle::SandboxExtensionHandle()
 {
 }
 
+SandboxExtensionHandle::SandboxExtensionHandle(const SandboxExtensionHandle& handle)
+{
+    m_sandboxExtension = WTF::makeUnique<SandboxExtensionImpl>(handle.m_sandboxExtension->getSerializedFormat());
+}
+
 SandboxExtensionHandle::SandboxExtensionHandle(SandboxExtensionHandle&&) = default;
 SandboxExtensionHandle& SandboxExtensionHandle::operator=(SandboxExtensionHandle&&) = default;
 

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -79,9 +79,9 @@ private:
 #endif
 
 class SandboxExtensionHandle {
-    WTF_MAKE_NONCOPYABLE(SandboxExtensionHandle);
 public:
     SandboxExtensionHandle();
+    SandboxExtensionHandle(const SandboxExtensionHandle&);
 #if ENABLE(SANDBOX_EXTENSIONS)
     SandboxExtensionHandle(SandboxExtensionHandle&&);
     SandboxExtensionHandle& operator=(SandboxExtensionHandle&&);
@@ -159,6 +159,7 @@ String resolveAndCreateReadWriteDirectoryForSandboxExtension(StringView path);
 #if !ENABLE(SANDBOX_EXTENSIONS)
 
 inline SandboxExtensionHandle::SandboxExtensionHandle() { }
+inline SandboxExtensionHandle::SandboxExtensionHandle(const SandboxExtensionHandle&) { }
 inline SandboxExtensionHandle::~SandboxExtensionHandle() { }
 inline RefPtr<SandboxExtension> SandboxExtension::create(Handle&&) { return nullptr; }
 inline auto SandboxExtension::createHandle(StringView, Type) -> std::optional<Handle> { return Handle { }; }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1483,6 +1483,9 @@ void WebProcessPool::handleMemoryPressureWarning(Critical)
     if (RefPtr prewarmedProcess = m_prewarmedProcess.get())
         prewarmedProcess->shutDown();
     ASSERT(!m_prewarmedProcess);
+
+    for (Ref process : m_processes)
+        process->clearSandboxExtensions();
 }
 
 ProcessID WebProcessPool::prewarmedProcessID()

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -3102,6 +3102,21 @@ void WebProcessProxy::setResourceMonitorRuleLists(RefPtr<WebCompiledContentRuleL
 }
 #endif
 
+std::optional<SandboxExtension::Handle> WebProcessProxy::sandboxExtensionForFile(const String& fileName) const
+{
+    return m_fileSandboxExtensions.getOptional(fileName);
+}
+
+void WebProcessProxy::addSandboxExtensionForFile(const String& fileName, SandboxExtension::Handle handle)
+{
+    m_fileSandboxExtensions.add(fileName, handle);
+}
+
+void WebProcessProxy::clearSandboxExtensions()
+{
+    m_fileSandboxExtensions.clear();
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -557,6 +557,10 @@ public:
     void setResourceMonitorRuleLists(RefPtr<WebCompiledContentRuleList>, CompletionHandler<void()>&&);
 #endif
 
+    std::optional<SandboxExtension::Handle> sandboxExtensionForFile(const String& fileName) const;
+    void addSandboxExtensionForFile(const String& fileName, SandboxExtension::Handle);
+    void clearSandboxExtensions();
+
 private:
     Type type() const final { return Type::WebContent; }
 
@@ -863,6 +867,8 @@ private:
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
     HashMap<WebCore::ServiceWorkerIdentifier, Ref<ServiceWorkerDebuggableProxy>> m_serviceWorkerDebuggableProxies;
 #endif
+
+    HashMap<String, SandboxExtension::Handle> m_fileSandboxExtensions;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);


### PR DESCRIPTION
#### 5e5ea2a419109ebcc919759ca43bccfff4f9c555
<pre>
In some cases, we can&apos;t follow file:// links from a local file
<a href="https://rdar.apple.com/156619146">rdar://156619146</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=296808">https://bugs.webkit.org/show_bug.cgi?id=296808</a>

Reviewed by Sihui Liu.

When dropping a local file in a WKWebView or in the chrome of the embedding application, WebKit is normally only provided with a
temporary sandbox extension to that location in the UI process by the system or embedding application. If we later visit the same
local file URL, either by going back/forward in history, or manually entering the file URL in the address field, we are no longer
able to create a sandbox extension to that location for the WebContent process, since the temporary sandbox extension has been
revoked in the UI process. To address this, we add a sandbox extension cache in the process proxy, which lets us send a sandbox
extension to the WebContent process in these cases. This requires the SandboxExtensionHandle class to be copyable.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::handleMemoryPressureWarning):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::sandboxExtensionForFile const):
(WebKit::WebProcessProxy::addSandboxExtensionForFile):
(WebKit::WebProcessProxy::clearSandboxExtensions):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/298934@main">https://commits.webkit.org/298934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5d748a28bd34e1b7857c5af722999c387b0067d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68907 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26ab48b9-870e-4edf-80cb-9847ee98e0ff) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88771 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43516 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, imported/w3c/web-platform-tests/wasm/core/simd/simd_align.wast.js.html, js/dom/customAccessor-defineProperty.html, storage/indexeddb/cursor-continue-validity.html, storage/indexeddb/cursor-inconsistency-private.html, storage/indexeddb/modern/cursor-7-private.html, storage/indexeddb/modern/cursor-7.html, storage/indexeddb/modern/idbobjectstore-getall-1.html, storage/indexeddb/modern/index-cursor-1.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-rgb9_e5-rgb-half_float.html, webgl/2.0.0/conformance2/textures/image/tex-3d-rgba8ui-rgba_integer-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-2d-r32f-red-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-3d-rg8-rg-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-r32f-red-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-3d-rgb5_a1-rgba-unsigned_byte.html, webgl/2.0.y/conformance/context/context-creation-and-destruction.html, webgl/2.0.y/conformance/extensions/ext-disjoint-timer-query.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0b08876-5ba0-40c4-a2fd-4ecb2f7dc1fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69230 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28771 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66625 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126096 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97437 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44148 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97236 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20531 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40179 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18709 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49265 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43136 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46475 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->