### PR TITLE
Resync `css-tables` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-limited-quirks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-limited-quirks-expected.txt
@@ -10,16 +10,12 @@ decoration
 The collapsing table quirk does NOT apply to limited-quirks mode
 The table cell width calculation quirk does NOT apply to limited-quirks mode
 
-The "let cell grows downward be false" quirk does NOT apply to limited-quirks mode
-208 height
 
 PASS decoration propagates into table
-PASS rowspan can be zero
 PASS table 1
 PASS table 2
 PASS table 3
 PASS table 4
 PASS table 5
 PASS table 6
-PASS table 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-limited-quirks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-limited-quirks.html
@@ -65,14 +65,6 @@
   <td data-expected-width=184><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"></td>
 </table>
 
-<p><a href="https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows">The "let <i>cell grows downward</i> be false" quirk</a> does NOT apply to limited-quirks mode</p>
-<table>
-  <tr style="height: 100px">
-    <td id="rowspan" rowspan="0" data-expected-height=208>208 height</td>
-  </tr>
-  <tr style="height: 100px"></tr>
-</table>
-
 <script>
   let pngSrc="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACWAQMAAAChElVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABlBMVEUAgAD///8UPy9PAAAAAWJLR0QB/wIt3gAAAAd0SU1FB+MBDwkdA1Cz/EMAAAAbSURBVEjH7cGBAAAAAMOg+VPf4ARVAQAAAM8ADzwAAeM8wQsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDEtMTVUMTc6Mjk6MDMtMDg6MDCYDy9IAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAxLTE1VDE3OjI5OjAzLTA4OjAw6VKX9AAAAABJRU5ErkJggg=="
 ;
@@ -82,8 +74,5 @@
   test(_ => {
     assert_equals(window.getComputedStyle(document.querySelector("#italic")).fontStyle, "italic");
   }, "decoration propagates into table");
-  test(_ => {
-    assert_equals(document.querySelector("#rowspan").rowSpan, 0);
-  }, "rowspan can be zero");
   document.fonts.ready.then(() => checkLayout("table"));
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks-expected.txt
@@ -12,17 +12,12 @@ The collapsing table quirk
 Chrome Legacy/Edge/Safari ignore the quirk, FF does not. Proposal: deprecate the quirk
 The table cell width calculation quirk
 
-The "let cell grows downward be false" quirk
-Chrome LayoutNG and Safari ignore the quirk, FF does not. Proposal: deprecate the quirk
-208 height
 
 PASS decoration does not propagate into table
-PASS rowspan can be zero
 PASS table 1
 PASS table 2
 PASS table 3
 PASS table 4
 PASS table 5
 PASS table 6
-PASS table 7
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks.html
@@ -63,15 +63,6 @@
   <td data-expected-width=290><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"><img style="width:50px;height:20px"></td>
 </table>
 
-<p><a href="https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows">The "let <i>cell grows downward</i> be false" quirk</a></p>
-<p class="error">Chrome LayoutNG and Safari ignore the quirk, FF does not. <b>Proposal: deprecate the quirk</b></p>
-<table>
-  <tr style="height: 100px">
-    <td id="rowspan" rowspan="0" data-expected-height=208>208 height</td>
-  </tr>
-  <tr style="height: 100px"></tr>
-</table>
-
 <script>
   let pngSrc="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACWAQMAAAChElVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABlBMVEUAgAD///8UPy9PAAAAAWJLR0QB/wIt3gAAAAd0SU1FB+MBDwkdA1Cz/EMAAAAbSURBVEjH7cGBAAAAAMOg+VPf4ARVAQAAAM8ADzwAAeM8wQsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDEtMTVUMTc6Mjk6MDMtMDg6MDCYDy9IAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAxLTE1VDE3OjI5OjAzLTA4OjAw6VKX9AAAAABJRU5ErkJggg=="
 ;
@@ -81,8 +72,5 @@
   test(_ => {
     assert_equals(window.getComputedStyle(document.querySelector("#notitalic")).fontStyle, "normal");
   }, "decoration does not propagate into table");
-  test(_ => {
-    assert_equals(document.querySelector("#rowspan").rowSpan, 0);
-  }, "rowspan can be zero");
   document.fonts.ready.then(() => checkLayout("table"));
 </script>

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks-expected.txt
@@ -12,17 +12,12 @@ The collapsing table quirk
 Chrome Legacy/Edge/Safari ignore the quirk, FF does not. Proposal: deprecate the quirk
 The table cell width calculation quirk
 
-The "let cell grows downward be false" quirk
-Chrome LayoutNG and Safari ignore the quirk, FF does not. Proposal: deprecate the quirk
-208 height
 
 PASS decoration does not propagate into table
-PASS rowspan can be zero
 PASS table 1
 PASS table 2
 PASS table 3
 PASS table 4
 PASS table 5
 PASS table 6
-PASS table 7
 


### PR DESCRIPTION
#### e670997519189a6fdd71a3ee4685c959558e806c
<pre>
Resync `css-tables` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=297495">https://bugs.webkit.org/show_bug.cgi?id=297495</a>
<a href="https://rdar.apple.com/158448810">rdar://158448810</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/2d623bd1ab81ec5cc998ffd485860bdc14a61272">https://github.com/web-platform-tests/wpt/commit/2d623bd1ab81ec5cc998ffd485860bdc14a61272</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-limited-quirks-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-limited-quirks.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks.html:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/table-quirks-expected.txt: Platform Specific Baseline

Canonical link: <a href="https://commits.webkit.org/298808@main">https://commits.webkit.org/298808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83b334364072cce84ff24ad16bfc9e467ca7c389

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67312 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8e19ec8-47b4-4161-b3e6-a64d59ad9c43) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/44988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88643 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c114e479-2a94-457c-9397-bae17025d868) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69114 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125943 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43632 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/32754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97312 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/43996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100912 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97108 "Found 10 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/preferred-size, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42432 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20363 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39603 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43518 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/42985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->