### PR TITLE
Make WTF::hasEntitlement() preserve errno.

### DIFF
--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,8 +37,11 @@ bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
 {
     if (!task)
         return false;
+    auto savedErrno = errno;
     auto string = entitlement.createCFString();
-    return adoptCF(SecTaskCopyValueForEntitlement(task, string.get(), nullptr)) == kCFBooleanTrue;
+    auto result = adoptCF(SecTaskCopyValueForEntitlement(task, string.get(), nullptr)) == kCFBooleanTrue;
+    errno = savedErrno;
+    return result;
 }
 
 bool hasEntitlement(audit_token_t token, ASCIILiteral entitlement)


### PR DESCRIPTION
#### f554797429d2716fb1a2bd89a2319a6c19b3d046
<pre>
Make WTF::hasEntitlement() preserve errno.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297517">https://bugs.webkit.org/show_bug.cgi?id=297517</a>
<a href="https://rdar.apple.com/158550300">rdar://158550300</a>

Reviewed by Yusuke Suzuki.

We use WTF::hasEntitlement() to sometimes check for the presence of an entitlement, and
sometimes, to check for its absence.  When the entitlement is absent, it can end up
setting errno.  This might impact other code running subsequently that check errno.  For
example, WTF::stringToDouble() was checking errno, and failing due to this.  Though
WTF::stringToDouble() has now been fixed in 298754@main, we should just make
hasEntitlement() not change the errno value to avoid other potential fallout like this.

* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):

Canonical link: <a href="https://commits.webkit.org/298830@main">https://commits.webkit.org/298830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6a7198ee16772899b9cfdfa7a6e677365e59297

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67377 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1a97fef1-9d49-4ccb-bdcf-5cc182d8512b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88690 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43101 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50fcd360-3a03-4f09-9105-5c732a059041) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69160 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66531 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108904 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126000 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115318 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97359 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97157 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39690 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49171 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144016 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43042 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37077 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44747 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->