### PR TITLE
3 tests using Pointer Lock API can be unskipped on iOS

### DIFF
--- a/LayoutTests/fast/js-promise/js-promise-invalid-context-access.html
+++ b/LayoutTests/fast/js-promise/js-promise-invalid-context-access.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <script>
 function f0() {
   var v46 = x76.contentWindow;

--- a/LayoutTests/fast/shadow-dom/pointerlockelement-in-shadow-tree.html
+++ b/LayoutTests/fast/shadow-dom/pointerlockelement-in-shadow-tree.html
@@ -1,7 +1,8 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 </head>
 <body>
 <div id="host"></div>
@@ -9,6 +10,7 @@
 description('Test pointerLockElement is the node in the same tree as the context object.<br>'
     + 'To manually test, click on "Click here" below.');
 window.jsTestIsAsync = true;
+window.testRunner?.setHasMouseDeviceForTesting(true);
 
 shadowHost = document.getElementById('host');
 shadowRoot = shadowHost.attachShadow({mode: 'closed'});
@@ -21,14 +23,23 @@ target.onclick = function () {
     target.requestPointerLock();
 }
 
-function clickElement(element) {
-    eventSender.mouseMoveTo(element.offsetLeft + 5, element.offsetTop + 5);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+function requestPointerLock(element) {
+    // webkit.org/b/285901 EventSender.mouse[Up|Down|MoveTo] do not work on iOS
+    if (UIHelper.isIOSFamily()) {
+        shouldBe("document.pointerLockElement", "null");
+        shouldBe("shadowRoot.pointerLockElement", "null");
+        internals.withUserGesture(() => {
+            element.requestPointerLock();
+        });
+    } else {
+        eventSender.mouseMoveTo(element.offsetLeft + 5, element.offsetTop + 5);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
 }
 
 if (window.eventSender)
-    clickElement(target);
+    requestPointerLock(target);
 
 let state = 0;
 document.addEventListener('pointerlockchange', function () {
@@ -48,6 +59,5 @@ document.addEventListener('pointerlockchange', function () {
 });
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/shadow-dom/pointerlockelement-in-slot.html
+++ b/LayoutTests/fast/shadow-dom/pointerlockelement-in-slot.html
@@ -1,7 +1,8 @@
-<!DOCTYPE HTML>
+<!DOCTYPE HTML> <!-- webkit-test-runner [ PointerLockEnabled=true ] -->
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 </head>
 <body>
 <div id="host"><span id="target" tabindex=0>Click here</span></div>
@@ -10,6 +11,7 @@
 description('Test pointerLockElement is the node in the same tree as the context object.<br>'
     + 'To manually test, click on "Click here" below.');
 window.jsTestIsAsync = true;
+window.testRunner?.setHasMouseDeviceForTesting(true);
 
 shadowHost = document.getElementById('host');
 shadowRoot = shadowHost.attachShadow({mode: 'closed'});
@@ -24,14 +26,23 @@ target.onclick = function () {
     target.requestPointerLock();
 }
 
-function clickElement(element) {
-    eventSender.mouseMoveTo(element.offsetLeft + 5, element.offsetTop + 5);
-    eventSender.mouseDown();
-    eventSender.mouseUp();
+function requestPointerLock(element) {
+    // webkit.org/b/285901 EventSender.mouse[Up|Down|MoveTo] do not work on iOS
+    if (UIHelper.isIOSFamily()) {
+        shouldBe("document.pointerLockElement", "null");
+        shouldBe("shadowRoot.pointerLockElement", "null");
+        internals.withUserGesture(() => {
+            element.requestPointerLock();
+        });
+    } else {
+        eventSender.mouseMoveTo(element.offsetLeft + 5, element.offsetTop + 5);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
 }
 
 if (window.eventSender)
-    clickElement(target);
+    requestPointerLock(target);
 
 let state = 0;
 document.addEventListener('pointerlockchange', function () {
@@ -53,6 +64,5 @@ document.addEventListener('pointerlockchange', function () {
 });
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -338,9 +338,6 @@ http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html
 http/tests/security/contentSecurityPolicy/object-redirect-blocked3.html
 
 # Pointer-lock not supported on iOS: https://bugs.webkit.org/show_bug.cgi?id=216621
-fast/shadow-dom/pointerlockelement-in-shadow-tree.html
-fast/shadow-dom/pointerlockelement-in-slot.html
-fast/js-promise/js-promise-invalid-context-access.html [ Skip ]
 imported/w3c/web-platform-tests/pointerlock [ Skip ]
 
 # webkit.org/b/285901 EventSender.mouse[Up|Down|MoveTo] do not work on iOS


### PR DESCRIPTION
#### 1de3cc17d9efa5e5c16a5839f64beb3eab96581a
<pre>
3 tests using Pointer Lock API can be unskipped on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=297559">https://bugs.webkit.org/show_bug.cgi?id=297559</a>
<a href="https://rdar.apple.com/158636482">rdar://158636482</a>

Reviewed by Tim Horton.

We have all the requisite support to run these tests. This patch enables
the Pointer Lock API web preference and, when needed, adds a mock mouse
pointing device as test support. For the shadow-dom tests, we also move
away from clicking the element on iOS to simply requesting pointer lock
with user gesture as a workaround for webkit.org/b/285901.

Also, as a drive-by fix, we move away from the js-test-[pre|post].js
idiom to js-test.js instead.

* LayoutTests/fast/js-promise/js-promise-invalid-context-access.html:
* LayoutTests/fast/shadow-dom/pointerlockelement-in-shadow-tree.html:
* LayoutTests/fast/shadow-dom/pointerlockelement-in-slot.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298883@main">https://commits.webkit.org/298883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7b5917109236be822a29bfea5fe79c5053fdc10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68957 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a67fdfa-a6b2-4feb-b64a-7d5e0390d442) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bce13989-9fec-4c78-b4c0-daaec02e9104) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69275 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23016 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66682 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126153 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97477 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97280 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40236 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18676 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43726 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43193 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->