### PR TITLE
[AutoFill Debugging] Part 6: [macOS] Add support for choosing options in select popup menus

### DIFF
--- a/Source/WebKit/UIProcess/WebPopupMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebPopupMenuProxy.h
@@ -70,6 +70,8 @@ public:
 
     void invalidate() { m_client = nullptr; }
 
+    virtual bool isWebPopupMenuProxyMac() const { return false; }
+
 protected:
     explicit WebPopupMenuProxy(Client& client)
         : m_client(&client)

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
@@ -23,13 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WebPopupMenuProxyMac_h
-#define WebPopupMenuProxyMac_h
+#pragma once
 
 #if USE(APPKIT)
 
 #include "WebPopupMenuProxy.h"
 #include <wtf/RetainPtr.h>
+#include <wtf/TypeCasts.h>
 #include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS NSPopUpButtonCell;
@@ -51,18 +51,27 @@ public:
     void hidePopupMenu() override;
     void cancelTracking() override;
 
+    RetainPtr<NSPopUpButtonCell> protectedPopup() const;
+    bool isVisible() const { return m_isVisible; }
+
 private:
     WebPopupMenuProxyMac(NSView *, WebPopupMenuProxy::Client&);
 
     void populate(const Vector<WebPopupItem>&, NSFont *, WebCore::TextDirection);
+    bool isWebPopupMenuProxyMac() const final { return true; }
+    RetainPtr<NSMenu> protectedMenu() const;
 
     RetainPtr<NSPopUpButtonCell> m_popup;
     WeakObjCPtr<NSView> m_webView;
-    bool m_wasCanceled;
+    bool m_wasCanceled { false };
+    bool m_isVisible { false };
 };
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPopupMenuProxyMac) \
+    static bool isType(const WebKit::WebPopupMenuProxy& menu) { return menu.isWebPopupMenuProxyMac(); } \
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // USE(APPKIT)
 
-#endif // WebPopupMenuProxyMac_h

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -282,6 +282,7 @@ Tests/WebKitCocoa/TabOutOfWebView.mm
 Tests/WebKitCocoa/TestAwakener.mm
 Tests/WebKitCocoa/SOAuthorizationTests.mm
 Tests/WebKitCocoa/TestURLSchemeHandler.mm
+Tests/WebKitCocoa/TextExtractionTests.mm
 Tests/WebKitCocoa/TextFragments.mm
 Tests/WebKitCocoa/TextManipulation.mm
 Tests/WebKitCocoa/TextSize.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1440,6 +1440,7 @@
 		F4AD183825ED791500B1A19F /* FloatQuadTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4AD183725ED791500B1A19F /* FloatQuadTests.cpp */; };
 		F4B0168425AE08F800E445C4 /* DisableSpellcheckPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B0167F25AE02D600E445C4 /* DisableSpellcheckPlugIn.mm */; };
 		F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */; };
+		F4BB14E82E53A80600C62BA6 /* debug-text-extraction.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4BB14E72E53A80600C62BA6 /* debug-text-extraction.html */; };
 		F4BC0B142146C849002A0478 /* FocusPreservationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BC0B132146C849002A0478 /* FocusPreservationTests.mm */; };
 		F4BFA68E1E4AD08000154298 /* LegacyDragAndDropTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BFA68C1E4AD08000154298 /* LegacyDragAndDropTests.mm */; };
 		F4C8797F2059D8D3009CD00B /* ScrollViewInsetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */; };
@@ -1905,6 +1906,7 @@
 				A17C473D2C98E5C20023F3C7 /* DataTransfer-setDragImage.html in Copy Resources */,
 				A17C473E2C98E5C20023F3C7 /* DataTransfer.html in Copy Resources */,
 				A17C473F2C98E5C20023F3C7 /* DataTransferItem-getAsEntry.html in Copy Resources */,
+				F4BB14E82E53A80600C62BA6 /* debug-text-extraction.html in Copy Resources */,
 				A17C46AB2C98E54B0023F3C7 /* deferred-script-load.html in Copy Resources */,
 				A17C46AC2C98E54B0023F3C7 /* deferred-script.js in Copy Resources */,
 				A17C466F2C98E4D20023F3C7 /* devicePixelRatio.html in Copy Resources */,
