### PR TITLE
[AutoFill Debugging] Part 5: Add basic support for performing interactions based on debug text output

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -1,0 +1,18 @@
+PASS clickSucceeded is true
+PASS clickCount.textContent is "1"
+PASS textInputSucceeded is true
+PASS textField.value is "bar"
+PASS selectMenuItemSucceeded is true
+PASS select.value is "Three"
+PASS selectTextSucceeded is true
+PASS getSelection().toString() is "Subject"
+PASS invalidActionSucceeded is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Test
+Subject
+
+Hello world.
+
+1

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -1,0 +1,77 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <button id="test-button" aria-label="Click Me">Test</button>
+    <input type="email" placeholder="Enter some text" value="foo" />
+    <select role="menu">
+        <option>One</option>
+        <option selected>Two</option>
+        <option>Three</option>
+    </select>
+    <div contenteditable="plaintext-only">
+        <h3 aria-label="Heading">Subject</h3>
+        <p>Hello world.</p>
+    </div>
+    <h1 class="click-count">0</h1>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        textField = document.querySelector("input");
+        select = document.querySelector("select");
+        clickCount = document.querySelector(".click-count");
+        document.getElementById("test-button").addEventListener("click", () => {
+            clickCount.textContent = parseInt(clickCount.textContent) + 1;
+        });
+
+        if (!window.testRunner)
+            return;
+
+        const debugText = await UIHelper.requestDebugText();
+
+        clickSucceeded = await UIHelper.performTextExtractionInteraction("click", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Click Me")
+        });
+
+        textInputSucceeded = await UIHelper.performTextExtractionInteraction("textinput", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Enter some text"),
+            replaceAll: true,
+            text: "bar"
+        });
+
+        selectMenuItemSucceeded = await UIHelper.performTextExtractionInteraction("selectmenuitem", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "menu"),
+            text: "Three"
+        });
+
+        selectTextSucceeded = await UIHelper.performTextExtractionInteraction("selecttext", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "contentEditable"),
+            text: "Subject"
+        });
+
+        invalidActionSucceeded = await UIHelper.performTextExtractionInteraction("click", {
+            nodeIdentifier: "invalid_id"
+        });
+
+        shouldBeTrue("clickSucceeded");
+        shouldBeEqualToString("clickCount.textContent", "1");
+        shouldBeTrue("textInputSucceeded");
+        shouldBeEqualToString("textField.value", "bar");
+        shouldBeTrue("selectMenuItemSucceeded");
+        shouldBeEqualToString("select.value", "Three");
+        shouldBeTrue("selectTextSucceeded");
+        shouldBeEqualToString("getSelection().toString()", "Subject");
+        shouldBeFalse("invalidActionSucceeded");
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2463,6 +2463,34 @@ window.UIHelper = class UIHelper {
             });
         });
     }
