### PR TITLE
Set a first-party cookie before setting cross-site cookies in `sandboxed-iframe-allow-storage-access.html`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-sandboxed-iframe-allow-storage-access.sub.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-sandboxed-iframe-allow-storage-access.sub.https.window.js
@@ -7,6 +7,6 @@ const frameSourceUrl =
     'https://{{hosts[alt][www]}}:{{ports[https][0]}}/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html';
 
 const sandboxAttribute =
-    'allow-scripts allow-same-origin allow-storage-access-by-user-activation';
+    'allow-scripts allow-same-origin allow-storage-access-by-user-activation allow-popups';
 
 RunTestsInIFrame(frameSourceUrl, sandboxAttribute);

--- a/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html
@@ -29,6 +29,7 @@
     t.add_cleanup(async () => {
       await test_driver.set_permission({name: 'storage-access'}, 'prompt');
     });
+    await SetFirstPartyCookie(location.origin, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
     await document.requestStorageAccess();
@@ -45,6 +46,7 @@
     t.add_cleanup(async () => {
       await test_driver.set_permission({name: 'storage-access'}, 'prompt');
     });
+    await SetFirstPartyCookie(location.origin, "initial-cookie=unpartitioned;Secure;SameSite=None;Path=/");
     await test_driver.set_permission({name: 'storage-access'}, 'granted');
     await MaybeSetStorageAccess('*', '*', 'blocked');
 


### PR DESCRIPTION
#### 72ed0a23a373b9070caf1a9323ea2fd52ee6d457
<pre>
Set a first-party cookie before setting cross-site cookies in `sandboxed-iframe-allow-storage-access.html`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297525">https://bugs.webkit.org/show_bug.cgi?id=297525</a>
<a href="https://rdar.apple.com/158571529">rdar://158571529</a>

Reviewed by Matthew Finkel.

This is needed to comply with Safari’s cookie policy. This is similar to the changes made in
298703@main, which I should have included there but missed.

* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-sandboxed-iframe-allow-storage-access.sub.https.window.js:
* LayoutTests/imported/w3c/web-platform-tests/storage-access-api/resources/sandboxed-iframe-allow-storage-access.html:

Canonical link: <a href="https://commits.webkit.org/298919@main">https://commits.webkit.org/298919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4146ba726faf62da18daaedc3af3e149e708b2a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67403 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c7cecb1-23de-4ffb-8e57-bb3077ac9dac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88706 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43116 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, ietestcenter/Javascript/15.4.4.18-5-2.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dfg-dead-min-one-arg.html, js/dom/JSON-stringify-string-object-with-tojson.html, js/dom/Promise-init-in-workers.html, storage/indexeddb/cursor-inconsistency.html, storage/indexeddb/factory-cmp-private.html, storage/indexeddb/modern/cursor-7.html, storage/indexeddb/mozilla/indexes.html, streams/readable-stream-lock-after-worker-terminates-crash.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfef7b18-eec2-420c-a6a0-1a8ec3f4f54a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69175 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66556 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126025 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97373 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/100990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97171 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42500 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39722 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18696 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43600 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46406 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->