### PR TITLE
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 2)

### DIFF
--- a/Source/JavaScriptCore/heap/Weak.h
+++ b/Source/JavaScriptCore/heap/Weak.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/JSExportMacros.h>
 #include <cstddef>
 #include <wtf/Atomics.h>
+#include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/VectorTraits.h>

--- a/Source/JavaScriptCore/heap/WeakImpl.h
+++ b/Source/JavaScriptCore/heap/WeakImpl.h
@@ -119,16 +119,6 @@ inline WeakImpl* WeakImpl::asWeakImpl(JSValue* slot)
     return reinterpret_cast_ptr<WeakImpl*>(reinterpret_cast_ptr<char*>(slot) + OBJECT_OFFSETOF(WeakImpl, m_jsValue));
 }
 
-template<typename T>
-inline void Weak<T>::clear()
-{
-    auto* pointer = impl();
-    if (!pointer)
-        return;
-    pointer->clear();
-    m_impl = nullptr;
-}
-
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -108,6 +108,15 @@ template<typename T> inline bool Weak<T>::was(T* other) const
     return static_cast<T*>(m_impl->jsValue().asCell()) == other;
 }
 
+template<typename T> inline void Weak<T>::clear()
+{
+    auto* pointer = impl();
+    if (!pointer)
+        return;
+    pointer->clear();
+    m_impl = nullptr;
+}
+
 template<typename T> inline bool Weak<T>::operator!() const
 {
     auto* pointer = impl();

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -29,6 +29,7 @@
 #include "JSArrayBufferView.h"
 #include "JSCellInlines.h"
 #include "WaiterListManager.h"
+#include "WeakInlines.h"
 #include <wtf/Gigacage.h>
 #include <wtf/SafeStrerror.h>
 
@@ -537,6 +538,8 @@ RefPtr<ArrayBuffer> ArrayBuffer::tryCreateShared(VM& vm, size_t numElements, uns
     auto* memory = static_cast<uint8_t*>(handle->memory());
     return createShared(SharedArrayBufferContents::create({ memory, sizeInBytes.value() }, maxByteLength, WTFMove(handle), nullptr, SharedArrayBufferContents::Mode::Default));
 }
+
+ArrayBuffer::~ArrayBuffer() { }
 
 Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(VM& vm, size_t newByteLength)
 {

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -331,7 +331,7 @@ public:
     static constexpr ptrdiff_t offsetOfData() { return OBJECT_OFFSETOF(ArrayBuffer, m_contents) + OBJECT_OFFSETOF(ArrayBufferContents, m_data); }
     static constexpr ptrdiff_t offsetOfShared() { return OBJECT_OFFSETOF(ArrayBuffer, m_contents) + OBJECT_OFFSETOF(ArrayBufferContents, m_shared); }
 
-    ~ArrayBuffer() { }
+    JS_EXPORT_PRIVATE ~ArrayBuffer();
 
     JS_EXPORT_PRIVATE static Ref<SharedTask<void(void*)>> primitiveGigacageDestructor();
 

--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/CompactPointerTuple.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -36,7 +36,9 @@
 #include <wtf/Assertions.h>
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
+#include <wtf/HashIterators.h>
 #include <wtf/HashSet.h>
+#include <wtf/KeyValuePair.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -23,12 +23,14 @@
 #include <initializer_list>
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
+#include <wtf/HashFunctions.h>
 #include <wtf/HashIterators.h>
 #include <wtf/HashTable.h>
 #include <wtf/HashTraits.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/KeyValuePair.h>
 #include <wtf/OptionSetHash.h>
+#include <wtf/Packed.h>
 
 namespace WTF {
 

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -26,10 +26,12 @@
 
 #pragma once
 
+#include <type_traits>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompactRefPtrTuple.h>
 #include <wtf/GetPtr.h>
 #include <wtf/Packed.h>
+#include <wtf/TypeTraits.h>
 #include <wtf/WeakPtrFactory.h>
 #include <wtf/WeakRef.h>
 

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <wtf/CompactRefPtrTuple.h>
+#include <wtf/Forward.h>
 #include <wtf/Packed.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakRef.h>

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -24,6 +24,8 @@
 // This file would be called String.h, but that conflicts with <string.h>
 // on systems without case-sensitive file systems.
 
+#include <span>
+
 #include <wtf/Compiler.h>
 #include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringImpl.h>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1837,6 +1837,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/integration/inline/LineSelection.h
 
     layout/layouttree/LayoutBox.h
+    layout/layouttree/LayoutBoxGeometry.h
     layout/layouttree/LayoutChildIterator.h
     layout/layouttree/LayoutContainingBlockChainIterator.h
     layout/layouttree/LayoutDescendantIterator.h
@@ -2194,6 +2195,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/writing-tools/WritingToolsTypes.h
 
     platform/AbortableTaskQueue.h
+    platform/AudioEncoderActiveConfiguration.h
     platform/AudioSampleFormat.h
     platform/BoxExtents.h
     platform/BoxSides.h

--- a/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
+++ b/Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp
@@ -32,6 +32,7 @@
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemFileEntry.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FileSystem.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -35,6 +35,7 @@
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemEntriesCallback.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "WindowEventLoop.h"
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -34,6 +34,7 @@
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemEntryCallback.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "WindowEventLoop.h"
 #include <wtf/FileSystem.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -40,6 +40,7 @@
 #include "MediaStreamTrackEvent.h"
 #include "Page.h"
 #include "RealtimeMediaSource.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
@@ -37,6 +37,7 @@
 #include "Logging.h"
 #include "PeerConnectionBackend.h"
 #include "RTCRtpCapabilities.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -41,6 +41,7 @@
 #include "RTCPeerConnection.h"
 #include "RTCRtpCapabilities.h"
 #include "RTCRtpTransceiver.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCSessionDescription.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCSessionDescription.cpp
@@ -36,6 +36,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "RTCSessionDescriptionInit.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -57,6 +58,8 @@ Ref<RTCSessionDescription> RTCSessionDescription::create(RTCSdpType type, String
 {
     return adoptRef(*new RTCSessionDescription(type, WTFMove(sdp)));
 }
+
+RTCSessionDescription::~RTCSessionDescription() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/RTCSessionDescription.h
+++ b/Source/WebCore/Modules/mediastream/RTCSessionDescription.h
@@ -50,6 +50,8 @@ public:
     static Ref<RTCSessionDescription> create(RTCSessionDescriptionInit&&);
     static Ref<RTCSessionDescription> create(RTCSdpType, String&& sdp);
 
+    ~RTCSessionDescription();
+
     RTCSdpType type() const { return m_type; }
 
     const String& sdp() const { return m_sdp; }

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -363,6 +363,8 @@ void AudioBuffer::applyNoiseIfNeeded()
     m_noiseInjectionMultiplier = 0;
 }
 
+AudioBuffer::~AudioBuffer() = default;
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -52,6 +52,8 @@ public:
     // Returns nullptr if data is not a valid audio file.
     static RefPtr<AudioBuffer> createFromAudioFileData(std::span<const uint8_t> data, bool mixToMono, float sampleRate);
 
+    ~AudioBuffer();
+
     // Format
     size_t originalLength() const { return m_originalLength; }
     double originalDuration() const { return originalLength() / static_cast<double>(sampleRate()); }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -38,6 +38,7 @@
 #include "JSCallbackData.h"
 #include "JSDOMExceptionHandling.h"
 #include "MessagePort.h"
+#include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <wtf/GetPtr.h>

--- a/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "Exception.h"
 #include "ExceptionOr.h"
+#include "ScriptWrappableInlines.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -40,9 +41,9 @@ namespace WebCore {
 
 // https://immersive-web.github.io/webxr/#xrboundedreferencespace-native-bounds-geometry
 // It is suggested that points of the native bounds geometry be quantized to the nearest 5cm.
-static constexpr float BoundsPrecisionInMeters = 0.05; 
+static constexpr float BoundsPrecisionInMeters = 0.05;
 // A valid polygon has at least 3 vertices.
-static constexpr int MinimumBoundsVertices = 3; 
+static constexpr int MinimumBoundsVertices = 3;
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebXRBoundedReferenceSpace);
 

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBXR)
 #include "EventNames.h"
