### PR TITLE
SVG text element with text-anchor: middle is misaligned using icon font

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -64,6 +64,7 @@ private:
     void updateRelativePositionAdjustmentsIfNeeded(float dx, float dy);
 
     void recordTextFragment(InlineIterator::SVGTextBoxIterator, const Vector<SVGTextMetrics>&);
+    void computeCurrentFragmentMetrics(InlineIterator::SVGTextBoxIterator);
     bool parentDefinesTextLength(RenderObject*) const;
 
     void layoutTextOnLineOrPath(InlineIterator::SVGTextBoxIterator, const RenderSVGInlineText&, const RenderStyle&);


### PR DESCRIPTION
#### 58865102f3f004d1e2800fe7d2175336ad82b91e
<pre>
SVG text element with text-anchor: middle is misaligned using icon font
<a href="https://bugs.webkit.org/show_bug.cgi?id=215321">https://bugs.webkit.org/show_bug.cgi?id=215321</a>
<a href="https://rdar.apple.com/66869020">rdar://66869020</a>

Reviewed by NOBODY (OOPS!).

Summing up advance per each fragment will not always
match the whole content as codepoint to glyph relation
is not 1:1. There are cases in which one codepoint is
shaped as multiple glyphs and there are cases in which
multiple codepoints are shaped as a single glyph, for example.

* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::computeCurrentFragmentMetrics):
(WebCore::SVGTextLayoutEngine::recordTextFragment):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58865102f3f004d1e2800fe7d2175336ad82b91e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68935 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07803334-8311-45d7-80d0-4e0196d0cb23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45184 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88800 "Found 60 new test failures: imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/w3c/web-platform-tests/svg/text/scripted/lengthadjust.html imported/w3c/web-platform-tests/svg/text/scripted/textpath-textlength-text-anchor-001.tentative.svg svg/W3C-SVG-1.1-SE/types-dom-04-b.svg svg/W3C-SVG-1.1/interact-order-01-b.svg svg/W3C-SVG-1.1/text-align-04-b.svg ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43525 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, ietestcenter/Javascript/15.5.4.20-4-55.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dom/script-line-number.html, storage/domstorage/sessionstorage/delete-removal.html, storage/domstorage/sessionstorage/enumerate-storage.html, storage/domstorage/sessionstorage/window-open.html, storage/indexeddb/cursor-leak.html, storage/indexeddb/deletedatabase-delayed-by-open-and-versionchange-workers.html, storage/indexeddb/modern/cursor-4-private.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-3d-r11f_g11f_b10f-rgb-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image/tex-2d-r32f-red-float.html, webgl/2.0.y/conformance2/rendering/rgb-format-support.html, webgl/2.0.y/conformance2/textures/canvas/tex-2d-rgb5_a1-rgba-unsigned_byte.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/719b4d2e-1df6-47ce-9a5a-c070df8a6bc7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119868 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29738 "Found 60 new test failures: fast/forms/file/file-input-reset-using-open-panel.html http/tests/IndexedDB/storage-limit-2.https.html http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html http/tests/iframe-monitor/dark-mode.html http/tests/iframe-monitor/eligibility.html http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/workers/service-worker-not-count-twice.html http/tests/iframe-monitor/workers/service-worker.html http/tests/iframe-monitor/workers/shared-worker.html http/wpt/content-security-policy/duplicate-body-hide-nonce-attribute.https.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69259 "Passed tests") | | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28805 "Found 3 new test failures: imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed.svg imported/w3c/web-platform-tests/svg/text/scripted/lengthadjust.html imported/w3c/web-platform-tests/svg/text/scripted/textpath-textlength-text-anchor-001.tentative.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/22996 "Found 60 new test failures: fast/css/aspect-ratio-min-height-replaced.html fullscreen/fullscreen-document-gc-crash.html http/tests/loading/main-resource-delegates-on-back-navigation.html http/tests/loading/unfinished-load-back-to-cached-page-callbacks.html http/tests/media/hls/hls-webvtt-default.html http/tests/security/contentSecurityPolicy/script-src-none-inline-event.html http/tests/security/contentSecurityPolicy/script-src-parsing-implicit-and-explicit-port-number.html http/tests/security/contentSecurityPolicy/script-src-star-cross-scheme.html http/tests/security/contentSecurityPolicy/source-list-parsing-10.html http/tests/security/cookie-module-import-propagate.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99124 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23150 "Found 60 new test failures: fast/media/media-type-syntax-01.html fast/shadow-dom/imperative-slot-update-3.html http/tests/navigation/ping-attribute/anchor-cross-origin-from-https-UpgradeMixedContent.html imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-003.html imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126131 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43819 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32933 "Found 60 new test failures: fast/mediastream/mediastream-gc.html fast/parser/entity-comment-in-textarea.html fast/scrolling/mac/stateless-user-scroll-scrollend.html http/tests/navigation/redirect-to-random-url-versus-memory-cache.html http/tests/websocket/tests/hybi/handshake-ok-with-legacy-websocket-response-headers.html http/tests/xmlhttprequest/cors-non-standard-safelisted-headers-should-trigger-preflight.html http/wpt/mediarecorder/MediaRecorder-multiple-start-stop.html http/wpt/webauthn/public-key-credential-get-success-hid.https.html imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97463 "Found 59 new test failures: imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/w3c/web-platform-tests/svg/text/scripted/lengthadjust.html imported/w3c/web-platform-tests/svg/text/scripted/textpath-textlength-text-anchor-001.tentative.svg svg/W3C-SVG-1.1-SE/types-dom-04-b.svg svg/W3C-SVG-1.1/animate-elem-06-t.svg svg/W3C-SVG-1.1/text-align-04-b.svg ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97265 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42593 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20538 "Found 60 new test failures: compositing/backing/overflow-gains-content.html css3/calc/simple-composited-mask.html css3/flexbox/flex-item-margin-top-no-crash.html fast/media/mq-transform-02.html imported/mozilla/svg/text/multiple-chunks-multiple-dx-different-anchor.svg imported/mozilla/svg/text/multiple-x-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-end.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle-bidi.svg imported/mozilla/svg/text/simple-multiple-dx-anchor-middle.svg imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_go_to_uri.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40214 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49300 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44876 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->