### PR TITLE
Refactor VMManager out of VMInspector.

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1375,6 +1375,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/VMEntryScope.h
     runtime/VMEntryScopeInlines.h
     runtime/VMInlines.h
+    runtime/VMManager.h
     runtime/VMTraps.h
     runtime/VMTrapsInlines.h
     runtime/WaiterListManager.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -794,8 +794,6 @@
 		14F7256614EE265E00B1652B /* WeakHandleOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F7256414EE265E00B1652B /* WeakHandleOwner.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14F79F70216EAFD200046D39 /* Opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07950ED1D3AE00F1F681 /* Opcode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A28D4A8177B71C80007FA3C /* JSStringRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A28D4A7177B71C80007FA3C /* JSStringRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2392A1302DD51DB100DD1CB9 /* WebAssemblyBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */; };
-		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; };
 		233D76752E288A2F00EB9FFB /* basic.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 53C3D5E421ECE6CE0087FDFC /* basic.js */; };
 		233D76762E288A2F00EB9FFB /* foo.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 52D1308F221CE03A009C836C /* foo.js */; };
 		233D76882E288AD500EB9FFB /* testapi.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767F2E288A8600EB9FFB /* testapi.js */; };
@@ -807,6 +805,8 @@
 		233D768F2E288BCA00EB9FFB /* missingImport.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767B2E288A8600EB9FFB /* missingImport.js */; };
 		233D76902E288BCA00EB9FFB /* referenceError.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767C2E288A8600EB9FFB /* referenceError.js */; };
 		233D76912E288BCA00EB9FFB /* syntaxError.js in CopyFiles */ = {isa = PBXBuildFile; fileRef = 233D767D2E288A8600EB9FFB /* syntaxError.js */; };
+		2392A1302DD51DB100DD1CB9 /* WebAssemblyBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */; };
+		2392A1312DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */; };
 		2600B5A7152BAAA70091EE5F /* JSStringJoiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */; };
 		262D85B71C0D650F006ACB61 /* AirFixPartialRegisterStalls.h in Headers */ = {isa = PBXBuildFile; fileRef = 262D85B51C0D650F006ACB61 /* AirFixPartialRegisterStalls.h */; };
 		2684D4381C00161C0081D663 /* AirLiveness.h in Headers */ = {isa = PBXBuildFile; fileRef = 2684D4371C00161C0081D663 /* AirLiveness.h */; };
@@ -2128,6 +2128,7 @@
 		F6D67D4226F902E9006E0349 /* TemporalInstantConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3C26F902E7006E0349 /* TemporalInstantConstructor.h */; };
 		F6D67D4426F902E9006E0349 /* TemporalInstantPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D67D3E26F902E8006E0349 /* TemporalInstantPrototype.h */; };
 		FE041553252EC0730091EB5D /* SlotVisitorMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = FE041552252EC0730091EB5D /* SlotVisitorMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE05D3A62E53FBE5007668DD /* VMManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FE05D3A42E53FBE5007668DD /* VMManager.h */; };
 		FE086BCA2123DEFB003F2929 /* EntryFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = FE086BC92123DEFA003F2929 /* EntryFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE0D4A061AB8DD0A002F54BF /* ExecutionTimeLimitTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE0D4A041AB8DD0A002F54BF /* ExecutionTimeLimitTest.cpp */; };
 		FE0D4A091ABA2437002F54BF /* GlobalContextWithFinalizerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE0D4A071ABA2437002F54BF /* GlobalContextWithFinalizerTest.cpp */; };
