### PR TITLE
[Tools] `jsc-armv7-tests` EWS Fails due to syntax error in Python Script

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3737,7 +3737,7 @@ class RunJavaScriptCoreTests(shell.Test, AddToLogMixin, ShellMixin):
             self.command.extend(['--memory-limited', '--verbose'])
 
         if self.getProperty('architecture') in ["armv7"]:
-            self.command = ["linux32"] ++ self.command
+            self.command = ["linux32"] + self.command
 
         self.setCommand(self.command + customBuildFlag(self.getProperty('platform'), self.getProperty('fullPlatform')))
         self.command.extend(self.command_extra)


### PR DESCRIPTION
#### 773e81357a0cefb81c765101348892116b29a306
<pre>
[Tools] `jsc-armv7-tests` EWS Fails due to syntax error in Python Script
<a href="https://bugs.webkit.org/show_bug.cgi?id=297510">https://bugs.webkit.org/show_bug.cgi?id=297510</a>

Reviewed by NOBODY (OOPS!).

`jsc-armv7-tests` EWS fails due to syntax error in Python Script.
builtins.TypeError: bad operand type for unary +: &apos;list&apos;.

* Tools/CISupport/ews-build/steps.py:
(RunJavaScriptCoreTests.start):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/773e81357a0cefb81c765101348892116b29a306

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/26993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88664 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22842 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32784 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97337 "Failure limit exceed. At least found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/116195 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100939 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97130 "Found 10 new API test failures: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/open-window-default-size, /WebKitGTK/TestWebKitFindController:/webkit/WebKitFindController/hide, /TestWebKit:WebKit.OnDeviceChangeCrash, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/snapshot, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/preferred-size, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/test-page-list, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/page-visibility (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20390 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/39636 "The change is no longer eligible for processing.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18643 "Failed to checkout and rebase branch from PR 49505") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43545 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->