### PR TITLE
[css-anchor-position-1] height in container query fails to cycle back to trigger next fallback

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-container-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-container-query-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Size container query responds to fallback width
-FAIL Size container query responds to fallback width and applies height to not fit the first fallback assert_equals: expected "0px" but got "100px"
+PASS Size container query responds to fallback width and applies height to not fit the first fallback
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1329,7 +1329,7 @@ auto TreeResolver::updateStateForQueryContainer(Element& element, const RenderSt
     if (!style)
         return LayoutInterleavingAction::None;
 
-    if (m_queryContainerStates.contains(element))
+    if (m_queryContainerStates.get(element).invalidated)
         return LayoutInterleavingAction::None;
 
     auto* existingStyle = element.renderOrDisplayContentsStyle();
@@ -1637,8 +1637,22 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
 
     sortPositionOptionsIfNeeded(options, styleable);
 
+    auto invalidateQueryContainer = [&] () {
+        // Pseudo-elements can't be query containers, so skip invalidating for pseudo-elements.
+        if (styleable.pseudoElementIdentifier)
+            return;
+
+        auto iter = m_queryContainerStates.find(styleable.element);
+        if (iter == m_queryContainerStates.end())
+            return;
+
+        iter->value.invalidated = false;
+    };
+
     auto renderer = dynamicDowncast<RenderBox>(styleable.renderer());
     if (!renderer) {
+        invalidateQueryContainer();
+
         options.chosen = true;
         return ResolvedStyle { RenderStyle::clonePtr(options.originalStyle()) };
     }
@@ -1646,6 +1660,8 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
     // On the first try, we force apply the original style (which _could_ be different from
     // the existing style, since the original style might have a fallback applied to it)
     if (options.isFirstTry) {
+        invalidateQueryContainer();
+
         options.isFirstTry = false;
         options.index = 0;
         return ResolvedStyle { options.currentOption() };
@@ -1669,6 +1685,8 @@ std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleab
 
     // Next option to try if this doesn't work.
     ++options.index;
+
+    invalidateQueryContainer();
 
     if (options.index >= options.optionStyles.size()) {
         // None of the options worked, return back to the original.


### PR DESCRIPTION
#### 5912cc91b207c62ed94909aba62726ff89a35caf
<pre>
[css-anchor-position-1] height in container query fails to cycle back to trigger next fallback
<a href="https://rdar.apple.com/154355605">rdar://154355605</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295014">https://bugs.webkit.org/show_bug.cgi?id=295014</a>

Reviewed by Antti Koivisto.

When trying a position-try fallback, we forget to reset the query container
state, so the style resolution machinery don&apos;t re-evaluate container queries
after the new fallback style is applied.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-container-query-expected.txt:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateStateForQueryContainer):
(WebCore::Style::TreeResolver::tryChoosePositionOption):

Canonical link: <a href="https://commits.webkit.org/298999@main">https://commits.webkit.org/298999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/685d93a57440488d7945aaa2dfb0e156e81d4d08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69366 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3f39d83-5065-4f27-9176-9d3e3c541492) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89070 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43737 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4141ede-5b16-474f-b4b9-be9086c32735) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67151 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126599 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97739 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97533 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42892 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49808 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43605 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46950 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->