@@ -3887,10 +3888,6 @@
 		1CAA8B4A0D32C39A0041BCFF /* JavaScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScript.h; sourceTree = "<group>"; };
 		1CAA8B4B0D32C39A0041BCFF /* JavaScriptCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScriptCore.h; sourceTree = "<group>"; };
 		20ECB15EFC524624BC2F02D5 /* ModuleNamespaceAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleNamespaceAccessCase.cpp; sourceTree = "<group>"; };
-		2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyBuiltin.h; path = js/WebAssemblyBuiltin.h; sourceTree = "<group>"; };
-		2392A12B2DD51DB100DD1CB9 /* WebAssemblyBuiltin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyBuiltin.cpp; path = js/WebAssemblyBuiltin.cpp; sourceTree = "<group>"; };
-		2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyCompileOptions.h; path = js/WebAssemblyCompileOptions.h; sourceTree = "<group>"; };
-		2392A12D2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyCompileOptions.cpp; path = js/WebAssemblyCompileOptions.cpp; sourceTree = "<group>"; };
 		233D76772E288A8600EB9FFB /* badModuleImportId.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = badModuleImportId.js; sourceTree = "<group>"; };
 		233D76782E288A8600EB9FFB /* bar.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = bar.js; sourceTree = "<group>"; };
 		233D76792E288A8600EB9FFB /* dependenciesEntry.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = dependenciesEntry.js; sourceTree = "<group>"; };
@@ -3900,6 +3897,10 @@
 		233D767D2E288A8600EB9FFB /* syntaxError.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = syntaxError.js; sourceTree = "<group>"; };
 		233D767F2E288A8600EB9FFB /* testapi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = testapi.js; sourceTree = "<group>"; };
 		233D76802E288A8600EB9FFB /* testapi-function-overrides.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "testapi-function-overrides.js"; sourceTree = "<group>"; };
+		2392A12A2DD51DB100DD1CB9 /* WebAssemblyBuiltin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyBuiltin.h; path = js/WebAssemblyBuiltin.h; sourceTree = "<group>"; };
+		2392A12B2DD51DB100DD1CB9 /* WebAssemblyBuiltin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyBuiltin.cpp; path = js/WebAssemblyBuiltin.cpp; sourceTree = "<group>"; };
+		2392A12C2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblyCompileOptions.h; path = js/WebAssemblyCompileOptions.h; sourceTree = "<group>"; };
+		2392A12D2DD51DB100DD1CB9 /* WebAssemblyCompileOptions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyCompileOptions.cpp; path = js/WebAssemblyCompileOptions.cpp; sourceTree = "<group>"; };
 		2600B5A4152BAAA70091EE5F /* JSStringJoiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSStringJoiner.cpp; sourceTree = "<group>"; };
 		2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringJoiner.h; sourceTree = "<group>"; };
 		262D85B41C0D650F006ACB61 /* AirFixPartialRegisterStalls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirFixPartialRegisterStalls.cpp; path = b3/air/AirFixPartialRegisterStalls.cpp; sourceTree = "<group>"; };
@@ -6011,6 +6012,8 @@
 		F73926918DC64330AFCDF0D7 /* JSSourceCode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSSourceCode.cpp; sourceTree = "<group>"; };
 		FE00262223F3AF33003A358F /* WebAssembly.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = WebAssembly.asm; path = llint/WebAssembly.asm; sourceTree = "<group>"; };
 		FE041552252EC0730091EB5D /* SlotVisitorMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SlotVisitorMacros.h; sourceTree = "<group>"; };
+		FE05D3A42E53FBE5007668DD /* VMManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMManager.h; sourceTree = "<group>"; };
+		FE05D3A52E53FBE5007668DD /* VMManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VMManager.cpp; sourceTree = "<group>"; };
 		FE086BC92123DEFA003F2929 /* EntryFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntryFrame.h; sourceTree = "<group>"; };
 		FE0D4A041AB8DD0A002F54BF /* ExecutionTimeLimitTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ExecutionTimeLimitTest.cpp; path = API/tests/ExecutionTimeLimitTest.cpp; sourceTree = "<group>"; };
 		FE0D4A051AB8DD0A002F54BF /* ExecutionTimeLimitTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExecutionTimeLimitTest.h; path = API/tests/ExecutionTimeLimitTest.h; sourceTree = "<group>"; };
@@ -9098,6 +9101,8 @@
 				FE5932A6183C5A2600A1ECCC /* VMEntryScope.h */,
 				E39F87C129AB764100D17E85 /* VMEntryScopeInlines.h */,
 				FE90BB3A1B7CF64E006B3F03 /* VMInlines.h */,
