### PR TITLE
Cross-origin navigations should not preserve storage access

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -464,7 +464,7 @@ void WebLocalFrameLoaderClient::dispatchWillChangeDocument(const URL& currentURL
     if (!webPage)
         return;
 
-    if (m_frameSpecificStorageAccessIdentifier && !WebCore::areRegistrableDomainsEqual(currentURL, newURL)) {
+    if (m_frameSpecificStorageAccessIdentifier && !SecurityOrigin::create(currentURL)->isSameOriginAs(SecurityOrigin::create(newURL))) {
         WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame(
             m_frameSpecificStorageAccessIdentifier->frameID, m_frameSpecificStorageAccessIdentifier->pageID), 0);
         m_frameSpecificStorageAccessIdentifier = std::nullopt;


### PR DESCRIPTION
#### 3380fa2417647011479501b69e8f16823048dcde
<pre>
Cross-origin navigations should not preserve storage access
<a href="https://bugs.webkit.org/show_bug.cgi?id=297493">https://bugs.webkit.org/show_bug.cgi?id=297493</a>
<a href="https://rdar.apple.com/158446697">rdar://158446697</a>

Reviewed by Matthew Finkel.

We already had this check, but it was checking domain, not origin. Change it to origin to match the
specification.

<a href="https://privacycg.github.io/storage-access/#navigation">https://privacycg.github.io/storage-access/#navigation</a>

This progresses the following WPTs, though we won’t have CI coverage because we don’t have a local
DNS resolver:
imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation-relax.sub.https.window.html
imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.html

* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchWillChangeDocument):

Canonical link: <a href="https://commits.webkit.org/298820@main">https://commits.webkit.org/298820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49b5c4d6b95cea8054dce97f0bf9e402dd2c1684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67269 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8ddb494-323c-4897-ad54-ec4c19c40d31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88621 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43030 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbbde470-2dce-4a1f-801a-5e4350d3afcc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69092 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28609 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125906 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43595 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32740 "Build was cancelled. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (exception)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100885 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97082 "Found 10 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/preferred-size, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39557 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43481 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49156 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42948 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->