@@ -4236,6 +4238,8 @@
 		F4B825D61EF4DBD4006E417F /* compressed-files.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "compressed-files.zip"; sourceTree = "<group>"; };
 		F4B86D4E20BCD5970099A7E6 /* paint-significant-area-milestone.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "paint-significant-area-milestone.html"; sourceTree = "<group>"; };
 		F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressTests.cpp; sourceTree = "<group>"; };
+		F4BB14E72E53A80600C62BA6 /* debug-text-extraction.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "debug-text-extraction.html"; sourceTree = "<group>"; };
+		F4BB14FD2E53AC7900C62BA6 /* TextExtractionTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextExtractionTests.mm; sourceTree = "<group>"; };
 		F4BC0B132146C849002A0478 /* FocusPreservationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FocusPreservationTests.mm; sourceTree = "<group>"; };
 		F4BDA42E27F8BF2F00F9647D /* FullscreenVideoTextRecognition.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenVideoTextRecognition.mm; sourceTree = "<group>"; };
 		F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-fullscreen.html"; sourceTree = "<group>"; };
@@ -4957,6 +4961,7 @@
 				DFB80E362615124E002D4771 /* TestAwakener.mm */,
 				F4CD74C720FDB49600DE3794 /* TestURLSchemeHandler.h */,
 				F4CD74C820FDB49600DE3794 /* TestURLSchemeHandler.mm */,
+				F4BB14FD2E53AC7900C62BA6 /* TextExtractionTests.mm */,
 				2D9846FB28AE0F2F00CBA70C /* TextFragments.mm */,
 				9B02E0D5235FA47D004044B2 /* TextManipulation.mm */,
 				44DBE9512BD2272900307F65 /* TextPlaceholderTests.mm */,
@@ -5684,6 +5689,7 @@
 				F486B1CF1F6794FF00F34BDD /* DataTransfer-setDragImage.html */,
 				F457A9B3202D535300F7E9D5 /* DataTransfer.html */,
 				F4512E121F60C43400BB369E /* DataTransferItem-getAsEntry.html */,