+				FE05D3A52E53FBE5007668DD /* VMManager.cpp */,
+				FE05D3A42E53FBE5007668DD /* VMManager.h */,
 				FE6F56DC1E64E92000D17801 /* VMTraps.cpp */,
 				FE6F56DD1E64E92000D17801 /* VMTraps.h */,
 				FEF5B42B2628CBC80016E776 /* VMTrapsInlines.h */,
@@ -12078,6 +12083,7 @@
 				0F5AE2C41DF4F2800066EFE1 /* VMInlines.h in Headers */,
 				FE3022D71E42857300BAC493 /* VMInspector.h in Headers */,
 				FEC5797323105B5100BCA83F /* VMInspectorInlines.h in Headers */,
+				FE05D3A62E53FBE5007668DD /* VMManager.h in Headers */,
 				FE6F56DE1E64EAD600D17801 /* VMTraps.h in Headers */,
 				FEF5B42C2628CBC80016E776 /* VMTrapsInlines.h in Headers */,
 				FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1097,6 +1097,7 @@ runtime/TypedArrayType.cpp
 runtime/TypeofType.cpp
 runtime/VM.cpp
 runtime/VMEntryScope.cpp
+runtime/VMManager.cpp
 runtime/VMTraps.cpp
 runtime/VarOffset.cpp
 runtime/WaiterListManager.cpp

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -36,7 +36,8 @@
 #include "JSCJSValue.h"
 #include "LLIntPCRanges.h"
 #include "PureNaN.h"
-#include "VMInspector.h"
+#include "VM.h"
+#include "VMManager.h"
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1633,7 +1634,7 @@ bool A64DOpcodeMoveWide::handlePotentialDataPointer(void* ptr)
     ASSERT(Integrity::isSanePointer(ptr));
 
     bool handled = false;
