### PR TITLE
[iOS] Adopt GCMouseInput.mouseMovedHandler to generate mousemove events when pointer lock is engaged

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
@@ -29,6 +29,7 @@
 
 #import "GameControllerSPI.h"
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebCore, GameController)
 SOFT_LINK_CLASS_FOR_HEADER(WebCore, GCController)
@@ -83,6 +84,13 @@ SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, GameController, ControllerClassForService
 #import <GameController/GCEventInteraction.h>
 
 SOFT_LINK_CLASS_FOR_HEADER(WebCore, GCEventInteraction)
+#endif
+
+#if HAVE(UIKIT_WITH_MOUSE_SUPPORT) && ENABLE(POINTER_LOCK)
+SOFT_LINK_CLASS_FOR_HEADER(WebCore, GCMouse)
+SOFT_LINK_CONSTANT_FOR_HEADER(WebCore, GameController, GCMouseDidStopBeingCurrentNotification, NSString *)
+
+SPECIALIZE_OBJC_TYPE_TRAITS(GCMouse, WebCore::getGCMouseClass())
 #endif
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/GameControllerSoftLinkAdditions.h>)

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
@@ -67,6 +67,11 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, GameController, ControllerClassForService
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL_WITH_EXPORT(WebCore, GameController, GCEventInteraction, WEBCORE_EXPORT)
 #endif
 
+#if HAVE(UIKIT_WITH_MOUSE_SUPPORT) && ENABLE(POINTER_LOCK)
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(WebCore, GameController, GCMouse, WEBCORE_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(WebCore, GameController, GCMouseDidStopBeingCurrentNotification, NSString *, WEBCORE_EXPORT)
+#endif
+
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/GameControllerSoftLinkAdditions.mm>)
 #import <WebKitAdditions/GameControllerSoftLinkAdditions.mm>
 #endif

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -138,6 +138,7 @@ extern "C" {
     M(PageLoadObserver) \
     M(Pasteboard) \
     M(PerformanceLogging) \
+    M(PointerLock) \
     M(Plugins) \
     M(Printing) \
     M(PrivateClickMeasurement) \

--- a/Source/WebKit/Shared/ios/NativeWebMouseEventIOS.mm
+++ b/Source/WebKit/Shared/ios/NativeWebMouseEventIOS.mm
@@ -39,12 +39,12 @@ NativeWebMouseEvent::NativeWebMouseEvent(::WebEvent *event)
 }
 
 NativeWebMouseEvent::NativeWebMouseEvent(WebEventType type, WebMouseEventButton button, unsigned short buttons, const WebCore::DoublePoint& position, const WebCore::DoublePoint& globalPosition, float deltaX, float deltaY, float deltaZ, int clickCount, OptionSet<WebEventModifier> modifiers, WallTime timestamp, double force, GestureWasCancelled gestureWasCancelled, const String& pointerType)
-    : WebMouseEvent({ type, modifiers, timestamp }, button, buttons, position, globalPosition, deltaX, deltaY, deltaZ, clickCount, force, WebMouseEventSyntheticClickType::NoTap, WebCore::mousePointerID, pointerType, gestureWasCancelled)
+    : WebMouseEvent({ type, modifiers, timestamp }, button, buttons, position, globalPosition, deltaX, deltaY, deltaZ, clickCount, force, WebMouseEventSyntheticClickType::NoTap, WebCore::mousePointerID, pointerType, gestureWasCancelled, { deltaX, deltaY })
 {
 }
 
 NativeWebMouseEvent::NativeWebMouseEvent(const NativeWebMouseEvent& otherEvent, const WebCore::DoublePoint& position, const WebCore::DoublePoint& globalPosition, float deltaX, float deltaY, float deltaZ)
-    : WebMouseEvent({ otherEvent.type(), otherEvent.modifiers(), otherEvent.timestamp() }, otherEvent.button(), otherEvent.buttons(), position, globalPosition, deltaX, deltaY, deltaZ, otherEvent.clickCount(), otherEvent.force(), otherEvent.syntheticClickType(), otherEvent.pointerId(), otherEvent.pointerType(), otherEvent.gestureWasCancelled())
+    : WebMouseEvent({ otherEvent.type(), otherEvent.modifiers(), otherEvent.timestamp() }, otherEvent.button(), otherEvent.buttons(), position, globalPosition, deltaX, deltaY, deltaZ, otherEvent.clickCount(), otherEvent.force(), otherEvent.syntheticClickType(), otherEvent.pointerId(), otherEvent.pointerType(), otherEvent.gestureWasCancelled(), { deltaX, deltaY })
 {
 }
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -833,6 +833,11 @@ public:
     virtual void setURLIsPictureInPictureForScreenTime(bool) { };
     virtual void setURLIsPlayingVideoForScreenTime(bool) { };
 #endif