+				F4BB14E72E53A80600C62BA6 /* debug-text-extraction.html */,
 				0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */,
 				63A61B8A1FAD204D00F06885 /* display-mode.html */,
 				F41AB99E1EF4692C0083FA08 /* div-and-large-image.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "TestWKWebView.h"
+#import "Utilities.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKTextExtraction.h>
+
+@interface WKWebView (TextExtractionTests)
+- (NSString *)synchronouslyGetDebugText:(_WKTextExtractionConfiguration *)configuration;
+@end
+
+@implementation WKWebView (TextExtractionTests)
+
+- (NSString *)synchronouslyGetDebugText:(_WKTextExtractionConfiguration *)configuration
+{
+    RetainPtr configurationToUse = configuration;
+    if (!configurationToUse)
+        configurationToUse = adoptNS([_WKTextExtractionConfiguration new]);
+
+    __block bool done = false;
+    __block RetainPtr<NSString> result;
+    [self _debugTextWithConfiguration:configurationToUse.get() completionHandler:^(NSString *text) {
+        result = text;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result.autorelease();
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+#if PLATFORM(MAC)
+
+static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText)
+{
+    for (NSString *line in [debugText componentsSeparatedByString:@"\n"]) {
+        if (![line containsString:searchText])
+            continue;
+
+        RetainPtr regex = [NSRegularExpression regularExpressionWithPattern:@"uid=(\\d+)" options:0 error:nil];
+        RetainPtr match = [regex firstMatchInString:line options:0 range:NSMakeRange(0, line.length)];
+        if (!match)
+            continue;
+
+        NSRange identifierRange = [match rangeAtIndex:1];
+        return [line substringWithRange:identifierRange];
+    }
+
+    return nil;
+}
+
+TEST(TextExtractionTests, SelectPopupMenu)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+    RetainPtr click = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [click setNodeIdentifier:extractNodeIdentifier(debugText.get(), @"menu")];
+
+    __block bool doneSelectingOption = false;
+    __block RetainPtr<NSString> debugTextAfterClickingSelect;
+    [webView _performInteraction:click.get() completionHandler:^(BOOL clickSuccess) {
+        EXPECT_TRUE(clickSuccess);
+        EXPECT_TRUE([[webView synchronouslyGetDebugText:nil] containsString:@"nativePopupMenu"]);
+
+        RetainPtr selectOption = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionSelectMenuItem]);
+        [selectOption setText:@"Three"];
+        [webView _performInteraction:selectOption.get() completionHandler:^(BOOL selectOptionSuccess) {
+            EXPECT_TRUE(selectOptionSuccess);
+            doneSelectingOption = true;
+        }];
+    }];
+
+    Util::run(&doneSelectingOption);
+    EXPECT_WK_STREQ("Three", [webView stringByEvaluatingJavaScript:@"select.value"]);
+}
+
+#endif // PLATFORM(MAC)
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm
@@ -29,6 +29,7 @@
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <wtf/RetainPtr.h>
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -29,6 +29,7 @@
 
 #import "HTTPServer.h"
 #import "TestUIDelegate.h"
+#import "TestWKWebView.h"
 #import "WebExtensionUtilities.h"
 
 namespace TestWebKitAPI {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
+</head>
+<body>
+    <button id="test-button" aria-label="Click Me">Test</button>
+    <input type="email" placeholder="Enter some text" value="foo" />
+    <select role="menu">
+        <option>One</option>
+        <option selected>Two</option>
+        <option>Three</option>
+    </select>
+    <div contenteditable="plaintext-only">
+        <h3 aria-label="Heading">Subject</h3>
+        <p>Hello world.</p>
+    </div>
+    <h1 class="click-count">0</h1>
+    <script>
+    addEventListener("load", async () => {
+        textField = document.querySelector("input");
+        select = document.querySelector("select");
+        clickCount = document.querySelector(".click-count");
+        document.getElementById("test-button").addEventListener("click", () => {
+            clickCount.textContent = parseInt(clickCount.textContent) + 1;
+        });
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### af800d18008e016be2f92d216b009797d8cfc20e
<pre>
[AutoFill Debugging] Part 6: [macOS] Add support for choosing options in select popup menus
<a href="https://bugs.webkit.org/show_bug.cgi?id=297550">https://bugs.webkit.org/show_bug.cgi?id=297550</a>
<a href="https://rdar.apple.com/158621862">rdar://158621862</a>

Reviewed by Abrar Rahman Protyasha.

Add the ability to choose items in select popup menus via `.selectMenuItem({ text: &quot;…&quot; })`, where
the text represents the title of the option to choose. See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _activePopupButtonCell]):

Add a macOS-specific helper method to get the currently active (and visible) popup menu button cell.

(-[WKWebView _popupMenuForTextExtractionResults]):

Add a helper method to create a `WKTextExtractionPopupMenu` representing the currently active menu.
Only implemented for macOS at the moment; the iOS implementation (which will need to bridge into
UIKit context menu interactions) will come in a later patch.

(-[WKWebView _performInteraction:completionHandler:]):

When there&apos;s an active (and open) menu, handle `.selectMenuItem` by selecting the option indicated
by the given `text`. Also use `callAfterNextPresentationUpdate` instead of
`-_doAfterNextPresentationUpdate` here — there&apos;s no need to call the SPI from within the engine,
when we can directly call into `WebPageProxy`.

(-[WKWebView _requestTextExtraction:completionHandler:]):

Compute and set the `popupMenu`.

* Source/WebKit/UIProcess/WebPopupMenuProxy.h:
(WebKit::WebPopupMenuProxy::isWebPopupMenuProxyMac const):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h:
(WebKit::WebPopupMenuProxyMac::isVisible const):
(isType):

Make it possible to `dynamicDowncast` from `WebPopupMenuProxy` to `WebPopupMenuProxyMac`.

* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::WebPopupMenuProxyMac):
(WebKit::WebPopupMenuProxyMac::populate):
(WebKit::WebPopupMenuProxyMac::showPopupMenu):
(WebKit::WebPopupMenuProxyMac::hidePopupMenu):
(WebKit::WebPopupMenuProxyMac::cancelTracking):

Drive-by — deploy smart pointers (`protectedMenu`) in a few places.

(WebKit::WebPopupMenuProxyMac::protectedPopup const):
(WebKit::WebPopupMenuProxyMac::protectedMenu const):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm: Added.

Add a new test suite to exercise `-_debugTextWithConfiguration:` and `-_performInteraction:`.

(-[WKWebView synchronouslyGetDebugText:]):
(TestWebKitAPI::extractNodeIdentifier):
(TestWebKitAPI::TEST(TextExtractionTests, SelectPopupMenu)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKFragmentDirectiveGeneration.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:

Unrelated unified source build fixes.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html: Added.

Canonical link: <a href="https://commits.webkit.org/298866@main">https://commits.webkit.org/298866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/875e64abf90e4ba37436cf28cb3048e44ff14634

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122988 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/68919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/80f22fb9-c239-4328-ba44-0ea608afb2b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/68919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cbaf7116-ecf0-4160-a276-e4c6e25e365f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119852 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/29723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104867 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69245 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66644 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126115 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97453 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24761 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20518 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49284 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43155 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->