-    VMInspector::forEachVM([&] (VM& vm) {
+    VMManager::forEachVM([&] (VM& vm) {
         if (ptr == &vm) {
             bufferPrintf(" vm");
             handled = true;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -128,7 +128,7 @@
 #include "UnlinkedProgramCodeBlockInlines.h"
 #include "VMEntryScopeInlines.h"
 #include "VMInlines.h"
-#include "VMInspector.h"
+#include "VMManager.h"
 #include "VariableEnvironment.h"
 #include "WaiterListManager.h"
 #include "WasmWorklist.h"
@@ -242,7 +242,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     if (vmCreationShouldCrash || g_jscConfig.vmCreationDisallowed) [[unlikely]]
         CRASH_WITH_EXTRA_SECURITY_IMPLICATION_AND_INFO(VMCreationDisallowed, "VM creation disallowed"_s, 0x4242424220202020, 0xbadbeef0badbeef, 0x1234123412341234, 0x1337133713371337);
 
-    VMInspector::singleton().add(this);
+    VMManager::add(this);
 
     // Set up lazy initializers.
     {
@@ -506,7 +506,7 @@ VM::~VM()
 
     JSRunLoopTimer::Manager::singleton().unregisterVM(*this);
 
-    VMInspector::singleton().remove(this);
+    VMManager::remove(this);
 
     delete emptyList;
 

--- a/Source/JavaScriptCore/runtime/VMManager.cpp
+++ b/Source/JavaScriptCore/runtime/VMManager.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VMManager.h"
+
+#include "VM.h"
+
+namespace JSC {
+
+Lock g_vmListLock;
+VM* VMManager::s_recentVM { nullptr };
+
+static DoublyLinkedList<VM>& vmList() WTF_REQUIRES_LOCK(g_vmListLock)
+{
+    static NeverDestroyed<DoublyLinkedList<VM>> list;
+    return list;
+}
+
+void VMManager::add(VM* vm)
+{
+    Locker locker { g_vmListLock };
+    s_recentVM = vm;
+    vmList().append(vm);
+}
+
+void VMManager::remove(VM* vm)
+{
+    Locker locker { g_vmListLock };
+    if (s_recentVM == vm)
+        s_recentVM = nullptr;
+    vmList().remove(vm);
+}
+
+bool VMManager::isValidVMSlow(VM* vm)
+{
+    bool found = false;
+    forEachVM([&] (VM& nextVM) {
+        if (vm == &nextVM) {
+            s_recentVM = vm;
+            found = true;
+            return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    });
+    return found;
+}
+
+void VMManager::dumpVMs()
+{
+    unsigned i = 0;
+    WTFLogAlways("Registered VMs:");
+    forEachVM([&] (VM& nextVM) {
+        WTFLogAlways("  [%u] VM %p", i++, &nextVM);
+        return IterationStatus::Continue;
+    });
+}
+
+static void iterateVMs(const Invocable<IterationStatus(VM&)> auto& functor) WTF_REQUIRES_LOCK(g_vmListLock)
+{
+    for (VM* vm = vmList().head(); vm; vm = vm->next()) {
+        IterationStatus status = functor(*vm);
+        if (status == IterationStatus::Done)
+            return;
+    }
+}
+
+VM* VMManager::findMatchingVMImpl(const ScopedLambda<VMManager::TestCallback>& test)
+{
+    Locker lock { g_vmListLock };
+    if (s_recentVM && test(*s_recentVM))
+        return s_recentVM;
+
+    VM* result = nullptr;
+    iterateVMs(scopedLambda<IteratorCallback>([&] (VM& vm) {
+        if (test(vm)) {
+            result = &vm;
+            s_recentVM = &vm;
+            return IterationStatus::Done;
+        }
+        return IterationStatus::Continue;
+    }));
+    return result;
+}
+
+void VMManager::forEachVMImpl(const ScopedLambda<VMManager::IteratorCallback>& func)
+{
+    Locker lock { g_vmListLock };
+    iterateVMs(func);
+}
+
+VMManager::Error VMManager::forEachVMWithTimeoutImpl(Seconds timeout, const ScopedLambda<VMManager::IteratorCallback>& func)
+{
+    if (!g_vmListLock.tryLockWithTimeout(timeout))
+        return Error::TimedOut;
+
+    Locker locker { AdoptLock, g_vmListLock };
+    iterateVMs(func);
+    return Error::None;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/DoublyLinkedList.h>
+#include <wtf/IterationStatus.h>
+#include <wtf/Lock.h>
+#include <wtf/ScopedLambda.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+
+namespace JSC {
+
+class VM;
+
+class VMManager {
+    WTF_FORBID_HEAP_ALLOCATION;
+    WTF_MAKE_NONCOPYABLE(VMManager);
+public:
+    enum class Error {
+        None,
+        TimedOut
+    };
+
+    static void add(VM*);
+    static void remove(VM*);
+    ALWAYS_INLINE static bool isValidVM(VM* vm)
+    {
+        return vm == s_recentVM ? true : isValidVMSlow(vm);
+    }
+
+    using IteratorCallback = IterationStatus(VM&);
+    using TestCallback = bool(VM&);
+
+    static VM* findMatchingVM(const Invocable<TestCallback> auto& test)
+    {
+        SUPPRESS_FORWARD_DECL_ARG return findMatchingVMImpl(scopedLambda<TestCallback>(test));
+    }
+
+    static void forEachVM(const Invocable<IteratorCallback> auto& functor)
+    {
+        SUPPRESS_FORWARD_DECL_ARG forEachVMImpl(scopedLambda<IteratorCallback>(functor));
+    }
+
+    static Error forEachVMWithTimeout(Seconds timeout, const Invocable<IteratorCallback> auto& functor)
+    {
+        SUPPRESS_FORWARD_DECL_ARG return forEachVMWithTimeoutImpl(timeout, scopedLambda<IteratorCallback>(functor));
+    }
+
+    JS_EXPORT_PRIVATE static void dumpVMs();
+
+private:
+    JS_EXPORT_PRIVATE static bool isValidVMSlow(VM*);
+    JS_EXPORT_PRIVATE static VM* findMatchingVMImpl(const ScopedLambda<TestCallback>&);
+    JS_EXPORT_PRIVATE static void forEachVMImpl(const ScopedLambda<IteratorCallback>&);
+    JS_EXPORT_PRIVATE static Error forEachVMWithTimeoutImpl(Seconds timeout, const ScopedLambda<IteratorCallback>&);
+
+    JS_EXPORT_PRIVATE static VM* s_recentVM;
+};
+
+} // namespace JSC
+

--- a/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/Source/JavaScriptCore/tools/Integrity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
 #include "JSCellInlines.h"
 #include "JSGlobalObject.h"
 #include "Options.h"
-#include "VMInspectorInlines.h"
+#include "VMManager.h"
 #include <wtf/DataLog.h>
 
 #if OS(DARWIN)
@@ -179,10 +179,10 @@ JSValue doAudit(JSValue value)
 
 bool Analyzer::analyzeVM(VM& vm, Analyzer::Action action)
 {
-    IA_ASSERT_WITH_ACTION(VMInspector::isValidVM(&vm), {
-        VMInspector::dumpVMs();
+    IA_ASSERT_WITH_ACTION(VMManager::isValidVM(&vm), {
+        VMManager::dumpVMs();
         if (action == Action::LogAndCrash)
-            RELEASE_ASSERT(VMInspector::isValidVM(&vm));
+            RELEASE_ASSERT(VMManager::isValidVM(&vm));
         else
             return false;
     }, "Invalid VM %p", &vm);

--- a/Source/JavaScriptCore/tools/IntegrityInlines.h
+++ b/Source/JavaScriptCore/tools/IntegrityInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 #include "JSCJSValue.h"
 #include "StructureID.h"
 #include "VM.h"
-#include "VMInspector.h"
+#include "VMManager.h"
 #include <wtf/Atomics.h>
 #include <wtf/Gigacage.h>
 
@@ -117,7 +117,7 @@ JS_EXPORT_PRIVATE VM* doAuditSlow(VM*);
 
 ALWAYS_INLINE VM* doAudit(VM* vm)
 {
-    if (!VMInspector::isValidVM(vm)) [[unlikely]]
+    if (!VMManager::isValidVM(vm)) [[unlikely]]
         return doAuditSlow(vm);
     return vm;
 }

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
 #include "LLIntThunks.h"
 #include "NativeCalleeRegistry.h"
 #include "PCToCodeOriginMap.h"
-#include "VMInspector.h"
+#include "VMManager.h"
 #include "WasmCallingConvention.h"
 #include "WasmModuleInformation.h"
 #include "WebAssemblyBuiltin.h"
@@ -78,8 +78,7 @@ Callee::Callee(Wasm::CompilationMode compilationMode, FunctionSpaceIndex index, 
 void Callee::reportToVMsForDestruction()
 {
     // We don't know which VMs a Module has ever run on so we just report to all of them.
-    Locker locker(VMInspector::singleton().getLock());
-    VMInspector::singleton().iterate([&] (VM& vm) {
+    VMManager::forEachVM([&] (VM& vm) {
         vm.heap.reportWasmCalleePendingDestruction(Ref(*this));
         return IterationStatus::Continue;
     });

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@
 #include "JITCompilation.h"
 #include "LinkBuffer.h"
 #include "NativeCalleeRegistry.h"
-#include "VMInspector.h"
 #include "WasmCallee.h"
 #include "WasmIRGeneratorHelpers.h"
 #include "WasmNameSection.h"


### PR DESCRIPTION
#### ccf0be33dc3b2f7d60c4cde045955933012e8101
<pre>
Refactor VMManager out of VMInspector.
<a href="https://bugs.webkit.org/show_bug.cgi?id=297578">https://bugs.webkit.org/show_bug.cgi?id=297578</a>
<a href="https://rdar.apple.com/158659702">rdar://158659702</a>

Reviewed by Keith Miller and Yijia Huang.

Previously, we only needed to enumerate VMs for debugging purposes.  As a result, we implemented
a container of VMs in VMInspector to support enumeration and inspection.  However, since then,
production code has come to rely on this container of VMs.  Additionally, we will soon need to
add more code in the area of VM management and coordination.  Hence, it makes sense to refactor
this container code out of VMInspector into a VMManager class of its own.

Changes include:

1. Changing VMManager::forEachVM() to take a ScopedLambda instead of a Function.  forEachVM() is
   an iteration mechanism, and the life cycle of the callback does not need to extend beyond the
   iteration operation.  Hence, then context of the iteration function can live on the stack in
   a ScopedLambda instead of needing to be malloc&apos;ed in a Function.

2. Some clients were previously using VMInspector&apos;s VM iteration simply for the purpose of
   finding a VM matching some criteria.  Most of the time, the recent most added or searched
   for VM is the matching one.  Hence, we have a s_recentVM cache for that.  However, the
   iteration operation should still be holding the g_vmListLock to prevent the VM instance from
   being destructed before we call the client&apos;s callback with the VM in s_recentVM.

   Previously, this was done by requiring the client to manually acquire g_vmListLock before
   checking s_recentVM, and subsequently, using VMInspector::iterate() to iterate the VMs.
   This can be a source of bugs if the client does handle the lock correctly.  Additionally,
   it requires a lot more of VM container implementation to be exposed as API.

   In VMManager, we introduce a findVM() operation that will encapsulate this synchronization,
   checking of s_recentVM, and thereafter, iterating the container if needed.  This makes the
   interface more robust and simpler to use correctly.

3. Removed the dependency for VMInspector::isValidExecutableMemory() and
   VMInspector::codeBlockForMachinePC() on the VMInspector&apos;s lock.

   VMInspector::isValidExecutableMemory() never needed the VMInspector lock.  The real lock that
   actually needs to be acquired belongs to the ExecutableAllocator instead.
   VMInspector::isValidExecutableMemory() already acquires that.

   VMInspector::codeBlockForMachinePC() now uses VMManager::forEachVM() which handles its
   locking internally.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64DOpcodeMoveWide::handlePotentialDataPointer):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::dumpInfoAndCrashForInvalidHandleV2):
* Source/JavaScriptCore/jsc.cpp:
(startTimeoutTimer):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::~VM):
* Source/JavaScriptCore/runtime/VMManager.cpp: Added.
(JSC::WTF_REQUIRES_LOCK):
(JSC::VMManager::add):
(JSC::VMManager::remove):
(JSC::VMManager::isValidVMSlow):
(JSC::VMManager::dumpVMs):
(JSC::VMManager::findVMImpl):
(JSC::VMManager::forEachVMImpl):
(JSC::VMManager::forEachVMWithTimeoutImpl):
* Source/JavaScriptCore/runtime/VMManager.h: Added.
(JSC::VMManager::isValidVM):
(JSC::VMManager::findVM):
(JSC::VMManager::forEachVM):
(JSC::VMManager::forEachVMWithTimeout):
* Source/JavaScriptCore/tools/HeapVerifier.cpp:
(JSC::HeapVerifier::checkIfRecorded):
* Source/JavaScriptCore/tools/Integrity.cpp:
(JSC::Integrity::Analyzer::analyzeVM):
* Source/JavaScriptCore/tools/IntegrityInlines.h:
(JSC::Integrity::doAudit):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::vmForCallFrame):
(JSC::VMInspector::codeBlockForMachinePC):
(JSC::VMInspector::singleton): Deleted.
(JSC::VMInspector::add): Deleted.
(JSC::VMInspector::remove): Deleted.
(JSC::VMInspector::isValidVMSlow): Deleted.
(JSC::VMInspector::dumpVMs): Deleted.
(JSC::VMInspector::forEachVM): Deleted.
* Source/JavaScriptCore/tools/VMInspector.h:
(JSC::VMInspector::isValidVM): Deleted.
(JSC::VMInspector::WTF_RETURNS_LOCK): Deleted.
(JSC::VMInspector::WTF_REQUIRES_LOCK): Deleted.
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::reportToVMsForDestruction):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:

Canonical link: <a href="https://commits.webkit.org/298937@main">https://commits.webkit.org/298937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a86897e9e5f07b71524ab3d949d6184eb261a3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117249 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69234 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc44fcc5-bc5a-4392-ba34-83bec0cdf99a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d9ae8bd-a544-43d4-a3b0-0292254d5c4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29934 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69478 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67021 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/109354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126469 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115756 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44146 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97440 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24810 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42789 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44019 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144456 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/43475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/46820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->