### PR TITLE
Part 2: Modernize length conversion in SVGLengthValue

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-svglength-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-svglength-expected.txt
@@ -2,10 +2,10 @@ CONSOLE MESSAGE: Error: Invalid value for <rect> attribute width="calc(10cqmin +
 CONSOLE MESSAGE: Error: Invalid value for <rect> attribute height="calc(10cqw + 3px)"
 
 PASS unitType with container-relative units
-FAIL cqw,cqh can be resolved The operation is not supported.
-FAIL cqi,cqb can be resolved The operation is not supported.
-FAIL cqmin,cqmax can be resolved The operation is not supported.
+PASS cqw,cqh can be resolved
+PASS cqi,cqb can be resolved
+PASS cqmin,cqmax can be resolved
 FAIL calc() with container-relative units can be resolved assert_equals: expected 35 but got 0
-FAIL Can modify value with container-relative units The operation is not supported.
-FAIL CSS Container Queries Test: container-relative units in SVGLength assert_approx_equals: expected 15 +/- 1 but got 0
+FAIL Can modify value with container-relative units assert_equals: expected "80" but got "40cqw"
+PASS CSS Container Queries Test: container-relative units in SVGLength
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-container-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-container-element-expected.txt
@@ -1,5 +1,5 @@
 
 PASS IntersectionObserver observing an SVG container element changing position
 FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.right expected 108 +/- 1 but got 8
-FAIL Change inner svg element assert_equals: entries.length expected 2 but got 1
+FAIL Change inner svg element assert_approx_equals: entries[1].boundingClientRect.right expected 108 +/- 1 but got 8
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-cap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-cap-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL cap unit in SVGLength The operation is not supported.
-FAIL Convert back to cap from new user unit value The operation is not supported.
+PASS cap unit in SVGLength
+PASS Convert back to cap from new user unit value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL ic unit in SVGLength The operation is not supported.
-FAIL Convert back to ic from new user unit value The operation is not supported.
+PASS ic unit in SVGLength
+PASS Convert back to ic from new user unit value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-px-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-px-expected.txt
@@ -5,7 +5,7 @@ FAIL SVGLength, converting from 'px' to other units (detached), ems The operatio
 FAIL SVGLength, converting from 'px' to other units (detached), exs The operation is not supported.
 PASS SVGLength, converting from 'px' to other units (detached), cm
 PASS SVGLength, converting from 'px' to other units (detached), mm
-FAIL SVGLength, converting from 'px' to other units (detached), q The operation is not supported.
+PASS SVGLength, converting from 'px' to other units (detached), q
 PASS SVGLength, converting from 'px' to other units (detached), in
 PASS SVGLength, converting from 'px' to other units (detached), pt
 PASS SVGLength, converting from 'px' to other units (detached), pc

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL rem unit in SVGLength The operation is not supported.
-FAIL Convert back to rem from new user unit value The operation is not supported.
+FAIL rem unit in SVGLength assert_equals: expected 100 but got 225
+PASS Convert back to rem from new user unit value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rlh-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rlh-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL rlh unit in SVGLength The operation is not supported.
-FAIL Convert back to rlh from new user unit value The operation is not supported.
+PASS rlh unit in SVGLength
+PASS Convert back to rlh from new user unit value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-viewport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-viewport-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL vw unit in SVGLength The operation is not supported.
-FAIL Convert back to vw from new user unit value The operation is not supported.
-FAIL vh unit in SVGLength The operation is not supported.
-FAIL Convert back to vh from new user unit value The operation is not supported.
-FAIL vmin unit in SVGLength The operation is not supported.
-FAIL Convert back to vmin from new user unit value The operation is not supported.
-FAIL vmax unit in SVGLength The operation is not supported.
-FAIL Convert back to vmax from new user unit value The operation is not supported.
+PASS vw unit in SVGLength
+PASS Convert back to vw from new user unit value
+PASS vh unit in SVGLength
+PASS Convert back to vh from new user unit value
+PASS vmin unit in SVGLength
+PASS Convert back to vmin from new user unit value
+PASS vmax unit in SVGLength
+PASS Convert back to vmax from new user unit value
 