+
+#if ENABLE(POINTER_LOCK)
+    virtual void beginPointerLockMouseTracking() { }
+    virtual void endPointerLockMouseTracking() { }
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1877,10 +1877,6 @@ public:
     void resumeAllMediaPlayback(CompletionHandler<void()>&&);
     void requestMediaPlaybackState(CompletionHandler<void(MediaPlaybackState)>&&);
 
-#if ENABLE(POINTER_LOCK)
-    void requestPointerUnlock(CompletionHandler<void(bool)>&&);
-#endif
-
     void setSuppressVisibilityUpdates(bool flag);
     bool suppressVisibilityUpdates() { return m_suppressVisibilityUpdates; }
 
@@ -2839,6 +2835,9 @@ private:
     void didAllowPointerLock(CompletionHandler<void(bool)>&&);
     void didDenyPointerLock(CompletionHandler<void(bool)>&&);
     void requestPointerLock(IPC::Connection&, CompletionHandler<void(bool)>&&);
+    void requestPointerUnlock(CompletionHandler<void(bool)>&&);
+    void platformLockPointer();
+    void platformUnlockPointer();
 #endif
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -374,6 +374,11 @@ private:
 
     void scheduleVisibleContentRectUpdate() final;
 
+#if ENABLE(POINTER_LOCK)
+    void beginPointerLockMouseTracking() final;
+    void endPointerLockMouseTracking() final;
+#endif
+
     RetainPtr<WKContentView> contentView() const { return m_contentView.get(); }
 
     WeakObjCPtr<WKContentView> m_contentView;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1281,6 +1281,20 @@ UIViewController *PageClientImpl::presentingViewController() const
     return nil;
 }
 
+#if ENABLE(POINTER_LOCK)
+
+void PageClientImpl::beginPointerLockMouseTracking()
+{
+    [contentView() _beginPointerLockMouseTracking];
+}
+
+void PageClientImpl::endPointerLockMouseTracking()
+{
+    [contentView() _endPointerLockMouseTracking];
+}
+
+#endif
+
 FloatRect PageClientImpl::rootViewToWebView(const FloatRect& rect) const
 {
     return [webView() convertRect:rect fromView:contentView().get()];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -1079,4 +1079,11 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 @end
 #endif
 
+#if ENABLE(POINTER_LOCK)
+@interface WKContentView (PointerLock)
+- (void)_beginPointerLockMouseTracking;
+- (void)_endPointerLockMouseTracking;
+@end
+#endif
+
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12142,6 +12142,16 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
     _page->handleMouseEvent(event);
 }
 
+#if ENABLE(POINTER_LOCK)
+- (void)mouseInteractionDidLoseMouseDeviceDuringPointerLock:(WKMouseInteraction *)interaction
+{
+    if (!_page->hasRunningProcess())
+        return;
+
+    _page->resetPointerLockState();
+}
+#endif
+
 - (void)_configureMouseGestureRecognizer
 {
     [_mouseInteraction setEnabled:self.shouldUseMouseGestureRecognizer];
@@ -14283,6 +14293,28 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
 #endif // HAVE(UI_CONVERSATION_CONTEXT)
 
 @end
+
+#if ENABLE(POINTER_LOCK)
+
+@implementation WKContentView (PointerLock)
+
+- (void)_beginPointerLockMouseTracking
+{
+#if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
+    [_mouseInteraction beginPointerLockMouseTracking];
+#endif
+}
+
+- (void)_endPointerLockMouseTracking
+{
+#if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
+    [_mouseInteraction endPointerLockMouseTracking];
+#endif
+}
+
+@end
+
+#endif // ENABLE(POINTER_LOCK)
 
 @implementation WKContentView (WKTesting)
 

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.h
@@ -34,6 +34,9 @@
 
 @protocol WKMouseInteractionDelegate<NSObject>
 - (void)mouseInteraction:(WKMouseInteraction *)interaction changedWithEvent:(const WebKit::NativeWebMouseEvent&)event;
+#if ENABLE(POINTER_LOCK)
+- (void)mouseInteractionDidLoseMouseDeviceDuringPointerLock:(WKMouseInteraction *)interaction;
+#endif
 @end
 
 @interface WKMouseInteraction : NSObject<UIInteraction>
@@ -42,6 +45,11 @@
 
 - (CGPoint)locationInView:(UIView *)view;
 - (BOOL)hasGesture:(UIGestureRecognizer *)gesture;
+
+#if ENABLE(POINTER_LOCK)
+- (void)beginPointerLockMouseTracking;
+- (void)endPointerLockMouseTracking;
+#endif
 
 @property (nonatomic, getter=isEnabled) BOOL enabled;
 @property (nonatomic, readonly, weak) id <WKMouseInteractionDelegate> delegate;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1876,6 +1876,21 @@ void WebPageProxy::didEndContextMenuInteraction()
 
 #endif // USE(UICONTEXTMENU)
 
+#if ENABLE(POINTER_LOCK)
+
+void WebPageProxy::platformLockPointer()
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->beginPointerLockMouseTracking();
+}
+
+void WebPageProxy::platformUnlockPointer()
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->endPointerLockMouseTracking();
+}
+
+#endif
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
 bool WebPageProxy::hasMouseDevice()

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -69,6 +69,7 @@
 #import <WebCore/UserAgent.h>
 #import <WebCore/ValidationBubble.h>
 #import <mach-o/dyld.h>
