### PR TITLE
Implement the LargestContentfulPaint interface

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1501,6 +1501,7 @@ set(WebCore_NON_SVG_IDL_FILES
     page/IntersectionObserver.idl
     page/IntersectionObserverCallback.idl
     page/IntersectionObserverEntry.idl
+    page/LargestContentfulPaint.idl
     page/Location.idl
     page/NavigateEvent.idl
     page/Navigation.idl
@@ -1524,6 +1525,7 @@ set(WebCore_NON_SVG_IDL_FILES
     page/NavigatorUA.idl
     page/NavigatorUABrandVersion.idl
     page/NavigatorUAData.idl
+    page/PaintTimingMixin.idl
     page/Performance+EventCounts.idl
     page/Performance+NavigationTiming.idl
     page/Performance+PerformanceTimeline.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1869,6 +1869,7 @@ $(PROJECT_DIR)/page/IntersectionObserver.idl
 $(PROJECT_DIR)/page/IntersectionObserverCallback.idl
 $(PROJECT_DIR)/page/IntersectionObserverEntry.idl
 $(PROJECT_DIR)/page/IsLoggedIn.idl
+$(PROJECT_DIR)/page/LargestContentfulPaint.idl
 $(PROJECT_DIR)/page/Location.idl
 $(PROJECT_DIR)/page/NavigateEvent.idl
 $(PROJECT_DIR)/page/Navigation.idl
@@ -1894,6 +1895,7 @@ $(PROJECT_DIR)/page/NavigatorStorageManager.idl
 $(PROJECT_DIR)/page/NavigatorUA.idl
 $(PROJECT_DIR)/page/NavigatorUABrandVersion.idl
 $(PROJECT_DIR)/page/NavigatorUAData.idl
+$(PROJECT_DIR)/page/PaintTimingMixin.idl
 $(PROJECT_DIR)/page/Performance+EventCounts.idl
 $(PROJECT_DIR)/page/Performance+NavigationTiming.idl
 $(PROJECT_DIR)/page/Performance+PerformanceTimeline.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1812,6 +1812,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLandmark.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLandmark.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLandmarkType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLandmarkType.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLargestContentfulPaint.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLargestContentfulPaint.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLatencyMode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLatencyMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSLinkStyle.cpp
@@ -2198,6 +2200,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageTransitionEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPageTransitionEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintRenderingContext2D.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintRenderingContext2D.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintTimingMixin.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintTimingMixin.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintWorkletGlobalScope.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPaintWorkletGlobalScope.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPannerNode.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1534,6 +1534,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/IntersectionObserver.idl \
     $(WebCore)/page/IntersectionObserverCallback.idl \
     $(WebCore)/page/IntersectionObserverEntry.idl \
+    $(WebCore)/page/LargestContentfulPaint.idl \
     $(WebCore)/page/Location.idl \
     $(WebCore)/page/NavigateEvent.idl \
     $(WebCore)/page/Navigation.idl \
@@ -1558,6 +1559,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/NavigatorServiceWorker.idl \
     $(WebCore)/page/NavigatorShare.idl \
     $(WebCore)/page/NavigatorStorage.idl \
+    $(WebCore)/page/PaintTimingMixin.idl \
     $(WebCore)/page/Performance+EventCounts.idl \
     $(WebCore)/page/Performance+NavigationTiming.idl \
     $(WebCore)/page/Performance+PerformanceTimeline.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2137,6 +2137,7 @@ page/IntelligenceTextEffectsSupport.cpp
 page/InteractionRegion.cpp
 page/IntersectionObserver.cpp
 page/IntersectionObserverEntry.cpp
+page/LargestContentfulPaint.cpp
 page/LocalDOMWindow.cpp
 page/LocalDOMWindowProperty.cpp
 page/LocalFrame.cpp
@@ -4304,6 +4305,7 @@ JSKeyframeEffect.cpp
 JSKeyframeEffectOptions.cpp
 JSLandmark.cpp
 JSLandmarkType.cpp
+JSLargestContentfulPaint.cpp
 JSLatencyMode.cpp
 JSLocation.cpp
 JSLongRange.cpp

--- a/Source/WebCore/bindings/js/JSPerformanceEntryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPerformanceEntryCustom.cpp
@@ -33,12 +33,14 @@
 #include "JSPerformanceEntry.h"
 
 #include "JSDOMBinding.h"
+#include "JSLargestContentfulPaint.h"
 #include "JSPerformanceEventTiming.h"
 #include "JSPerformanceMark.h"
 #include "JSPerformanceMeasure.h"
 #include "JSPerformanceNavigationTiming.h"
 #include "JSPerformancePaintTiming.h"
 #include "JSPerformanceResourceTiming.h"
+#include "LargestContentfulPaint.h"
 #include "PerformanceEventTiming.h"
 #include "PerformanceMark.h"
 #include "PerformanceMeasure.h"
@@ -66,6 +68,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<P
     case PerformanceEntry::Type::Event: [[fallthrough]];
     case PerformanceEntry::Type::FirstInput:
         return createWrapper<PerformanceEventTiming>(globalObject, WTFMove(entry));
+    case PerformanceEntry::Type::LargestContentfulPaint:
+        return createWrapper<LargestContentfulPaint>(globalObject, WTFMove(entry));
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -296,6 +296,7 @@ namespace WebCore {
     macro(InstallEvent) \
     macro(IntersectionObserver) \
     macro(IntersectionObserverEntry) \
+    macro(LargestContentfulPaint) \
     macro(KeyframeEffect) \
     macro(Lock) \
     macro(LockManager) \

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4346,6 +4346,11 @@ bool Document::supportsPaintTiming() const
     return protectedSecurityOrigin()->isSameOriginDomain(topOrigin());
 }
 
+bool Document::supportsLargestContentfulPaint() const
+{
+    return settings().largestContentfulPaintEnabled();
+}
+
 // https://w3c.github.io/paint-timing/#ref-for-mark-paint-timing
 void Document::enqueuePaintTimingEntryIfNeeded()
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1270,6 +1270,7 @@ public:
     bool shouldDeferAsynchronousScriptsUntilParsingFinishes() const;
 
     bool supportsPaintTiming() const;
+    bool supportsLargestContentfulPaint() const;
 
 #if ENABLE(XSLT)
     void scheduleToApplyXSLTransforms();

--- a/Source/WebCore/page/LargestContentfulPaint.cpp
+++ b/Source/WebCore/page/LargestContentfulPaint.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LargestContentfulPaint.h"
+
+namespace WebCore {
+
+LargestContentfulPaint::LargestContentfulPaint(DOMHighResTimeStamp timeStamp)
+    : PerformanceEntry(emptyString(), timeStamp, timeStamp) // FIXME: Timestamps
+{
+}
+
+DOMHighResTimeStamp LargestContentfulPaint::paintTime() const
+{
+    return 0;
+}
+
+std::optional<DOMHighResTimeStamp> LargestContentfulPaint::presentationTime() const
+{
+    return { };
+}
+
+DOMHighResTimeStamp LargestContentfulPaint::loadTime() const
+{
+    return 0;
+}
+
+DOMHighResTimeStamp LargestContentfulPaint::renderTime() const
+{
+    return 0;
+}
+
+unsigned LargestContentfulPaint::size() const
+{
+    return 0;
+}
+
+String LargestContentfulPaint::id() const
+{
+    return emptyString();
+}
+
+String LargestContentfulPaint::url() const
+{
+    return emptyString();
+}
+
+Element* LargestContentfulPaint::element() const
+{
+    return nullptr;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/LargestContentfulPaint.h
+++ b/Source/WebCore/page/LargestContentfulPaint.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DOMHighResTimeStamp.h"
+#include "PerformanceEntry.h"
+
+namespace WebCore {
+
+class Element;
+
+class LargestContentfulPaint final : public PerformanceEntry {
+public:
+    static Ref<LargestContentfulPaint> create(DOMHighResTimeStamp timeStamp)
+    {
+        return adoptRef(*new LargestContentfulPaint(timeStamp));
+    }
+
+    ~LargestContentfulPaint() = default;
+
+    // PaintTimingMixin
+    DOMHighResTimeStamp paintTime() const;
+    std::optional<DOMHighResTimeStamp> presentationTime() const;
+
+    // LargestContentfulPaint
+    DOMHighResTimeStamp loadTime() const;
+    DOMHighResTimeStamp renderTime() const;
+    unsigned size() const;
+    String id() const;
+    String url() const;
+    Element* element() const;
+
+    ASCIILiteral entryType() const final { return "largest-contentful-paint"_s; }
+
+protected:
+    LargestContentfulPaint(DOMHighResTimeStamp);
+
+private:
+    Type performanceEntryType() const final { return Type::LargestContentfulPaint; }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/LargestContentfulPaint.idl
+++ b/Source/WebCore/page/LargestContentfulPaint.idl
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
+
+typedef double DOMHighResTimeStamp;
+
+[
+    Exposed=Window,
+    EnabledBySetting=LargestContentfulPaintEnabled
+] interface LargestContentfulPaint : PerformanceEntry {
+    readonly attribute DOMHighResTimeStamp loadTime;
+    readonly attribute DOMHighResTimeStamp renderTime;
+    readonly attribute unsigned long size;
+    readonly attribute DOMString id;
+    readonly attribute DOMString url;
+    readonly attribute Element? element;
+    [Default] object toJSON();
+};
+
+LargestContentfulPaint includes PaintTimingMixin;

--- a/Source/WebCore/page/LocalDOMWindowProperty.cpp
+++ b/Source/WebCore/page/LocalDOMWindowProperty.cpp
@@ -39,7 +39,7 @@ LocalDOMWindowProperty::LocalDOMWindowProperty(LocalDOMWindow* window)
 
 LocalFrame* LocalDOMWindowProperty::frame() const
 {
-    return m_window ? m_window->localFrame() : nullptr;
+    return m_window ? protectedWindow()->localFrame() : nullptr;
 }
 
 LocalDOMWindow* LocalDOMWindowProperty::window() const

--- a/Source/WebCore/page/PaintTimingMixin.idl
+++ b/Source/WebCore/page/PaintTimingMixin.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/paint-timing/#sec-PaintTimingMixin
+
+typedef double DOMHighResTimeStamp;
+
+[
+    Exposed=Window,
+    EnabledBySetting=LargestContentfulPaintEnabled
+] interface mixin PaintTimingMixin {
+    readonly attribute DOMHighResTimeStamp paintTime;
+    readonly attribute DOMHighResTimeStamp? presentationTime;
+};

--- a/Source/WebCore/page/PerformanceEntry.cpp
+++ b/Source/WebCore/page/PerformanceEntry.cpp
@@ -69,6 +69,9 @@ std::optional<PerformanceEntry::Type> PerformanceEntry::parseEntryTypeString(con
     if (entryType == "first-input"_s)
         return std::optional<Type>(Type::FirstInput);
 
+    if (entryType == "largest-contentful-paint"_s)
+        return std::optional<Type>(Type::LargestContentfulPaint);
+
     return std::nullopt;
 }
 

--- a/Source/WebCore/page/PerformanceEntry.h
+++ b/Source/WebCore/page/PerformanceEntry.h
@@ -47,13 +47,14 @@ public:
     virtual double duration() const { return m_duration; }
 
     enum class Type : uint8_t {
-        Navigation  = 1 << 0,
-        Mark        = 1 << 1,
-        Measure     = 1 << 2,
-        Resource    = 1 << 3,
-        Paint       = 1 << 4,
-        Event       = 1 << 5,
-        FirstInput  = 1 << 6
+        Navigation              = 1 << 0,
+        Mark                    = 1 << 1,
+        Measure                 = 1 << 2,
+        Resource                = 1 << 3,
+        Paint                   = 1 << 4,
+        Event                   = 1 << 5,
+        FirstInput              = 1 << 6,
+        LargestContentfulPaint  = 1 << 7,
     };
 
     virtual Type performanceEntryType() const = 0;

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -164,6 +164,9 @@ Vector<String> PerformanceObserver::supportedEntryTypes(ScriptExecutionContext& 
         entryTypes.append("first-input"_s);
     }
 
+    if (document && document->supportsLargestContentfulPaint())
+        entryTypes.append("largest-contentful-paint"_s);
+
     entryTypes.append("mark"_s);
     entryTypes.append("measure"_s);
     entryTypes.append("navigation"_s);

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <WebCore/DoublePoint.h>
 #include <WebCore/EventTarget.h>
 #include <WebCore/MouseEventTypes.h>
 #include <WebCore/PointerID.h>


### PR DESCRIPTION
#### 2eec14d73ded2bf390bb6ea1716937fa151e7a54
<pre>
Implement the LargestContentfulPaint interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=297568">https://bugs.webkit.org/show_bug.cgi?id=297568</a>
<a href="https://rdar.apple.com/157604838">rdar://157604838</a>

Reviewed by Tim Nguyen and Ryosuke Niwa.

Add and implement the PaintTimingMixin and LargestContentfulPaint PerformanceEntry,
per <a href="https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface">https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface</a>,
adding the IDL files and implementing JS wrapper creation.

Exposure is gated on `Document::supportsLargestContentfulPaint()` which consults the Setting.

The performance entries are never created yet.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSPerformanceEntryCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::supportsLargestContentfulPaint const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/LargestContentfulPaint.cpp: Added.
(WebCore::LargestContentfulPaint::LargestContentfulPaint):
(WebCore::LargestContentfulPaint::paintTime const):
(WebCore::LargestContentfulPaint::presentationTime const):
(WebCore::LargestContentfulPaint::loadTime const):
(WebCore::LargestContentfulPaint::renderTime const):
(WebCore::LargestContentfulPaint::size const):
(WebCore::LargestContentfulPaint::id const):
(WebCore::LargestContentfulPaint::url const):
(WebCore::LargestContentfulPaint::element const):
* Source/WebCore/page/LargestContentfulPaint.h: Copied from Source/WebCore/page/PerformanceEntry.cpp.
* Source/WebCore/page/LargestContentfulPaint.idl: Added.
* Source/WebCore/page/LocalDOMWindowProperty.cpp:
(WebCore::LocalDOMWindowProperty::frame const):
* Source/WebCore/page/PaintTimingMixin.idl: Added.
* Source/WebCore/page/PerformanceEntry.cpp:
(WebCore::PerformanceEntry::parseEntryTypeString):
* Source/WebCore/page/PerformanceEntry.h:
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::supportedEntryTypes):
* Source/WebCore/page/PointerCaptureController.h: Unified sources fix.

Canonical link: <a href="https://commits.webkit.org/299598@main">https://commits.webkit.org/299598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9fe67fc8a9812606de2f79e363f0b0b7d5dc183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71565 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d7be7c6-ba47-4751-a429-e912bcb6b2c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/60088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abaf680c-c037-4ff3-926a-a41fd88bb271) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33677300-32d2-4a4c-b0b3-efe5e35bbfa4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25251 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69409 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128739 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99370 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42977 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51981 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45739 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->