--- a/LayoutTests/svg/dom/SVGLength-value-in-inactive-document-expected.txt
+++ b/LayoutTests/svg/dom/SVGLength-value-in-inactive-document-expected.txt
@@ -1,2 +1,1 @@
-CONSOLE MESSAGE: NotSupportedError: The operation is not supported.
 PASS if no assert is triggered.

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -26,6 +26,7 @@
 
 namespace WebCore {
 
+class CSSToLengthConversionData;
 class SVGElement;
 class WeakPtrImplWithEventTargetData;
 
@@ -72,6 +73,9 @@ public:
     ExceptionOr<float> convertValueToUserUnits(float, SVGLengthType, SVGLengthMode) const;
     ExceptionOr<float> convertValueFromUserUnits(float, SVGLengthType, SVGLengthMode) const;
 
+    ExceptionOr<float> resolveValueToUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
+    ExceptionOr<CSS::LengthPercentage<>> resolveValueFromUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
+
     std::optional<FloatSize> viewportSize() const;
 
 private:
@@ -92,7 +96,9 @@ private:
     ExceptionOr<float> convertValueFromChToUserUnits(float) const;
 
     std::optional<FloatSize> computeViewportSize() const;
+    float computeNonCalcLength(float, CSS::LengthUnit) const;
 
+    std::optional<CSSToLengthConversionData> cssConversionData() const;
     RefPtr<const SVGElement> protectedContext() const;
 
     template<typename SizeType> float valueForSizeType(const SizeType&, SVGLengthMode = SVGLengthMode::Other);


### PR DESCRIPTION
#### 896ad5ea54317eb640ef344823ab68708281ef9d
<pre>
Modernize length conversion in SVGLengthValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=297555">https://bugs.webkit.org/show_bug.cgi?id=297555</a>
<a href="https://rdar.apple.com/158634833">rdar://158634833</a>

Reviewed by Tim Nguyen.

This PR modernizes SVGLengthValue length conversion by replacing
selected call sites of convertValueToUserUnits and convertValueFromUserUnits
with modern APIs that reuse the existing CSS length conversion machinery.

The goal is to migrate all consumers from the old length conversion
APIs and eventually remove all individual conversion functions,
as the CSS length conversion machinery will make these redundant.

A few caveats:

- The handling of the ex unit continues to use the
legacy conversion path to preserve compatibility

- Percentages still use the old path, as they require
SVG viewport information

- The convertToSpecifiedUnits API continues to use the old conversion
logic; this will be migrated in a separate PR.

LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-svglength-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-container-element-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-cap-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ic-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-px-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rem-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-rlh-expected.txt:
LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-viewport-expected.txt:
LayoutTests/svg/dom/SVGLength-value-in-inactive-document-expected.txt:
Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::computeLengthWithUnit const):
(WebCore::SVGLengthContext::resolveLengthToUserUnits const):
(WebCore::SVGLengthContext::expressFromUserUnits const):
(WebCore::rootRenderStyleForLengthResolving):
(WebCore::SVGLengthContext::cssConversionData const):
Source/WebCore/svg/SVGLengthContext.h:
Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::valueForBindings const):
(WebCore::SVGLengthValue::setValue):

Canonical link: <a href="https://commits.webkit.org/299087@main">https://commits.webkit.org/299087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ebb8fa0af103027af1fc6c710d332c6fd1b6eb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36dd0a7c-7896-4996-bf9f-e2bcb4c3cdba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89382 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/58574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a9d6d5be-d80e-4e71-9543-abb6a38b707d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69875 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/112727f2-b0a2-444d-8a5a-dfebab672705) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67573 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127002 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24891 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43214 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41044 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44550 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50224 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44008 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47355 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45699 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->