### PR TITLE
Update filter-build-webkit to filter out more noise

### DIFF
--- a/Source/WebCore/Scripts/generate-log-declarations.py
+++ b/Source/WebCore/Scripts/generate-log-declarations.py
@@ -32,8 +32,6 @@ def get_arguments_string(parameter_string, flags):
 
 
 def generate_log_client_declarations_file(log_messages, log_client_declarations_file):
-    print("Log message receiver header file:", log_client_declarations_file)
-
     with open(log_client_declarations_file, 'w') as file:
 
         file.write("#pragma once\n\n")
@@ -46,8 +44,6 @@ def generate_log_client_declarations_file(log_messages, log_client_declarations_
 
 
 def generate_log_client_virtual_functions(log_messages, log_client_virtual_functions_file):
-    print("Log client virtual_functions file:", log_client_virtual_functions_file)
-
     with open(log_client_virtual_functions_file, 'w') as file:
         for log_message in log_messages:
             function_name = log_message[0]
@@ -95,8 +91,6 @@ def main(argv):
         log_client_virtual_functions_file = sys.argv[3]
     else:
         log_client_virtual_functions_file = None
-
-    print("Log messages input file:", log_messages_input_file)
 
     log_messages = get_log_messages(log_messages_input_file)
 

--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -8,8 +8,6 @@ log_declarations_module = importlib.import_module("generate-log-declarations")
 
 
 def generate_messages_file(log_messages, log_messages_receiver_input_file, streaming_ipc):
-    print("Log messages receiver input file:", log_messages_receiver_input_file)
-
     with open(log_messages_receiver_input_file, 'w') as file:
         file.write("#if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)\n")
         file.write("[\n")
@@ -35,8 +33,6 @@ def generate_messages_file(log_messages, log_messages_receiver_input_file, strea
 
 
 def generate_log_client_declarations_file(log_messages, log_client_declarations_file):
-    print("Log client declarations file:", log_client_declarations_file)
-
     with open(log_client_declarations_file, 'w') as file:
 
         for log_message in log_messages:
@@ -60,8 +56,6 @@ def generate_log_client_declarations_file(log_messages, log_client_declarations_
 
 
 def generate_message_receiver_declarations_file(log_messages, log_messages_receiver_declarations_file):
-    print("Log messages receiver declarations file:", log_messages_receiver_declarations_file)
-
     with open(log_messages_receiver_declarations_file, 'w') as file:
         for log_message in log_messages:
             function_name = log_message[0]
@@ -75,8 +69,6 @@ def generate_message_receiver_declarations_file(log_messages, log_messages_recei
 
 
 def generate_message_receiver_implementations_file(log_messages, log_messages_receiver_implementations_file):
-    print("Log messages receiver implementations file:", log_messages_receiver_implementations_file)
-
     with open(log_messages_receiver_implementations_file, 'w') as file:
         for log_message in log_messages:
             function_name = log_message[0]
@@ -134,9 +126,6 @@ def main(argv):
     webkit_log_client_declarations_file = sys.argv[6]
     webcore_log_client_declarations_file = sys.argv[7]
     defines = sys.argv[8]
-
-    print("WebKit Log messages input file:", webkit_log_messages_input_file)
-    print("WebCore Log messages input file:", webcore_log_messages_input_file)
 
     streaming_ipc = defines.find("ENABLE_STREAMING_IPC_IN_LOG_FORWARDING") != -1
 

--- a/Tools/Scripts/filter-build-webkit
+++ b/Tools/Scripts/filter-build-webkit
@@ -176,7 +176,7 @@ sub main() {
             printLine($line, $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /\*\* BUILD SUCCEEDED \*\*/) {
             printLine("Build Succeeded", $target, $project, STYLE_SUCCESS);
-        } elsif ($line =~ /^(\e\[1m)?(PhaseScriptExecution|RuleScriptExecution|ClCompile|CompileC|Distributed-CompileC|Ld|PBXCp|CpResource|CopyPNGFile|CopyTiffFile|CpHeader|Preprocess|Processing|ProcessInfoPlistFile|ProcessPCH|ProcessPCH\+\+|Touch|Libtool|CopyStringsFile|Mig|CreateUniversalBinary|Analyze|AnalyzeShallow|ProcessProductPackaging|ProcessProductPackagingDER|CodeSign|Validate|SymLink|Updating|CompileDTraceScript|CompileXIB|StripNIB|CopyPlistFile|GenerateDSYMFile|GenerateTAPI|CompileStoryboard|ExternalBuildToolExecution|CreateBuildDirectory|WriteAuxiliaryFile|RegisterWithLaunchServices|RegisterExecutionPolicyException|MkDir|Strip|MetalLink|CompileMetalFile|ValidateEmbeddedBinary|Copy|ScanDependencies)(\e\[0m)? ("[^"]+"|(\\|(?<=\\)\s|\S)+)?/) {
+        } elsif ($line =~ /^(\e\[1m)?(PhaseScriptExecution|RuleScriptExecution|ClCompile|CompileC|Distributed-CompileC|Ld|PBXCp|CpResource|CopyPNGFile|CopyTiffFile|CpHeader|Preprocess|Processing|ProcessInfoPlistFile|ProcessPCH|ProcessPCH\+\+|Touch|Libtool|CopyStringsFile|Mig|CreateUniversalBinary|Analyze|AnalyzeShallow|ProcessProductPackaging|ProcessProductPackagingDER|CodeSign|Validate|SymLink|Updating|CompileDTraceScript|CompileXIB|StripNIB|CopyPlistFile|GenerateDSYMFile|GenerateTAPI|CompileStoryboard|ExternalBuildToolExecution|CreateBuildDirectory|WriteAuxiliaryFile|RegisterWithLaunchServices|RegisterExecutionPolicyException|MkDir|Strip|MetalLink|CompileMetalFile|ValidateEmbeddedBinary|Copy|ScanDependencies|SwiftDriver|SwiftMergeGeneratedHeaders|SwiftDriverJobDiscovery|SwiftEmitModule|EmitSwiftModule|SwiftCompile|VerifyModule|ExecuteExternalTool|Unifdef|MergeInfoPlistFile|CompileAssetCatalogVariant|LinkAssetCatalog|GenerateAssetSymbols|GeneratedAssetSymbols|CopySwiftLibs|CopySwiftLibs)(\e\[0m)? ("[^"]+"|(\\|(?<=\\)\s|\S)+)?/) {
             my ($command, $path) = ($2, basename($4));
             $command = "ScanDeps" if $command eq "ScanDependencies";
             $path =~ s/("|\\|\.[ah]$)//g;
@@ -198,9 +198,24 @@ sub main() {
         } elsif ($line =~ /^cp (\S+)/) {
             my $path = basename($1);
             printLine("cp $path", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^mv (\S+)/) {
+            my $path = basename($1);
+            printLine("mv $path", $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /python(\d\.\d+)? (\S+) (.+)/) {
-            my ($command, $path) = (basename($2), basename($3));
-            printLine("python $command $path", $target, $project, STYLE_PLAIN);
+            my ($command, $arguments) = (basename($2), $3);
+            my ($content) = $arguments;
+            $command =~ s/"//g;
+            if (($command eq "process-css-properties.py") || ($command eq "process-css-values.py") || ($command eq "process-css-pseudo-selectors.py")) {
+                $content = "";
+            } elsif ($command eq "generate-derived-log-sources.py") {
+                $arguments =~ /(\S+) +(\S+ +\S+ +\S+ +\S+ +\S+ +\S+).+/;
+                $content = "$1 $2";
+            } else {
+                $content = basename($arguments);
+            }
+            printLine("python $command $content", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^Generating bindings for the (\S+) builtin\./) {
+            printLine("Generating $1 builtin", $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^\/\S+?(strip|WebCoreExportFileGenerator) .*?(\/|\> )(\S+)/) {
             my ($command, $path) = (basename($1), basename($3));
             printLine("$command $path", $target, $project, STYLE_PLAIN);
@@ -222,6 +237,8 @@ sub main() {
             printLine($line, $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^Pre-processing (\S+) sandbox profile/) {
             printLine($line, $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /compile-sandbox.sh\s+(\S+)/) {
+            printLine("compile-sandbox.sh ".$1, $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^Scripts\/generate-unified-source-bundles.rb/) {
             printLine("Generating unified sources", $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^ruby JavaScriptCore\/generator\/main.rb JavaScriptCore\/bytecode\/BytecodeList.rb.*/) {
@@ -240,7 +257,7 @@ sub main() {
             printLine("Converting WHLSLStandardLibrary", $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^sh .*\/generate-https-upgrade-database\.sh .*\/HTTPSUpgradeList.txt HTTPSUpgradeList.db/) {
             printLine("Converting HTTPSUpgradeList", $target, $project, STYLE_PLAIN);
-        } elsif ($line =~ /^ruby .*\/GeneratePreferences\.rb\s+--frontend\s+(\S+)\s+.*\s+--template\s+.*(\/\S+).erb/) {
+        } elsif ($line =~ /^ruby .*\/GeneratePreferences\.rb\s+--frontend\s+(\S+)\s+--template\s+.*(\/\S+).erb.+/) {
             my $path = basename($2);
             printLine("Generating preferences $1 $path", $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^### (Generating \.xcfilelists for .*)$/) {
@@ -261,6 +278,29 @@ sub main() {
             printLine("$1", $target, $project, STYLE_PLAIN);
         } elsif ($line =~ /^(running build command .*+)$/) {
             printLine("$1", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^.+(platform-enabled-swift-args.+):.+$/) {
+            printLine("$1", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /(\w+\.framework.+\.xpc) -> (.+)/) {
+            printLine("$1 -> $2", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /(\w+\.framework.+\.dylib) -> (.+)/) {
+            printLine("$1 -> $2", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /(\w+\.framework.+XPCServices) -> (.+)/) {
+            printLine("$1 -> $2", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^ExtractAppIntentsMetadata/) {
+            printLine("$line", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^.+(appintentsmetadataprocessor)\[\d+:\d+\] (.+)$/) {
+            printLine("$1 $2", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^(Creating.+log definitions.+)$/) {
+            printLine("$1", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^(Generating derived log sources from.+)$/) {
+            printLine("$1", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^(Copying .+ from)\s+(\S+) to (\S+)$/) {
+            my ($source) = basename($2);
+            my ($dest) = basename($3);
+            printLine("$1 $source to $dest", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^(Setting fixed entry values for )(\S+)/) {
+            my ($file) = basename($2);
+            printLine("$1 $file", $target, $project, STYLE_PLAIN);
         } else {
             # This only gets hit if stderr is redirected to stdout.
             if (($line =~ /\*\* BUILD FAILED \*\*/) || ($line =~ /^Build FAILED./)) {
@@ -396,6 +436,14 @@ sub shouldIgnoreLine($$)
     return 1 if $line =~ /^User defaults from command line:/;
     return 1 if $line =~ /^Prepare build/;
     return 1 if $line =~ /^Build system information/;
+    return 1 if $line =~ /^CreateBuildRequest/;
+    return 1 if $line =~ /^SendProjectDescription/;
+    return 1 if $line =~ /^CreateBuildOperation/;
+    return 1 if $line =~ /^ComputeTargetDependencyGraph/;
+    return 1 if $line =~ /^ComputePackagePrebuildTargetDependencyGraph/;
+    return 1 if $line =~ /^GatherProvisioningInputs/;
+    return 1 if $line =~ /^CreateBuildDescription/;
+    return 1 if $line =~ /Xcode.app loaded specs from/;
     return 1 if $line =~ /^note: Planning build/;
     return 1 if $line =~ /^note: Constructing build description/;
     return 1 if $line =~ /^note: Build description (constructed|loaded) in .*/;
@@ -436,6 +484,8 @@ sub shouldIgnoreLine($$)
     return 1 if $line =~ /.* com.apple.actool.compilation-results .*/;
     return 1 if $line =~ /.*\/Assets.car/;
     return 1 if $line =~ /.*\/assetcatalog_generated_info.plist/;
+    return 1 if $line =~ /assetcatalog_output/;
+    return 1 if $line =~ /GeneratedAssetSymbols/;
     return 1 if $line =~ /^mount: .+ failed with/;
     return 1 if $line =~ /^Using .+ production environment.$/;
     return 1 if $line =~ /replacing existing signature$/;
@@ -456,6 +506,10 @@ sub shouldIgnoreLine($$)
     return 1 if $line =~ /^Build description signature:/;
     return 1 if $line =~ /^Build description path:/;
     return 1 if $line =~ /^note: Building targets in dependency order/;
+    return 1 if $line =~ /Xfrontend/;
+    return 1 if $line =~ /SwiftDriver\\ Compilation/;
+    return 1 if $line =~ /SwiftExplicitDependencyGeneratePcm/;
+    return 1 if $line =~ /SwiftExplicitDependencyCompileModuleFromInterface/;
     return 1 if $line =~ /^warning: .*libtool: archive library: .* the table of contents is empty \(no object file members in the library define global symbols\)/;
     # Investigate these in https://bugs.webkit.org/show_bug.cgi?id=245263.
     return 1 if $line =~ /warning: Could not read serialized diagnostics file: error\(\"Failed to open diagnostics file\"\)/;


### PR DESCRIPTION
#### a8768a44da1f29ae9401e1d10163bdad0cab2d4b
<pre>
Update filter-build-webkit to filter out more noise
<a href="https://bugs.webkit.org/show_bug.cgi?id=297484">https://bugs.webkit.org/show_bug.cgi?id=297484</a>
<a href="https://rdar.apple.com/158437549">rdar://158437549</a>

Reviewed by Wenson Hsieh.

Add more filtering logic to `filter-build-webkit` to remove ignorable output from Swift compilation,
and from the scripts that generate loggging and settings code.

Fix generate-derived-log-sources.py and generate-log-declarations.py to not log. If someone cares
about logging in these scripts, they should add a verbose mode.

* Source/WebCore/Scripts/generate-log-declarations.py:
(generate_log_client_declarations_file):
(generate_log_client_virtual_functions):
(main):
* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_messages_file):
(generate_log_client_declarations_file):
(generate_message_receiver_declarations_file):
(generate_message_receiver_implementations_file):
(main):
* Tools/Scripts/filter-build-webkit:
(main):
(shouldIgnoreLine):

Canonical link: <a href="https://commits.webkit.org/298787@main">https://commits.webkit.org/298787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c2a8ed60cf5af89346a012cdf3e6b1065c43ce1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67235 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/308c62b7-040a-40e4-8fed-282f326c3570) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44916 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68eb389f-5164-4b81-b6b8-320c054f67bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69067 "Passed tests") | | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/116037 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66404 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125873 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42385 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43448 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42915 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46254 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/44620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->