### PR TITLE
Simplify JavaScriptEvaluationResult extraction and insertion

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -44,11 +44,57 @@
 
 namespace WebKit {
 
-JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSObjectID root, HashMap<JSObjectID, Value>&& map)
+class JavaScriptEvaluationResult::JSExtractor {
+public:
+    Map takeMap() { return WTFMove(m_map); }
+    JSObjectID addObjectToMap(JSGlobalContextRef, JSValueRef);
+private:
+    Value toValue(JSGlobalContextRef, JSValueRef);
+
+    Map m_map;
+    HashMap<Protected<JSValueRef>, JSObjectID> m_objectsInMap;
+};
+
+class JavaScriptEvaluationResult::JSInserter {
+public:
+    using Dictionaries = Vector<std::pair<ObjectMap, Protected<JSObjectRef>>>;
+    using Arrays = Vector<std::pair<Vector<JSObjectID>, Protected<JSValueRef>>>;
+    JSValueRef toJS(JSGlobalContextRef, Value&&);
+    Dictionaries takeDictionaries() { return WTFMove(m_dictionaries); }
+    Arrays takeArrays() { return WTFMove(m_arrays); }
+private:
+    Dictionaries m_dictionaries;
+    Arrays m_arrays;
+};
+
+class JavaScriptEvaluationResult::APIExtractor {
+public:
+    Map takeMap() { return WTFMove(m_map); }
+    JSObjectID addObjectToMap(API::Object&);
+private:
+    Value toValue(API::Object&);
+
+    HashMap<Ref<API::Object>, JSObjectID> m_objectsInMap;
+    Map m_map;
+};
+
+class JavaScriptEvaluationResult::APIInserter {
+public:
+    using Dictionaries = Vector<std::pair<ObjectMap, Ref<API::Dictionary>>>;
+    using Arrays = Vector<std::pair<Vector<JSObjectID>, Ref<API::Array>>>;
+    RefPtr<API::Object> toAPI(Value&&);
+    Dictionaries takeDictionaries() { return WTFMove(m_dictionaries); }
+    Arrays takeArrays() { return WTFMove(m_arrays); }
+private:
+    Dictionaries m_dictionaries;
+    Arrays m_arrays;
+};
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSObjectID root, Map&& map)
     : m_map(WTFMove(map))
     , m_root(root) { }
 
-RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Value&& root)
+RefPtr<API::Object> JavaScriptEvaluationResult::APIInserter::toAPI(Value&& root)
 {
     return WTF::switchOn(WTFMove(root), [] (EmptyType) -> RefPtr<API::Object> {
         return nullptr;
@@ -64,7 +110,7 @@ RefPtr<API::Object> JavaScriptEvaluationResult::toAPI(Value&& root)
         Ref array = API::Array::create();
         m_arrays.append({ WTFMove(vector), array });
         return { WTFMove(array) };
-    }, [&] (HashMap<JSObjectID, JSObjectID>&& map) -> RefPtr<API::Object> {
+    }, [&] (ObjectMap&& map) -> RefPtr<API::Object> {
         Ref dictionary = API::Dictionary::create();
         m_dictionaries.append({ WTFMove(map), dictionary });
         return { WTFMove(dictionary) };
@@ -102,36 +148,37 @@ static bool isSerializable(API::Object* object)
     }
 }
 
-auto JavaScriptEvaluationResult::toValue(API::Object* object) -> Value
+auto JavaScriptEvaluationResult::APIExtractor::toValue(API::Object& object) -> Value
 {
-    if (!object)
-        return EmptyType::Undefined;
-
-    switch (object->type()) {
+    switch (object.type()) {
     case API::Object::Type::String:
-        return downcast<API::String>(object)->string();
+        return downcast<API::String>(object).string();
     case API::Object::Type::Boolean:
-        return downcast<API::Boolean>(object)->value();
+        return downcast<API::Boolean>(object).value();
     case API::Object::Type::Double:
-        return downcast<API::Double>(object)->value();
+        return downcast<API::Double>(object).value();
     case API::Object::Type::UInt64:
-        return static_cast<double>(downcast<API::UInt64>(object)->value());
+        return static_cast<double>(downcast<API::UInt64>(object).value());
     case API::Object::Type::Int64:
-        return static_cast<double>(downcast<API::Int64>(object)->value());
+        return static_cast<double>(downcast<API::Int64>(object).value());
     case API::Object::Type::JSHandle:
-        return downcast<API::JSHandle>(object)->info();
+        return downcast<API::JSHandle>(object).info();
     case API::Object::Type::SerializedNode:
-        return makeUniqueRef<WebCore::SerializedNode>(downcast<API::SerializedNode>(object)->coreSerializedNode());
+        return makeUniqueRef<WebCore::SerializedNode>(downcast<API::SerializedNode>(object).coreSerializedNode());
     case API::Object::Type::Array: {
         Vector<JSObjectID> vector;
-        for (auto& element : downcast<API::Array>(object)->elements())
-            vector.append(addObjectToMap(element.get()));
+        for (RefPtr element : downcast<API::Array>(object).elements()) {
+            if (element)
+                vector.append(addObjectToMap(*element));
+        }
         return { WTFMove(vector) };
     }
     case API::Object::Type::Dictionary: {
-        HashMap<JSObjectID, JSObjectID> map;
-        for (auto& [key, value] : downcast<API::Dictionary>(object)->map())
-            map.set(addObjectToMap(API::String::create(key).ptr()), addObjectToMap(value.get()));
+        ObjectMap map;
+        for (auto& [key, value] : downcast<API::Dictionary>(object).map()) {
+            if (RefPtr protectedValue = value)
+                map.set(addObjectToMap(API::String::create(key).get()), addObjectToMap(*protectedValue));
+        }
         return { WTFMove(map) };
     }
     default:
@@ -143,82 +190,69 @@ auto JavaScriptEvaluationResult::toValue(API::Object* object) -> Value
 
 std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(API::Object* object)
 {
+    if (!object)
+        return jsUndefined();
     if (!isSerializable(object))
         return std::nullopt;
-    return JavaScriptEvaluationResult(object);
+    APIExtractor extractor;
+    auto root = extractor.addObjectToMap(*object);
+    return JavaScriptEvaluationResult { root, extractor.takeMap() };
 }
 
-JavaScriptEvaluationResult::JavaScriptEvaluationResult(API::Object* object)
-    : m_root(addObjectToMap(object))
+JSObjectID JavaScriptEvaluationResult::APIExtractor::addObjectToMap(API::Object& object)
 {
-}
-
-JSObjectID JavaScriptEvaluationResult::addObjectToMap(API::Object* object)
-{
-    if (!object) {
-        if (!m_nullObjectID) {
-            m_nullObjectID = JSObjectID::generate();
-            m_map.add(*m_nullObjectID, Value { EmptyType::Undefined });
-        }
-        return *m_nullObjectID;
-    }
-
-    auto it = m_apiObjectsInMap.find(object);
-    if (it != m_apiObjectsInMap.end())
+    auto it = m_objectsInMap.find(object);
+    if (it != m_objectsInMap.end())
         return it->value;
 
     auto identifier = JSObjectID::generate();
-    m_apiObjectsInMap.set(object, identifier);
+    m_objectsInMap.set(object, identifier);
     m_map.add(identifier, toValue(object));
     return identifier;
 }
 
 RefPtr<API::Object> JavaScriptEvaluationResult::toAPI()
 {
+    HashMap<JSObjectID, RefPtr<API::Object>> instantiatedObjects;
+    APIInserter inserter;
+
     for (auto&& [identifier, value] : std::exchange(m_map, { }))
-        m_instantiatedObjects.add(identifier, toAPI(WTFMove(value)));
-    for (auto [vector, array] : std::exchange(m_arrays, { })) {
+        instantiatedObjects.add(identifier, inserter.toAPI(WTFMove(value)));
+
+    for (auto [vector, array] : inserter.takeArrays()) {
         for (auto identifier : vector) {
-            if (RefPtr object = m_instantiatedObjects.get(identifier))
+            if (RefPtr object = instantiatedObjects.get(identifier))
                 Ref { array }->append(object.releaseNonNull());
         }
     }
-    for (auto [map, dictionary] : std::exchange(m_dictionaries, { })) {
+
+    for (auto [map, dictionary] : inserter.takeDictionaries()) {
         for (auto [keyIdentifier, valueIdentifier] : map) {
-            RefPtr key = dynamicDowncast<API::String>(m_instantiatedObjects.get(keyIdentifier));
+            RefPtr key = dynamicDowncast<API::String>(instantiatedObjects.get(keyIdentifier));
             if (!key)
                 continue;
-            RefPtr value = m_instantiatedObjects.get(valueIdentifier);
+            RefPtr value = instantiatedObjects.get(valueIdentifier);
             if (!value)
                 continue;
             Ref { dictionary }->add(key->string(), WTFMove(value));
         }
     }
-    return std::exchange(m_instantiatedObjects, { }).take(m_root);
+
+    return std::exchange(instantiatedObjects, { }).take(m_root);
 }
 
-WKRetainPtr<WKTypeRef> JavaScriptEvaluationResult::toWK()
+JSObjectID JavaScriptEvaluationResult::JSExtractor::addObjectToMap(JSGlobalContextRef context, JSValueRef object)
 {
-    return WebKit::toAPI(toAPI().get());
-}
-
-JSObjectID JavaScriptEvaluationResult::addObjectToMap(JSGlobalContextRef context, JSValueRef object)
-{
-    if (!object) {
-        if (!m_nullObjectID) {
-            m_nullObjectID = JSObjectID::generate();
-            m_map.add(*m_nullObjectID, Value { EmptyType::Undefined });
-        }
-        return *m_nullObjectID;
-    }
+    ASSERT(context);
+    ASSERT(object);
 
     Protected<JSValueRef> value(context, object);
-    auto it = m_jsObjectsInMap.find(value);
-    if (it != m_jsObjectsInMap.end())
+    auto it = m_objectsInMap.find(value);
+    if (it != m_objectsInMap.end())
         return it->value;
 
     auto identifier = JSObjectID::generate();
-    m_jsObjectsInMap.set(WTFMove(value), identifier);
+    m_objectsInMap.set(WTFMove(value), identifier);
     m_map.add(identifier, toValue(context, object));
     return identifier;
 }
@@ -240,16 +274,27 @@ static std::optional<std::pair<JSGlobalContextRef, JSValueRef>> roundTripThrough
 
 std::optional<JavaScriptEvaluationResult> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
 {
+    if (!context || !value) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
     JSRetainPtr deserializationContext = API::SerializedScriptValue::deserializationContext();
 
     auto result = roundTripThroughSerializedScriptValue(context, deserializationContext.get(), value);
     if (!result)
         return std::nullopt;
-    return { JavaScriptEvaluationResult { result->first, result->second } };
+
+    if (!result->first || !result->second)
+        return jsUndefined();
+
+    JSExtractor extractor;
+    auto root = extractor.addObjectToMap(result->first, result->second);
+    return JavaScriptEvaluationResult { root, extractor.takeMap() };
 }
 
 // Similar to JSValue's valueToObjectWithoutCopy.
-auto JavaScriptEvaluationResult::toValue(JSGlobalContextRef context, JSValueRef value) -> Value
+auto JavaScriptEvaluationResult::JSExtractor::toValue(JSGlobalContextRef context, JSValueRef value) -> Value
 {
     if (!JSValueIsObject(context, value)) {
         if (JSValueIsBoolean(context, value))
@@ -302,7 +347,7 @@ auto JavaScriptEvaluationResult::toValue(JSGlobalContextRef context, JSValueRef 
 
     JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(context, object);
     size_t length = JSPropertyNameArrayGetCount(names);
-    HashMap<JSObjectID, JSObjectID> map;
+    ObjectMap map;
     for (size_t i = 0; i < length; i++) {
         JSRetainPtr<JSStringRef> key = JSPropertyNameArrayGetNameAtIndex(names, i);
         SUPPRESS_UNCOUNTED_ARG map.add(addObjectToMap(context, JSValueMakeString(context, key.get())), addObjectToMap(context, JSObjectGetPropertyForKey(context, object, JSValueMakeString(context, key.get()), nullptr)));
@@ -311,14 +356,7 @@ auto JavaScriptEvaluationResult::toValue(JSGlobalContextRef context, JSValueRef 
     return { WTFMove(map) };
 }
 
-JavaScriptEvaluationResult::JavaScriptEvaluationResult(JSGlobalContextRef context, JSValueRef value)
-    : m_root(addObjectToMap(context, value))
-{
-    m_jsObjectsInMap.clear();
-    m_nullObjectID = std::nullopt;
-}
-
-JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Value&& root)
+JSValueRef JavaScriptEvaluationResult::JSInserter::toJS(JSGlobalContextRef context, Value&& root)
 {
     auto globalObjectTuple = [] (auto context) {
         auto* lexicalGlobalObject = ::toJS(context);
@@ -348,11 +386,11 @@ JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Value&& 
         return JSObjectMakeDate(context, 1, &argument, 0);
     }, [&] (Vector<JSObjectID>&& vector) -> JSValueRef {
         JSValueRef array = JSObjectMakeArray(context, 0, nullptr, 0);
-        m_jsArrays.append({ WTFMove(vector), Protected<JSValueRef>(context, array) });
+        m_arrays.append({ WTFMove(vector), Protected<JSValueRef>(context, array) });
         return array;
-    }, [&] (HashMap<JSObjectID, JSObjectID>&& map) -> JSValueRef {
+    }, [&] (ObjectMap&& map) -> JSValueRef {
         JSObjectRef dictionary = JSObjectMake(context, 0, 0);
-        m_jsDictionaries.append({ WTFMove(map), Protected<JSObjectRef>(context, dictionary) });
+        m_dictionaries.append({ WTFMove(map), Protected<JSObjectRef>(context, dictionary) });
         return dictionary;
     }, [&] (JSHandleInfo&& info) -> JSValueRef {
         auto [originalDocument, object] = WebCore::WebKitJSHandle::objectForIdentifier(info.identifier);
@@ -370,32 +408,38 @@ JSValueRef JavaScriptEvaluationResult::toJS(JSGlobalContextRef context, Value&& 
 
 Protected<JSValueRef> JavaScriptEvaluationResult::toJS(JSGlobalContextRef context)
 {
+    HashMap<JSObjectID, Protected<JSValueRef>> instantiatedJSObjects;
+    JSInserter inserter;
+
     for (auto&& [identifier, value] : std::exchange(m_map, { }))
-        m_instantiatedJSObjects.add(identifier, Protected<JSValueRef>(context, toJS(context, WTFMove(value))));
-    for (auto& [vector, array] : std::exchange(m_jsArrays, { })) {
+        instantiatedJSObjects.add(identifier, Protected<JSValueRef>(context, inserter.toJS(context, WTFMove(value))));
+
+    for (auto& [vector, array] : inserter.takeArrays()) {
         JSObjectRef jsArray = JSValueToObject(context, array.get(), 0);
         for (size_t index = 0; index < vector.size(); ++index) {
             auto identifier = vector[index];
-            if (Protected<JSValueRef> element = m_instantiatedJSObjects.get(identifier))
+            if (Protected<JSValueRef> element = instantiatedJSObjects.get(identifier))
                 JSObjectSetPropertyAtIndex(context, jsArray, index, element.get(), 0);
         }
     }
-    for (auto& [map, dictionary] : std::exchange(m_jsDictionaries, { })) {
+
+    for (auto& [map, dictionary] : inserter.takeDictionaries()) {
         for (auto [keyIdentifier, valueIdentifier] : map) {
-            Protected<JSValueRef> key = m_instantiatedJSObjects.get(keyIdentifier);
+            Protected<JSValueRef> key = instantiatedJSObjects.get(keyIdentifier);
             if (!key)
                 continue;
             ASSERT(JSValueIsString(context, key.get()));
             SUPPRESS_UNCOUNTED_ARG auto keyString = adopt(JSValueToStringCopy(context, key.get(), nullptr));
             if (!keyString)
                 continue;
-            Protected<JSValueRef> value = m_instantiatedJSObjects.get(valueIdentifier);
+            Protected<JSValueRef> value = instantiatedJSObjects.get(valueIdentifier);
             if (!value)
                 continue;
             SUPPRESS_UNCOUNTED_ARG JSObjectSetProperty(context, dictionary.get(), keyString.get(), value.get(), 0, 0);
         }
     }
-    return std::exchange(m_instantiatedJSObjects, { }).take(m_root);
+
+    return std::exchange(instantiatedJSObjects, { }).take(m_root);
 }
 
 JavaScriptEvaluationResult::JavaScriptEvaluationResult(JavaScriptEvaluationResult&&) = default;
@@ -413,6 +457,14 @@ String JavaScriptEvaluationResult::toString() const
     if (!string)
         return { };
     return *string;
+}
+
+JavaScriptEvaluationResult JavaScriptEvaluationResult::jsUndefined()
+{
+    auto root = JSObjectID::generate();
+    Map map;
+    map.set(root, EmptyType::Undefined);
+    return { root, WTFMove(map) };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/APIScriptMessage.cpp
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.cpp
@@ -44,8 +44,8 @@ ScriptMessage::ScriptMessage(RetainPtr<id>&& body, WebKit::WebPageProxy& page, R
     , m_world(WTFMove(world)) { }
 #endif
 
-ScriptMessage::ScriptMessage(WKRetainPtr<WKTypeRef>&& body, WebKit::WebPageProxy& page, Ref<API::FrameInfo>&& frame, const WTF::String& name, Ref<API::ContentWorld>&& world)
-    : m_wkBody(WTFMove(body))
+ScriptMessage::ScriptMessage(RefPtr<API::Object>&& body, WebKit::WebPageProxy& page, Ref<API::FrameInfo>&& frame, const WTF::String& name, Ref<API::ContentWorld>&& world)
+    : m_apiBody(WTFMove(body))
     , m_page(page)
     , m_frame(WTFMove(frame))
     , m_name(name)

--- a/Source/WebKit/UIProcess/API/APIScriptMessage.h
+++ b/Source/WebKit/UIProcess/API/APIScriptMessage.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "APIObject.h"
-#include "WKRetainPtr.h"
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,20 +52,20 @@ public:
 #if PLATFORM(COCOA)
     const RetainPtr<id>& body() const { return m_body; }
 #endif
-    WKTypeRef wkBody() const { return m_wkBody.get(); }
+    API::Object* apiBody() const { return m_apiBody.get(); }
     WebKit::WebPageProxy* page() const;
     API::FrameInfo& frame() const { return m_frame.get(); }
     const WTF::String& name() const { return m_name; }
     API::ContentWorld& world() const { return m_world.get(); }
 
 private:
-    ScriptMessage(WKRetainPtr<WKTypeRef>&&, WebKit::WebPageProxy&, Ref<API::FrameInfo>&&, const WTF::String&, Ref<API::ContentWorld>&&);
+    ScriptMessage(RefPtr<API::Object>&&, WebKit::WebPageProxy&, Ref<API::FrameInfo>&&, const WTF::String&, Ref<API::ContentWorld>&&);
 #if PLATFORM(COCOA)
     ScriptMessage(RetainPtr<id>&&, WebKit::WebPageProxy&, Ref<API::FrameInfo>&&, const WTF::String&, Ref<API::ContentWorld>&&);
 
     const RetainPtr<id> m_body;
 #endif
-    const WKRetainPtr<WKTypeRef> m_wkBody;
+    const RefPtr<API::Object> m_apiBody;
     const WeakPtr<WebKit::WebPageProxy> m_page;
     const Ref<API::FrameInfo> m_frame;
     const WTF::String m_name;

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -2774,7 +2774,7 @@ void WKPageEvaluateJavaScriptInFrame(WKPageRef pageRef, WKFrameInfoRef frame, WK
         if (!callback)
             return;
         if (result)
-            callback(result->toWK().get(), nullptr, context);
+            callback(toAPI(result->toAPI().get()), nullptr, context);
         else
             callback(nullptr, nullptr, context);
     });
@@ -2807,7 +2807,7 @@ void WKPageCallAsyncJavaScript(WKPageRef page, WKStringRef script, WKDictionaryR
         if (!callback)
             return;
         if (result)
-            callback(result->toWK().get(), nullptr, context);
+            callback(toAPI(result->toAPI().get()), nullptr, context);
         else
             callback(nullptr, nullptr, context);
     });

--- a/Source/WebKit/UIProcess/API/C/WKScriptMessageRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKScriptMessageRef.cpp
@@ -37,7 +37,7 @@ WKTypeID WKScriptMessageGetTypeID()
 
 WKTypeRef WKScriptMessageGetBody(WKScriptMessageRef message)
 {
-    return WebKit::toImpl(message)->wkBody();
+    return WebKit::toAPI(WebKit::toImpl(message)->apiBody());
 }
 
 WKFrameInfoRef WKScriptMessageGetFrameInfo(WKScriptMessageRef message)

--- a/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
@@ -90,7 +90,7 @@ public:
 private:
     void didPostMessage(WebPageProxy& page, FrameInfoData&& frameInfo, API::ContentWorld&, JavaScriptEvaluationResult&& result, CompletionHandler<void(Expected<JavaScriptEvaluationResult, String>&&)>&& completionHandler) override
     {
-        Ref message = API::ScriptMessage::create(result.toWK(), page, API::FrameInfo::create(WTFMove(frameInfo), &page), m_name, API::ContentWorld::pageContentWorldSingleton());
+        Ref message = API::ScriptMessage::create(result.toAPI(), page, API::FrameInfo::create(WTFMove(frameInfo), &page), m_name, API::ContentWorld::pageContentWorldSingleton());
         Ref listener = API::CompletionListener::create([completionHandler = WTFMove(completionHandler)] (WKTypeRef reply) mutable {
             if (auto result = JavaScriptEvaluationResult::extract(toProtectedImpl(reply).get()))
                 return completionHandler(WTFMove(*result));


### PR DESCRIPTION
#### 2abf1685b31248d3c8f90448c83cbda3ddd718a2
<pre>
Simplify JavaScriptEvaluationResult extraction and insertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=297490">https://bugs.webkit.org/show_bug.cgi?id=297490</a>
<a href="https://rdar.apple.com/158441459">rdar://158441459</a>

Reviewed by Sihui Liu.

JavaScriptEvaluationResult is an IPC-friendly representation of serializable JavaScript
values that can be extracted from and inserted into four different API environments:
JavaScript, GLib, ObjC, and WebKit&apos;s API abstractions.  This simplifies and cleans up
those transitions.  Not only does it reduce sizeof(JavaScriptEvaluationResult) and move
the structures associated with transitions onto the stack with the correct lifetimes,
but it also cleans up layering a bit and isolates the handling of null in those environments,
removing the need for m_nullObjectID and replacing it with JavaScriptEvaluationResult::jsUndefined.

This is a necessary step before replacing roundTripThroughSerializedScriptValue with
a faster solution that will also be able to handle JSWebKitJSHandle and JSWebKitSerializedNode
objects inside arrays and maps.

This functionality is well covered by many tests, including TestWebKitAPI.EvaluateJavaScript.ReturnTypes,
TestWebKitAPI.WKWebView.EvaluateJavaScriptErrorCases, the EvaluateJavaScript API tests, and many others.

* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::APIInsertionContext::toAPI):
(WebKit::JavaScriptEvaluationResult::APIExtractionContext::toValue):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::JavaScriptEvaluationResult::APIExtractionContext::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::toAPI):
(WebKit::JavaScriptEvaluationResult::JSExtractionContext::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::JSExtractionContext::toValue):
(WebKit::JavaScriptEvaluationResult::JSInsertionContext::toJS):
(WebKit::JavaScriptEvaluationResult::toJS):
(WebKit::JavaScriptEvaluationResult::jsUndefined):
(WebKit::JavaScriptEvaluationResult::toValue): Deleted.
(WebKit::JavaScriptEvaluationResult::addObjectToMap): Deleted.
(WebKit::JavaScriptEvaluationResult::toWK): Deleted.
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
(WebKit::JavaScriptEvaluationResult::map const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCInsertionContext::toID):
(WebKit::JavaScriptEvaluationResult::toID):
(WebKit::JavaScriptEvaluationResult::ObjCExtractionContext::toValue):
(WebKit::JavaScriptEvaluationResult::ObjCExtractionContext::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::JavaScriptEvaluationResult::toValue): Deleted.
(WebKit::JavaScriptEvaluationResult::addObjectToMap): Deleted.
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult): Deleted.
* Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp:
(WebKit::JavaScriptEvaluationResult::GLibExtractionContext::addObjectToMap):
(WebKit::JavaScriptEvaluationResult::GLibExtractionContext::toValue):
(WebKit::JavaScriptEvaluationResult::extract):
(WebKit::JavaScriptEvaluationResult::addObjectToMap): Deleted.
(WebKit::JavaScriptEvaluationResult::toValue): Deleted.
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult): Deleted.
* Source/WebKit/UIProcess/API/APIScriptMessage.cpp:
(API::ScriptMessage::ScriptMessage):
* Source/WebKit/UIProcess/API/APIScriptMessage.h:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageEvaluateJavaScriptInFrame):
(WKPageCallAsyncJavaScript):
* Source/WebKit/UIProcess/API/C/WKScriptMessageRef.cpp:
(WKScriptMessageGetBody):
* Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp:

Canonical link: <a href="https://commits.webkit.org/298845@main">https://commits.webkit.org/298845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f56703131f4e5144b1e33886621bdf3c511fdfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67440 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1dacf6d-a086-4e8c-a887-a03d21c8ed60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88737 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e2d514b7-53ff-4a95-b666-942b841d655f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69197 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28739 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66591 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126062 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97406 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97204 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42533 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20472 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39766 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18655 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49231 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43102 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->