### PR TITLE
Navigations initiated by another cross-site frame should not preserve storage access

### DIFF
--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https-expected.txt
@@ -4,8 +4,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS Storage access was granted. document.cookie == firstPartyCookie=value, cookies seen server-side == {"firstPartyCookie":"value"}
-Did navigate iframe same-site and will now check that it still has storage access.
-PASS document.cookie == firstPartyCookie=value, cookies seen server-side == {"firstPartyCookie":"value"}
+Did navigate iframe from a cross-site parent and will now check that it does not have storage access.
+PASS document.cookie == , cookies seen server-side == "No cookies"
+PASS Storage access was granted. document.cookie == firstPartyCookie=value, cookies seen server-side == {"firstPartyCookie":"value"}
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html
@@ -124,7 +124,7 @@
                     // Navigate the frame same-site.
                     let existingIframe1 = document.getElementById("TheIframeThatRequestsStorageAccess");
                     existingIframe1.onload = function () {
-                        debug("Did navigate iframe same-site and will now check that it still has storage access.");
+                        debug("Did navigate iframe from a cross-site parent and will now check that it does not have storage access.");
                         let iframe = document.getElementById("TheIframeThatRequestsStorageAccess");
                         iframe.contentWindow.postMessage("reportBackCookies", "https://localhost:8443");
                     };
@@ -132,19 +132,30 @@
                     break;
                 case "#step8":
                     document.location.hash = "step9";
-                    // Navigate the frame cross-site. This should clear out storage access.
+                    // Re-grant storage access after same-site navigation.
                     let existingIframe2 = document.getElementById("TheIframeThatRequestsStorageAccess");
-                    existingIframe2.onload = runTest;
-                    existingIframe2.src = "https://" + partitionHost;
+                    existingIframe2.onload = function() {
+                        testRunner.statisticsUpdateCookieBlocking(function() {
+                            activateElement("TheIframeThatRequestsStorageAccess");
+                        });
+                    };
+                    existingIframe2.src = "https://localhost:8443/storageAccess/resources/request-storage-access-iframe.html?bogus#userShouldGrantAccess,userShouldBeConsulted,policyShouldGrantAccess,isNotSameOriginIframe";
                     break;
                 case "#step9":
                     document.location.hash = "step10";
-                    // Again open localhost in the existing frame and check that no cookie gets sent for localhost under 127.0.0.1 since it has been navigated cross-site.
+                    // Navigate the frame cross-site. This should clear out storage access.
                     let existingIframe3 = document.getElementById("TheIframeThatRequestsStorageAccess");
                     existingIframe3.onload = runTest;
-                    existingIframe3.src = thirdPartyBaseUrl + subPathToGetCookies + "&message=After the top frame navigates the sub frame cross-site and back, the sub frame should no longer have access to cookies.";
+                    existingIframe3.src = "https://" + partitionHost;
                     break;
                 case "#step10":
+                    document.location.hash = "step11";
+                    // Again open localhost in the existing frame and check that no cookie gets sent for localhost under 127.0.0.1 since it has been navigated cross-site.
+                    let existingIframe4 = document.getElementById("TheIframeThatRequestsStorageAccess");
+                    existingIframe4.onload = runTest;
+                    existingIframe4.src = thirdPartyBaseUrl + subPathToGetCookies + "&message=After the top frame navigates the sub frame cross-site and back, the sub frame should no longer have access to cookies.";
+                    break;
+                case "#step11":
                     // Reset access scope.
                     internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
                     setEnableFeature(false, finishJSTest);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -286,6 +286,8 @@ private:
     void didExceedNetworkUsageThreshold();
 #endif
 
+    void removeStorageAccess();
+
 #if ENABLE(PDF_PLUGIN)
     RefPtr<PluginView> m_pluginView;
     bool m_hasSentResponseToPluginView { false };


### PR DESCRIPTION
#### 4c868351be511249e30f9c7013f174075ab465c4
<pre>
Navigations initiated by another cross-site frame should not preserve storage access
<a href="https://bugs.webkit.org/show_bug.cgi?id=297504">https://bugs.webkit.org/show_bug.cgi?id=297504</a>
<a href="https://rdar.apple.com/158494253">rdar://158494253</a>

Reviewed by Matthew Finkel.

Remove storage access when the frame that initiates a navigation is cross-site from the navigating frame.
Also add a removeStorageAccess() function, since this code is now used three times in this file.

<a href="https://privacycg.github.io/storage-access/#navigation">https://privacycg.github.io/storage-access/#navigation</a>

This progresses the following WPT, but we won’t have CI coverage because we don’t have a local DNS resolver:
imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-cross-origin-iframe-navigation.sub.https.window.html

* LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https-expected.txt:
* LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html:
Update this test to expect iframe navigations initiated by a cross-site parent to lose storage access.

* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::detachedFromParent2):
(WebKit::WebLocalFrameLoaderClient::dispatchWillChangeDocument):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
(WebKit::WebLocalFrameLoaderClient::removeStorageAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/298918@main">https://commits.webkit.org/298918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d43a9285c283339b88f4aeb06b6eb020618983d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67373 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/186f0b04-3a39-4357-b573-38f3836378a0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88687 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43097 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25c5c84e-8609-4f03-8b83-8a8976dbd4e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69157 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22870 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66528 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125997 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97356 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97154 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42479 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20418 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39684 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18695 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43572 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49168 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43039 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46378 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44744 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->