+#include "ScriptWrappableInlines.h"
 #include "WebXRInputSource.h"
 #include "WebXRSession.h"
 #include "XRInputSourceEvent.h"
@@ -89,7 +90,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
         init.session = &m_session;
         init.added = WTFMove(added);
         init.removed = WTFMove(removed);
-        
+
         auto event = XRInputSourcesChangeEvent::create(eventNames().inputsourceschangeEvent, init);
         ActiveDOMObject::queueTaskToDispatchEvent(m_session, TaskSource::WebXR, WTFMove(event));
     }

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
@@ -30,6 +30,7 @@
 
 #include "DOMPointReadOnly.h"
 #include "ExceptionOr.h"
+#include "ScriptWrappableInlines.h"
 #include "TransformationMatrix.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -149,7 +150,7 @@ const WebXRRigidTransform& WebXRRigidTransform::inverse()
     // Inverse should always return the same object.
     if (m_inverse)
         return *m_inverse;
-    
+
     auto inverseTransform = m_rawTransform.inverse();
     ASSERT(!!inverseTransform);
 

--- a/Source/WebCore/PAL/pal/text/TextEncoding.h
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include "UnencodableHandling.h"
+#include <pal/ExportMacros.h>
 #include <wtf/URL.h>
 #include <wtf/text/StringView.h>
+#include <wtf/text/WTFString.h>
 
 namespace PAL {
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -26,10 +26,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "AXCoreObject.h"
-#import "CocoaAccessibilityConstants.h"
-#import "FontPlatformData.h"
 #import <CoreGraphics/CoreGraphics.h>
+#import <WebCore/AXCoreObject.h>
+#import <WebCore/CocoaAccessibilityConstants.h>
+#import <WebCore/FontPlatformData.h>
 #import <wtf/Markable.h>
 #import <wtf/RefPtr.h>
 #import <wtf/WeakPtr.h>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.h
@@ -26,8 +26,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "AXTextMarker.h"
-#import "WebAccessibilityObjectWrapperBase.h"
+#import <WebCore/AXTextMarker.h>
+#import <WebCore/WebAccessibilityObjectWrapperBase.h>
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/animation/AnimationFrameRatePreset.h
+++ b/Source/WebCore/animation/AnimationFrameRatePreset.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "AnimationFrameRate.h"
+#include <WebCore/AnimationFrameRate.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -27,7 +27,7 @@
 
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/AnimationFrameRate.h>
-#include "AnimationFrameRatePreset.h"
+#include <WebCore/AnimationFrameRatePreset.h>
 #include <WebCore/CSSKeywordValue.h>
 #include <WebCore/CSSNumericValue.h>
 #include <WebCore/ContextDestructionObserverInlines.h>

--- a/Source/WebCore/bindings/js/ScriptWrappable.h
+++ b/Source/WebCore/bindings/js/ScriptWrappable.h
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include <JavaScriptCore/WeakInlines.h>
+#include <JavaScriptCore/Weak.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -49,7 +49,7 @@ public:
     static constexpr ptrdiff_t offsetOfWrapper() { return CAST_OFFSET(Derived*, ScriptWrappable*) + OBJECT_OFFSETOF(ScriptWrappable, m_wrapper); }
 
 protected:
-    ~ScriptWrappable() = default;
+    ~ScriptWrappable();
 
 private:
     JSC::Weak<JSDOMObject> m_wrapper;

--- a/Source/WebCore/bindings/js/ScriptWrappableInlines.h
+++ b/Source/WebCore/bindings/js/ScriptWrappableInlines.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/WeakInlines.h>
 #include <WebCore/JSDOMWrapper.h>
 #include <WebCore/ScriptWrappable.h>
 
@@ -51,5 +52,7 @@ inline void ScriptWrappable::clearWrapper(JSDOMObject* wrapper)
 {
     weakClear(m_wrapper, wrapper);
 }
+
+inline ScriptWrappable::~ScriptWrappable() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSStyleDeclaration.cpp
@@ -28,6 +28,7 @@
 
 #include "Document.h"
 #include "NodeInlines.h"
+#include "ScriptWrappableInlines.h"
 #include "Settings.h"
 #include "StyledElement.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -40,5 +41,7 @@ const Settings* CSSStyleDeclaration::settings() const
 {
     return parentElement() ? &parentElement()->document().settings() : nullptr;
 }
+
+CSSStyleDeclaration::~CSSStyleDeclaration() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSStyleDeclaration.h
+++ b/Source/WebCore/css/CSSStyleDeclaration.h
@@ -49,7 +49,7 @@ class CSSStyleDeclaration : public ScriptWrappable, public AbstractRefCountedAnd
     WTF_MAKE_NONCOPYABLE(CSSStyleDeclaration);
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(CSSStyleDeclaration);
 public:
-    virtual ~CSSStyleDeclaration() = default;
+    virtual ~CSSStyleDeclaration();
 
     virtual StyleDeclarationType styleDeclarationType() const = 0;
 

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -34,6 +34,7 @@
 #include "DOMPoint.h"
 #include "MutableStyleProperties.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "StyleProperties.h"
 #include "TransformOperations.h"
 #include "TransformOperationsBuilder.h"
@@ -413,5 +414,7 @@ ExceptionOr<String> DOMMatrixReadOnly::toString() const
 
     return makeString("matrix3d("_s, m_matrix.m11(), ", "_s, m_matrix.m12(), ", "_s, m_matrix.m13(), ", "_s, m_matrix.m14(), ", "_s, m_matrix.m21(), ", "_s, m_matrix.m22(), ", "_s, m_matrix.m23(), ", "_s, m_matrix.m24(), ", "_s, m_matrix.m31(), ", "_s, m_matrix.m32(), ", "_s, m_matrix.m33(), ", "_s, m_matrix.m34(), ", "_s, m_matrix.m41(), ", "_s, m_matrix.m42(), ", "_s, m_matrix.m43(), ", "_s, m_matrix.m44(), ')');
 }
