### PR TITLE
auto-start-reverse WPT is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-marker-orient-from-auto-to-auto-start-reverse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-marker-orient-from-auto-to-auto-start-reverse-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animate SVGMarkerElement orientAttr from auto to auto-start-reverse assert_equals: expected (undefined) undefined but got (number) 0
+PASS Animate SVGMarkerElement orientAttr from auto to auto-start-reverse
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-SVGMarkerElement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-SVGMarkerElement-expected.txt
@@ -3,5 +3,5 @@ PASS Test SVGAnimatedEnumeration
 PASS Test SVGOrient
 PASS Test grad units
 PASS Test turn units
-FAIL Test auto-start-reverse Type error
+PASS Test auto-start-reverse
 

--- a/LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse-expected.txt
+++ b/LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse-expected.txt
@@ -5,8 +5,7 @@ Animate SVGMarkerElement orientAttr from an angle to auto-start-reverse.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS SVGMarkerElement.SVG_MARKER_ORIENT_AUTOSTARTREVERSE is undefined
-PASS marker.orientType.baseVal = 3 threw exception TypeError: Type error.
+PASS SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE is 3
 PASS marker.orientAngle.animVal.value is 0
 PASS marker.orientAngle.baseVal.value is 0
 PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE
@@ -21,15 +20,15 @@ PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE
 PASS marker.orientType.baseVal is SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE
 PASS marker.orientAngle.animVal.value is 0
 PASS marker.orientAngle.baseVal.value is 0
-PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_UNKNOWN
+PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE
 PASS marker.orientType.baseVal is SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE
 PASS marker.orientAngle.animVal.value is 0
 PASS marker.orientAngle.baseVal.value is 0
-PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_UNKNOWN
+PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE
 PASS marker.orientType.baseVal is SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE
 PASS marker.orientAngle.animVal.value is 0
 PASS marker.orientAngle.baseVal.value is 0
-PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_UNKNOWN
+PASS marker.orientType.animVal is SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE
 PASS marker.orientType.baseVal is SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE
 PASS successfullyParsed is true
 

--- a/LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse.html
+++ b/LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse.html
@@ -76,7 +76,7 @@ function sample3() {
     shouldBeCloseEnough("marker.orientAngle.animVal.value", "0");
     shouldBe("marker.orientAngle.baseVal.value", "0");
 
-    shouldBe("marker.orientType.animVal", "SVGMarkerElement.SVG_MARKER_ORIENT_UNKNOWN");
+    shouldBe("marker.orientType.animVal", "SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE");
     shouldBe("marker.orientType.baseVal", "SVGMarkerElement.SVG_MARKER_ORIENT_ANGLE");
 }
 
@@ -92,10 +92,7 @@ function executeTest() {
     ];
 
     // Ensure new enum value is not exposed through the IDL
-    shouldBe("SVGMarkerElement.SVG_MARKER_ORIENT_AUTOSTARTREVERSE", "undefined");
-
-    // Ensure we cannot set autostartreverse through the orient property.
-    shouldThrow("marker.orientType.baseVal = 3");
+    shouldBe("SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE", "3");
 
     runAnimationTest(expectedValues);
 }

--- a/LayoutTests/svg/dynamic-updates/SVGMarkerElement-dom-orient-attr-expected.txt
+++ b/LayoutTests/svg/dynamic-updates/SVGMarkerElement-dom-orient-attr-expected.txt
@@ -22,7 +22,7 @@ PASS markerElement.getAttribute('orient') is "auto"
 
 PASS markerElement.orient = 'auto-start-reverse' is "auto-start-reverse"
 PASS markerElement.orient is "auto-start-reverse"
-PASS markerElement.orientType.baseVal is SVGMarkerElement.SVG_MARKER_ORIENT_UNKNOWN
+PASS markerElement.orientType.baseVal is SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE
 PASS markerElement.orientAngle.baseVal.value is 0
 PASS markerElement.getAttribute('orient') is "auto-start-reverse"
 

--- a/LayoutTests/svg/dynamic-updates/SVGMarkerElement-dom-orient-attr.html
+++ b/LayoutTests/svg/dynamic-updates/SVGMarkerElement-dom-orient-attr.html
@@ -66,7 +66,7 @@ shouldBeEqualToString("markerElement.getAttribute('orient')", "auto");
 debug("");
 shouldBeEqualToString("markerElement.orient = 'auto-start-reverse'", "auto-start-reverse");
 shouldBeEqualToString("markerElement.orient", "auto-start-reverse");
-shouldBe("markerElement.orientType.baseVal", "SVGMarkerElement.SVG_MARKER_ORIENT_UNKNOWN");
+shouldBe("markerElement.orientType.baseVal", "SVGMarkerElement.SVG_MARKER_ORIENT_AUTO_START_REVERSE");
 shouldBe("markerElement.orientAngle.baseVal.value", "0");
 shouldBeEqualToString("markerElement.getAttribute('orient')", "auto-start-reverse");
 

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -166,6 +166,12 @@ void SVGMarkerElement::setOrientToAngle(const SVGAngle& angle)
     invalidateMarkerResource();
 }
 
