### PR TITLE
[WPE] WPE Platform: remove all public constructors of platform specific WPEView

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -429,7 +429,7 @@ static gboolean wpeDisplayDRMConnect(WPEDisplay* display, GError** error)
 static WPEView* wpeDisplayDRMCreateView(WPEDisplay* display)
 {
     auto* displayDRM = WPE_DISPLAY_DRM(display);
-    auto* view = wpe_view_drm_new(displayDRM);
+    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_DRM, "display", display, nullptr));
 
     if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
         GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_drm_new(displayDRM));

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -570,18 +570,3 @@ static void wpe_view_drm_class_init(WPEViewDRMClass* viewDRMClass)
     viewClass->set_cursor_from_name = wpeViewDRMSetCursorFromName;
     viewClass->set_cursor_from_bytes = wpeViewDRMSetCursorFromBytes;
 }
-
-/**
- * wpe_view_drm_new:
- * @display: a #WPEDisplayDRM
- *
- * Create a new #WPEViewDRM
- *
- * Returns: (transfer full): a #WPEView
- */
-WPEView* wpe_view_drm_new(WPEDisplayDRM* display)
-{
-    g_return_val_if_fail(WPE_IS_DISPLAY_DRM(display), nullptr);
-
-    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_DRM, "display", display, nullptr));
-}

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.h
@@ -39,8 +39,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_VIEW_DRM (wpe_view_drm_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEViewDRM, wpe_view_drm, WPE, VIEW_DRM, WPEView)
 
-WPE_API WPEView *wpe_view_drm_new (WPEDisplayDRM *display);
-
 G_END_DECLS
 
 #endif /* WPEViewDRM_h */

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -84,7 +84,7 @@ static gboolean wpeDisplayHeadlessConnect(WPEDisplay*, GError**)
 
 static WPEView* wpeDisplayHeadlessCreateView(WPEDisplay* display)
 {
-    auto* view = wpe_view_headless_new(WPE_DISPLAY_HEADLESS(display));
+    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_HEADLESS, "display", display, nullptr));
     if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
         GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_headless_new(WPE_DISPLAY_HEADLESS(display)));
         wpe_view_set_toplevel(view, toplevel.get());

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -138,18 +138,3 @@ static void wpe_view_headless_class_init(WPEViewHeadlessClass* viewHeadlessClass
     WPEViewClass* viewClass = WPE_VIEW_CLASS(viewHeadlessClass);
     viewClass->render_buffer = wpeViewHeadlessRenderBuffer;
 }
-
-/**
- * wpe_view_headless_new:
- * @display: a #WPEDisplayHeadless
- *
- * Create a new #WPEViewHeadless
- *
- * Returns: (transfer full): a #WPEView
- */
-WPEView* wpe_view_headless_new(WPEDisplayHeadless* display)
-{
-    g_return_val_if_fail(WPE_IS_DISPLAY_HEADLESS(display), nullptr);
-
-    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_HEADLESS, "display", display, nullptr));
-}

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.h
@@ -39,8 +39,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_VIEW_HEADLESS (wpe_view_headless_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEViewHeadless, wpe_view_headless, WPE, VIEW_HEADLESS, WPEView)
 
-WPE_API WPEView *wpe_view_headless_new (WPEDisplayHeadless *display);
-
 G_END_DECLS
 
 #endif /* WPEViewHeadless_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -490,11 +490,10 @@ static gboolean wpeDisplayWaylandConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayWaylandCreateView(WPEDisplay* display)
 {
-    auto* displayWayland = WPE_DISPLAY_WAYLAND(display);
-    auto* view = wpe_view_wayland_new(displayWayland);
+    auto* view = WPE_VIEW(g_object_new(WPE_TYPE_VIEW_WAYLAND, "display", display, nullptr));
 
     if (wpe_settings_get_boolean(wpe_display_get_settings(display), WPE_SETTING_CREATE_VIEWS_WITH_A_TOPLEVEL, nullptr)) {
-        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(displayWayland, 1));
+        GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(WPE_DISPLAY_WAYLAND(display), 1));
         wpe_view_set_toplevel(view, toplevel.get());
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -731,21 +731,6 @@ static void wpe_view_wayland_class_init(WPEViewWaylandClass* viewWaylandClass)
 }
 
 /**
- * wpe_view_wayland_new:
- * @display: a #WPEDisplayWayland
- *
- * Create a new #WPEViewWayland
- *
- * Returns: (transfer full): a #WPEView
- */
-WPEView* wpe_view_wayland_new(WPEDisplayWayland* display)
-{
-    g_return_val_if_fail(WPE_IS_DISPLAY_WAYLAND(display), nullptr);
-
-    return WPE_VIEW(g_object_new(WPE_TYPE_VIEW_WAYLAND, "display", display, nullptr));
-}
-
-/**
  * wpe_view_wayland_get_wl_surface: (skip)
  * @view: a #WPEViewWayland
  *

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.h
@@ -40,7 +40,6 @@ G_BEGIN_DECLS
 #define WPE_TYPE_VIEW_WAYLAND (wpe_view_wayland_get_type())
 WPE_API G_DECLARE_FINAL_TYPE (WPEViewWayland, wpe_view_wayland, WPE, VIEW_WAYLAND, WPEView)
 
-WPE_API WPEView           *wpe_view_wayland_new            (WPEDisplayWayland *display);
 WPE_API struct wl_surface *wpe_view_wayland_get_wl_surface (WPEViewWayland    *view);
 
 G_END_DECLS


### PR DESCRIPTION
#### d8ff0809c8e8218f7a98aaf23012c2fef40c4955
<pre>
[WPE] WPE Platform: remove all public constructors of platform specific WPEView
<a href="https://bugs.webkit.org/show_bug.cgi?id=297522">https://bugs.webkit.org/show_bug.cgi?id=297522</a>

Reviewed by Adrian Perez de Castro.

Remove wpe_view_wayland_new(), wpe_view_drm_new() and
wpe_view_headless_new() since they are only used by platform WPEDisplay
implementation. The only public constructor of a WPEView should be
wpe_view_new() because it&apos;s the one calling WPEDisplay::create-view.

Canonical link: <a href="https://commits.webkit.org/298880@main">https://commits.webkit.org/298880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc4881666175e4adc513ec374ea714ae2e80c5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67402 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88704 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43113 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28705 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66555 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126024 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97372 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97170 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20438 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39721 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18674 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49195 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->