### PR TITLE
[JSC] Fix `Iterator#flatMap` to handle iterators without `return` method

### DIFF
--- a/JSTests/stress/iterator-prototype-flatMap-return-method.js
+++ b/JSTests/stress/iterator-prototype-flatMap-return-method.js
@@ -1,0 +1,90 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(
+            "bad value: actual=" + actual + ", expected=" + expected,
+        );
+}
+
+{
+    let map = new Map([
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+    ]);
+    let result = [];
+
+    for (let item of map.entries().flatMap(([k, v]) => [[k, v]])) {
+        result.push(item);
+        if (result.length === 2) {
+            break;
+        }
+    }
+
+    shouldBe(result.length, 2);
+}
+
+{
+    let getReturnCount = 0;
+    let callReturnCount = 0;
+
+    let baseIterator = {
+        count: 0,
+        next() {
+            if (this.count < 3) {
+                return { done: false, value: ++this.count };
+            }
+            return { done: true };
+        },
+        get return() {
+            getReturnCount++;
+            return function () {
+                callReturnCount++;
+                return { done: true };
+            };
+        },
+    };
+
+    let iter = {
+        [Symbol.iterator]() {
+            return baseIterator;
+        },
+    };
+
+    let result1 = [];
+    for (let item of Iterator.from(iter).flatMap((x) => [x])) {
+        result1.push(item);
+    }
+    shouldBe(result1.length, 3);
+    shouldBe(getReturnCount, 0);
+
+    baseIterator.count = 0;
+    getReturnCount = 0;
+    callReturnCount = 0;
+
+    let result2 = [];
+    for (let item of Iterator.from(iter).flatMap((x) => [x])) {
+        result2.push(item);
+        if (result2.length === 1) {
+            break;
+        }
+    }
+    shouldBe(result2.length, 1);
+}
+
+{
+    let set = new Set(["a", "b", "c"]);
+    let result = [];
+
+    for (let item of set.values().flatMap((x) => [x, x.toUpperCase()])) {
+        result.push(item);
+        if (result.length === 3) {
+            break;
+        }
+    }
+
+    shouldBe(result.length, 3);
+    shouldBe(result[0], "a");
+    shouldBe(result[1], "A");
+    shouldBe(result[2], "b");
+}
+

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -224,7 +224,12 @@ function flatMap(mapper)
     var iteratedWrapper = {
         @@iterator: function() { return this; },
         next: function() { return iteratedNextMethod.@call(iterated); },
-        return: function() { return iterated.return(@undefined); },
+        return: function() {
+            var iteratedReturnMethod = iterated.return;
+            if (iteratedReturnMethod !== @undefined)
+                return iteratedReturnMethod.@call(iterated, @undefined);
+            return { done: true };
+        },
     };
 
     var generator = (function*() {


### PR DESCRIPTION
#### c4fa114ca0b70c47a1c64a6cdb4695b4b2281b55
<pre>
[JSC] Fix `Iterator#flatMap` to handle iterators without `return` method
<a href="https://bugs.webkit.org/show_bug.cgi?id=297532">https://bugs.webkit.org/show_bug.cgi?id=297532</a>

Reviewed by Keith Miller.

According to the spec, IteratorClose should check if the　return method
exists before calling it, returning the completion value unchanged　when
the method is undefined.

However, the current implementation of Iterator.prototype.flatMap unconditionally
calls iterated.return(), causing a TypeError when used with iterators that don&apos;t
have a return method (e.g., Map.prototype.entries(), Set.prototype.values()).

This patch fixes the issue by checking if the return method exists before calling
it.

* JSTests/stress/iterator-prototype-flatMap-return-method.js: Added.
(shouldBe):
(throw.new.Error):
(shouldBe.let.baseIterator.get return):
(shouldBe.set result):
(shouldBe.let.set new):
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(flatMap.iteratedWrapper.return):

Canonical link: <a href="https://commits.webkit.org/298966@main">https://commits.webkit.org/298966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dea535cdf8130e2b9d47c4ec787b6981563b7a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/67429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88730 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43133 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66581 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/108954 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126052 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115368 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97397 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97195 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42519 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20462 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/39754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43625 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49221 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144067 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43092 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37096 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->