### PR TITLE
[CSS] Remove const_cast in nesting selector resolution

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -850,38 +850,6 @@ bool CSSSelector::visitSimpleSelectors(VisitFunctor&& functor, VisitFunctionalPs
     return false;
 }
 
-void CSSSelector::resolveNestingParentSelectors(const CSSSelectorList& parent)
-{
-    auto replaceParentSelector = [&parent] (CSSSelector& selector) {
-        if (selector.match() == CSSSelector::Match::NestingParent) {
-            // FIXME: Optimize cases where we can include the parent selector directly instead of wrapping it in a ":is" pseudo class.
-            selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClass(PseudoClass::Is);
-            selector.setSelectorList(makeUnique<CSSSelectorList>(parent));
-        }
-        return false;
-    };
-
-    visitSimpleSelectors(WTFMove(replaceParentSelector), VisitFunctionalPseudoClasses::Yes);
-}
-
-void CSSSelector::replaceNestingParentByPseudoClassScope()
-{
-    auto replaceParentSelector = [] (CSSSelector& selector) {
-        if (selector.match() == Match::NestingParent) {
-            // Replace by :scope
-            selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClass(PseudoClass::Scope);
-            // Top-level nesting parent selector acts like :scope with zero specificity.
-            // https://github.com/w3c/csswg-drafts/issues/10196#issuecomment-2161119978
-            selector.setImplicit();
-        }
-        return false;
-    };
-
-    visitSimpleSelectors(WTFMove(replaceParentSelector), VisitFunctionalPseudoClasses::Yes);
-}
-
 bool CSSSelector::hasExplicitNestingParent() const
 {
     return visitSimpleSelectors([](const CSSSelector& selector) {

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -73,8 +73,6 @@ public:
 
     bool hasExplicitNestingParent() const;
     bool hasExplicitPseudoClassScope() const;
-    void resolveNestingParentSelectors(const CSSSelectorList& parent);
-    void replaceNestingParentByPseudoClassScope();
 
     using PseudoClass = CSSSelectorPseudoClass;
     using PseudoElement = CSSSelectorPseudoElement;

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1306,20 +1306,17 @@ bool CSSSelectorParser::containsUnknownWebKitPseudoElements(const CSSSelector& c
 CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& nestedSelectorList, const CSSSelectorList* parentResolvedSelectorList)
 {
     MutableCSSSelectorList result;
-    CSSSelectorList copiedSelectorList { nestedSelectorList };
-    for (auto& selector : copiedSelectorList) {
+    for (auto& originalSelector : nestedSelectorList) {
+        auto selector = makeUnique<MutableCSSSelector>(originalSelector);
         if (parentResolvedSelectorList) {
-            // FIXME: We should build a new MutableCSSSelector from this selector and resolve it
-            const_cast<CSSSelector&>(selector).resolveNestingParentSelectors(*parentResolvedSelectorList);
+            selector->replaceNestingByParentSelector(*parentResolvedSelectorList);
         } else {
             // It's top-level, the nesting parent selector should be replaced by :scope
-            const_cast<CSSSelector&>(selector).replaceNestingParentByPseudoClassScope();
+            selector->replaceNestingByPseudoClassScope();
         }
-        result.append(makeUnique<MutableCSSSelector>(selector));
+        result.append(WTFMove(selector));
     }
-
-    auto final = CSSSelectorList { WTFMove(result) };
-    return final;
+    return CSSSelectorList { WTFMove(result) };
 }
 
 static std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifierFor(CSSSelectorPseudoElement type)

--- a/Source/WebCore/css/parser/MutableCSSSelector.cpp
+++ b/Source/WebCore/css/parser/MutableCSSSelector.cpp
@@ -289,4 +289,36 @@ bool MutableCSSSelector::startsWithExplicitCombinator() const
     return relation != CSSSelector::Relation::Subselector && relation != CSSSelector::Relation::DescendantSpace;
 }
 
+void MutableCSSSelector::replaceNestingByParentSelector(const CSSSelectorList& parent)
+{
+    auto replaceParentSelector = [&parent] (CSSSelector& selector) {
+        if (selector.match() == CSSSelector::Match::NestingParent) {
+            // FIXME: Optimize cases where we can include the parent selector directly instead of wrapping it in a ":is" pseudo class.
+            selector.setMatch(CSSSelector::Match::PseudoClass);
+            selector.setPseudoClass(CSSSelector::PseudoClass::Is);
+            selector.setSelectorList(makeUnique<CSSSelectorList>(parent));
+        }
+        return false;
+    };
+
+    selector()->visitSimpleSelectors(WTFMove(replaceParentSelector), CSSSelector::VisitFunctionalPseudoClasses::Yes);
+}
+
+void MutableCSSSelector::replaceNestingByPseudoClassScope()
+{
+    auto replaceParentSelector = [] (CSSSelector& selector) {
+        if (selector.match() == CSSSelector::Match::NestingParent) {
+            // Replace by :scope
+            selector.setMatch(CSSSelector::Match::PseudoClass);
+            selector.setPseudoClass(CSSSelector::PseudoClass::Scope);
+            // Top-level nesting parent selector acts like :scope with zero specificity.
+            // https://github.com/w3c/csswg-drafts/issues/10196#issuecomment-2161119978
+            selector.setImplicit();
+        }
+        return false;
+    };
+
+    selector()->visitSimpleSelectors(WTFMove(replaceParentSelector), CSSSelector::VisitFunctionalPseudoClasses::Yes);
+}
+
 }

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -91,6 +91,8 @@ public:
 
     bool hasExplicitNestingParent() const;
     bool hasExplicitPseudoClassScope() const;
+    void replaceNestingByParentSelector(const CSSSelectorList& parent);
+    void replaceNestingByPseudoClassScope();
 
     // FIXME-NEWPARSER: "slotted" was removed here for now, since it leads to a combinator
     // connection of ShadowDescendant, and the current shadow DOM code doesn't expect this. When


### PR DESCRIPTION
#### 3e77a097a27cadfd7ff861e09790db5f2f146b3c
<pre>
[CSS] Remove const_cast in nesting selector resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=297530">https://bugs.webkit.org/show_bug.cgi?id=297530</a>

Reviewed by NOBODY (OOPS!).

Use a MutableCSSSelector instead.
Rename to be more descriptive: resolveNestingParentSelectors -&gt; replaceNestingByParentSelector

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::resolveNestingParentSelectors): Deleted.
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope): Deleted.
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/css/parser/MutableCSSSelector.cpp:
(WebCore::MutableCSSSelector::replaceNestingByParentSelector):
(WebCore::MutableCSSSelector::replaceNestingByPseudoClassScope):
* Source/WebCore/css/parser/MutableCSSSelector.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e77a097a27cadfd7ff861e09790db5f2f146b3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8e68f14a-885f-44b3-bfb0-b95e7060978c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45097 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88722 "24 flakes 116 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43128 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cde17a6-7355-4c78-bdc5-20d2023e80b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119781 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29654 "Found 60 new test failures: accessibility/text-marker/text-marker-previous-next.html compositing/iframes/overlapped-nested-iframes.html compositing/tiling/crash-when-unapplying-mask-border.html compositing/transforms/transformed-replaced-with-shadow-children.html compositing/video/video-controls-layer-creation.html contentfiltering/allow-media-document.html editing/selection/ios/clear-selection-after-tap-on-video.html editing/selection/ios/do-not-allow-text-selection-in-audio-element.html editing/selection/move-by-line-crash.html editing/text-iterator/backwards-text-iterator-basic.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104804 "Found 26 new API test failures: TestWebKitAPI.WebKit2.GetDisplayMediaWindowAndScreenPrompt, TestWebKitAPI.AVFoundationPref.PrefTest, TestWebKitAPI.WKWebExtensionAPIDevTools.PanelsThemeName, TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToBackground, TestWebKitAPI.WebKit2.CrashGPUProcessWhileCapturing, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.WKInspectorExtension.EvaluateScriptOnPage, TestWebKitAPI.WKWebExtensionAPIDevTools.InspectedWindowReload, TestWebKitAPI.WKWebExtensionAPIDevTools.NetworkNavigatedEvent ... (failure)") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28718 "Found 60 new test failures: imported/w3c/web-platform-tests/compat/webkit-box-item-shrink-001.html imported/w3c/web-platform-tests/css/CSS2/floats/crashtests/firefox-bug-1904419.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scope-shadow-names.html imported/w3c/web-platform-tests/css/css-break/table/repeated-section/special-elements-crash.html imported/w3c/web-platform-tests/css/css-cascade/scope-cssom.html imported/w3c/web-platform-tests/css/css-cascade/scope-deep.html imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html imported/w3c/web-platform-tests/css/css-cascade/scope-hover.html imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html imported/w3c/web-platform-tests/css/css-cascade/scope-layer.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22910 "Found 60 new test failures: fast/block/float/list-marker-is-float-crash.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba4444.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/css/aspect-ratio-min-height-replaced.html fast/css/first-letter-block-form-controls-crash.html fast/forms/input-user-modify.html fast/forms/lazy-shadow-tree-creation-crash.html fast/repaint/do-no-repaint-on-internal-move.html fast/spatial-navigation/snav-media-elements.html fullscreen/full-screen-iframe-legacy.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66573 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99033 "Found 13 new API test failures: TestWebKitAPI.WebKit2.OrientationNotAffectedByCSSOrientation, TestWebKitAPI.AVFoundationPref.PrefTest, TestWebKitAPI.SiteIsolation.MutesAndSetsAudioInMultipleFrames, TestWebKitAPI.WebKit.InterruptionBetweenSameProcessPages, TestWebKitAPI.WebKit.MSEHasMediaStreamingActivity, TestWebKitAPI.SiteIsolation.PlayAudioInRemoteFrameThenRemove, TestWebKitAPI.WebKit.GetUserMediaWithWebThread, TestWebKitAPI.WebKit2.CaptureIndicatorDelay, TestWebKitAPI.SiteIsolation.StopsMediaCaptureInRemoteFrame, TestWebKitAPI.WebKit.ManagedMSEHasMediaStreamingActivity ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23064 "Found 60 new test failures: accessibility/mac/media-role-descriptions.html accessibility/smart-invert.html compositing/reflections/video-mask-reflection-crash.html editing/selection/move-by-line-crash.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-video-rgba5551.html fast/css/aspect-ratio-min-height-replaced.html fast/css/cssom-insertrule-crash.html fast/css/first-letter-block-form-controls-crash.html fast/css/nested-shadow-dom-css-container-query.html fast/css/parsing-error-recovery.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126048 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43731 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32847 "Found 60 new test failures: fast/css/scope-at-rule.html fast/shapes/assert-when-rounded-rect-overflows.html fullscreen/fullscreen-restore-scroll-position-with-scroll-during-enter.html fullscreen/video-specified-size.html http/tests/media/clearkey/clear-key-hls-aes128.html http/tests/media/media-document.html http/tests/media/video-hls-copy-into-canvas.html http/tests/preload/onerror_event.html http/tests/site-isolation/edge-sampling-viewport-constrained-object.html http/wpt/mediastream/transfer-videotrackgenerator-track.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97394 "Found 11 new test failures: fast/css/scope-at-rule.html imported/w3c/web-platform-tests/css/css-cascade/scope-deep.html imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation.html imported/w3c/web-platform-tests/css/css-cascade/scope-nesting.html imported/w3c/web-platform-tests/css/css-nesting/host-nesting-001.html imported/w3c/web-platform-tests/css/css-nesting/host-nesting-003.html imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting.html imported/w3c/web-platform-tests/css/css-nesting/nesting-basic.html imported/w3c/web-platform-tests/css/css-nesting/nesting-type-selector.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101005 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97192 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42513 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20456 "Found 60 new test failures: accessibility/aria-hidden-hides-all-elements.html accessibility/mac/media-role-descriptions.html accessibility/mac/text-marker-sentence-nav.html accessibility/media-controls.html accessibility/smart-invert.html compositing/geometry/clipped-video-controller.html compositing/scrolling/async-overflow-scrolling/self-painting-layer-float.html compositing/shared-backing/nested-shared-layers-with-opacity.html contentfiltering/allow-media-document.html css3/viewport-percentage-lengths/viewport-percentage-image-size.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39739 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43617 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49213 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43084 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46423 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->