+
+DOMMatrixReadOnly::~DOMMatrixReadOnly() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -47,6 +47,8 @@ class DOMMatrixReadOnly : public ScriptWrappable, public RefCounted<DOMMatrixRea
 public:
     static ExceptionOr<Ref<DOMMatrixReadOnly>> create(ScriptExecutionContext&, std::optional<Variant<String, Vector<double>>>&&);
 
+    ~DOMMatrixReadOnly();
+
     enum class Is2D : bool { No, Yes };
     static Ref<DOMMatrixReadOnly> create(const TransformationMatrix& matrix, Is2D is2D)
     {

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -29,6 +29,7 @@
 #include "GenericMediaQueryTypes.h"
 #include "MediaQueryParserContext.h"
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/SetForScope.h>
 #include <wtf/text/AtomStringHash.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -36,6 +36,7 @@
 #include "CSSStyleValueFactory.h"
 #include "CSSUnitValue.h"
 #include "ExceptionOr.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringView.h>
@@ -94,5 +95,7 @@ void CSSStyleValue::serialize(StringBuilder& builder, OptionSet<SerializationArg
     if (m_propertyValue)
         builder.append(m_propertyValue->cssText(CSS::defaultSerializationContext()));
 }
+
+CSSStyleValue::~CSSStyleValue() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -111,7 +111,7 @@ public:
 
 IGNORE_GCC_WARNINGS_BEGIN("mismatched-new-delete")
     // https://webkit.org/b/241516
-    virtual ~CSSStyleValue() = default;
+    virtual ~CSSStyleValue();
 IGNORE_GCC_WARNINGS_END
 
     virtual CSSStyleValueType getType() const { return CSSStyleValueType::CSSStyleValue; }

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -57,6 +57,7 @@
 #include "CSSVariableReferenceValue.h"
 #include "ExceptionOr.h"
 #include "RenderStyle.h"
+#include "ScriptWrappableInlines.h"
 #include "StylePropertiesInlines.h"
 #include "StylePropertyShorthand.h"
 #include "StyleURL.h"
@@ -393,5 +394,7 @@ ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValueFactory::vectorFromStyleVal
     }
     return { WTFMove(styleValues) };
 }
+
+CSSStyleValueFactory::~CSSStyleValueFactory() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -49,6 +49,8 @@ public:
     static RefPtr<CSSStyleValue> constructStyleValueForShorthandSerialization(Document&, const String&);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(Document&, const AtomString& property, FixedVector<Variant<RefPtr<CSSStyleValue>, String>>&&);
 
+    ~CSSStyleValueFactory();
+
 protected:
     CSSStyleValueFactory() = delete;
 

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#include "Element.h"
 #include "MainThreadStylePropertyMapReadOnly.h"
+#include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class Element;

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -38,6 +38,7 @@
 #include "DOMMatrix.h"
 #include "DOMMatrixInit.h"
 #include "ExceptionOr.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -166,5 +167,7 @@ RefPtr<CSSValue> CSSMatrixComponent::toCSSValue() const
         arguments.append(CSSPrimitiveValue::create(value));
     return CSSFunctionValue::create(CSSValueMatrix3d, WTFMove(arguments));
 }
+
+CSSMatrixComponent::~CSSMatrixComponent() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
@@ -42,6 +42,8 @@ public:
     static Ref<CSSTransformComponent> create(Ref<DOMMatrixReadOnly>&&, CSSMatrixComponentOptions&& = { });
     static ExceptionOr<Ref<CSSTransformComponent>> create(Ref<const CSSFunctionValue>, Document&);
 
+    ~CSSMatrixComponent();
+
     DOMMatrix& matrix();
     void setMatrix(Ref<DOMMatrix>&&);
 

--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -28,6 +28,7 @@
 
 #include "AbortSignal.h"
 #include "JSAbortController.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/AbstractRange.h
+++ b/Source/WebCore/dom/AbstractRange.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
 #include <optional>
+#include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/dom/CaretPosition.cpp
+++ b/Source/WebCore/dom/CaretPosition.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMRect.h"
 #include "Range.h"
+#include "ScriptWrappableInlines.h"
 #include "SimpleRange.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -48,5 +49,7 @@ RefPtr<DOMRect> CaretPosition::getClientRect()
 
     return Range::boundingClientRect(SimpleRange { BoundaryPoint { *m_offsetNode, m_offset }, BoundaryPoint { *m_offsetNode, m_offset } });
 }
+
+CaretPosition::~CaretPosition() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CaretPosition.h
+++ b/Source/WebCore/dom/CaretPosition.h
@@ -36,6 +36,7 @@ class CaretPosition : public ScriptWrappable, public RefCounted<CaretPosition> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(CaretPosition, WEBCORE_EXPORT);
 public:
     static Ref<CaretPosition> create(RefPtr<Node>&& offsetNode, unsigned offset) { return adoptRef(*new CaretPosition(WTFMove(offsetNode), offset)); }
