### PR TITLE
Introduce WTF_NO_DESTROY for static destructor suppression

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -653,6 +653,20 @@
 #define WTF_UNSAFE_BUFFER_USAGE
 #endif
 
+/* WTF_NO_DESTROY */
+
+#if COMPILER(CLANG)
+#if COMPILER_HAS_CPP_ATTRIBUTE(clang::no_destroy)
+#define WTF_NO_DESTROY [[clang::no_destroy]]
+#elif COMPILER_HAS_ATTRIBUTE(no_destroy)
+#define WTF_NO_DESTROY __attribute__((__no_destroy__))
+#else
+#define WTF_NO_DESTROY
+#endif
+#else
+#define WTF_NO_DESTROY
+#endif
+
 /* WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE */
 
 #define WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN \

--- a/Source/WTF/wtf/MainThreadDispatcher.cpp
+++ b/Source/WTF/wtf/MainThreadDispatcher.cpp
@@ -34,7 +34,7 @@ namespace WTF {
 MainThreadDispatcher& MainThreadDispatcher::singleton()
 {
     static std::once_flag onceKey;
-    static LazyNeverDestroyed<Ref<MainThreadDispatcher>> dispatcher;
+    WTF_NO_DESTROY static LazyNeverDestroyed<Ref<MainThreadDispatcher>> dispatcher;
     std::call_once(onceKey, [] {
         dispatcher.construct(adoptRef(*new MainThreadDispatcher()));
     });

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -53,7 +53,7 @@ static std::atomic<bool> s_hasCreatedMemoryPressureHandler;
 
 MemoryPressureHandler& MemoryPressureHandler::singleton()
 {
-    static LazyNeverDestroyed<MemoryPressureHandler> memoryPressureHandler;
+    WTF_NO_DESTROY static LazyNeverDestroyed<MemoryPressureHandler> memoryPressureHandler;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         memoryPressureHandler.construct();

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -67,7 +67,7 @@ void RunLoop::initializeMain()
 
 auto RunLoop::runLoopHolder() -> ThreadSpecific<Holder>&
 {
-    static LazyNeverDestroyed<ThreadSpecific<Holder>> runLoopHolder;
+    WTF_NO_DESTROY static LazyNeverDestroyed<ThreadSpecific<Holder>> runLoopHolder;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         runLoopHolder.construct();

--- a/Source/WTF/wtf/text/TextBreakIterator.cpp
+++ b/Source/WTF/wtf/text/TextBreakIterator.cpp
@@ -33,7 +33,7 @@ namespace WTF {
 
 TextBreakIteratorCache& TextBreakIteratorCache::singleton()
 {
-    static LazyNeverDestroyed<TextBreakIteratorCache> cache;
+    WTF_NO_DESTROY static LazyNeverDestroyed<TextBreakIteratorCache> cache;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         cache.construct();

--- a/Source/WebCore/crypto/CryptoAlgorithmRegistry.cpp
+++ b/Source/WebCore/crypto/CryptoAlgorithmRegistry.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 CryptoAlgorithmRegistry& CryptoAlgorithmRegistry::singleton()
 {
-    static LazyNeverDestroyed<CryptoAlgorithmRegistry> registry;
+    WTF_NO_DESTROY static LazyNeverDestroyed<CryptoAlgorithmRegistry> registry;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         registry.construct();

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValuePool);
 
-LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
+WTF_NO_DESTROY LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
 
 StaticCSSValuePool::StaticCSSValuePool()
 {
@@ -68,7 +68,7 @@ CSSValuePool::CSSValuePool() = default;
 // FIXME: Consider a design where the value pool thread-local storage so callers don't have to deal directly with the value pool at all.
 CSSValuePool& CSSValuePool::singleton()
 {
-    static MainThreadNeverDestroyed<CSSValuePool> pool;
+    WTF_NO_DESTROY static MainThreadNeverDestroyed<CSSValuePool> pool;
     return pool;
 }
 

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -707,7 +707,7 @@ SelectorQuery::SelectorQuery(CSSSelectorList&& selectorList)
 
 SelectorQueryCache& SelectorQueryCache::singleton()
 {
-    static NeverDestroyed<SelectorQueryCache> cache;
+    WTF_NO_DESTROY static NeverDestroyed<SelectorQueryCache> cache;
     return cache.get();
 }
 

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.cpp
@@ -118,7 +118,7 @@ CrossOriginPreflightResultCache& CrossOriginPreflightResultCache::singleton()
 {
     ASSERT(isMainThread());
 
-    static NeverDestroyed<CrossOriginPreflightResultCache> cache;
+    WTF_NO_DESTROY static NeverDestroyed<CrossOriginPreflightResultCache> cache;
     return cache;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingThread.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingThread.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 ScrollingThread& ScrollingThread::singleton()
 {
-    static LazyNeverDestroyed<ScrollingThread> scrollingThread;
+    WTF_NO_DESTROY static LazyNeverDestroyed<ScrollingThread> scrollingThread;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         scrollingThread.construct();

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -36,8 +36,8 @@
 namespace WebGPU {
 
 Lock QuerySet::querySetLock;
-__attribute__((no_destroy)) std::unique_ptr<Vector<id<MTLCounterSampleBuffer>>> QuerySet::m_counterSampleBuffers;
-__attribute__((no_destroy)) std::unique_ptr<Vector<RangeSet<Range<uint32_t>>>> QuerySet::m_counterSampleBufferFreeRanges;
+WTF_NO_DESTROY std::unique_ptr<Vector<id<MTLCounterSampleBuffer>>> QuerySet::m_counterSampleBuffers;
+WTF_NO_DESTROY std::unique_ptr<Vector<RangeSet<Range<uint32_t>>>> QuerySet::m_counterSampleBufferFreeRanges;
 
 Ref<QuerySet> Device::createQuerySet(const WGPUQuerySetDescriptor& descriptor)
 {

--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -35,9 +35,9 @@
 
 namespace WebGPU {
 
-__attribute__((no_destroy)) std::unique_ptr<Sampler::CachedSamplerStateContainer> Sampler::cachedSamplerStates = nullptr;
-__attribute__((no_destroy)) std::unique_ptr<Sampler::RetainedSamplerStateContainer> Sampler::retainedSamplerStates = nullptr;
-__attribute__((no_destroy)) std::unique_ptr<Sampler::CachedKeyContainer> Sampler::lastAccessedKeys = nullptr;
+WTF_NO_DESTROY std::unique_ptr<Sampler::CachedSamplerStateContainer> Sampler::cachedSamplerStates = nullptr;
+WTF_NO_DESTROY std::unique_ptr<Sampler::RetainedSamplerStateContainer> Sampler::retainedSamplerStates = nullptr;
+WTF_NO_DESTROY std::unique_ptr<Sampler::CachedKeyContainer> Sampler::lastAccessedKeys = nullptr;
 Lock Sampler::samplerStateLock;
 
 static bool validateCreateSampler(Device& device, const WGPUSamplerDescriptor& descriptor)


### PR DESCRIPTION
#### 7dac1dd752a3dd2c1f4aa80d90f99b5bb0ec7789
<pre>
Introduce WTF_NO_DESTROY for static destructor suppression
<a href="https://bugs.webkit.org/show_bug.cgi?id=297508">https://bugs.webkit.org/show_bug.cgi?id=297508</a>
<a href="https://rdar.apple.com/problem/158503190">rdar://problem/158503190</a>

Reviewed by NOBODY (OOPS!).

Clang supports [[clang::no_destroy]] (alternative form: `__attribute__((no_destroy))`) to disable
exit-time destructors of variables of static or thread local storage duration.
This feature was added for the XNU Kernel. It saved a non-trivial amount of code generation.

C++ standardization proposal: <a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1247r0.html">https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1247r0.html</a>

* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/MainThreadDispatcher.cpp:
(WTF::MainThreadDispatcher::singleton):
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::singleton):
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::runLoopHolder):
* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::TextBreakIteratorCache::singleton):
* Source/WebCore/crypto/CryptoAlgorithmRegistry.cpp:
(WebCore::CryptoAlgorithmRegistry::singleton):
* Source/WebCore/css/CSSValuePool.cpp:
(WebCore::CSSValuePool::singleton):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorQueryCache::singleton):
* Source/WebCore/loader/CrossOriginPreflightResultCache.cpp:
(WebCore::CrossOriginPreflightResultCache::singleton):
* Source/WebCore/page/scrolling/ScrollingThread.cpp:
(WebCore::ScrollingThread::singleton):
* Source/WebGPU/WebGPU/QuerySet.mm:
* Source/WebGPU/WebGPU/Sampler.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dac1dd752a3dd2c1f4aa80d90f99b5bb0ec7789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116922 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88805 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43530 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, ietestcenter/Javascript/15.4.5.1-3.d-1.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dfg-intrinsic-osr-exit.html, js/dfg-intrinsic-side-effect-assignment-osr-exit.html, js/dom/vardecl-preserve-vardecl.html, js/new-array-double-with-holes.html, storage/indexeddb/cursor-continue.html, storage/indexeddb/cursor-delete-private.html, storage/indexeddb/modern/cursor-7.html, storage/indexeddb/modern/cursor-8-private.html, storage/indexeddb/mozilla/indexes-private.html, streams/readable-stream-default-controller-error.html, streams/readable-stream-default-reader-read.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-r32f-red-float.html, webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-rgba16f-rgba-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-3d-r16f-red-half_float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image/tex-2d-rgba16f-rgba-half_float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_image_data/tex-2d-rg16f-rg-float.html, webgl/2.0.0/conformance2/textures/image_data/tex-2d-r8ui-red_integer-unsigned_byte.html, webgl/webgl2-rendering-context-obtain.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23000 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66663 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109038 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126134 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115450 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97466 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97268 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40217 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49303 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144149 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43174 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37122 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->