### PR TITLE
[First-Letter] Fix ::first-letter disappearing after style change.

### DIFF
--- a/LayoutTests/editing/first-letter-text-transform-bug-expected.txt
+++ b/LayoutTests/editing/first-letter-text-transform-bug-expected.txt
@@ -1,0 +1,1 @@
+Sample text

--- a/LayoutTests/editing/first-letter-text-transform-bug.html
+++ b/LayoutTests/editing/first-letter-text-transform-bug.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+   <head>
+      <meta charset="utf-8">
+      <title>Text Transform Bug Safari</title>
+      <style type="text/css">
+         .test {
+         text-transform: uppercase;
+         }
+         .test::first-letter {
+         text-transform: uppercase;
+         }
+      </style>
+      <script type="text/javascript">
+         if (window.testRunner){
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+         }
+         function runTest() {
+            let testElement = document.querySelector('.test');
+            testElement.style.textTransform = "lowercase";
+            if (window.testRunner)
+               testRunner.notifyDone();
+         }
+      </script>
+   </head>
+   <body onload="setTimeout(runTest, 0);">
+      <div class="test">SAMPLE TEXT</div>
+   </body>
+</html>

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -77,6 +77,12 @@ void RenderTextFragment::setTextInternal(const String& newText, bool force)
 
     m_start = 0;
     m_end = text().length();
+
+    if (text() == newText) {
+        ASSERT(!textNode() || textNode()->renderer() == this);
+        return;
+    }
+
     if (!m_firstLetter)
         return;
     if (RenderTreeBuilder::current())


### PR DESCRIPTION
#### f4bd524c1db48f7a9bd3824e43ddce8f4afa544b
<pre>
[First-Letter] Fix ::first-letter disappearing after style change.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297570">https://bugs.webkit.org/show_bug.cgi?id=297570</a>
&lt;<a href="https://rdar.apple.com/145550507">rdar://145550507</a>&gt;

Reviewed by NOBODY (OOPS!).

Changing a block with a ::first-letter renderer incorrectly destroys the ::first-letter renderer.
This would remove the first letter from the rendered output each time we update the text due
to style changes.

This PR fixes that bug by by removing the code that destroys the ::first-letter renderer in
`RenderTextFragment::setTextInternal` as it should not be responsible for destroying it.

* LayoutTests/editing/first-letter-text-transform-bug-expected.txt: Added.
* LayoutTests/editing/first-letter-text-transform-bug.html: Added.
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::setTextInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4bd524c1db48f7a9bd3824e43ddce8f4afa544b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69575 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb7fc4fc-b0b1-48cf-99ea-aae7cc904acd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45828 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89221 "Found 12 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-replace-text.html imported/blink/fast/css/first-letter-text-fragment-update.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-002b.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/45032 "Found 18 new test failures: compositing/transforms/transformed-replaced-with-shadow-children.html editing/first-letter-text-transform-bug.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html js/dom/promise-stack-overflow.html js/dom/prototype-chain-caching-with-impure-get-own-property-slot-traps-2.html js/function-toString-parentheses.html js/object-literal-shorthand-construction.html storage/indexeddb/intversion-close-between-events-private.html storage/indexeddb/key-type-binary.html ... (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e560efa6-b950-4e41-93de-fb8d79701629) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120520 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30202 "Found 7 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-replace-text.html imported/blink/fast/css/first-letter-text-fragment-update.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105413 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69723 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/455e3dac-6c65-40d4-ac81-8f2062347e60) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29264 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-002b.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html imported/w3c/web-platform-tests/css/css-content/quotes-first-letter-001.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23530 "Found 9 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-text-fragment-update.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67349 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99617 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23712 "Found 9 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-text-fragment-update.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126793 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44471 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33451 "Found 9 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-text-fragment-update.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97888 "Found 12 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-replace-text.html imported/blink/fast/css/first-letter-text-fragment-update.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-002b.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44829 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101643 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97676 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43045 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20999 "Found 9 new test failures: editing/first-letter-text-transform-bug.html fast/css/first-letter-detach.html fast/text/first-letter-partial-invalidation-crash.html fast/text/partial-text-invalidation-with-first-letter-crash.html imported/blink/fast/css/first-letter-associated-text-node-crash.html imported/blink/fast/css/first-letter-text-fragment-update.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-003.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-006.html imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-008.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40829 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50017 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43800 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47148 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->