+    ~CaretPosition();
 
     RefPtr<Node> offsetNode() const { return m_offsetNode; }
     unsigned offset() const { return m_offset; }

--- a/Source/WebCore/dom/CharacterData.h
+++ b/Source/WebCore/dom/CharacterData.h
@@ -23,6 +23,10 @@
 #pragma once
 
 #include <WebCore/ContainerNode.h>
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/PlatformExportMacros.h>
+#include <span>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/CustomStateSet.cpp
+++ b/Source/WebCore/dom/CustomStateSet.cpp
@@ -29,6 +29,7 @@
 #include "CSSSelector.h"
 #include "Element.h"
 #include "PseudoClassChangeInvalidation.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -66,5 +67,7 @@ bool CustomStateSet::has(const AtomString& state) const
 {
     return m_states.contains(state);
 }
+
+CustomStateSet::~CustomStateSet() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CustomStateSet.h
+++ b/Source/WebCore/dom/CustomStateSet.h
@@ -40,6 +40,8 @@ public:
         return adoptRef(*new CustomStateSet(element));
     };
 
+    ~CustomStateSet();
+
     bool addToSetLike(const AtomString& state);
     bool removeFromSetLike(const AtomString& state);
     void clearFromSetLike();

--- a/Source/WebCore/dom/DOMPointReadOnly.cpp
+++ b/Source/WebCore/dom/DOMPointReadOnly.cpp
@@ -32,6 +32,7 @@
 
 #include "DOMMatrixReadOnly.h"
 #include "DOMPoint.h"
+#include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -60,6 +61,8 @@ WebCoreOpaqueRoot root(DOMPointReadOnly* point)
 {
     return WebCoreOpaqueRoot { point };
 }
+
+DOMPointReadOnly::~DOMPointReadOnly() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/DOMPointReadOnly.h
+++ b/Source/WebCore/dom/DOMPointReadOnly.h
@@ -32,6 +32,7 @@
 
 #include "DOMPointInit.h"
 #include "FloatPoint3D.h"
+#include "PlatformExportMacros.h"
 #include "ScriptWrappable.h"
 #include <wtf/NoVirtualDestructorBase.h>
 #include <wtf/RefCounted.h>
@@ -51,6 +52,8 @@ public:
     static Ref<DOMPointReadOnly> create(const DOMPointInit& init) { return create(init.x, init.y, init.z, init.w); }
     static Ref<DOMPointReadOnly> fromPoint(const DOMPointInit& init) { return create(init.x, init.y, init.z, init.w); }
     static Ref<DOMPointReadOnly> fromFloatPoint(const FloatPoint3D& p) { return create(p.x(), p.y(), p.z(), 1); }
+
+    WEBCORE_EXPORT ~DOMPointReadOnly();
 
     double x() const { return m_x; }
     double y() const { return m_y; }

--- a/Source/WebCore/dom/DOMQuad.cpp
+++ b/Source/WebCore/dom/DOMQuad.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMPoint.h"
 #include "DOMRect.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -65,5 +66,7 @@ Ref<DOMRect> DOMQuad::getBounds() const
 
     return DOMRect::create(left, top, right - left, bottom - top);
 }
+
+DOMQuad::~DOMQuad() = default;
 
 }

--- a/Source/WebCore/dom/DOMQuad.h
+++ b/Source/WebCore/dom/DOMQuad.h
@@ -44,6 +44,8 @@ public:
     static Ref<DOMQuad> fromRect(const DOMRectInit& init) { return adoptRef(*new DOMQuad(init)); }
     static Ref<DOMQuad> fromQuad(const DOMQuadInit& init) { return create(init.p1, init.p2, init.p3, init.p4); }
 
+    ~DOMQuad();
+
     const DOMPoint& p1() const { return m_p1; }
     const DOMPoint& p2() const { return m_p2; }
     const DOMPoint& p3() const { return m_p3; }

--- a/Source/WebCore/dom/DataTransferItem.cpp
+++ b/Source/WebCore/dom/DataTransferItem.cpp
@@ -39,6 +39,7 @@
 #include "FileSystemDirectoryEntry.h"
 #include "FileSystemFileEntry.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include "StringCallback.h"
 #include <wtf/FileSystem.h>
 

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -34,6 +34,7 @@
 #include "ExceptionOr.h"
 #include "FileList.h"
 #include "Pasteboard.h"
+#include "ScriptWrappableInlines.h"
 #include "Settings.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -27,6 +27,7 @@
 #include "DatasetDOMStringMap.h"
 
 #include "ElementInlines.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/ASCIICType.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
@@ -210,5 +211,7 @@ Ref<Element> DatasetDOMStringMap::protectedElement() const
 {
     return m_element.get();
 }
+
+DatasetDOMStringMap::~DatasetDOMStringMap() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -42,6 +42,8 @@ public:
     {
     }
 
+    ~DatasetDOMStringMap();
+
     void ref();
     void deref();
 

--- a/Source/WebCore/dom/EventListener.h
+++ b/Source/WebCore/dom/EventListener.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -32,12 +32,19 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/RegisteredEventListener.h>
 #include <atomic>
 #include <memory>
+#include <wtf/Assertions.h>
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/Compiler.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
+#include <wtf/Locker.h>
+#include <wtf/Platform.h>
 #include <wtf/Threading.h>
+#include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -32,12 +32,18 @@
 
 #include <WebCore/EventListenerMap.h>
 #include <WebCore/EventListenerOptions.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/ScriptWrappable.h>
