### PR TITLE
Touch event handler assertion failure in Node::~Node

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9233,7 +9233,7 @@ void Document::didRemoveTouchEventHandler(Node& handler, EventHandlerRemoval rem
     removeHandlerFromSet(m_touchEventTargets, handler, removal);
 
     if (RefPtr parent = parentDocument())
-        parent->didRemoveTouchEventHandler(*this);
+        parent->didRemoveTouchEventHandler(*this, removal);
 
 #if ENABLE(TOUCH_EVENT_REGIONS)
     wheelOrTouchEventHandlersChanged(&handler);
@@ -11089,6 +11089,11 @@ const FixedVector<CSSPropertyID>& Document::exposedComputedCSSPropertyIDs()
 void Document::detachFromFrame()
 {
     observeFrame(nullptr);
+}
+
+void Document::willBeDisconnectedFromFrame(Document& parentDocument)
+{
+    parentDocument.didRemoveTouchEventHandler(*this, EventHandlerRemoval::All);
 }
 
 bool Document::hitTest(const HitTestRequest& request, HitTestResult& result)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1983,6 +1983,7 @@ public:
     void invalidateDOMCookieCache();
 
     void detachFromFrame();
+    void willBeDisconnectedFromFrame(Document&);
 
     PermissionsPolicy permissionsPolicy() const;
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -471,11 +471,11 @@ Node::~Node()
             document.decrementReferencingNodeCount(); // This may destroy the document.
     }
 
-#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY) && (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS))
+#if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY) && ASSERT_ENABLED
     for (auto& document : Document::allDocuments()) {
-        ASSERT_WITH_SECURITY_IMPLICATION(!document->touchEventListenersContain(*this));
-        ASSERT_WITH_SECURITY_IMPLICATION(!document->touchEventHandlersContain(*this));
-        ASSERT_WITH_SECURITY_IMPLICATION(!document->touchEventTargetsContain(*this));
+        ASSERT(!document->touchEventListenersContain(*this));
+        ASSERT(!document->touchEventHandlersContain(*this));
+        ASSERT(!document->touchEventTargetsContain(*this));
     }
 #endif
 

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -80,6 +80,8 @@ void HTMLFrameOwnerElement::clearContentFrame()
 void HTMLFrameOwnerElement::disconnectContentFrame()
 {
     if (RefPtr frame = m_contentFrame.get()) {
+        if (RefPtr innerDocument = contentDocument())
+            innerDocument->willBeDisconnectedFromFrame(protectedDocument());
         frame->frameDetached();
         if (frame == m_contentFrame.get())
             frame->disconnectOwnerElement();


### PR DESCRIPTION
#### 2cc0d72bb015f9fb0fd56fedb91e149a05fb57f6
<pre>
Touch event handler assertion failure in Node::~Node
<a href="https://bugs.webkit.org/show_bug.cgi?id=297575">https://bugs.webkit.org/show_bug.cgi?id=297575</a>

Reviewed by Wenson Hsieh.

The assertion failure was caused by didRemoveTouchEventHandler not getting called on an inner
document in an iframe when the iframe is getting disconnected from the outer document. Since
didAddTouchEventHandler recursively calls ancestor document&apos;s didAddTouchEventHandler using
the content document as the handler, we must call didRemoveTouchEventHandler when the inner
document gets disconnected from the frame.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didRemoveTouchEventHandler): Fix a bug that this wasn&apos;t passing removal
argument to the parent document&apos;s didRemoveTouchEventHandler.
(WebCore::Document::willBeDisconnectedFromFrame): Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::~Node):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::disconnectContentFrame): Call willBeDisconnectedFromFrame,
which in turn calls Document::didRemoveTouchEventHandler on the parent document. Note that
we can&apos;t use tree().parent() in this function since the frame tree had already been updated
by the time we get to this function.

Canonical link: <a href="https://commits.webkit.org/298942@main">https://commits.webkit.org/298942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f0b4ddb82811d4e8c6cdecdf01decc39fbeab7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69053 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93505884-49ce-4db3-993d-fb54f58a2ad0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88878 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43600 "Too many flaky failures: fast/canvas/offscreen-no-script-context-crash.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, imported/w3c/web-platform-tests/event-timing/contextmenu.html, imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html, imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative.html, js/dom/dfg-logical-not-final-object-or-other.html, storage/domstorage/localstorage/enumerate-with-length-and-key.html, storage/domstorage/sessionstorage/delete-removal.html, storage/indexeddb/modern/basic-put.html, storage/indexeddb/mozilla/cursor-mutation-objectstore-only-private.html, transforms/3d/general/preserve-3d.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_blob/tex-2d-r32f-red-float.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-r8ui-red_integer-unsigned_byte.html, webgl/2.0.y/conformance/context/context-creation-and-destruction.html, webgl/2.0.y/conformance/extensions/ext-disjoint-timer-query.html, webgl/2.0.y/conformance/extensions/webgl-compressed-texture-size-limit.html, webgl/2.0.y/conformance/ogles/GL/control_flow/control_flow_001_to_008.html, webgl/2.0.y/conformance2/query/occlusion-query.html, webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ca7dee5-2435-4aa2-9be3-7e6063add79a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69345 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66775 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126262 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97555 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97353 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20649 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40327 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18711 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49432 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46633 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->