### PR TITLE
[AutoFill Debugging] Part 7: Add an interaction to simulate individual key presses

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-key-events-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-key-events-expected.txt
@@ -1,0 +1,19 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+keydown: type=keydown key=a keyCode=65 code=KeyA
+keyup: type=keyup key=a keyCode=65 code=KeyA
+keydown: type=keydown key=Escape keyCode=27 code=Escape
+keyup: type=keyup key=Escape keyCode=27 code=Escape
+keydown: type=keydown key=ArrowLeft keyCode=37 code=ArrowLeft
+keyup: type=keyup key=ArrowLeft keyCode=37 code=ArrowLeft
+keydown: type=keydown key=Enter keyCode=13 code=Enter
+keyup: type=keyup key=Enter keyCode=13 code=Enter
+keydown: type=keydown key=/ keyCode=191 code=Slash
+keyup: type=keyup key=/ keyCode=191 code=Slash
+keydown: type=keydown key=Shift keyCode=16 code=Shift
+keyup: type=keyup key=Shift keyCode=16 code=Shift
+keydown: type=keydown key=Delete keyCode=46 code=Delete
+keyup: type=keyup key=Delete keyCode=46 code=Delete
+keydown: type=keydown key=Backspace keyCode=8 code=Backspace
+keyup: type=keyup key=Backspace keyCode=8 code=Backspace

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-key-events.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-key-events.html
@@ -1,0 +1,51 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+    .key-event-target {
+        border: 2px solid tomato;
+        box-sizing: border-box;
+        width: 100px;
+        height: 100px;
+        outline: none;
+    }
+    </style>
+</head>
+<body>
+    <div class="key-event-target" tabindex="0" aria-label="print key events"></div>
+    <pre id="output"></pre>
+    <script>
+    jsTestIsAsync = true;
+
+    container = document.getElementById("output");
+
+    function printEvent(event) {
+        const line = document.createElement("div");
+        line.textContent = `${event.type}: type=${event.type} key=${event.key} keyCode=${event.keyCode} code=${event.code}`;
+        container.appendChild(line);
+        if (event.cancelable)
+            event.preventDefault();
+    }
+
+    addEventListener("load", async () => {
+        target = document.querySelector(".key-event-target");
+
+        for (const event of ["keydown", "keypress", "keyup"])
+            target.addEventListener(event, printEvent);
+
+        target.focus();
+
+        const keysToTest = ["a", "Escape", "ArrowLeft", "Enter", "/", "Shift", "Delete", "Backspace"];
+        for (const key of keysToTest)
+            await UIHelper.performTextExtractionInteraction("keypress", { text: key });
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -40,6 +40,7 @@ enum class Action : uint8_t {
     SelectText,
     SelectMenuItem,
     TextInput,
+    KeyPress,
 };
 
 struct Interaction {

--- a/Source/WebCore/platform/PlatformKeyboardEvent.cpp
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.cpp
@@ -26,8 +26,13 @@
 #include "config.h"
 #include "PlatformKeyboardEvent.h"
 
+#include "WindowsKeyboardCodes.h"
+#include <wtf/HexNumber.h>
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 
@@ -55,4 +60,165 @@ void PlatformKeyboardEvent::setCurrentModifierState(OptionSet<Modifier> modifier
     s_currentModifiers = modifiers;
 }
 
+struct KeyEventData {
+    String text;
+    int keyCode { 0 };
+    String keyIdentifier;
+    int virtualKey { 0 };
+    String code;
+    std::optional<std::pair<String, String>> editCommandAndText { };
+};
+
+using KeyToEventDataMap = MemoryCompactLookupOnlyRobinHoodHashMap<String, KeyEventData>;
+static const KeyToEventDataMap& nonAlphaNumericKeys()
+{
+    static MainThreadNeverDestroyed<KeyToEventDataMap> table = [&] {
+        char16_t arrowLeftCharacter = u'\uF702';
+        char16_t arrowRightCharacter = u'\uF703';
+        char16_t arrowUpCharacter = u'\uF700';
+        char16_t arrowDownCharacter = u'\uF701';
+        char16_t deleteCharacter = u'\uF728';
+        return KeyToEventDataMap {
+            { "Escape"_s,       { emptyString(),                                27,     "U+001B"_s,     VK_ESCAPE,      "Escape"_s } },
+            { "Backspace"_s,    { emptyString(),                                8,      "U+0008"_s,     VK_BACK,        "Backspace"_s,        { { "deleteBackward"_s, { } } } } },
+            { "Enter"_s,        { "\r"_s,                                       13,     "Enter"_s,      VK_RETURN,      "Enter"_s,            { { "insertNewline"_s, { } } } } },
+            { "Tab"_s,          { "\t"_s,                                       9,      "U+0009"_s,     VK_TAB,         "Tab"_s,              { { "insertTab"_s, { } } } } },
+            { "Shift"_s,        { emptyString(),                                0,      "Shift"_s,      VK_SHIFT,       "Shift"_s } },
+            { "ShiftLeft"_s,    { emptyString(),                                0,      "Shift"_s,      VK_LSHIFT,      "ShiftLeft"_s } },
+            { "ShiftRight"_s,   { emptyString(),                                0,      "Shift"_s,      VK_RSHIFT,      "ShiftRight"_s } },
+            { "Control"_s,      { emptyString(),                                0,      "Control"_s,    VK_CONTROL,     "Control"_s } },
+            { "ControlLeft"_s,  { emptyString(),                                0,      "Control"_s,    VK_LCONTROL,    "ControlLeft"_s } },
+            { "ControlRight"_s, { emptyString(),                                0,      "Control"_s,    VK_RCONTROL,    "ControlRight"_s } },
+            { "Alt"_s,          { emptyString(),                                0,      "Alt"_s,        VK_MENU,        "Alt"_s } },
+            { "AltLeft"_s,      { emptyString(),                                0,      "Alt"_s,        VK_LMENU,       "AltLeft"_s } },
+            { "AltRight"_s,     { emptyString(),                                0,      "Alt"_s,        VK_RMENU,       "AltRight"_s } },
+            { "Meta"_s,         { emptyString(),                                0,      "Meta"_s,       VK_UNKNOWN,     "Meta"_s } },
+            { "MetaLeft"_s,     { emptyString(),                                0,      "Meta"_s,       VK_LWIN,        "MetaLeft"_s } },
+            { "MetaRight"_s,    { emptyString(),                                0,      "Meta"_s,       VK_APPS,        "MetaRight"_s } },
+            { "ArrowLeft"_s,    { { std::span { &arrowLeftCharacter, 1 } },     63234,  "Left"_s,       VK_LEFT,        "ArrowLeft"_s,        { { "moveLeft"_s, { } } } } },
+            { "ArrowRight"_s,   { { std::span { &arrowRightCharacter, 1 } },    63235,  "Right"_s,      VK_RIGHT,       "ArrowRight"_s,       { { "moveRight"_s, { } } } } },
+            { "ArrowUp"_s,      { { std::span { &arrowUpCharacter, 1 } },       63232,  "Up"_s,         VK_UP,          "ArrowUp"_s,          { { "moveUp"_s, { } } } } },
+            { "ArrowDown"_s,    { { std::span { &arrowDownCharacter, 1 } },     63233,  "Down"_s,       VK_DOWN,        "ArrowDown"_s,        { { "moveDown"_s, { } } } } },
+            { "Delete"_s,       { { std::span { &deleteCharacter, 1 } },        63272,  "U+007F"_s,     VK_DELETE,      "Delete"_s,           { { "deleteForward"_s, { } } } } },
+            { " "_s,            { " "_s,                                        32,     "U+0020"_s,     VK_SPACE,       "Space"_s,            { { "insertText"_s, " "_s } } } },
+            { "`"_s,            { "`"_s,                                        96,     "U+0060"_s,     VK_OEM_3,       "Backquote"_s,        { { "insertText"_s, "`"_s } } } },
+            { "~"_s,            { "~"_s,                                        126,    "U+007E"_s,     VK_OEM_3,       "Backquote"_s,        { { "insertText"_s, "~"_s } } } },
+            { "-"_s,            { "-"_s,                                        45,     "U+002D"_s,     VK_OEM_MINUS,   "Minus"_s,            { { "insertText"_s, "-"_s } } } },
+            { "_"_s,            { "_"_s,                                        95,     "U+005F"_s,     VK_OEM_MINUS,   "Minus"_s,            { { "insertText"_s, "_"_s } } } },
+            { "="_s,            { "="_s,                                        61,     "U+003D"_s,     VK_OEM_PLUS,    "Equal"_s,            { { "insertText"_s, "="_s } } } },
+            { "+"_s,            { "+"_s,                                        43,     "U+002B"_s,     VK_OEM_PLUS,    "Equal"_s,            { { "insertText"_s, "+"_s } } } },
+            { "\\"_s,           { "\\"_s,                                       92,     "U+005C"_s,     VK_OEM_5,       "Backslash"_s,        { { "insertText"_s, "\\"_s } } } },
+            { "|"_s,            { "|"_s,                                        124,    "U+007C"_s,     VK_OEM_5,       "Backslash"_s,        { { "insertText"_s, "|"_s } } } },
+            { "["_s,            { "["_s,                                        91,     "U+005B"_s,     VK_OEM_4,       "BracketLeft"_s,      { { "insertText"_s, "["_s } } } },
+            { "{ "_s,           { "{ "_s,                                       123,    "U+007B"_s,     VK_OEM_4,       "BracketLeft"_s,      { { "insertText"_s, "{"_s } } } },
+            { "]"_s,            { "]"_s,                                        93,     "U+005D"_s,     VK_OEM_6,       "BracketRight"_s,     { { "insertText"_s, "]"_s } } } },
+            { "}"_s,            { "}"_s,                                        125,    "U+007D"_s,     VK_OEM_6,       "BracketRight"_s,     { { "insertText"_s, "}"_s } } } },
+            { ";"_s,            { ";"_s,                                        59,     "U+003B"_s,     VK_OEM_1,       "Semicolon"_s,        { { "insertText"_s, ";"_s } } } },
+            { ":"_s,            { ":"_s,                                        58,     "U+003A"_s,     VK_OEM_1,       "Semicolon"_s,        { { "insertText"_s, ":"_s } } } },
+            { "'"_s,            { "'"_s,                                        39,     "U+0027"_s,     VK_OEM_7,       "Quote"_s,            { { "insertText"_s, "'"_s } } } },
+            { "\""_s,           { "\""_s,                                       34,     "U+0022"_s,     VK_OEM_7,       "Quote"_s,            { { "insertText"_s, "\""_s } } } },
+            { ","_s,            { ","_s,                                        44,     "U+002C"_s,     VK_OEM_COMMA,   "Comma"_s,            { { "insertText"_s, ","_s } } } },
+            { "<"_s,            { "<"_s,                                        60,     "U+003C"_s,     VK_OEM_COMMA,   "Comma"_s,            { { "insertText"_s, "<"_s } } } },
+            { "."_s,            { "."_s,                                        46,     "U+002E"_s,     VK_OEM_PERIOD,  "Period"_s,           { { "insertText"_s, "."_s } } } },
+            { ">"_s,            { ">"_s,                                        62,     "U+003E"_s,     VK_OEM_PERIOD,  "Period"_s,           { { "insertText"_s, ">"_s } } } },
+            { "/"_s,            { "/"_s,                                        47,     "U+002F"_s,     VK_OEM_2,       "Slash"_s,            { { "insertText"_s, "/"_s } } } },
+            { "?"_s,            { "?"_s,                                        63,     "U+003F"_s,     VK_OEM_2,       "Slash"_s,            { { "insertText"_s, "?"_s } } } },
+            { "0"_s,            { "0"_s,                                        48,     "U+0030"_s,     VK_0,           "Digit0"_s,           { { "insertText"_s, "0"_s } } } },
+            { "1"_s,            { "1"_s,                                        49,     "U+0031"_s,     VK_1,           "Digit1"_s,           { { "insertText"_s, "1"_s } } } },
+            { "2"_s,            { "2"_s,                                        50,     "U+0032"_s,     VK_2,           "Digit2"_s,           { { "insertText"_s, "2"_s } } } },
+            { "3"_s,            { "3"_s,                                        51,     "U+0033"_s,     VK_3,           "Digit3"_s,           { { "insertText"_s, "3"_s } } } },
+            { "4"_s,            { "4"_s,                                        52,     "U+0034"_s,     VK_4,           "Digit4"_s,           { { "insertText"_s, "4"_s } } } },
+            { "5"_s,            { "5"_s,                                        53,     "U+0035"_s,     VK_5,           "Digit5"_s,           { { "insertText"_s, "5"_s } } } },
+            { "6"_s,            { "6"_s,                                        54,     "U+0036"_s,     VK_6,           "Digit6"_s,           { { "insertText"_s, "6"_s } } } },
+            { "7"_s,            { "7"_s,                                        55,     "U+0037"_s,     VK_7,           "Digit7"_s,           { { "insertText"_s, "7"_s } } } },
+            { "8"_s,            { "8"_s,                                        56,     "U+0038"_s,     VK_8,           "Digit8"_s,           { { "insertText"_s, "8"_s } } } },
+            { "9"_s,            { "9"_s,                                        57,     "U+0039"_s,     VK_9,           "Digit9"_s,           { { "insertText"_s, "9"_s } } } },
+            { "!"_s,            { "!"_s,                                        33,     "U+0021"_s,     VK_1,           "Digit1"_s,           { { "insertText"_s, "!"_s } } } },
+            { "@"_s,            { "@"_s,                                        64,     "U+0040"_s,     VK_2,           "Digit2"_s,           { { "insertText"_s, "@"_s } } } },
+            { "#"_s,            { "#"_s,                                        35,     "U+0023"_s,     VK_3,           "Digit3"_s,           { { "insertText"_s, "#"_s } } } },
+            { "$"_s,            { "$"_s,                                        36,     "U+0024"_s,     VK_4,           "Digit4"_s,           { { "insertText"_s, "$"_s } } } },
+            { "%"_s,            { "%"_s,                                        37,     "U+0025"_s,     VK_5,           "Digit5"_s,           { { "insertText"_s, "%"_s } } } },
+            { "^"_s,            { "^"_s,                                        94,     "U+005E"_s,     VK_6,           "Digit6"_s,           { { "insertText"_s, "^"_s } } } },
+            { "&"_s,            { "&"_s,                                        38,     "U+0026"_s,     VK_7,           "Digit7"_s,           { { "insertText"_s, "&"_s } } } },
+            { "*"_s,            { "*"_s,                                        42,     "U+002A"_s,     VK_8,           "Digit8"_s,           { { "insertText"_s, "*"_s } } } },
+            { "("_s,            { "("_s,                                        40,     "U+0028"_s,     VK_9,           "Digit9"_s,           { { "insertText"_s, "("_s } } } },
+            { ")"_s,            { ")"_s,                                        41,     "U+0029"_s,     VK_0,           "Digit0"_s,           { { "insertText"_s, ")"_s } } } },
+        };
+    }();
+    return table.get();
 }
+
+static std::optional<KeyEventData> lookup(const String& key)
+{
+    if (key.isEmpty())
+        return { };
+
+    if (auto result = nonAlphaNumericKeys().getOptional(key))
+        return result;
+
+    if (key.length() != 1)
+        return { };
+
+    auto character = key.characterAt(0);
+    if (character >= 'A' && character <= 'Z') {
+        return { {
+            key,
+            static_cast<int>(character),
+            makeString("U+00"_s, hex(static_cast<unsigned>(character), 2, WTF::Uppercase)),
+            static_cast<int>(VK_A + (character - 'A')),
+            makeString("Key"_s, key),
+            { { "insertText"_s, key } },
+        } };
+    }
+
+    if (character >= 'a' && character <= 'z') {
+        int uppercaseCharacter = character - 'a' + 'A';
+        return { {
+            key,
+            static_cast<int>(character),
+            makeString("U+00"_s, hex(static_cast<unsigned>(uppercaseCharacter), 2, WTF::Uppercase)),
+            static_cast<int>(VK_A + (uppercaseCharacter - 'A')),
+            makeString("Key"_s, key.convertToASCIIUppercase()),
+            { { "insertText"_s, key } },
+        } };
+    }
+
+    if (character >= '0' && character <= '9') {
+        return { {
+            key,
+            static_cast<int>(character),
+            makeString("U+00"_s, hex(static_cast<unsigned>(character), 2, WTF::Uppercase)),
+            static_cast<int>(VK_0 + (character - '0')),
+            makeString("Digit"_s, key),
+            { { "insertText"_s, key } },
+        } };
+    }
+
+    return { };
+}
+
+std::optional<PlatformKeyboardEvent> PlatformKeyboardEvent::syntheticEventFromText(Type type, const String& key)
+{
+    auto info = lookup(key);
+    if (!info)
+        return { };
+
+    auto [text, keyCode, keyIdentifier, virtualKey, code, commandAndText] = *info;
+    PlatformKeyboardEvent event { type, text, text, key, code, keyIdentifier, virtualKey, false, false, false, { }, WallTime::now() };
+#if USE(APPKIT)
+    if (commandAndText) {
+        auto [editCommandName, text] = *commandAndText;
+        auto commandName = makeString(editCommandName, ':');
+        if (text.isEmpty())
+            event.m_commands = { KeypressCommand { WTFMove(commandName) } };
+        else
+            event.m_commands = { { WTFMove(commandName), WTFMove(text) } };
+    }
+#else
+    UNUSED_VARIABLE(commandAndText);
+#endif
+
+    return { WTFMove(event) };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/PlatformKeyboardEvent.h
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
@@ -52,6 +52,8 @@ namespace WebCore {
         {
         }
 
+        static std::optional<PlatformKeyboardEvent> syntheticEventFromText(Type, const String&);
+
         PlatformKeyboardEvent(Type type, const String& text, const String& unmodifiedText, const String& key, const String& code,
         const String& keyIdentifier, int windowsVirtualKeyCode, bool isAutoRepeat, bool isKeypad, bool isSystemKey, OptionSet<Modifier> modifiers, WallTime timestamp)
             : PlatformEvent(type, modifiers, timestamp)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7053,7 +7053,8 @@ header: <WebCore/TextExtractionTypes.h>
     Click,
     SelectText,
     SelectMenuItem,
-    TextInput
+    TextInput,
+    KeyPress
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6429,6 +6429,8 @@ static inline std::optional<WebCore::NodeIdentifier> toNodeIdentifier(const Stri
             return WebCore::TextExtraction::Action::SelectMenuItem;
         case _WKTextExtractionActionTextInput:
             return WebCore::TextExtraction::Action::TextInput;
+        case _WKTextExtractionActionKeyPress:
+            return WebCore::TextExtraction::Action::KeyPress;
         default:
             ASSERT_NOT_REACHED();
             return WebCore::TextExtraction::Action::Click;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionSelectText,
     _WKTextExtractionActionSelectMenuItem,
     _WKTextExtractionActionTextInput,
+    _WKTextExtractionActionKeyPress,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -388,6 +388,8 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         action = _WKTextExtractionActionSelectMenuItem;
     if (equalLettersIgnoringASCIICase(actionName, "textinput"))
         action = _WKTextExtractionActionTextInput;
+    if (equalLettersIgnoringASCIICase(actionName, "keypress"))
+        action = _WKTextExtractionActionKeyPress;
 
     if (!action) {
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 65b2fb1c3c4d0e85ca39026e6d25a24638340f3c
<pre>
[AutoFill Debugging] Part 7: Add an interaction to simulate individual key presses
<a href="https://bugs.webkit.org/show_bug.cgi?id=297567">https://bugs.webkit.org/show_bug.cgi?id=297567</a>
<a href="https://rdar.apple.com/158644428">rdar://158644428</a>

Reviewed by Abrar Rahman Protyasha.

Add support for simulating key presses (`keydown`, `keypress`, `keyup`) events via the new
`.keypress` interaction type. See below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-key-events-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-key-events.html: Added.

Add a layout test to exercise the new interaction.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::simulateKeyPress):

Use `PlatformKeyboardEvent::syntheticEventFromText` to create key up/down events corresponding to
the input string. If the input key does not map to any known `key` type, we fall back to typing out
the text of the input string character by character, if it&apos;s an 8-bit string.

(WebCore::TextExtraction::handleInteraction):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebCore/platform/PlatformKeyboardEvent.cpp:
(WebCore::nonAlphaNumericKeys):
(WebCore::lookup):
(WebCore::PlatformKeyboardEvent::syntheticEventFromText):

Add the ability to create a synthetic platform key event from a `event.key` string value (i.e. the
`text` of the platform event). This is similar to existing `WebAutomationSession` support for
simulating key events, but this approach keeps the interactions fully contained in the DOM layer
(i.e. such that it doesn&apos;t trigger any platform key bindings or affect the UI-side key event queue).

On macOS, we additionally create and attach simulated `KeypressCommand`s to these key events, to
ensure that text input behaves as normal when triggering these events. A bit more work will be
required on iOS to ensure that keyboard editing is hooked up, since that currently relies on round-
tripping through UIKit&apos;s keyboard code when interpreting key events as editing.

Note that we also don&apos;t currently support modifier keys yet.

* Source/WebCore/platform/PlatformKeyboardEvent.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _performInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/298902@main">https://commits.webkit.org/298902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f53770ba5f7247e3d606e323a7b3a71ae44f1fa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69047 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8cd39c34-c4c3-41cc-a5cb-859b050f33c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88873 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/41fa3c84-4d35-4712-8f61-a4089a081623) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69338 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66769 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126256 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97545 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49426 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43281 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46627 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44991 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->