+#include <bmalloc/TZoneHeap.h>
 #include <memory>
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WeakPtrFactory.h>
 #include <wtf/WeakPtrImpl.h>
 
 namespace JSC {

--- a/Source/WebCore/dom/Exception.h
+++ b/Source/WebCore/dom/Exception.h
@@ -27,6 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <WebCore/ExceptionCode.h>
+#include <span>
+#include <utility>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/ExceptionOr.h
+++ b/Source/WebCore/dom/ExceptionOr.h
@@ -27,9 +27,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <WebCore/Exception.h>
+#include <utility>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/Expected.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/Unexpected.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -26,11 +26,17 @@
 
 #include <WebCore/EventTarget.h>
 #include <WebCore/NodeIdentifier.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleValidity.h>
+#include <bit>
 #include <compare>
+#include <new>
+#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompactPointerTuple.h>
 #include <wtf/CompactUniquePtrTuple.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 #include <wtf/ListHashSet.h>
@@ -38,9 +44,12 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/TypeCasts.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WTF {
 class TextStream;

--- a/Source/WebCore/dom/NodeList.cpp
+++ b/Source/WebCore/dom/NodeList.cpp
@@ -26,10 +26,13 @@
 #include "config.h"
 #include "NodeList.h"
 
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(NodeList);
+
+NodeList::~NodeList() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/NodeList.h
+++ b/Source/WebCore/dom/NodeList.h
@@ -36,7 +36,7 @@ class ScriptExecutionContext;
 class NodeList : public ScriptWrappable, public RefCounted<NodeList> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(NodeList, WEBCORE_EXPORT);
 public:
-    virtual ~NodeList() = default;
+    virtual ~NodeList();
 
     // DOM methods & attributes for NodeList
     virtual unsigned length() const = 0;

--- a/Source/WebCore/dom/Observable.cpp
+++ b/Source/WebCore/dom/Observable.cpp
@@ -49,6 +49,7 @@
 #include "ObservableInspector.h"
 #include "PredicateCallback.h"
 #include "ReducerCallback.h"
+#include "ScriptWrappableInlines.h"
 #include "SubscribeOptions.h"
 #include "Subscriber.h"
 #include "SubscriberCallback.h"
@@ -180,5 +181,7 @@ Observable::Observable(Ref<SubscriberCallback> callback)
     : m_subscriberCallback(callback)
 {
 }
+
+Observable::~Observable() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -28,6 +28,7 @@
 #include "ScriptWrappable.h"
 #include "SubscriberCallback.h"
 #include "VoidCallback.h"
+#include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -54,6 +55,8 @@ public:
     static Ref<Observable> create(Ref<SubscriberCallback>);
 
     explicit Observable(Ref<SubscriberCallback>);
+
+    ~Observable();
 
     void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
     void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);

--- a/Source/WebCore/dom/RegisteredEventListener.h
+++ b/Source/WebCore/dom/RegisteredEventListener.h
@@ -24,7 +24,11 @@
 #pragma once
 
 #include <WebCore/EventListener.h>
+#include <wtf/Forward.h>
 #include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -26,6 +26,12 @@
 #pragma once
 
 #include <WebCore/BoundaryPoint.h>
+#include <WebCore/EventTarget.h>
+#include <WebCore/PlatformExportMacros.h>
+#include <wtf/Ref.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/WeakPtrImpl.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "InternalObserver.h"
 #include "JSDOMExceptionHandling.h"
+#include "ScriptWrappableInlines.h"
 #include "SubscriberCallback.h"
 #include "SubscriptionObserverCallback.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -171,6 +172,8 @@ void Subscriber::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
 
     observerConcurrently()->visitAdditionalChildren(visitor);
 }
+
+Subscriber::~Subscriber() = default;
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Subscriber);
 

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -54,6 +54,8 @@ public:
 
     static Ref<Subscriber> create(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);
 
+    ~Subscriber();
+
     void reportErrorObject(JSC::JSValue);
 
     // JSCustomMarkFunction; for JSSubscriberCustom

--- a/Source/WebCore/dom/TrustedHTML.cpp
+++ b/Source/WebCore/dom/TrustedHTML.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TrustedHTML.h"
 
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -41,5 +42,7 @@ TrustedHTML::TrustedHTML(const String& data)
     : m_data(data)
 {
 }
+
+TrustedHTML::~TrustedHTML() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedHTML.h
+++ b/Source/WebCore/dom/TrustedHTML.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/ScriptWrappable.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -35,7 +36,7 @@ class TrustedHTML : public ScriptWrappable, public RefCounted<TrustedHTML> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedHTML, WEBCORE_EXPORT);
 public:
     static Ref<TrustedHTML> create(const String& data);
-    ~TrustedHTML() = default;
+    WEBCORE_EXPORT ~TrustedHTML();
 
     String toString() const { return m_data; }
     String toJSON() const { return toString(); }

--- a/Source/WebCore/dom/TrustedScript.cpp
+++ b/Source/WebCore/dom/TrustedScript.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TrustedScript.h"
 
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -41,5 +42,7 @@ TrustedScript::TrustedScript(const String& data)
     : m_data(data)
 {
 }
+
+TrustedScript::~TrustedScript() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedScript.h
+++ b/Source/WebCore/dom/TrustedScript.h
@@ -33,7 +33,7 @@ class TrustedScript final : public ScriptWrappable, public RefCounted<TrustedScr
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedScript, WEBCORE_EXPORT);
 public:
     static Ref<TrustedScript> create(const String& data);
-    ~TrustedScript() = default;
+    ~TrustedScript();
 
     String toString() const { return m_data; }
     String toJSON() const { return toString(); }

--- a/Source/WebCore/dom/TrustedScriptURL.cpp
+++ b/Source/WebCore/dom/TrustedScriptURL.cpp
@@ -42,4 +42,6 @@ TrustedScriptURL::TrustedScriptURL(const String& data)
 {
 }
 
+TrustedScriptURL::~TrustedScriptURL() = default;
+
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedScriptURL.h
+++ b/Source/WebCore/dom/TrustedScriptURL.h
@@ -35,7 +35,7 @@ class TrustedScriptURL : public ScriptWrappable, public RefCounted<TrustedScript
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedScriptURL, WEBCORE_EXPORT);
 public:
     static Ref<TrustedScriptURL> create(const String& data);
-    ~TrustedScriptURL() = default;
+    ~TrustedScriptURL();
 
     String toString() const { return m_data; }
     String toJSON() const { return toString(); }

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -27,6 +27,7 @@
 #include "TrustedTypePolicy.h"
 
 #include "ExceptionOr.h"
+#include "ScriptWrappableInlines.h"
 #include "TrustedHTML.h"
 #include "TrustedScript.h"
 #include "TrustedScriptURL.h"
@@ -133,5 +134,7 @@ WebCoreOpaqueRoot root(TrustedTypePolicy* policy)
 {
     return WebCoreOpaqueRoot { policy };
 }
+
+TrustedTypePolicy::~TrustedTypePolicy() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedTypePolicy.h
+++ b/Source/WebCore/dom/TrustedTypePolicy.h
@@ -51,7 +51,7 @@ class TrustedTypePolicy : public ScriptWrappable, public RefCounted<TrustedTypeP
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TrustedTypePolicy);
 public:
     static Ref<TrustedTypePolicy> create(const String&, const TrustedTypePolicyOptions&);
