### PR TITLE
[JSC] non standard new Date('2024-12-3') yields to Invalid Date

### DIFF
--- a/JSTests/stress/date-parse-with-hyphen.js
+++ b/JSTests/stress/date-parse-with-hyphen.js
@@ -1,0 +1,41 @@
+function shouldBe(actual, expected) {
+    if (Number.isNaN(expected)) {
+        if (!Number.isNaN(actual)) {
+            throw new Error(`expected ${expected} but got ${actual}`);
+        }
+    } else if (actual !== expected) {
+        throw new Error(`expected ${expected} but got ${actual}`);
+    }
+}
+
+function validateDate(dateString, expected) {
+    shouldBe(new Date(dateString).getTime(), expected);
+    shouldBe(Date.parse(dateString), expected);
+    shouldBe(new Date(dateString).getTime(), Date.parse(dateString));
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    validateDate("2024-12-3", 1733212800000);
+    validateDate("2024-12-03", 1733184000000);
+
+    validateDate("2024-1-3", 1704268800000);
+    validateDate("2024-01-3", 1704268800000);
+    validateDate("2024-1-03", 1704268800000);
+    validateDate("2024-01-03", 1704240000000);
+
+    validateDate("2024-11-03", 1730592000000);
+    validateDate("2024-11-3", 1730617200000);
+
+    validateDate("1970-01-01", 0);
+    validateDate("1970-01-1", 28800000);
+    validateDate("1970-1-01", 28800000);
+    validateDate("1970-1-1", 28800000);
+    validateDate("1970-01-1T", NaN);
+    validateDate("1970-01-01T", NaN);
+
+    validateDate("1970-01-01T00:00:00", 28800000);
+    validateDate("1970-01-01T00:00:00Z", 0);
+    validateDate("1970-1-01T00:00:00", NaN);
+    validateDate("1970-01-1T00:00:00", NaN);
+    validateDate("1970-1-1T00:00:00", NaN);
+}

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -655,6 +655,9 @@ double parseES5Date(std::span<const LChar> dateString, bool& isLocalTime)
     if (!dateString.empty())
         return std::numeric_limits<double>::quiet_NaN();
 
+    if (isSingleDigit)
+        isLocalTime = true;
+
     // A few of these checks could be done inline above, but since many of them are interrelated
     // we would be sacrificing readability to "optimize" the (presumably less common) failure path.
     if (month < 1 || month > 12)


### PR DESCRIPTION
#### 82a3a3991176fb5224c11618257260f4f68358e1
<pre>
non standard new Date(&apos;2024-12-3&apos;) yields to Invalid Date
<a href="https://bugs.webkit.org/show_bug.cgi?id=283825">https://bugs.webkit.org/show_bug.cgi?id=283825</a>

Reviewed by Yusuke Suzuki.

Date constructor and Date.parse() in WebKit previously produced
the following results:

  new Date(&apos;2024-12-3&apos;)   // -&gt; Invalid Date
  Date.parse(&apos;2024-12-3&apos;) // -&gt; NaN

This occurred because the hyphenated format does not conform to
the TC39 spec date format [1].
As a result, Each browser falls back to any implementation-specific heuristics or
implementation-specific date formats [2].
However, the WebKit&apos;s behavior is different from that of Chrome and FireFox,
introducing inconsistencies and additional complexity in web development [3][4].
This patch fixes the date parsing behavior for hyphenated date strings
to align with Chrome and Firefox.

[1]: <a href="https://tc39.es/ecma262/#sec-date-time-string-format">https://tc39.es/ecma262/#sec-date-time-string-format</a>
[2]: <a href="https://tc39.es/ecma262/#sec-date.parse">https://tc39.es/ecma262/#sec-date.parse</a>
[3]: <a href="https://stackoverflow.com/questions/4310953/invalid-date-in-safari">https://stackoverflow.com/questions/4310953/invalid-date-in-safari</a>
[4]: <a href="https://stackoverflow.com/questions/3085937/safari-js-cannot-parse-yyyy-mm-dd-date-format">https://stackoverflow.com/questions/3085937/safari-js-cannot-parse-yyyy-mm-dd-date-format</a>

* JSTests/stress/date-parse-with-hyphen.js: Added.
(shouldBe):
(validateDate):
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseES5Date):

Canonical link: <a href="https://commits.webkit.org/299182@main">https://commits.webkit.org/299182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dfb5c5cc441bf709d79c028b1a57069d5800ebc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89664 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67981 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/110269 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127390 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116668 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98344 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98132 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24953 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21512 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/41526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50607 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/145366 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44393 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37397 "Found 1 new JSC binary failure: testapi, Found 19691 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->