### PR TITLE
[Navigation API] Fix cross-window navigation with document.domain.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7073,7 +7073,7 @@ webkit.org/b/297414 [ Debug ] imported/w3c/web-platform-tests/navigation-api/nav
 webkit.org/b/291451 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted.html [ Pass Crash ]
 webkit.org/b/297477 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-back-bfcache.html [ Timeout Pass Failure ]
 
-# These cross-window tests won't work on ports that don't run on the web-platform.test domains (not glib).
+# These cross-window needs --allowed-host=www1.localhost, so tested manually.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-crossdocument-crossorigin-sameorigindomain.sub.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-crossorigin-sameorigindomain.sub.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?foo
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT clicking on an <a> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window Test timed out
+PASS clicking on an <a> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html#foo
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT clicking on an <a> element that navigates same-document targeting a same-origin-domain (but cross-origin) window Test timed out
+PASS clicking on an <a> element that navigates same-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?foo
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT using location.href to navigate cross-document targeting a same-origin-domain (but cross-origin) window Test timed out
+PASS using location.href to navigate cross-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html#foo
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT using location.href to navigate same-document targeting a same-origin-domain (but cross-origin) window Test timed out
+PASS using location.href to navigate same-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?foo
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT using window.open() to navigate cross-document targeting a same-origin-domain (but cross-origin) window Test timed out
+PASS using window.open() to navigate cross-document targeting a same-origin-domain (but cross-origin) window
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,0 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html#foo
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT using window.open() to navigate same-document targeting a same-origin-domain (but cross-origin) window Test timed out
-

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,0 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?start
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT submitting a <form> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window Test timed out
-

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt
@@ -1,8 +1,0 @@
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?
-Blocked access to external URL http://www1.localhost:8800/navigation-api/navigate-event/cross-window/resources/document-domain-setter.sub.html?#foo
-
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT submitting a <form> element that navigates cross-document targeting a same-origin-domain (but cross-origin) window Test timed out
-

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -766,8 +766,12 @@ static bool documentCanHaveURLRewritten(const Document& document, const URL& tar
     const URL& documentURL = document.url();
     Ref documentOrigin = document.securityOrigin();
     auto targetOrigin = SecurityOrigin::create(targetURL);
+    bool isSameSite = documentOrigin->isSameSiteAs(targetOrigin);
+    bool isSameOrigin = documentOrigin->isSameOriginAs(targetOrigin);
 
-    if (!documentOrigin->isSameSiteAs(targetOrigin))
+    // For cross-window navigation with document.domain, we need to check same-origin rather than same-site
+    // to account for document.domain modifications that make cross-origin windows same-origin-domain
+    if (!isSameSite && !isSameOrigin)
         return false;
 
     if (targetURL.protocolIsInHTTPFamily())


### PR DESCRIPTION
#### eb6808f3fd93553fd1afa41207e852d23b0ff068
<pre>
[Navigation API] Fix cross-window navigation with document.domain.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297511">https://bugs.webkit.org/show_bug.cgi?id=297511</a>
<a href="https://rdar.apple.com/158494847">rdar://158494847</a>

Reviewed by Tim Nguyen.

Navigation API cross-window WPT tests were failing due to two issues:

1. documentCanHaveURLRewritten() only checked same-site origins, but cross-window
    navigation with document.domain requires same-origin-domain support. When both
    windows set document.domain to the same value, they become same-origin-domain
    even if they were originally cross-origin.

2. WebKitTestRunner blocked WPT hostnames (e.g., www1.localhost) as external URLs,
    preventing cross-window test scenarios from working.

This patch addresses the first issue and confirm the fix by running test with
following options:

$ run-webkit-tests --allowed-host=www1.localhost --force \
  imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-crossdocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/click-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-crossdocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/location-samedocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-crossdocument-crossorigin-sameorigindomain.sub-expected.txt:
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-samedocument-crossorigin-sameorigindomain.sub-expected.txt: Removed.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-crossorigin-sameorigindomain.sub-expected.txt: Removed.
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub-expected.txt: Removed.
* Source/WebCore/page/Navigation.cpp:
(WebCore::documentCanHaveURLRewritten):

Canonical link: <a href="https://commits.webkit.org/298896@main">https://commits.webkit.org/298896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc84c83ac331c29ed86a5a1f48edb487ebafd3a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69033 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39e37213-0050-4ee6-80cc-f30e5a256ec7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb9a6d1d-bf1a-4612-98f4-b1891cb5e275) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69330 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23083 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66756 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126240 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97537 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43268 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44979 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->