### PR TITLE
Crash in WebKit::CoreIPCError::toID()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8014,3 +8014,5 @@ imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/video-tag.h
 imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/audio-tag.https.html
 imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/beacon.https.html
 imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/video-tag.https.html
+
+webkit.org/b/293973 [ Debug ] http/tests/ipc/gpu-load-error-empty-user-info-crssh.html [ Skip ]

--- a/LayoutTests/http/tests/ipc/gpu-load-error-empty-user-info-crssh-expected.txt
+++ b/LayoutTests/http/tests/ipc/gpu-load-error-empty-user-info-crssh-expected.txt
@@ -1,0 +1,1 @@
+This test passes if Webkit does not crash

--- a/LayoutTests/http/tests/ipc/gpu-load-error-empty-user-info-crssh.html
+++ b/LayoutTests/http/tests/ipc/gpu-load-error-empty-user-info-crssh.html
@@ -1,0 +1,19 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    if (window.IPC) {
+        import('./coreipc.js').then(({
+            CoreIPC
+        }) => {
+            CoreIPC.GPU.RemoteMediaResourceManager.LoadFailed(0, {identifier:262145, error:{ipcData:{optionalValue:{type:4, nsError:{optionalValue:{wrapper:{domain:location.href, code:523986010202, userInfo:{vector:{}},underlyingError:{optionalValue:{domain:'A', code:29, userInfo:{vector:{}}, underlyingError:{}}}}}}, isSanitized:false}}}});
+        });
+    }
+
+    function callDone() {
+        window.testRunner?.notifyDone();
+    }
+</script>
+<body onload="setTimeout(callDone, 200)">
+    <p>This test passes if Webkit does not crash</p>
+</body>

--- a/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCError.mm
@@ -74,7 +74,11 @@ RetainPtr<id> CoreIPCError::toID() const
         if (!underlyingNSError)
             return nil;
 
-        auto mutableUserInfo = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, CFDictionaryGetCount(m_userInfo.get()) + 1, m_userInfo.get()));
+        RetainPtr<CFMutableDictionaryRef> mutableUserInfo;
+        if (!m_userInfo)
+            mutableUserInfo = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, NULL, NULL));
+        else
+            mutableUserInfo = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, CFDictionaryGetCount(m_userInfo.get()) + 1, m_userInfo.get()));
         CFDictionarySetValue(mutableUserInfo.get(), (__bridge CFStringRef)NSUnderlyingErrorKey, (__bridge CFTypeRef)underlyingNSError.get());
         return adoptNS([[NSError alloc] initWithDomain:m_domain.createNSString().get() code:m_code userInfo:(__bridge NSDictionary *)mutableUserInfo.get()]);
     }


### PR DESCRIPTION
#### bc87370c74d0f50dcd8a0d86677551cc754cc03b
<pre>
Crash in WebKit::CoreIPCError::toID()
<a href="https://bugs.webkit.org/show_bug.cgi?id=293973">https://bugs.webkit.org/show_bug.cgi?id=293973</a>

Reviewed by Ryosuke Niwa.

User info can be empty like in the testcase, in that case m_userInfo becomes a null pointer.
CFDictionaryGetCount does not deal well with null pointers, so for this case simply create
an empty dictionary.

* LayoutTests/http/tests/ipc/gpu-load-error-empty-user-info-crssh-expected.txt: Added.
* LayoutTests/http/tests/ipc/gpu-load-error-empty-user-info-crssh.html: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCError.mm:
(WebKit::CoreIPCError::toID const):

Originally-landed-as: 292955.12@webkit-2025.4-embargoed (7ba67b380dff). <a href="https://rdar.apple.com/158443174">rdar://158443174</a>
Canonical link: <a href="https://commits.webkit.org/298806@main">https://commits.webkit.org/298806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce7e9141ad56dcad5ff6dbe26c9bc4eab9c6ddb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122758 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67303 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4d5418c-d9bd-4650-bde6-02ca96140688) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/571cbf6d-5af7-4f63-ba6d-95c8e53807ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69082 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22796 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66425 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125894 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43583 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97282 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100893 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97076 "Found 10 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/preferred-size, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42402 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39545 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18639 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49064 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->