+#import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/WritingToolsSPI.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <pal/spi/mac/NSMenuSPI.h>
@@ -1066,6 +1067,22 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
 
     return WebContentMode::Recommended;
 }
+
+#if ENABLE(POINTER_LOCK)
+
+void WebPageProxy::platformLockPointer()
+{
+    CGDisplayHideCursor(CGMainDisplayID());
+    CGAssociateMouseAndMouseCursorPosition(false);
+}
+
+void WebPageProxy::platformUnlockPointer()
+{
+    CGAssociateMouseAndMouseCursorPosition(true);
+    CGDisplayShowCursor(CGMainDisplayID());
+}
+
+#endif
 
 } // namespace WebKit
 

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
@@ -133,9 +133,15 @@ WK_WRITING_TOOLS_UI_LDFLAGS_maccatalyst_MACOS_SINCE_1500 = -weak_framework Writi
 WK_WRITING_TOOLS_UI_LDFLAGS_macosx = $(WK_WRITING_TOOLS_UI_LDFLAGS$(WK_MACOS_1500));
 WK_WRITING_TOOLS_UI_LDFLAGS_MACOS_SINCE_1500 = -weak_framework WritingToolsUI;
 
+WK_GAMECONTROLLER_LDFLAGS = $(WK_GAMECONTROLLER_LDFLAGS_$(WK_PLATFORM_NAME))
+WK_GAMECONTROLLER_LDFLAGS_iphoneos = -framework GameController
+WK_GAMECONTROLLER_LDFLAGS_iphonesimulator = -framework GameController
+WK_GAMECONTROLLER_LDFLAGS_xros = -framework GameController
+WK_GAMECONTROLLER_LDFLAGS_xrsimulator = -framework GameController
+
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) $(GTEST_LDFLAGS) -lxml2 -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices -framework CFNetwork -framework CoreGraphics -framework CoreLocation -framework CoreText -framework IOKit -lboringssl -licucore -framework LocalAuthentication -framework QuartzCore -framework Security -framework AVKit $(WK_BROWSERENGINEKIT_LDFLAGS) $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(WK_WRITING_TOOLS_LDFLAGS) $(WK_WRITING_TOOLS_UI_LDFLAGS) $(OTHER_LDFLAGS_DELAY_INIT) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH)) $(OTHER_LDFLAGS_ENTITLEMENTS);
+OTHER_LDFLAGS = $(inherited) $(GTEST_LDFLAGS) -lxml2 -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices -framework CFNetwork -framework CoreGraphics -framework CoreLocation -framework CoreText -framework IOKit -lboringssl -licucore -framework LocalAuthentication -framework QuartzCore -framework Security -framework AVKit $(WK_BROWSERENGINEKIT_LDFLAGS) $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(WK_WRITING_TOOLS_LDFLAGS) $(WK_WRITING_TOOLS_UI_LDFLAGS) $(WK_GAMECONTROLLER_LDFLAGS) $(OTHER_LDFLAGS_DELAY_INIT) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH)) $(OTHER_LDFLAGS_ENTITLEMENTS);
 
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -47,6 +47,19 @@
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+
+#if ENABLE(POINTER_LOCK)
+#import <GameController/GameController.h>
+
+@interface GCMouse ()
+- (instancetype)initWithName:(NSString *)name additionalButtons:(uint32_t)additionalButtons;
+@end
+
+@interface GCMouseInput ()
+- (void)handleMouseMovementEventWithDelta:(CGPoint)delta;
+@end
+#endif
+
 #import <WebKit/_WKFeature.h>
 #import <WebKit/_WKHitTestResult.h>
 #import <wtf/BlockPtr.h>
