### PR TITLE
[WPE] WPE Platform: add API tests for WPEDisplay::create-view

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplayWayland.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestDisplayWayland.cpp
@@ -116,12 +116,37 @@ static void testDisplayWaylandAvailableInputDevices(WPEWaylandPlatformTest* test
     g_assert_false(devices & WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
 }
 
+static void testDisplayWaylandCreateView(WPEWaylandPlatformTest* test, gconstpointer)
+{
+    connectOrSkipIfNotUnderWayland();
+
+    GRefPtr<WPEView> view1 = adoptGRef(wpe_view_new(test->display()));
+    g_assert_true(WPE_IS_VIEW_WAYLAND(view1.get()));
+    test->assertObjectIsDeletedWhenTestFinishes(view1.get());
+    g_assert_true(wpe_view_get_display(view1.get()) == test->display());
+    auto* toplevel = wpe_view_get_toplevel(view1.get());
+    g_assert_true(WPE_IS_TOPLEVEL_WAYLAND(toplevel));
+    test->assertObjectIsDeletedWhenTestFinishes(toplevel);
+    g_assert_cmpuint(wpe_toplevel_get_max_views(toplevel), ==, 1);
+
+    auto* settings = wpe_display_get_settings(test->display());
+    GUniqueOutPtr<GError> error;
+    wpe_settings_set_boolean(settings, WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, FALSE, WPE_SETTINGS_SOURCE_APPLICATION, &error.outPtr());
+    g_assert_no_error(error.get());
+    GRefPtr<WPEView> view2 = adoptGRef(wpe_view_new(test->display()));
+    g_assert_true(WPE_IS_VIEW_WAYLAND(view2.get()));
+    test->assertObjectIsDeletedWhenTestFinishes(view2.get());
+    g_assert_true(wpe_view_get_display(view2.get()) == test->display());
+    g_assert_null(wpe_view_get_toplevel(view2.get()));
+}
+
 void beforeAll()
 {
     WPEWaylandPlatformTest::add("DisplayWayland", "connect", testDisplayWaylandConnect);
     WPEWaylandPlatformTest::add("DisplayWayland", "keymap", testDisplayWaylandKeymap);
     WPEWaylandPlatformTest::add("DisplayWayland", "screens", testDisplayWaylandScreens);
     WPEWaylandPlatformTest::add("DisplayWayland", "available-input-devices", testDisplayWaylandAvailableInputDevices);
+    WPEWaylandPlatformTest::add("DisplayWayland", "create-view", testDisplayWaylandCreateView);
 }
 
 void afterAll()

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
@@ -1,8 +1,9 @@
 # WPE Mock Platform
 set(WPEPlatformMock_SOURCES
     ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
-    ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEViewMock.cpp
     ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEScreenMock.cpp
+    ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.cpp
+    ${TOOLS_DIR}/TestWebKitAPI/glib/WPEPlatform/mock/WPEViewMock.cpp
 )
 
 set(WPEPlatformMock_PRIVATE_INCLUDE_DIRECTORIES

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEDisplayMock.cpp
@@ -27,6 +27,7 @@
 #include "WPEDisplayMock.h"
 
 #include "WPEScreenMock.h"
+#include "WPEToplevelMock.h"
 #include "WPEViewMock.h"
 #include <gio/gio.h>
 #include <gmodule.h>
@@ -85,7 +86,15 @@ static gboolean wpeDisplayMockConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayMockCreateView(WPEDisplay* display)
 {
-    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_MOCK, "display", display, nullptr));
+    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_MOCK, "display", display, nullptr));
+
+    if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
+        WPEToplevel* toplevel = wpeToplevelMockNew(WPE_DISPLAY_MOCK(display), 1);
+        wpe_view_set_toplevel(view, toplevel);
+        g_object_unref(toplevel);
+    }
+
+    return view;
 }
 
 static WPEInputMethodContext* wpeDisplayMockCreateInputMethodContext(WPEDisplay* display, WPEView*)

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEToplevelMock.h"
+
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEToplevelMockPrivate {
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEToplevelMock, wpe_toplevel_mock, WPE_TYPE_TOPLEVEL, WPEToplevel)
+
+static void wpe_toplevel_mock_class_init(WPEToplevelMockClass*)
+{
+}
+
+WPEToplevel* wpeToplevelMockNew(WPEDisplayMock* display, guint maxViews)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_MOCK, "display", display, "max-views", maxViews, nullptr));
+}

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WPEDisplayMock.h"
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_TOPLEVEL_MOCK (wpe_toplevel_mock_get_type())
+G_DECLARE_FINAL_TYPE(WPEToplevelMock, wpe_toplevel_mock, WPE, TOPLEVEL_MOCK, WPEToplevel)
+
+WPEToplevel* wpeToplevelMockNew(WPEDisplayMock*, guint);
+
+G_END_DECLS


### PR DESCRIPTION
#### 24b5e127caeb2f5810b8fe9d43856050b8d64a0a
<pre>
[WPE] WPE Platform: add API tests for WPEDisplay::create-view
<a href="https://bugs.webkit.org/show_bug.cgi?id=297520">https://bugs.webkit.org/show_bug.cgi?id=297520</a>

Reviewed by Miguel Gomez.

Canonical link: <a href="https://commits.webkit.org/298881@main">https://commits.webkit.org/298881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d60515784b89b2399b0b47bbc87aa18881b22c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88699 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43111 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, storage/domstorage/localstorage/delete-defineproperty-removal.html, storage/domstorage/localstorage/file-can-access.html, storage/domstorage/sessionstorage/blocked-file-access.html, storage/indexeddb/intversion-gated-on-delete.html, storage/indexeddb/intversion-omit-parameter-private.html, storage/indexeddb/intversion-open-in-upgradeneeded.html, storage/indexeddb/mozilla/global-data-private.html, storage/indexeddb/mozilla/key-requirements-put-null-key-private.html, streams/readable-stream-lock-after-worker-terminates-crash.html, transforms/2d/scale-percent.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-3d-r11f_g11f_b10f-rgb-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgba8ui-rgba_integer-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image_data/tex-2d-rgba8-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_data/tex-3d-rgb565-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/webgl_canvas/tex-2d-rgba16f-rgba-float.html, webgl/2.0.y/conformance/misc/hint.html, webgl/webgl-image-rendering.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22886 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97369 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97167 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39714 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18675 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43592 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->