### PR TITLE
[jsc] Add option to force the address of JIT memory

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -99,6 +99,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed"_s) \
     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
     v(Unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)"_s) \
+    v(Size, jitMemoryReservationAddress, 0, Restricted, "If non-zero, we will attempt to allocate JIT memory at the address provided and crash if we cannot.") \
     \
     v(Bool, forceCodeBlockLiveness, false, Normal, nullptr) \
     v(Bool, forceICFailure, false, Normal, nullptr) \

--- a/Source/WTF/wtf/MallocSpan.h
+++ b/Source/WTF/wtf/MallocSpan.h
@@ -109,9 +109,9 @@ public:
     }
 
 #if HAVE(MMAP)
-    static MallocSpan mmap(size_t sizeInBytes, int pageProtection, int options, int fileDescriptor)
+    static MallocSpan mmap(void* addr, size_t sizeInBytes, int pageProtection, int options, int fileDescriptor)
     {
-        return MallocSpan { static_cast<T*>(Malloc::mmap(sizeInBytes, pageProtection, options, fileDescriptor)), sizeInBytes };
+        return MallocSpan { static_cast<T*>(Malloc::mmap(addr, sizeInBytes, pageProtection, options, fileDescriptor)), sizeInBytes };
     }
 #endif
 

--- a/Source/WTF/wtf/Mmap.h
+++ b/Source/WTF/wtf/Mmap.h
@@ -33,9 +33,9 @@
 namespace WTF {
 
 struct Mmap {
-    static void* mmap(size_t size, int pageProtection, int options, int fileDescriptor)
+    static void* mmap(void* addr, size_t size, int pageProtection, int options, int fileDescriptor)
     {
-        auto* data = ::mmap(0, size, pageProtection, options, fileDescriptor, 0);
+        auto* data = ::mmap(addr, size, pageProtection, options, fileDescriptor, 0);
         return data == MAP_FAILED ? nullptr : data;
     }
 

--- a/Source/WTF/wtf/PageAllocation.h
+++ b/Source/WTF/wtf/PageAllocation.h
@@ -84,7 +84,7 @@ public:
     static PageAllocation allocate(size_t size, OSAllocator::Usage usage = OSAllocator::UnknownUsage, bool writable = true, bool executable = false)
     {
         ASSERT(isPageAligned(size));
-        return PageAllocation(OSAllocator::reserveAndCommit(size, usage, writable, executable), size);
+        return PageAllocation(OSAllocator::reserveAndCommit(size, usage, nullptr, writable, executable), size);
     }
 
     void deallocate()

--- a/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
@@ -38,11 +38,12 @@
 
 namespace WTF {
 
-void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
 {
     ASSERT_UNUSED(includesGuardPages, !includesGuardPages);
     ASSERT_UNUSED(jitCageEnabled, !jitCageEnabled);
     ASSERT_UNUSED(executable, !executable);
+    ASSERT_UNUSED(address, !address);
 
     void* result = memory_extra::vss::reserve(bytes);
     if (!result)
@@ -57,13 +58,14 @@ void* OSAllocator::tryReserveAndCommit(size_t bytes, Usage usage, bool writable,
     return result;
 }
 
-void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
 {
     UNUSED_PARAM(usage);
     UNUSED_PARAM(writable);
     ASSERT_UNUSED(includesGuardPages, !includesGuardPages);
     ASSERT_UNUSED(jitCageEnabled, !jitCageEnabled);
     ASSERT_UNUSED(executable, !executable);
+    ASSERT_UNUSED(address, !address);
 
     void* result = memory_extra::vss::reserve(bytes);
     if (!result)
@@ -72,18 +74,19 @@ void* OSAllocator::tryReserveUncommitted(size_t bytes, Usage usage, bool writabl
     return result;
 }
 
-void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
 {
-    void* result = tryReserveUncommitted(bytes, usage, writable, executable, jitCageEnabled, includesGuardPages);
+    void* result = tryReserveUncommitted(bytes, usage, address, writable, executable, jitCageEnabled, includesGuardPages);
     RELEASE_ASSERT(result);
     return result;
 }
 
-void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
 {
     ASSERT_UNUSED(includesGuardPages, !includesGuardPages);
     ASSERT_UNUSED(jitCageEnabled, !jitCageEnabled);
     ASSERT_UNUSED(executable, !executable);
+    ASSERT_UNUSED(address, !address);
     UNUSED_PARAM(usage);
     UNUSED_PARAM(writable);
     ASSERT(hasOneBitSet(alignment) && alignment >= pageSize());
@@ -95,9 +98,9 @@ void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, 
     return result;
 }
 
-void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
+void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled, bool includesGuardPages)
 {
-    void* result = tryReserveAndCommit(bytes, usage, writable, executable, jitCageEnabled, includesGuardPages);
+    void* result = tryReserveAndCommit(bytes, usage, address, writable, executable, jitCageEnabled, includesGuardPages);
     RELEASE_ASSERT(result);
     return result;
 }

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -182,7 +182,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode mapMode, FileOpenMo
 #endif
     }
 
-    auto fileData = MallocSpan<uint8_t, Mmap>::mmap(size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), platformHandle());
+    auto fileData = MallocSpan<uint8_t, Mmap>::mmap(nullptr, size, pageProtection, MAP_FILE | (mapMode == MappedFileMode::Shared ? MAP_SHARED : MAP_PRIVATE), platformHandle());
     if (!fileData)
         return { };
 

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -45,7 +45,7 @@ static constexpr uint8_t defaultMessageFlags = 0;
 #if OS(DARWIN)
 static inline MallocSpan<uint8_t, Mmap> allocateBuffer(size_t size)
 {
-    auto buffer = MallocSpan<uint8_t, Mmap>::mmap(size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1);
+    auto buffer = MallocSpan<uint8_t, Mmap>::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1);
     RELEASE_ASSERT(!!buffer);
     return buffer;
 }


### PR DESCRIPTION
#### c42cc0d597b192b5c92ba019aa8167cc26aca31d
<pre>
[jsc] Add option to force the address of JIT memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=297560">https://bugs.webkit.org/show_bug.cgi?id=297560</a>
<a href="https://rdar.apple.com/158636737">rdar://158636737</a>

Reviewed by Yusuke Suzuki and Mark Lam.

The new JSC_jitMemoryReservationAddress option allows us to specify an
address at which to mmap JIT memory. If the operating system is not able
to do so, then we will instead crash.
Notably we do not use MAP_FIXED as we don&apos;t want to clobber existing
mappings, but would rather bail out if someone else has already mapped
the location requested.

Canonical link: <a href="https://commits.webkit.org/299073@main">https://commits.webkit.org/299073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f91004c6ca986e84f63c2ce24b64d3103a7a513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123834 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/69713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b73179c9-8fcb-4e39-b018-a62e6b12254c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45960 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/69713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1b2ca18-54d4-419e-9763-a370b29793f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120652 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69823 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75beb81d-6196-4906-8c9d-18b4eb161a14) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67492 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109811 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126927 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116209 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33570 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101767 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24882 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43154 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/21123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44475 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/50149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144907 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43933 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/47280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->