@@ -1434,21 +1447,37 @@ TEST(WebKit, DidNotHandleWheelEvent)
 
 #if ENABLE(POINTER_LOCK)
 
-@interface PointerLockDelegate : NSObject <WKUIDelegatePrivate>
+@interface PointerLockDelegate : NSObject <WKUIDelegatePrivate, WKScriptMessageHandler>
 @property (nonatomic, readonly) bool didEngagePointerLock;
+@property (nonatomic, readonly) NSArray<NSValue *> *mouseMoveEvents;
 - (void)resetState;
 - (void)waitForPointerLockEngaged;
 - (void)waitForPointerLockLost;
+- (void)waitForMouseMoveEvents;
 @end
 
 @implementation PointerLockDelegate {
     bool _didLosePointerLock;
+    RetainPtr<NSMutableArray<NSValue *>> _mouseMoveEvents;
+}
+
+- (instancetype)init
+{
+    if (self = [super init])
+        _mouseMoveEvents = adoptNS([[NSMutableArray alloc] init]);
+    return self;
+}
+
+- (NSArray<NSValue *> *)mouseMoveEvents
+{
+    return _mouseMoveEvents.get();
 }
 
 - (void)resetState
 {
     _didEngagePointerLock = false;
     _didLosePointerLock = false;
+    [_mouseMoveEvents removeAllObjects];
 }
 
 - (void)waitForPointerLockEngaged
@@ -1461,6 +1490,13 @@ TEST(WebKit, DidNotHandleWheelEvent)
     TestWebKitAPI::Util::run(&_didLosePointerLock);
 }
 
+- (void)waitForMouseMoveEvents
+{
+    TestWebKitAPI::Util::waitFor([&] {
+        return [_mouseMoveEvents count];
+    });
+}
+
 - (void)_webViewDidRequestPointerLock:(WKWebView *)webView completionHandler:(void (^)(BOOL))completionHandler
 {
     completionHandler(YES);
@@ -1470,6 +1506,17 @@ TEST(WebKit, DidNotHandleWheelEvent)
 - (void)_webViewDidLosePointerLock:(WKWebView *)webView
 {
     _didLosePointerLock = true;
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message
+{
+#if PLATFORM(IOS_FAMILY)
+    if ([message.name isEqualToString:@"testHandler"]) {
+        NSDictionary *moveData = message.body;
+        CGPoint delta = CGPointMake([moveData[@"deltaX"] floatValue], [moveData[@"deltaY"] floatValue]);
+        [_mouseMoveEvents addObject:[NSValue valueWithCGPoint:delta]];
+    }
+#endif
 }
 
 @end
@@ -1494,13 +1541,35 @@ public:
 #endif
         setHasMouseDeviceForTesting(true);
 
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+        m_fakeMouse = adoptNS([[GCMouse.class alloc] initWithName:@"TestMouse" additionalButtons:0]);
+        m_currentMouseSwizzler = makeUnique<ClassMethodSwizzler>(GCMouse.class, @selector(current),
+            imp_implementationWithBlock(^GCMouse *() {
+                return m_fakeMouse.get();
+            })
+        );
+        m_miceSwizzler = makeUnique<ClassMethodSwizzler>(GCMouse.class, @selector(mice),
+            imp_implementationWithBlock(^NSArray<GCMouse *> *() {
+                return @[ m_fakeMouse.get() ];
+            })
+        );
+#endif
+
         m_webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configurationForWebViewTestingPointerLock().get()]);
         m_delegate = adoptNS([[PointerLockDelegate alloc] init]);
         [m_webView setUIDelegate:m_delegate.get()];