+
+    static nodeIdentifierFromDebugText(text, searchTerm)
+    {
+        for (let line of text.split("\n")) {
+            if (!line.includes(searchTerm))
+                continue;
+
+            const match = line.match(/uid=(\d+)/);
+            if (match)
+                return match[1];
+        }
+        return null;
+    }
+
+    static async performTextExtractionInteraction(action, options)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve(false);
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.performTextExtractionInteraction("${action}"
+                    , ${JSON.stringify(options)}
+                    , result => uiController.uiScriptComplete(result));`, (result) => {
+                        resolve(result === "true")
+                    });
+        });
+    }
 }
 
 UIHelper.EventStreamBuilder = class {

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -41,6 +41,8 @@ namespace TextExtraction {
 WEBCORE_EXPORT Item extractItem(Request&&, Page&);
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 
+WEBCORE_EXPORT void handleInteraction(Interaction&&, Page&, CompletionHandler<void(bool)>&&);
+
 struct RenderedText {
     String textWithReplacedContent;
     String textWithoutReplacedContent;

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -35,6 +35,21 @@
 namespace WebCore {
 namespace TextExtraction {
 
+enum class Action : uint8_t {
+    Click,
+    SelectText,
+    SelectMenuItem,
+    TextInput,
+};
+
+struct Interaction {
+    Action action { Action::Click };
+    String text;
+    std::optional<FloatPoint> locationInRootView;
+    std::optional<NodeIdentifier> nodeIdentifier;
+    bool replaceAll { false };
+};
+
 enum class EventListenerCategory : uint8_t {
     Click       = 1 << 0,
     Hover       = 1 << 1,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7042,6 +7042,23 @@ header: <WebCore/LayerTreeAsTextOptions.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] enum class WebCore::TextExtraction::Action : uint8_t {
+    Click,
+    SelectText,
+    SelectMenuItem,
+    TextInput
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::Interaction {
+    WebCore::TextExtraction::Action action;
+    String text;
+    std::optional<WebCore::FloatPoint> locationInRootView;
+    std::optional<WebCore::NodeIdentifier> nodeIdentifier;
+    bool replaceAll;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Request {
     std::optional<WebCore::FloatRect> collectionRectInRootView;
     bool mergeParagraphs;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -142,6 +142,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @class _WKTargetedElementRequest;
 @class _WKTextInputContext;
 @class _WKTextExtractionConfiguration;
+@class _WKTextExtractionInteraction;
 @class WKTextExtractionResult;
 @class _WKTextManipulationConfiguration;
 @class _WKTextManipulationItem;
@@ -167,7 +168,6 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @protocol _WKIconLoadingDelegate;
 @protocol _WKInputDelegate;
 @protocol _WKResourceLoadDelegate;
-@protocol _WKTextExtractionInteraction;
 @protocol _WKTextManipulationDelegate;
 
 @interface WKWebView (WKPrivate)
@@ -637,6 +637,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 #endif
 
 - (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
+- (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL success))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -41,4 +41,29 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 
 @end
 
+typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
+    _WKTextExtractionActionClick,
+    _WKTextExtractionActionSelectText,
+    _WKTextExtractionActionSelectMenuItem,
+    _WKTextExtractionActionTextInput,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_SWIFT_UI_ACTOR
+NS_REQUIRES_PROPERTY_DEFINITIONS
+@interface _WKTextExtractionInteraction : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithAction:(_WKTextExtractionAction)action NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic, readonly) _WKTextExtractionAction action;
+@property (nonatomic, copy, nullable) NSString *nodeIdentifier;
+@property (nonatomic, copy, nullable) NSString *text;
+@property (nonatomic) BOOL replaceAll;
+
+// Must be within the visible bounds of the web view.
+@property (nonatomic) CGPoint location;
+
+@end
+
 NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -39,3 +39,51 @@
 }
 
 @end
+
+@implementation _WKTextExtractionInteraction {
+    RetainPtr<NSString> _nodeIdentifier;
+    RetainPtr<NSString> _text;
+}
+
+@synthesize action = _action;
+@synthesize replaceAll = _replaceAll;
+@synthesize location = _location;
+@synthesize hasSetLocation = _hasSetLocation;
+
+- (instancetype)initWithAction:(_WKTextExtractionAction)action
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _location = CGPointZero;
+    _action = action;
+    return self;
+}
+
+- (NSString *)nodeIdentifier
+{
+    return _nodeIdentifier.get();
+}
+
+- (void)setNodeIdentifier:(NSString *)nodeIdentifier
+{
+    _nodeIdentifier = adoptNS(nodeIdentifier.copy);
+}
+
+- (NSString *)text
+{
+    return _text.get();
+}
+
+- (void)setText:(NSString *)text
+{
+    _text = adoptNS(text.copy);
+}
+
+- (void)setLocation:(CGPoint)location
+{
+    _hasSetLocation = YES;
+    _location = location;
+}
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift
@@ -619,14 +619,7 @@ extension WKTextExtractionScrollableItem {
 @_objcImplementation
 extension WKTextExtractionSelectItem {
     let selectedValues: [String]
-
-    @nonobjc
-    private let backingSupportsMultiple: Bool
-    @objc(multiple)
-    var supportsMultiple: Bool {
-        @objc(supportsMultiple)
-        get { backingSupportsMultiple }
-    }
+    let supportsMultiple: Bool
 
     init(
         selectedValues: [String],
@@ -639,7 +632,7 @@ extension WKTextExtractionSelectItem {
         nodeIdentifier: String?
     ) {
         self.selectedValues = selectedValues
-        self.backingSupportsMultiple = supportsMultiple
+        self.supportsMultiple = supportsMultiple
         super
             .init(
                 with: rectInWebView,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -52,6 +52,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface _WKTextExtractionInteraction ()
+
+@property (nonatomic, readonly) BOOL hasSetLocation;
+
+@end
+
 typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
     WKTextExtractionContainerRoot,
     WKTextExtractionContainerViewportConstrained,

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16496,6 +16496,14 @@ void WebPageProxy::requestTextExtraction(WebCore::TextExtraction::Request&& requ
     sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(WTFMove(request)), WTFMove(completion));
 }
 
+void WebPageProxy::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool)>&& completion)
+{
+    if (!hasRunningProcess())
+        return completion(false);
+
+    sendWithAsyncReply(Messages::WebPage::HandleTextExtractionInteraction(WTFMove(interaction)), WTFMove(completion));
+}
+
 void WebPageProxy::addConsoleMessage(FrameIdentifier frameID, MessageSource messageSource, MessageLevel messageLevel, const String& message, std::optional<ResourceLoaderIdentifier> coreIdentifier)
 {
     send(Messages::WebPage::AddConsoleMessage { frameID, messageSource, messageLevel, message, coreIdentifier });

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -338,6 +338,7 @@ struct OpenID4VPRequest;
 #endif
 
 namespace TextExtraction {
+struct Interaction;
 struct Item;
 struct Request;
 }
@@ -2621,6 +2622,7 @@ public:
     void takeSnapshotForTargetedElement(const API::TargetedElementInfo&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
     void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool)>&&);
 
     void hasVideoInPictureInPictureDidChange(bool);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10066,6 +10066,11 @@ void WebPage::requestTextExtraction(TextExtraction::Request&& request, Completio
     completion(TextExtraction::extractItem(WTFMove(request), Ref { *corePage() }));
 }
 
+void WebPage::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool)>&& completion)
+{
+    TextExtraction::handleInteraction(WTFMove(interaction), Ref { *corePage() }, WTFMove(completion));
+}
+
 template<typename T> T WebPage::contentsToRootView(WebCore::FrameIdentifier frameID, T geometry)
 {
     RefPtr webFrame = WebProcess::singleton().webFrame(frameID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -349,6 +349,7 @@ using ScrollOffset = IntPoint;
 using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierType>;
 
 namespace TextExtraction {
+struct Interaction;
 struct Item;
 struct Request;
 }
@@ -2584,6 +2585,7 @@ private:
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<WebCore::TargetedElementInfo>>&&)>&&);
 
     void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool)>&&);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     static void setHasLaunchedWebContentProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -810,6 +810,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     RequestAllTargetableElements(float hitTestInterval) -> (Vector<Vector<WebCore::TargetedElementInfo>> elements)
 
     RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
+    HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool success)
 
 #if PLATFORM(IOS_FAMILY)
     ShouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint point) -> (bool shouldDismiss)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -49,6 +49,14 @@ dictionary TextExtractionOptions {
     boolean skipNearlyTransparentContent = false;
 };
 
+dictionary TextExtractionInteractionOptions {
+    DOMString nodeIdentifier;
+    DOMString text;
+    double x = -1;
+    double y = -1;
+    boolean replaceAll = false;
+};
+
 interface UIScriptController {
 
     undefined doAsyncTask(object callback); // Used to test the harness.
@@ -431,6 +439,7 @@ interface UIScriptController {
 
     undefined requestTextExtraction(object callback, TextExtractionOptions options);
     undefined requestDebugText(object callback);
+    undefined performTextExtractionInteraction(DOMString action, TextExtractionInteractionOptions options, object callback);
 
     undefined requestRenderedTextForFrontmostTarget(long x, long y, object callback);
     undefined adjustVisibilityForFrontmostTarget(long x, long y, object callback);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -67,6 +67,15 @@ struct TextExtractionOptions {
 
 TextExtractionOptions* toTextExtractionOptions(JSContextRef, JSValueRef);
 
+struct TextExtractionInteractionOptions {
+    JSRetainPtr<JSStringRef> nodeIdentifier;
+    JSRetainPtr<JSStringRef> text;
+    std::optional<std::pair<double, double>> location;
+    bool replaceAll { false };
+};
+
+TextExtractionInteractionOptions* toTextExtractionInteractionOptions(JSContextRef, JSValueRef);
+
 class UIScriptController : public JSWrappable {
 public:
     static Ref<UIScriptController> create(UIScriptContext&);
@@ -437,6 +446,7 @@ public:
     // Text Extraction
     virtual void requestTextExtraction(JSValueRef, TextExtractionOptions*) { notImplemented(); }
     virtual void requestDebugText(JSValueRef) { notImplemented(); }
+    virtual void performTextExtractionInteraction(JSStringRef, TextExtractionInteractionOptions*, JSValueRef) { notImplemented(); }
 
     // Element Targeting
     virtual void requestRenderedTextForFrontmostTarget(int, int, JSValueRef) { notImplemented(); }

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -29,6 +29,7 @@
 #include "JSBasics.h"
 #include "JSUIScriptController.h"
 #include "UIScriptContext.h"
+#include <JavaScriptCore/JSRetainPtr.h>
 #include <JavaScriptCore/JSValueRef.h>
 #include <JavaScriptCore/OpaqueJSString.h>
 
@@ -75,6 +76,35 @@ TextExtractionOptions* toTextExtractionOptions(JSContextRef context, JSValueRef 
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);
     options.canIncludeIdentifiers = booleanProperty(context, (JSObjectRef)argument, "canIncludeIdentifiers", false);
+    return &options;
+}
+
+TextExtractionInteractionOptions* toTextExtractionInteractionOptions(JSContextRef context, JSValueRef argument)
+{
+    if (!JSValueIsObject(context, argument))
+        return nullptr;
+
+    static TextExtractionInteractionOptions options;
+    if (auto nodeIdentifier = property(context, (JSObjectRef)argument, "nodeIdentifier"); isValidValue(context, nodeIdentifier))
+        options.nodeIdentifier = createJSString(context, nodeIdentifier);
+    else
+        options.nodeIdentifier = nullptr;
+
+    if (auto text = property(context, (JSObjectRef)argument, "text"); isValidValue(context, text))
+        options.text = createJSString(context, text);
+    else
+        options.text = nullptr;
+
+    options.replaceAll = booleanProperty(context, (JSObjectRef)argument, "replaceAll");
+
+    if (auto locationObject = objectProperty(context, (JSObjectRef)argument, "location")) {
+        options.location = {
+            numericProperty(context, locationObject, "x"),
+            numericProperty(context, locationObject, "y")
+        };
+    } else
+        options.location = std::nullopt;
+
     return &options;
 }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -91,6 +91,7 @@ private:
 
     void requestTextExtraction(JSValueRef callback, TextExtractionOptions*) final;
     void requestDebugText(JSValueRef callback) final;
+    void performTextExtractionInteraction(JSStringRef action, TextExtractionInteractionOptions*, JSValueRef callback) final;
 
     void requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback) final;
     void adjustVisibilityForFrontmostTarget(int x, int y, JSValueRef callback) final;


### PR DESCRIPTION
#### 836aff4c889665e9fdfc77e0c7aed2b348bf1184
<pre>
[AutoFill Debugging] Part 5: Add basic support for performing interactions based on debug text output
<a href="https://bugs.webkit.org/show_bug.cgi?id=297506">https://bugs.webkit.org/show_bug.cgi?id=297506</a>
<a href="https://rdar.apple.com/158496489">rdar://158496489</a>

Reviewed by Richard Robinson.

Add support for performing interactions based on the output of `-_debugText`. Clients may now create
a `_WKTextExtractionInteraction` object that describes a single interaction with the page (clicking,
selecting text, editing) and send it through `-[WKWebView performInteraction:completionHandler:]`.

See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html: Added.

Add a layout test to exercise the new interaction actions.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.nodeIdentifierFromDebugText):

Add a new `UIHelper` method to extract a `nodeIdentifier` from raw debug text returned from
`UIHelper.requestDebugText`, of the form `uid=…`.

(window.UIHelper.async performTextExtractionInteraction):

Add a new `UIHelper` method to perform an interaction, taking an action name and an options
dictionary.

(window.UIHelper):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::searchForText):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::selectOptionByValue):
(WebCore::TextExtraction::selectText):
(WebCore::TextExtraction::focusAndInsertText):
(WebCore::TextExtraction::handleInteraction):

Add support for each of the action types. Note that these are all currently synchronous, but may (in
the future) require asynchronous handling; we pass completion handlers through these helper methods
to help make that change easier in the near future.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(toNodeIdentifier):
(-[WKWebView _performInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionInteraction initWithAction:]):
(-[_WKTextExtractionInteraction nodeIdentifier]):
(-[_WKTextExtractionInteraction setNodeIdentifier:]):
(-[_WKTextExtractionInteraction text]):
(-[_WKTextExtractionInteraction setText:]):
(-[_WKTextExtractionInteraction setLocation:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.swift:
(WKTextExtractionSelectItem.supportsMultiple): Deleted.

Drive-by fix: remove `backingSupportsMultiple`. This is unnecessary, since this readonly getter is
not `is`-prefixed.

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleTextExtractionInteraction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::handleTextExtractionInteraction):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::performTextExtractionInteraction):
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionInteractionOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/298819@main">https://commits.webkit.org/298819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cba3c5d0993837172c325efd94a33a2fa8ac4b03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67366 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e8e8f3d-c3f7-432f-a035-472735a5739c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88682 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a3e831e6-8abf-457b-a092-40bfff8ecf11) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69152 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22862 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66522 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125991 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97352 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39674 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49162 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43033 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->