### PR TITLE
http/tests/pointer-lock should not be skipped on iOS

### DIFF
--- a/LayoutTests/http/tests/pointer-lock/iframe-sandboxed-allow-pointer-lock.html
+++ b/LayoutTests/http/tests/pointer-lock/iframe-sandboxed-allow-pointer-lock.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test sandboxed iframe with allow-pointer-lock allows pointer lock.");
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];
@@ -29,6 +30,5 @@
     ];
     // doNextStep() called by iframe onload handler.
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/pointer-lock/iframe-sandboxed-nested-allow-pointer-lock.html
+++ b/LayoutTests/http/tests/pointer-lock/iframe-sandboxed-nested-allow-pointer-lock.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test nested sandboxed iframes with allow-pointer-lock allow pointer lock.");
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];

--- a/LayoutTests/http/tests/pointer-lock/iframe-sandboxed-nested-disallow-then-allow-pointer-lock.html
+++ b/LayoutTests/http/tests/pointer-lock/iframe-sandboxed-nested-disallow-then-allow-pointer-lock.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test nested sandboxed iframes without and then with allow-pointer-lock disallow pointer lock.");
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];
@@ -29,6 +30,5 @@
     ];
     // doNextStep() called by iframe onload handler.
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/pointer-lock/iframe-sandboxed.html
+++ b/LayoutTests/http/tests/pointer-lock/iframe-sandboxed.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test sandboxed iframe blocks pointer lock.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];
@@ -29,6 +30,5 @@
     ];
     // doNextStep() called by iframe onload handler.
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/pointer-lock/pointerlockelement-different-origin.html
+++ b/LayoutTests/http/tests/pointer-lock/pointerlockelement-different-origin.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test iframe from different origin can not access pointerLockElement.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];
@@ -38,6 +39,5 @@
     ];
     // doNextStep() called by iframe onload handler.
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/pointer-lock/pointerlockelement-same-origin.html
+++ b/LayoutTests/http/tests/pointer-lock/pointerlockelement-same-origin.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test iframe from same origin can not access pointerLockElement.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];
@@ -38,6 +39,5 @@
     ];
     // doNextStep() called by iframe onload handler.
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/pointer-lock/requestPointerLock-can-not-transfer-between-documents.html
+++ b/LayoutTests/http/tests/pointer-lock/requestPointerLock-can-not-transfer-between-documents.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 <script src="../resources/pointer-lock/pointer-lock-test-harness.js"></script>
 </head>
 <body>
@@ -12,6 +12,7 @@
 <script>
     description("Test iframe from same origin can not transfer pointer lock across documents.")
     window.jsTestIsAsync = true;
+    window.testRunner?.setHasMouseDeviceForTesting(true);
 
     targetDiv1 = document.getElementById("target1");
     iframe = document.getElementsByTagName("iframe")[0];
@@ -46,6 +47,5 @@
     ];
     // doNextStep() called by iframe onload handler.
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/http/tests/resources/pointer-lock/inner-iframe.html
+++ b/LayoutTests/http/tests/resources/pointer-lock/inner-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
 <script src="iframe-common.js"></script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -338,7 +338,6 @@ http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html
 http/tests/security/contentSecurityPolicy/object-redirect-blocked3.html
 
 # Pointer-lock not supported on iOS: https://bugs.webkit.org/show_bug.cgi?id=216621
-http/tests/pointer-lock
 fast/shadow-dom/pointerlockelement-in-shadow-tree.html
 fast/shadow-dom/pointerlockelement-in-slot.html
 fast/js-promise/js-promise-invalid-context-access.html [ Skip ]


### PR DESCRIPTION
#### 133efc1d90735199e6cd35b5691cd7bbda4e87b9
<pre>
http/tests/pointer-lock should not be skipped on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=297557">https://bugs.webkit.org/show_bug.cgi?id=297557</a>
<a href="https://rdar.apple.com/158636009">rdar://158636009</a>

Reviewed by Tim Horton.

We have all the requisite support to run these tests. This patch enables
the Pointer Lock API web preference and adds a mock mouse pointing
device as test support. Also, as a drive-by fix, we move away from the
js-test-[pre|post].js idiom to /js-test-resources/js-test.js instead.

* LayoutTests/http/tests/pointer-lock/iframe-sandboxed-allow-pointer-lock.html:
* LayoutTests/http/tests/pointer-lock/iframe-sandboxed-nested-allow-pointer-lock.html:
* LayoutTests/http/tests/pointer-lock/iframe-sandboxed-nested-disallow-then-allow-pointer-lock.html:
* LayoutTests/http/tests/pointer-lock/iframe-sandboxed.html:
* LayoutTests/http/tests/pointer-lock/pointerlockelement-different-origin.html:
* LayoutTests/http/tests/pointer-lock/pointerlockelement-same-origin.html:
* LayoutTests/http/tests/pointer-lock/requestPointerLock-can-not-transfer-between-documents.html:
* LayoutTests/http/tests/resources/pointer-lock/inner-iframe.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298870@main">https://commits.webkit.org/298870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acb0ecc7fb573c2330cbc34f3c844c3bef035ddf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/122987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68918 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1c0b35d-7394-4fc9-a439-fa77e90c68e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88784 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f95258c-5093-45e7-b5b7-5d780ea2ce90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69243 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22977 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66643 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126114 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97248 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42576 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20522 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18668 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43687 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43154 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44859 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->