+        [[m_webView configuration].userContentController addScriptMessageHandler:m_delegate.get() name:@"testHandler"];
         [m_webView synchronouslyLoadHTMLString:
             @"<canvas width='800' height='600'></canvas><script>"
             @"var canvas = document.querySelector('canvas');"
+            @"var mouseMoveEvents = [];"
             @"canvas.onclick = () => canvas.requestPointerLock();"
+            @"document.addEventListener('pointermove', (e) => {"
+            @"    if (document.pointerLockElement) {"
+            @"        mouseMoveEvents.push({deltaX: e.movementX, deltaY: e.movementY, timeStamp: e.timeStamp});"
+            @"        window.webkit.messageHandlers.testHandler.postMessage({deltaX: e.movementX, deltaY: e.movementY});"
+            @"    }"
+            @"});"
             @"</script>"
         ];
 
@@ -1543,6 +1612,8 @@ public:
 
     RetainPtr<TestWKWebView> webView() const { return m_webView.get(); }
     RetainPtr<PointerLockDelegate> pointerLockDelegate() const { return m_delegate.get(); }
+    RetainPtr<GCMouse> fakeMouse() const { return m_fakeMouse.get(); }
+
 private:
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
     static WKMouseDeviceObserver *sharedMouseDeviceObserver()
@@ -1565,6 +1636,9 @@ private:
 
     RetainPtr<TestWKWebView> m_webView;
     RetainPtr<PointerLockDelegate> m_delegate;
+    RetainPtr<GCMouse> m_fakeMouse;
+    std::unique_ptr<ClassMethodSwizzler> m_currentMouseSwizzler;
+    std::unique_ptr<ClassMethodSwizzler> m_miceSwizzler;
 };
 
 TEST_F(PointerLockTests, Simple)
@@ -1612,6 +1686,33 @@ TEST_F(PointerLockTests, DeniedWithoutMouseDevice)
     }];
 
     TestWebKitAPI::Util::run(&done);
+}
+
+TEST_F(PointerLockTests, MouseDeviceMove)
+{
+    click(200, 200);
+    [pointerLockDelegate() waitForPointerLockEngaged];
+
+    float deltaX = 10.0f;
+    float deltaY = 5.0f;
+    RetainPtr mouseInput = [fakeMouse() mouseInput];
+    [mouseInput handleMouseMovementEventWithDelta:CGPointMake(deltaX, deltaY)];
+
+    [pointerLockDelegate() waitForMouseMoveEvents];
+    CGPoint capturedDelta = [[pointerLockDelegate() mouseMoveEvents].firstObject CGPointValue];
+    EXPECT_EQ(deltaX, capturedDelta.x);
+    EXPECT_EQ(deltaY, capturedDelta.y);
+}
+
+TEST_F(PointerLockTests, MouseDeviceDisconnect)
+{
+    click(200, 200);
+
+    RetainPtr delegate = pointerLockDelegate();
+    [delegate waitForPointerLockEngaged];
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:GCMouseDidStopBeingCurrentNotification object:fakeMouse().get() userInfo:nil];
+    [delegate waitForPointerLockLost];
 }
 
 #endif


### PR DESCRIPTION
#### a1a06db34436a11ba53ea724715e5271de5b4a9f
<pre>
[iOS] Adopt GCMouseInput.mouseMovedHandler to generate mousemove events when pointer lock is engaged
<a href="https://bugs.webkit.org/show_bug.cgi?id=297305">https://bugs.webkit.org/show_bug.cgi?id=297305</a>
<a href="https://rdar.apple.com/157599039">rdar://157599039</a>

Reviewed by Tim Horton.

This is a second attempt at landing this patch, after its earlier
iteration 298789@main got reverted because of linking failures against
GameController symbols in certain configurations. This patch adds
softlinking support for said symbols.

When UIPointerLockState.isLocked==YES, UIHoverGestureRecognizer
instances do not get relative offsets for pointer movements because
their locations are not updated at all, c.f. <a href="https://rdar.apple.com/57987082">rdar://57987082</a>. As a
result, our existing WKMouseInteraction machinery does not lend well to
event generation when pointer lock is engaged.

In this patch, we teach WKMouseInteraction about pointer lock by hooking
into pointer lock lifecycle methods on WebPageProxy. We do so by
introducing the notion of &quot;platform&quot; specific pointer lock steps, where
macOS hides the cursor through CG SPI. On the other hand, iOS plumbs
pointer lock state to WKMouseInteraction which then establishes a
mechanism to receive movement updates from a mouse pointing device. We
accomplish this through the GCMouseMoved handler on the GCMouseInput
object associated with the current mouse. Once set up, this handler is
used to generate NativeWebMouseEvent instances of mousemove type with a
locked location (i.e. the last touch location) and a raw movement delta.

