### PR TITLE
Fix sandbox compilation of development sandboxes

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in
@@ -22,5 +22,6 @@
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
 #define deny allow (with report)
+#define NO_REPORT
 
 #include "Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in"

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -214,7 +214,7 @@
     ;; <rdar://problem/10809394>
     (deny file-write-create
         (home-prefix "/Library/Preferences/com.apple.Accessibility.plist")
-        (with no-report))
+        NO_REPORT)
 )
 
 (define-once (media-accessibility-support)
@@ -267,7 +267,7 @@
            (literal "/dev/random")
            (literal "/dev/urandom"))
     ;; <rdar://problem/14215718>
-    (deny file-write-data (with no-report)
+    (deny file-write-data NO_REPORT
           (literal "/dev/random")
           (literal "/dev/urandom")))
 
@@ -312,7 +312,7 @@
     ;; <rdar://problem/13796537>
     (deny file-write-create
         (home-prefix "/Library/Preferences/com.apple.UIKit.plist")
-        (with no-report))
+        NO_REPORT)
 )
 
 (deny file-map-executable)
@@ -450,7 +450,7 @@
 (allow system-sched (with telemetry)
        (require-entitlement "com.apple.private.kernel.override-cpumon"))
 
-(deny sysctl-read (with no-report)
+(deny sysctl-read NO_REPORT
       (sysctl-name
           "hw.tbfrequency_compat" ;; <rdar://71740719>
           "sysctl.proc_native"))
@@ -473,7 +473,7 @@
 
 (managed-configuration-read-public)
 
-(deny system-info (with no-report)
+(deny system-info NO_REPORT
       (info-type "net.link.addr"))
 
 (allow-well-known-system-group-container-subpath-read
@@ -523,7 +523,7 @@
 
 ;; Silently deny unnecessary accesses caused by MessageUI framework.
 ;; This can be removed once <rdar://problem/47038102> is resolved.
-(deny file-read* (with no-report)
+(deny file-read* NO_REPORT
     (home-literal "/Library/Preferences/com.apple.mobilemail.plist"))
 
 (allow file-read*
@@ -539,7 +539,7 @@
 (uikit-requirements)
 
 ; Silently deny writes when CFData attempts to write to the cache directory.
-(deny file-write* (with no-report)
+(deny file-write* NO_REPORT
     (home-literal "/Library/Caches/DateFormats.plist"))
 
 ; <rdar://problem/7595408> , <rdar://problem/7643881>
@@ -549,7 +549,7 @@
 ; which will attempt to create the plist if it doesn't exist -- from any application.  Only SpringBoard is
 ; allowed to write its plist; ignore all others, they don't know what they are doing.
 ; See <rdar://problem/9375027> for sample backtraces.
-(deny file-write* (with no-report)
+(deny file-write* NO_REPORT
     (home-prefix "/Library/Preferences/com.apple.springboard.plist"))
 
 ;;;
@@ -691,7 +691,7 @@
         (global-name "com.apple.analyticsd")))
 
 ;; Silence reports about things we do not want access to:
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name
         "com.apple.audioanalyticsd"
         "com.apple.coremedia.mediaparserd.utilities"
@@ -700,10 +700,10 @@
 (deny file-write-create (vnode-type SYMLINK))
 (deny file-read-xattr file-write-xattr (xattr-prefix "com.apple.security.private."))
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name "com.apple.audio.AudioComponentRegistrar"))
 
 (deny mach-lookup
@@ -732,7 +732,7 @@
 (when (defined? 'syscall-unix)
     (deny syscall-unix (with telemetry))
     (when (defined? 'SYS_crossarch_trap)
-        (deny syscall-unix (with no-report) (syscall-number
+        (deny syscall-unix NO_REPORT (syscall-number
             SYS_crossarch_trap)))
 #if ASAN_ENABLED
     (allow syscall-unix

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
@@ -22,6 +22,7 @@
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
 #define deny allow (with report)
+#define NO_REPORT
 
 #include "Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in"
 

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -307,7 +307,7 @@
            (global-name "com.apple.cfnetwork.cfnetworkagent"))
 
     ;; <rdar://problem/12620714>
-    (deny file-write-create (with no-report)
+    (deny file-write-create NO_REPORT
           (home-prefix "/Library/Logs/CrashReporter/CFNetwork_"))
 
     (deny mach-lookup 
@@ -514,7 +514,7 @@
 (deny mach-lookup 
     (global-name "com.apple.ctkd.token-client"))
 
-(deny system-info (with no-report)
+(deny system-info NO_REPORT
     (info-type "net.link.addr"))
 
 (allow mach-lookup
@@ -624,7 +624,7 @@
 (deny file-write-create
       (vnode-type SYMLINK))
 
-(deny file-read* (with no-report)
+(deny file-read* NO_REPORT
     (literal "/private/etc/group"))
 
 ;; FIXME should be removed when <rdar://problem/30498072> is fixed.
@@ -687,7 +687,7 @@
     (allow file-read* file-write-data file-ioctl 
         (literal "/dev/dtracehelper"))
 ; else
-    (deny (with no-report) file-read* file-write-data file-ioctl
+    (deny NO_REPORT file-read* file-write-data file-ioctl
         (literal "/dev/dtracehelper"))
 )
 
@@ -709,9 +709,9 @@
 (when (defined? 'syscall-unix)
     (deny syscall-unix (with telemetry))
     (when (defined? 'SYS_crossarch_trap)
-        (deny syscall-unix (with no-report) (syscall-number
+        (deny syscall-unix NO_REPORT (syscall-number
             SYS_crossarch_trap)))
-    (deny syscall-unix (with no-report) (syscall-number
+    (deny syscall-unix NO_REPORT (syscall-number
         SYS___nexus_set_opt))
     (allow syscall-unix (syscall-number
         SYS___channel_get_info

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in
@@ -22,5 +22,6 @@
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
 #define deny allow (with report)
+#define NO_REPORT
 
 #include "Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in"

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -116,7 +116,7 @@
     ;; <rdar://problem/10809394>
     (deny file-write-create
         (home-prefix "/Library/Preferences/com.apple.Accessibility.plist")
-        (with no-report))
+        NO_REPORT)
 )
 
 (define-once (media-accessibility-support)
@@ -221,7 +221,7 @@
            (literal "/dev/random")
            (literal "/dev/urandom"))
     ;; <rdar://problem/14215718>
-    (deny file-write-data (with no-report)
+    (deny file-write-data NO_REPORT
           (literal "/dev/random")
           (literal "/dev/urandom"))
 
@@ -303,7 +303,7 @@
     ;; <rdar://problem/13796537>
     (deny file-write-create
         (home-prefix "/Library/Preferences/com.apple.UIKit.plist")
-        (with no-report))
+        NO_REPORT)
 )
 
 (define-once (dictionary-support)
@@ -434,7 +434,7 @@
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 #if ENABLE(REMOVE_XPC_AND_MACH_SANDBOX_EXTENSIONS_IN_WEBCONTENT)
 (with-filter (logd-blocking)
-    (deny mach-lookup (with no-report) (log-services)))
+    (deny mach-lookup NO_REPORT (log-services)))
 (with-filter (require-not (logd-blocking))
     (allow mach-lookup (log-services)))
 #else
@@ -445,10 +445,10 @@
 (allow mach-lookup (log-services))
 #endif
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name "com.apple.distributed_notifications@1v3"))
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name "com.apple.lsd.mapdb")) 
 
 ;; <rdar://problem/12413942>
@@ -458,13 +458,13 @@
 (allow iokit-get-properties
        (iokit-property "IORegistryEntryPropertyKeys"))
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name "com.apple.runningboard"))
 
 (allow system-sched
        (require-entitlement "com.apple.private.kernel.override-cpumon"))
 
-(deny sysctl-read (with no-report)
+(deny sysctl-read NO_REPORT
       (sysctl-name
           "hw.cpufrequency_compat"
           "hw.tbfrequency_compat" ;; <rdar://71740719>
@@ -485,7 +485,7 @@
     (allow mach-lookup (global-name "com.apple.system.notification_center")
         (apply-message-filter
             (deny mach-message-send)
-            (deny mach-message-send (with no-report) (message-number 1023))
+            (deny mach-message-send NO_REPORT (message-number 1023))
             (allow mach-message-send (notifyd-message-numbers)))))
 
 #if ENABLE(NOTIFY_BLOCKING)
@@ -497,7 +497,7 @@
 
 (managed-configuration-read-public)
 
-(deny system-info (with no-report)
+(deny system-info NO_REPORT
     (info-type "net.link.addr"))
 
 (allow file-read*
@@ -557,7 +557,7 @@
 
 ;; Silently deny unnecessary accesses caused by MessageUI framework.
 ;; This can be removed once <rdar://problem/47038102> is resolved.
-(deny file-read* (with no-report)
+(deny file-read* NO_REPORT
     (home-literal "/Library/Preferences/com.apple.mobilemail.plist"))
 
 ;; <rdar://problem/12985925> Need read access to /var/mobile/Library/Fonts to all apps
@@ -586,7 +586,7 @@
 (allow file-read*
     (home-literal "/Library/Caches/DateFormats.plist"))
 ; Silently deny writes when CFData attempts to write to the cache directory.
-(deny file-write* (with no-report)
+(deny file-write* NO_REPORT
     (home-literal "/Library/Caches/DateFormats.plist"))
 
 (framebuffer-access)
@@ -598,7 +598,7 @@
 ; which will attempt to create the plist if it doesn't exist -- from any application.  Only SpringBoard is
 ; allowed to write its plist; ignore all others, they don't know what they are doing.
 ; See <rdar://problem/9375027> for sample backtraces.
-(deny file-write* (with no-report)
+(deny file-write* NO_REPORT
     (home-prefix "/Library/Preferences/com.apple.springboard.plist"))
 
 ;; <rdar://problem/34986314>
@@ -606,7 +606,7 @@
 
 (mobile-preferences-read "com.apple.AdLib.plist")
 
-(deny file-read* (with no-report)
+(deny file-read* NO_REPORT
     (home-literal
         "/Library/Preferences/com.apple.WebKit.WebContent.plist"
         "/Library/Preferences/com.apple.CFNetwork.plist"
@@ -670,7 +670,7 @@
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76782530>
 )
 
-(deny sysctl-read (with no-report)
+(deny sysctl-read NO_REPORT
     (sysctl-name "vm.task_no_footprint_for_debug"))
 
 (with-filter (require-not (webcontent-process-launched))
@@ -776,7 +776,7 @@
 
 (media-accessibility-support)
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name
         "com.apple.SystemConfiguration.configd"
         "com.apple.aggregated"
@@ -802,10 +802,10 @@
 )
 
 ;; <rdar://problem/60983812>
-(deny file-write* (with no-report)
+(deny file-write* NO_REPORT
     (home-subpath "/Library/Preferences/"))
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (global-name
         "com.apple.containermanagerd"
         "com.apple.containermanagerd.system"))
@@ -820,7 +820,7 @@
             (extension "com.apple.webkit.extension.mach")
             (global-name "com.apple.mobilegestalt.xpc"))))
 
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (xpc-service-name "com.apple.audio.toolbox.reporting.service"))
 
 #if !ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)
@@ -840,11 +840,11 @@
         (iokit-user-client-class "IOSurfaceAcceleratorClient")))
 #endif
 
-(deny iokit-open-user-client (with no-report)
+(deny iokit-open-user-client NO_REPORT
     (iokit-user-client-class "AppleJPEGDriverUserClient"))
 
 #if ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)
-(deny iokit-open-service (with no-report))
+(deny iokit-open-service NO_REPORT)
 #else
 (with-filter (state-flag "BlockIOKitInWebContentSandbox")
     (deny iokit-open-service)
@@ -883,7 +883,7 @@
             (global-name "com.apple.webinspector"))))
 
 ;; Silence warnings about these connections if we have decided not to extend access to them:
-(deny mach-lookup (with no-report)
+(deny mach-lookup NO_REPORT
     (require-all
         (require-not (extension "com.apple.webkit.extension.mach"))
         (global-name "com.apple.audio.AudioComponentRegistrar")))
@@ -1081,7 +1081,7 @@
         (syscall-quicklook)))
 #endif
 
-(deny syscall-unix (with no-report)
+(deny syscall-unix NO_REPORT
     (syscall-unix-blocked-without-report))
 
 (when (defined? 'SYS_map_with_linking_np)
@@ -1143,7 +1143,7 @@
     (allow process-codesigning-entitlements-blob-get) ;; WK reading entitlments via SecTaskCopyValueForEntitlement and _getSelfParsedEntitlements (accessibility)
     (allow process-codesigning-status-get) ;; _xpc_get_entitlements
     (allow process-codesigning-status-set (target self))
-    (deny process-info-codesignature (with no-report)) ;; SecTaskCopyValueForEntitlement - granting this grants all the process-codesign-* checks
+    (deny process-info-codesignature NO_REPORT) ;; SecTaskCopyValueForEntitlement - granting this grants all the process-codesign-* checks
 )
 
 (when (not (defined? 'process-codesigning*))
@@ -1168,7 +1168,7 @@
 
 (allow mach-bootstrap
     (apply-message-filter
-        (deny mach-message-send (with no-report))
+        (deny mach-message-send NO_REPORT)
 #if PLATFORM(IOS) || PLATFORM(VISION)
         (with-filter (extension "com.apple.webkit.mach-bootstrap")
             (allow mach-message-send (mach-bootstrap-message-numbers-post-launch)))
@@ -1363,7 +1363,7 @@
         (with message "kernel mig routine used after launch")
         (kernel-mig-routine-only-in-use-during-launch)))
 #if ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)
-(deny syscall-mig (with no-report) (kernel-mig-routines-iokit-service))
+(deny syscall-mig NO_REPORT (kernel-mig-routines-iokit-service))
 #else
 (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
     (allow syscall-mig (kernel-mig-routines-iokit-service)))
@@ -1390,7 +1390,7 @@
 (when (defined? 'mach_port_is_connection_for_service)
     (allow syscall-mig (kernel-mig-routine mach_port_is_connection_for_service)))
 
-(deny darwin-notification-post (with no-report))
+(deny darwin-notification-post NO_REPORT)
 (allow darwin-notification-post
     (notification-name
 #if ENABLE(NOTIFY_BLOCKING)

--- a/Source/WebKit/Shared/Sandbox/common.sb
+++ b/Source/WebKit/Shared/Sandbox/common.sb
@@ -28,12 +28,16 @@
 #endif
 (deny default)
 
+#ifndef NO_REPORT
+#define NO_REPORT (with no-report)
+#endif
+
 (deny nvram*)
 (deny system-privilege)
 (allow system-audit file-read-metadata)
 
 ;; Silence spurious logging due to rdar://20117923 and rdar://72366475
-(deny system-privilege (privilege-id PRIV_GLOBAL_PROC_INFO) (with no-report))
+(deny system-privilege (privilege-id PRIV_GLOBAL_PROC_INFO) NO_REPORT)
 
 #if USE(SANDBOX_VERSION_3)
 #if PLATFORM(MACCATALYST) || PLATFORM(VISION)


### PR DESCRIPTION
#### 11a2031c8c6112a0eabcec1e6530b543827903cc
<pre>
Fix sandbox compilation of development sandboxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=297516">https://bugs.webkit.org/show_bug.cgi?id=297516</a>
<a href="https://rdar.apple.com/158509405">rdar://158509405</a>

Reviewed by Basuke Suzuki and Ben Nham.

Replace no-report modifier with report modifier in development sandboxes, since the no-report modifier
is not permitted in allow rules.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Sandbox/common.sb:

Canonical link: <a href="https://commits.webkit.org/298822@main">https://commits.webkit.org/298822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0d28c90b36fbbe6f0dd9734b4fc450316e27a9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67371 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/39dbe29f-d846-47eb-a195-43127e4089d1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88686 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77ef8ef7-8123-46e6-8256-938ebfbe140f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69156 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28680 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66527 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/125996 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32807 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97355 "Found 11 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic-opacity.html imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/basic.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-writing-modes/inline-block-alignment-005.xht imported/w3c/web-platform-tests/css/css-writing-modes/inline-table-alignment-005.xht ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97153 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42478 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20417 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39680 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18647 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43571 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46377 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->