+void SVGMarkerElement::setOrientToAutoStartReverse()
+{
+    Ref { m_orientType }->setBaseVal(SVGMarkerOrientAutoStartReverse);
+    invalidateMarkerResource();
+}
+
 RenderPtr<RenderElement> SVGMarkerElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
     if (document().settings().layerBasedSVGEngineEnabled())

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -42,7 +42,8 @@ public:
     enum {
         SVG_MARKER_ORIENT_UNKNOWN = SVGMarkerOrientUnknown,
         SVG_MARKER_ORIENT_AUTO = SVGMarkerOrientAuto,
-        SVG_MARKER_ORIENT_ANGLE = SVGMarkerOrientAngle
+        SVG_MARKER_ORIENT_ANGLE = SVGMarkerOrientAngle,
+        SVG_MARKER_ORIENT_AUTO_START_REVERSE = SVGMarkerOrientAutoStartReverse
     };
 
     static Ref<SVGMarkerElement> create(const QualifiedName&, Document&);
@@ -70,6 +71,7 @@ public:
 
     void setOrientToAuto();
     void setOrientToAngle(const SVGAngle&);
+    void setOrientToAutoStartReverse();
 
 private:
     SVGMarkerElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGMarkerElement.idl
+++ b/Source/WebCore/svg/SVGMarkerElement.idl
@@ -32,9 +32,10 @@
     const unsigned short SVG_MARKERUNITS_STROKEWIDTH    = 2;
 
     // Marker Orientation Types
-    const unsigned short SVG_MARKER_ORIENT_UNKNOWN      = 0;
-    const unsigned short SVG_MARKER_ORIENT_AUTO         = 1;
-    const unsigned short SVG_MARKER_ORIENT_ANGLE        = 2;
+    const unsigned short SVG_MARKER_ORIENT_UNKNOWN            = 0;
+    const unsigned short SVG_MARKER_ORIENT_AUTO               = 1;
+    const unsigned short SVG_MARKER_ORIENT_ANGLE              = 2;
+    const unsigned short SVG_MARKER_ORIENT_AUTO_START_REVERSE = 3;
 
     [SameObject] readonly attribute SVGAnimatedLength      refX;
     [SameObject] readonly attribute SVGAnimatedLength      refY;

--- a/Source/WebCore/svg/SVGMarkerTypes.h
+++ b/Source/WebCore/svg/SVGMarkerTypes.h
@@ -41,10 +41,7 @@ enum SVGMarkerOrientType {
     SVGMarkerOrientUnknown = 0,
     SVGMarkerOrientAuto,
     SVGMarkerOrientAngle,
-
-    // The DOM can't set the property 'orientType' to this value. It is used only
-    // internally when setting the 'orient' attribute to "auto-start-reverse".
-    SVGMarkerOrientAutoStartReverse = SVGMarkerOrientUnknown
+    SVGMarkerOrientAutoStartReverse
 };
     
 template<>
@@ -81,7 +78,7 @@ struct SVGPropertyTraits<SVGMarkerOrientType> {
         static const NeverDestroyed<String> autoStartReverseString = MAKE_STATIC_STRING_IMPL("auto-start-reverse");
         return autoStartReverseString;
     }
-    static unsigned highestEnumValue() { return SVGMarkerOrientAngle; }
+    static unsigned highestEnumValue() { return SVGMarkerOrientAutoStartReverse; }
     static SVGMarkerOrientType fromString(const String& string)
     {
         if (string == autoAtom())


### PR DESCRIPTION
#### ced6588f9f23122a7de18471a3e2ec2067bb560c
<pre>
auto-start-reverse WPT is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=269477">https://bugs.webkit.org/show_bug.cgi?id=269477</a>
<a href="https://rdar.apple.com/123453058">rdar://123453058</a>

Reviewed by Said Abou-Hallawa.

This doesn&apos;t add any new features.
It progresses some WPT tests and aligns the WebKit implementation with
what Firefox is already doing. It also matches the specification IDL by
adding SVG_MARKER_ORIENT_AUTO_START_REVERSE.
The SVG 2 specIDL for SVG Marker Element and its orient type was
recently fixed.
See <a href="https://github.com/w3c/svgwg/pull/994">https://github.com/w3c/svgwg/pull/994</a>
and discussions on <a href="https://github.com/w3c/svgwg/issues/993">https://github.com/w3c/svgwg/issues/993</a>
and <a href="https://github.com/w3c/svgwg/issues/424">https://github.com/w3c/svgwg/issues/424</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-marker-orient-from-auto-to-auto-start-reverse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-SVGMarkerElement-expected.txt:
* LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse-expected.txt:
* LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse.html:
* LayoutTests/svg/dynamic-updates/SVGMarkerElement-dom-orient-attr-expected.txt:
* LayoutTests/svg/dynamic-updates/SVGMarkerElement-dom-orient-attr.html:
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::setOrientToAutoStartReverse):
* Source/WebCore/svg/SVGMarkerElement.h:
* Source/WebCore/svg/SVGMarkerElement.idl:
* Source/WebCore/svg/SVGMarkerTypes.h:
(WebCore::SVGPropertyTraits&lt;SVGMarkerOrientType&gt;::highestEnumValue):

Canonical link: <a href="https://commits.webkit.org/299042@main">https://commits.webkit.org/299042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c658dd48eebdf95849bea2c9580a59873ff0d88d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117602 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27904 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/123714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/69610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23a5c573-319e-4a98-9cc1-85afaa3799ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45862 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/123714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/69610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e70257b3-341e-4faa-9433-deeed5c6b8b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120554 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/123714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14f9a7c2-f907-44d3-8039-6d450b9714cc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/67383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126827 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/44505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/44863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18767 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/44376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/50051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/43834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/47182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45526 "Failed to checkout and rebase branch from PR 49526") | | | | 
<!--EWS-Status-Bubble-End-->