We make WKMouseInteraction register for GCMouseDidDisconnectNotification
as a exit hatch in case the current mouse device disconnects from the
system. When notifications are received, we plumb this data back to
PointerLockController through the mouse interaction delegate.

Finally, this patch adds test coverage for this integration through the
PointerLockTests.MouseDevice[Move|Disconnect] API tests. To facilitate
testing, we instantiate a fake GCMouse instance and manually send a
delta to the GCMouseInput machinery under it. We link the GameController
framework against TestWebKitAPI, too, to be able to access the GCMouse
class and the GC notification key.

* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.h
* Source/WebCore/platform/gamepad/cocoa/GameControllerSoftLink.mm
Softlink GCMouse and GCMouseDidStopBeingCurrentNotification. The
GameController framework is not available in all configurations, so we
cannot link against it from WebKit proper.

* Source/WebKit/Platform/Logging.h:
Add a PointerLock logging channel.

* Source/WebKit/Shared/ios/NativeWebMouseEventIOS.mm:
(WebKit::NativeWebMouseEvent::NativeWebMouseEvent):
Plumb the unadjustment movement deltas as a straight mapping of the
regular movement deltas.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::beginPointerLockMouseTracking):
(WebKit::PageClient::endPointerLockMouseTracking):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestPointerLock):
(WebKit::WebPageProxy::didAllowPointerLock):
(WebKit::WebPageProxy::requestPointerUnlock):
(WebKit::WebPageProxy::webContentPointerLockProcess):
(WebKit::WebPageProxy::clearWebContentPointerLockProcess):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::beginPointerLockMouseTracking):
(WebKit::PageClientImpl::endPointerLockMouseTracking):

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView mouseInteractionDidLoseMouseDeviceDuringPointerLock:]):
WKMouseInteractionDelegate method to inform the web page that we can no
longer stay engaged in pointer lock.
(-[WKContentView _beginPointerLockMouseTracking]):
(-[WKContentView _endPointerLockMouseTracking]):

* Source/WebKit/UIProcess/ios/WKMouseInteraction.h:
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(PointerLockState::reset):
(-[WKMouseInteraction _resetCachedState]):
(-[WKMouseInteraction createMouseEventWithType:wasCancelled:]):
(-[WKMouseInteraction dealloc]):
(-[WKMouseInteraction beginPointerLockMouseTracking]):
(-[WKMouseInteraction endPointerLockMouseTracking]):
(-[WKMouseInteraction handleGameControllerMouseMove:deltaY:]):
(-[WKMouseInteraction _startObservingMouseNotifications]):
(-[WKMouseInteraction _stopObservingMouseNotifications]):
(-[WKMouseInteraction _mouseDidStopBeingCurrent:]):
(-[WKMouseInteraction _setupMouseMovedHandlerForMouse:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::platformLockPointer):
(WebKit::WebPageProxy::platformUnlockPointer):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::platformLockPointer):
(WebKit::WebPageProxy::platformUnlockPointer):
* Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[PointerLockDelegate waitForPointerLockEngaged]):
(-[PointerLockDelegate waitForPointerLockLost]):
(-[PointerLockDelegate _webViewDidRequestPointerLock:completionHandler:]):
(-[PointerLockDelegate _webViewDidLosePointerLock:]):
(-[PointerLockDelegate userContentController:didReceiveScriptMessage:]):
((PointerLockTests, MouseDeviceMove)):
((PointerLockTests, MouseDeviceDisconnect)):

Canonical link: <a href="https://commits.webkit.org/298821@main">https://commits.webkit.org/298821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/124ee87027c79893ad66e54d801c4bf93572afbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67330 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cf7990e9-89ab-4657-abae-619272335201) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88658 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43062 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, imported/w3c/web-platform-tests/wasm/core/table_fill.wast.js.html, storage/indexeddb/cursor-index-delete.html, storage/indexeddb/modern/abort-objectstore-info-private.html, storage/indexeddb/modern/objectstore-cursor-advance-failures.html, storage/indexeddb/mozilla/key-requirements-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, webgl/2.0.0/conformance2/textures/image/tex-3d-rgb32f-rgb-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-srgb8-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image/tex-2d-rgb565-rgb-unsigned_byte.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/449ffb7e-85d5-45c2-87b3-df1eeb3c936c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69129 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22835 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66491 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125960 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97326 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100932 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97124 "Found 10 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/preferred-size, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39624 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18646 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43535 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49130 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43002 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46341 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->