### PR TITLE
Change StringBuilder in percentEncodeCharacters() to use RecordOverflow

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1206,6 +1206,10 @@ imported/w3c/web-platform-tests/webauthn/remote-desktop-client-override.tentativ
 # This test adds a lot of iframes and is slow to run.
 fast/dom/connected-subframe-counter-overflow.html [ Slow ]
 
+# These tests normally timeout on mac-AS-debug-wk2.
+fast/dom/DOMURL/url-very-large-username-no-crash.html [ Slow ]
+fast/dom/DOMURL/url-very-large-password-no-crash.html [ Slow ]
+
 http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html [ Skip ]
 http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Skip ]
 

--- a/LayoutTests/fast/dom/DOMURL/url-very-large-password-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/DOMURL/url-very-large-password-no-crash-expected.txt
@@ -1,0 +1,11 @@
+Test setting the password attribute of a URL object with a very large value does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Setting password
+PASS url.href is 'http://example.com/'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/DOMURL/url-very-large-password-no-crash.html
+++ b/LayoutTests/fast/dom/DOMURL/url-very-large-password-no-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+    }
+
+    var url = new URL("about:blank");
+
+    function runTest() {
+        const largeSize = 800_000_000;
+        const largeString = "\u0000".repeat(largeSize);
+
+        description('Test setting the password attribute of a URL object with a very large value does not crash.');
+        debug("Setting password");
+        url.href = "http://@example.com/";
+        url.password = largeString;
+        shouldBe("url.href", "'http://example.com/'");
+    }
+
+    runTest();
+    testRunner.notifyDone();
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/DOMURL/url-very-large-username-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/DOMURL/url-very-large-username-no-crash-expected.txt
@@ -1,0 +1,11 @@
+Test setting the username attribute of a URL object with a very large value does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Setting username
+PASS url.href is 'http://example.com/'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/DOMURL/url-very-large-username-no-crash.html
+++ b/LayoutTests/fast/dom/DOMURL/url-very-large-username-no-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+    }
+
+    var url = new URL("about:blank");
+
+    function runTest() {
+        const largeSize = 800_000_000;
+        const largeString = "\u0000".repeat(largeSize);
+
+        description('Test setting the username attribute of a URL object with a very large value does not crash.');
+        debug("Setting username");
+        url.href = "http://example.com/";
+        url.username = largeString;
+        shouldBe("url.href", "'http://example.com/'");
+    }
+
+    runTest();
+    testRunner.notifyDone();
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -613,12 +613,14 @@ static String percentEncodeCharacters(const StringType& input, bool(*shouldEncod
 {
     auto encode = [shouldEncode] (const StringType& input) {
         auto result = input.tryGetUTF8([&](std::span<const char8_t> span) -> String {
-            StringBuilder builder;
+            StringBuilder builder(OverflowPolicy::RecordOverflow);
             for (char c : span) {
                 if (shouldEncode(c))
                     builder.append('%', upperNibbleToASCIIHexDigit(c), lowerNibbleToASCIIHexDigit(c));
                 else
                     builder.append(c);
+                if (builder.hasOverflowed())
+                    return { };
             }
             return builder.toString();
         });


### PR DESCRIPTION
#### c2305a63f21d47a6b405b35a78dbe472e96b401e
<pre>
Change StringBuilder in percentEncodeCharacters() to use RecordOverflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=297514">https://bugs.webkit.org/show_bug.cgi?id=297514</a>
<a href="https://rdar.apple.com/157533134">rdar://157533134</a>

Reviewed by Alex Christensen.

Assigning a very large string to the username or password properties of
a URL object can result in a StringBuilder overflow during the call to
percentEncodeCharacters(), which will crash with the default overflow policy.
Change the policy from CrashOnOverflow to RecordOverflow.

* LayoutTests/fast/dom/DOMURL/url-very-large-password-no-crash-expected.txt: Added.
* LayoutTests/fast/dom/DOMURL/url-very-large-password-no-crash.html: Added.
* LayoutTests/fast/dom/DOMURL/url-very-large-username-no-crash-expected.txt: Added.
* LayoutTests/fast/dom/DOMURL/url-very-large-username-no-crash.html: Added.
* Source/WTF/wtf/URL.cpp:
(WTF::percentEncodeCharacters):

Canonical link: <a href="https://commits.webkit.org/298985@main">https://commits.webkit.org/298985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69c608309dff3c1ab15cce7f67ac79d7a9480378

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69302 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4bc8880-f7f3-4538-b245-edd5d1e05685) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89033 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43702 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6388f4ee-b524-431e-9315-b106808e13d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69540 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/72890a22-2653-4946-b928-7bb7a240f50b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23303 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67088 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109421 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126536 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115823 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97698 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97493 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40563 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49745 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144523 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43542 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37201 "Found 1 new JSC binary failure: testapi, Found 20026 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->