-    ~TrustedTypePolicy() = default;
+    ~TrustedTypePolicy();
     ExceptionOr<Ref<TrustedHTML>> createHTML(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&);
     ExceptionOr<Ref<TrustedScript>> createScript(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&);
     ExceptionOr<Ref<TrustedScriptURL>> createScriptURL(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&);

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
@@ -132,4 +132,6 @@ String TrustedTypePolicyFactory::getPropertyType(const String& tagName, const St
     return nullString();
 }
 
+TrustedTypePolicyFactory::~TrustedTypePolicyFactory() = default;
+
 }

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.h
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.h
@@ -44,7 +44,7 @@ class TrustedTypePolicyFactory : public ScriptWrappable, public RefCounted<Trust
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(TrustedTypePolicyFactory);
 public:
     static Ref<TrustedTypePolicyFactory> create(ScriptExecutionContext&);
-    ~TrustedTypePolicyFactory() = default;
+    ~TrustedTypePolicyFactory();
 
     ExceptionOr<Ref<TrustedTypePolicy>> createPolicy(ScriptExecutionContext&, const String& policyName, const TrustedTypePolicyOptions&);
     bool isHTML(JSC::JSValue) const;

--- a/Source/WebCore/editing/cocoa/AlternativeTextContextController.h
+++ b/Source/WebCore/editing/cocoa/AlternativeTextContextController.h
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "DictationContext.h"
-#import "PlatformTextAlternatives.h"
+#import <WebCore/DictationContext.h>
+#import <WebCore/PlatformTextAlternatives.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
 

--- a/Source/WebCore/editing/cocoa/AlternativeTextUIController.h
+++ b/Source/WebCore/editing/cocoa/AlternativeTextUIController.h
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "AlternativeTextContextController.h"
+#import <WebCore/AlternativeTextContextController.h>
 #import <wtf/TZoneMalloc.h>
 
 @class NSView;

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#import "Color.h"
-#import "TextAttachmentForSerialization.h"
+#import <WebCore/Color.h>
+#import <WebCore/TextAttachmentForSerialization.h>
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/URL.h>

--- a/Source/WebCore/fileapi/FileList.cpp
+++ b/Source/WebCore/fileapi/FileList.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "FileList.h"
+#include "ScriptWrappableInlines.h"
 
 #include <wtf/TZoneMallocInlines.h>
 
@@ -45,5 +46,7 @@ Vector<String> FileList::paths() const
         return file->path();
     });
 }
+
+FileList::~FileList() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/FileList.h
+++ b/Source/WebCore/fileapi/FileList.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -46,6 +46,8 @@ public:
     {
         return adoptRef(*new FileList(WTFMove(files)));
     }
+
+    WEBCORE_EXPORT ~FileList();
 
     unsigned length() const { return m_files.size(); }
     WEBCORE_EXPORT File* item(unsigned index) const;

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ArrayBuffer.h>
 #include <WebCore/BlobResourceHandle.h>
 #include <WebCore/ExceptionCode.h>
 #include <WebCore/ThreadableLoaderClient.h>

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -32,6 +32,7 @@
 #include "ImageBitmap.h"
 #include "PaintRenderingContext2D.h"
 #include "ScriptExecutionContext.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/JSCJSValue.h>
 #include <WebCore/ActiveDOMObject.h>
 #include <WebCore/CanvasBase.h>
 #include <WebCore/Document.h>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -39,6 +39,7 @@
 #include "OriginAccessPatterns.h"
 #include "PixelFormat.h"
 #include "SVGImageElement.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/layout/floats/PlacedFloats.h
+++ b/Source/WebCore/layout/floats/PlacedFloats.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "LayoutBoxGeometry.h"
+#include <WebCore/LayoutBoxGeometry.h>
 #include <WebCore/LayoutElementBox.h>
 #include <WebCore/LayoutShape.h>
 #include <wtf/OptionSet.h>

--- a/Source/WebCore/layout/layouttree/LayoutBoxGeometry.h
+++ b/Source/WebCore/layout/layouttree/LayoutBoxGeometry.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "LayoutGeometryRect.h"
-#include "LayoutUnits.h"
+#include <WebCore/LayoutGeometryRect.h>
+#include <WebCore/LayoutUnits.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/ActivityState.h
+++ b/Source/WebCore/page/ActivityState.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
+#include <cstdint>
 #include <wtf/OptionSet.h>
 
 namespace WTF {

--- a/Source/WebCore/page/BarProp.cpp
+++ b/Source/WebCore/page/BarProp.cpp
@@ -32,6 +32,7 @@
 #include "Chrome.h"
 #include "LocalFrame.h"
 #include "Page.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -69,5 +70,7 @@ bool BarProp::visible() const
     ASSERT_NOT_REACHED();
     return false;
 }
+
+BarProp::~BarProp() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/page/BarProp.h
+++ b/Source/WebCore/page/BarProp.h
@@ -42,6 +42,8 @@ public:
 
     static Ref<BarProp> create(LocalDOMWindow& window, Type type) { return adoptRef(*new BarProp(window, type)); }
 
+    ~BarProp();
+
     bool visible() const;
 
 private:

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -41,6 +41,7 @@
 #include "Page.h"
 #include "Quirks.h"
 #include "ScriptController.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MainThread.h>
@@ -311,5 +312,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
     frame->loader().updateURLAndHistory(fullURL, WTFMove(data), historyBehavior);
     return { };
 }
+
+History::~History() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -42,6 +42,8 @@ class History final : public ScriptWrappable, public RefCounted<History>, public
 public:
     static Ref<History> create(LocalDOMWindow& window) { return adoptRef(*new History(window)); }
 
