### PR TITLE
Flex Item with aspect-ratio ignores padding when rendering its content

### DIFF
--- a/LayoutTests/css3/flexbox/flex-item-aspect-ratio-expected.html
+++ b/LayoutTests/css3/flexbox/flex-item-aspect-ratio-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<style>     
+.container {
+  display: flex;
+  flex-direction: column;
+}
+.box {
+  height: 200px;
+  width: 200px;
+  padding: 20px; 
+  background: blue;
+} 
+</style>
+</head>
+<body>
+<div class="container">
+ <div class="box">
+ </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/css3/flexbox/flex-item-aspect-ratio.html
+++ b/LayoutTests/css3/flexbox/flex-item-aspect-ratio.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<style> 
+.container {
+  display: flex;
+  flex-direction: column;
+}
+.box {
+  width:200px;
+  padding: 20px;
+  aspect-ratio: 1; 
+  background: blue;
+  box-sizing: content-box;
+}
+</style>
+</head>
+<body>
+<div class="container">
+ <div class="box">
+ </div>
+</div>
+</body>
+</html>
+
+

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1188,7 +1188,10 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
 
     auto crossSizeOptional = WTF::switchOn(crossSizeLength,
         [&](const SizeType::Fixed& fixedCrossSizeLength) -> std::optional<LayoutUnit> {
-            return LayoutUnit(fixedCrossSizeLength.resolveZoom(flexItem.style().usedZoomForLength()));
+            auto crossSizeLength = LayoutUnit(fixedCrossSizeLength.resolveZoom(flexItem.style().usedZoomForLength()));
+            return mainAxisIsFlexItemInlineAxis(flexItem)
+                ? crossSizeLength + flexItem.verticalBorderAndPaddingExtent()
+                : crossSizeLength + flexItem.horizontalBorderAndPaddingExtent();
         },
         [&](const SizeType::Percentage& percentageCrossSizeLength) -> std::optional<LayoutUnit> {
             return mainAxisIsFlexItemInlineAxis(flexItem)
@@ -1231,7 +1234,6 @@ template<typename SizeType> LayoutUnit RenderFlexibleBox::computeMainSizeFromAsp
         if (flexItem.style().boxSizing() == BoxSizing::BorderBox)
             crossSize -= isHorizontalFlow() ? flexItem.verticalBorderAndPaddingExtent() : flexItem.horizontalBorderAndPaddingExtent();
     }
-
     auto preferredAspectRatio = preferredAspectRatioForFlexItem(flexItem);
     return std::max(0_lu, LayoutUnit(crossSize * preferredAspectRatio) - borderAndPadding);
 }


### PR DESCRIPTION
#### 16c57d1eaace3ce7cca3bcad307491dab9a9a974
<pre>
Flex Item with aspect-ratio ignores padding when rendering its content
<a href="https://bugs.webkit.org/show_bug.cgi?id=295629">https://bugs.webkit.org/show_bug.cgi?id=295629</a>

Reviewed by NOBODY (OOPS!).

When a flexbox with a fixed cross size uses the aspect ratio to determine the main-axis size
in any dimension (width/height), padding is not taken into consideration.

This happens because, while computing the cross size that will be used to derive
the other dimension via the aspect ratio, padding is not accounted for in the calculation.

This path fix this problem by including padding when calculating the cross size in
`RenderFlexibleBox::computeMainSizeFromAspectRatioUsing`
so when computing the main axis size it uses the right dimension length

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeMainSizeFromAspectRatioUsing const):
* LayoutTests/css3/flexbox/flex-item-aspect-ratio-expected.html: Added.
* LayoutTests/css3/flexbox/flex-item-aspect-ratio.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16c57d1eaace3ce7cca3bcad307491dab9a9a974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28517 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120271 "Found 11 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-005.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007v.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-025.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84867 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100961 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21542 "Found 11 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-005.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007v.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-025.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19655 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166647 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10815 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18994 "Found 11 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-005.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007v.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-025.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128379 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-005.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007v.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-025.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-026.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28211 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23689 "Found 11 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-005.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007v.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-025.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128515 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/85572 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23351 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15974 "Found 11 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-005.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-height-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002a.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002b.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-min-width-auto-002c.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007.html imported/w3c/web-platform-tests/css/css-flexbox/image-as-flexitem-size-007v.html imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-025.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27829 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91932 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->