### PR TITLE
AX: Fix missing includes and forward declarations in AXUtilities

### DIFF
--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "HTMLImageElement.h"
+#include "HTMLMapElement.h"
 #include "HTMLMediaElement.h"
 #include "HTMLNames.h"
 #include "Node.h"
@@ -54,13 +55,13 @@ ContainerNode* composedParentIgnoringDocumentFragments(const Node* node)
     return node ? composedParentIgnoringDocumentFragments(*node) : nullptr;
 }
 
-ElementName elementName(Node* node)
+NodeName elementName(Node* node)
 {
     auto* element = dynamicDowncast<Element>(node);
     return element ? element->elementName() : ElementName::Unknown;
 }
 
-ElementName elementName(Node& node)
+NodeName elementName(Node& node)
 {
     auto* element = dynamicDowncast<Element>(node);
     return element ? element->elementName() : ElementName::Unknown;

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -26,6 +26,16 @@
 
 namespace WebCore {
 
+enum class AXNotification : uint8_t;
+enum class NodeName : uint16_t;
+class ContainerNode;
+class Document;
+class Element;
+class Node;
+class RenderImage;
+class RenderStyle;
+class RenderObject;
+
 bool hasRole(Element&, StringView role);
 bool hasAnyRole(Element&, Vector<StringView>&& roles);
 bool hasAnyRole(Element*, Vector<StringView>&& roles);
@@ -37,8 +47,9 @@ bool isRowGroup(Node*);
 ContainerNode* composedParentIgnoringDocumentFragments(const Node&);
 ContainerNode* composedParentIgnoringDocumentFragments(const Node*);
 
-ElementName elementName(Node*);
-ElementName elementName(Node&);
+// Returns NodeName and not ElementName because it's impossible to forward declare ElementName.
+NodeName elementName(Node*);
+NodeName elementName(Node&);
 
 RenderImage* toSimpleImage(RenderObject&);
 


### PR DESCRIPTION
#### 2db1f631017faa5b6203346ef350707284377d49
<pre>
AX: Fix missing includes and forward declarations in AXUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=297572">https://bugs.webkit.org/show_bug.cgi?id=297572</a>
<a href="https://rdar.apple.com/problem/158655489">rdar://problem/158655489</a>

Reviewed by Chris Fleizach.

* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::elementName):
* Source/WebCore/accessibility/AXUtilities.h:

Canonical link: <a href="https://commits.webkit.org/298890@main">https://commits.webkit.org/298890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31fe5c8cc549979f512f86b98563a77c546dc8fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/68972 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88823 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43544 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c45af3d-734f-4dfa-89ca-d110a1274ddd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69284 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23027 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66695 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97487 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97290 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49335 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44911 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->