+    ~History();
+
     ExceptionOr<unsigned> length() const;
 
     enum class ScrollRestoration {

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -36,6 +36,7 @@
 #include "LocalFrame.h"
 #include "NavigationScheduler.h"
 #include "Quirks.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include "ServiceWorkerContainer.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -335,5 +336,7 @@ RefPtr<DOMWindow> Location::protectedWindow()
 {
     return m_window.get();
 }
+
+Location::~Location() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -45,6 +45,8 @@ class Location final : public ScriptWrappable, public RefCounted<Location> {
 public:
     static Ref<Location> create(DOMWindow& window) { return adoptRef(*new Location(window)); }
 
+    ~Location();
+
     ExceptionOr<void> setHref(LocalDOMWindow& incumbentWindow, LocalDOMWindow& firstWindow, const String&);
     String href() const;
 

--- a/Source/WebCore/page/NavigationActivation.cpp
+++ b/Source/WebCore/page/NavigationActivation.cpp
@@ -27,6 +27,7 @@
 #include "NavigationActivation.h"
 
 #include "NavigationHistoryEntry.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -39,6 +40,8 @@ NavigationActivation::NavigationActivation(NavigationNavigationType type, Ref<Na
     , m_fromEntry(WTFMove(fromEntry))
 {
 }
+
+NavigationActivation::~NavigationActivation() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/NavigationActivation.h
+++ b/Source/WebCore/page/NavigationActivation.h
@@ -41,6 +41,8 @@ public:
         return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
     }
 
+    ~NavigationActivation();
+
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
     const NavigationHistoryEntry& entry() const { return m_entry; };

--- a/Source/WebCore/page/NavigationDestination.cpp
+++ b/Source/WebCore/page/NavigationDestination.cpp
@@ -27,6 +27,7 @@
 #include "NavigationDestination.h"
 
 #include "JSDOMGlobalObject.h"
+#include "ScriptWrappableInlines.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -49,5 +50,7 @@ JSC::JSValue NavigationDestination::getState(JSDOMGlobalObject& globalObject) co
 
     return m_stateObject->deserialize(globalObject, &globalObject, SerializationErrorMode::Throwing);
 }
+
+NavigationDestination::~NavigationDestination() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationDestination.h
+++ b/Source/WebCore/page/NavigationDestination.h
@@ -42,6 +42,8 @@ class NavigationDestination final : public RefCounted<NavigationDestination>, pu
 public:
     static Ref<NavigationDestination> create(const URL& url, RefPtr<NavigationHistoryEntry>&& entry, bool isSameDocument) { return adoptRef(*new NavigationDestination(url, WTFMove(entry), isSameDocument)); };
 
+    ~NavigationDestination();
+
     const URL& url() const { return m_url; };
     String key() const { return m_entry ? m_entry->key() : String(); };
     String id() const { return m_entry ? m_entry->id() : String(); };

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -48,6 +48,7 @@
 #include "Quirks.h"
 #include "ResourceLoadObserver.h"
 #include "ScriptController.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include "Settings.h"
 #include "ShareData.h"

--- a/Source/WebCore/page/PerformanceEventTiming.h
+++ b/Source/WebCore/page/PerformanceEventTiming.h
@@ -26,10 +26,10 @@
 
 #pragma once
 
-#include "DOMHighResTimeStamp.h"
-#include "EventNames.h"
-#include "EventTarget.h"
-#include "PerformanceEntry.h"
+#include <WebCore/DOMHighResTimeStamp.h>
+#include <WebCore/EventNames.h>
+#include <WebCore/EventTarget.h>
+#include <WebCore/PerformanceEntry.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/PerformanceLogging.cpp
+++ b/Source/WebCore/page/PerformanceLogging.cpp
@@ -35,6 +35,7 @@
 #include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "Page.h"
+#include <JavaScriptCore/VM.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/ProcessSyncData.in
+++ b/Source/WebCore/page/ProcessSyncData.in
@@ -56,13 +56,13 @@
 #   - A header required to declare/define the type
 #   - Opting in to automatic inclusion in the "DocumentSyncData" struct
 
-AudioSessionType : WebCore::DOMAudioSessionType [DocumentSyncData Conditional=ENABLE(DOM_AUDIO_SESSION) Header="DOMAudioSession.h"]
+AudioSessionType : WebCore::DOMAudioSessionType [DocumentSyncData Conditional=ENABLE(DOM_AUDIO_SESSION) Header=<WebCore/DOMAudioSession.h>]
 IsAutofocusProcessed : bool [DocumentSyncData]
 UserDidInteractWithPage : bool [DocumentSyncData]
 IsClosing : bool [DocumentSyncData]
 DocumentURL : URL [DocumentSyncData Header=<wtf/URL.h>]
-DocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [DocumentSyncData Header="SecurityOrigin.h"]
-DocumentClasses : OptionSet<WebCore::DocumentClass> [DocumentSyncData Header="DocumentClasses.h"]
+DocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [DocumentSyncData Header=<WebCore/SecurityOrigin.h>]
+DocumentClasses : OptionSet<WebCore::DocumentClass> [DocumentSyncData Header=<WebCore/DocumentClasses.h>]
 HasInjectedUserScript : bool [DocumentSyncData]
 FrameCanCreatePaymentSession : bool [FrameTreeSyncData]
-FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [FrameTreeSyncData Header="SecurityOrigin.h"]
+FrameDocumentSecurityOrigin : RefPtr<WebCore::SecurityOrigin> [FrameTreeSyncData Header=<WebCore/SecurityOrigin.h>]

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -42,6 +42,7 @@
 #include "Quirks.h"
 #include "ResourceLoadObserver.h"
 #include "ScreenOrientation.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "pal/HysteresisActivity.h"
+#include <pal/HysteresisActivity.h>
 #if ENABLE(ASYNC_SCROLLING)
 
 #include <WebCore/ScrollingCoordinator.h>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -39,6 +39,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -26,13 +26,13 @@
 
 #pragma once
 
-#include "PlatformRawAudioData.h"
+#include <WebCore/PlatformRawAudioData.h>
 
 #if ENABLE(WEB_CODECS)
 
-#include "AudioEncoderActiveConfiguration.h"
+#include <WebCore/AudioEncoderActiveConfiguration.h>
 #include "BitrateMode.h"
-#include "WebCodecsAudioInternalData.h"
+#include <WebCore/WebCodecsAudioInternalData.h>
 #include <span>
 #include <wtf/NativePromise.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/platform/graphics/AV1Utilities.h
+++ b/Source/WebCore/platform/graphics/AV1Utilities.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <JavaScriptCore/DataView.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/EnumTraits.h>
 #include <wtf/text/StringView.h>

--- a/Source/WebCore/platform/graphics/AnimationFrameRate.h
+++ b/Source/WebCore/platform/graphics/AnimationFrameRate.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Seconds.h>
 

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include <WebCore/PlatformExportMacros.h>
 #include <wtf/OptionSet.h>
+#include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -30,6 +30,7 @@
 #include <gst/app/gstappsrc.h>
 #include <numbers>
 #include <wtf/IndexedRange.h>
+#include <wtf/MediaTime.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/plugins/DOMMimeTypeArray.cpp
+++ b/Source/WebCore/plugins/DOMMimeTypeArray.cpp
@@ -22,6 +22,7 @@
 
 #include "DOMMimeType.h"
 #include "Navigator.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 

--- a/Source/WebCore/plugins/DOMPlugin.cpp
+++ b/Source/WebCore/plugins/DOMPlugin.cpp
@@ -21,6 +21,7 @@
 
 #include "DOMMimeType.h"
 #include "Navigator.h"
+#include "ScriptWrappableInlines.h"
 #include <ranges>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>

--- a/Source/WebCore/plugins/DOMPluginArray.cpp
+++ b/Source/WebCore/plugins/DOMPluginArray.cpp
@@ -24,6 +24,7 @@
 #include "FrameInlines.h"
 #include "LocalFrameInlines.h"
 #include "Page.h"
+#include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -28,6 +28,7 @@
 #include <initializer_list>
 #include <limits>
 #include <optional>
+#include <type_traits>
 #include <wtf/EnumTraits.h>
 
 namespace WTF {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -36,6 +36,7 @@
 #include "SVGResources.h"
 #include "SVGResourcesCache.h"
 #include "SVGVisitedRendererTracking.h"
+#include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -32,6 +32,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "ScriptTrackingPrivacyCategory.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include "StorageArea.h"
 #include "StorageType.h"

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -47,6 +47,7 @@
 #include "StyleSheetContents.h"
 #include <ranges>
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/SetForScope.h>
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "Page.h"
 #include "ScriptSourceCode.h"
+#include "ScriptWrappableInlines.h"
 #include "SecurityOrigin.h"
 #include "WorkerRunLoop.h"
 #include "WorkletGlobalScope.h"

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -28,6 +28,8 @@
 
 #include "SessionState.h"
 #include "WebBackForwardListItem.h"
+#include <wtf/HashMap.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -26,6 +26,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 
 #ifdef __cplusplus
+#if !__has_feature(modules)
 
 #import "APIPageConfiguration.h"
 #import "WKObject.h"
@@ -55,6 +56,7 @@ _WKDragLiftDelay toWKDragLiftDelay(WebKit::DragLiftDelay);
 WebKit::DragLiftDelay fromWKDragLiftDelay(_WKDragLiftDelay);
 #endif
 
+#endif // !__has_feature(modules)
 #endif // __cplusplus
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -27,6 +27,7 @@
 #import <WebKit/_WKTextExtraction.h>
 
 #ifdef __cplusplus
+#if !__has_feature(modules)
 
 #import "PDFPluginIdentifier.h"
 #import <WebCore/CocoaView.h>
@@ -624,6 +625,7 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 
 WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContainerEdges&, WebCore::BoxSide);
 
+#endif // !__has_feature(modules)
 #endif // __cplusplus
 
 @interface WKWebView (NonCpp)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -40,6 +40,8 @@
 #include <WebCore/NotificationData.h>
 #include <WebCore/SecurityOriginData.h>
 #include <ranges>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Ref.h>
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -36,6 +36,8 @@
 #include <WebCore/RTCDataChannel.h>
 #include <WebCore/RTCError.h>
 #include <WebCore/ScriptExecutionContext.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Ref.h>
 
 namespace WebKit {
 

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -33,6 +33,7 @@
 #import "WebFrameInternal.h"
 #import <JavaScriptCore/JSLock.h>
 #import <JavaScriptCore/MemoryStatistics.h>
+#import <JavaScriptCore/VM.h>
 #import <WebCore/BackForwardCache.h>
 #import <WebCore/CommonVM.h>
 #import <WebCore/FontCache.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/FidoConstants.h>
 #include <WebCore/Pin.h>
+#include <WebCore/ScriptWrappableInlines.h>
 #include <WebCore/WebAuthenticationConstants.h>
 #include <WebCore/WebAuthenticationUtils.h>
 #include <pal/crypto/CryptoDigest.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/NodeInlines.h>
 #include <WebCore/ParserContentPolicy.h>
 #include <WebCore/ProcessWarming.h>
+#include <WebCore/ScriptWrappableInlines.h>
 #include <WebCore/Settings.h>
 #include <WebCore/Text.h>
 #include <wtf/text/WTFString.h>


### PR DESCRIPTION
#### 9f2ca0320ff28a530dfdab33d763a5b3e8d109bc
<pre>
[Swift in WebKit] Work towards modularizing WebCore private headers (Part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=297503">https://bugs.webkit.org/show_bug.cgi?id=297503</a>
<a href="https://rdar.apple.com/158487517">rdar://158487517</a>

Reviewed by Abrar Rahman Protyasha.

- Fix some more quoted imports to angle bracket imports
- Convert some more private headers to project that don&apos;t need to be private, and vice versa
- Add some missing headers to the Xcode project
- Add a few missing imports
- Let Xcode fix some erroneous file character encoding (macOS Western -&gt; UTF-8)

* Source/WebCore/PAL/pal/text/TextEncoding.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/animation/AnimationFrameRatePreset.h:
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/editing/cocoa/AlternativeTextContextController.h:
* Source/WebCore/editing/cocoa/AlternativeTextUIController.h:
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/layout/floats/PlacedFloats.h:
* Source/WebCore/layout/layouttree/LayoutBoxGeometry.h:
* Source/WebCore/page/PerformanceEventTiming.h:
* Source/WebCore/page/ProcessSyncData.in:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/platform/AudioEncoder.h:
* Source/WebCore/platform/graphics/AV1Utilities.h:
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:

Canonical link: <a href="https://commits.webkit.org/298877@main">https://commits.webkit.org/298877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/336130952f8fc6927ec6a0ff4a722a9a4e2890ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68946 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a40133e8-6ade-419e-8cef-71230ad2b5b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4946d75-39cd-44dd-a55c-a70da28eaf5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104899 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69268 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28808 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23006 "Found 1 new test failure: inspector/worker/dom-debugger-event-after-terminate-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66671 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109046 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99128 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126142 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115458 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97471 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97274 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24767 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40225 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49311 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144157 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43182 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37123 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->