### PR TITLE
All errors handling should be done through VideoMediaSampleRenderer

### DIFF
--- a/Source/WebCore/platform/graphics/WebMResourceClient.h
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.h
@@ -28,13 +28,13 @@
 #if ENABLE(COCOA_WEBM_PLAYER)
 
 #include "PlatformMediaResourceLoader.h"
+#include <wtf/AbstractThreadSafeRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class WebMResourceClientParent : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebMResourceClientParent, WTF::DestructionThread::Main> {
+class WebMResourceClientParent : public AbstractThreadSafeRefCountedAndCanMakeWeakPtr {
 public:
     virtual ~WebMResourceClientParent() = default;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
@@ -56,10 +56,8 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
     // SourceBufferPrivateAVFObjCErrorClient
-    void videoRendererDidReceiveError(WebSampleBufferVideoRendering *, NSError *, bool& shouldIgnore) override;
-ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    void audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *, bool& shouldIgnore) override;
-ALLOW_NEW_API_WITHOUT_GUARDS_END
+    void videoRendererDidReceiveError(NSError *, bool& shouldIgnore) final;
+    void audioRendererDidReceiveError(NSError *, bool& shouldIgnore) final;
 
     void addSourceBuffer(SourceBufferPrivateAVFObjC*);
     void removeSourceBuffer(SourceBufferPrivateAVFObjC*);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm
@@ -60,7 +60,7 @@ CDMSessionMediaSourceAVFObjC::~CDMSessionMediaSourceAVFObjC()
     m_sourceBuffers.clear();
 }
 
-void CDMSessionMediaSourceAVFObjC::videoRendererDidReceiveError(WebSampleBufferVideoRendering *, NSError *error, bool& shouldIgnore)
+void CDMSessionMediaSourceAVFObjC::videoRendererDidReceiveError(NSError *error, bool& shouldIgnore)
 {
     if (!m_client)
         return;
@@ -73,7 +73,7 @@ void CDMSessionMediaSourceAVFObjC::videoRendererDidReceiveError(WebSampleBufferV
         m_client->sendError(LegacyCDMSessionClient::MediaKeyErrorDomain, code);
 }
 
-void CDMSessionMediaSourceAVFObjC::audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *error, bool& shouldIgnore)
+void CDMSessionMediaSourceAVFObjC::audioRendererDidReceiveError(NSError *error, bool& shouldIgnore)
 {
     if (!m_client)
         return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1106,10 +1106,6 @@ Ref<VideoMediaSampleRenderer> MediaPlayerPrivateMediaSourceAVFObjC::createVideoM
 {
     Ref videoRenderer = VideoMediaSampleRenderer::create(renderer);
     videoRenderer->setTimebase([m_synchronizer timebase]);
-    videoRenderer->notifyWhenDecodingErrorOccurred([weakThis = WeakPtr { *this }](OSStatus) {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->setNetworkState(MediaPlayer::NetworkState::DecodeError);
-    });
     videoRenderer->notifyFirstFrameAvailable([weakThis = WeakPtr { *this }](const MediaTime&, double) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->setHasAvailableVideoFrame(true);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -81,10 +81,8 @@ struct TrackInfo;
 class SourceBufferPrivateAVFObjCErrorClient {
 public:
     virtual ~SourceBufferPrivateAVFObjCErrorClient() = default;
-    virtual void videoRendererDidReceiveError(WebSampleBufferVideoRendering *, NSError *, bool& shouldIgnore) = 0;
-ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    virtual void audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *, bool& shouldIgnore) = 0;
-ALLOW_NEW_API_WITHOUT_GUARDS_END
+    virtual void videoRendererDidReceiveError(NSError *, bool& shouldIgnore) = 0;
+    virtual void audioRendererDidReceiveError(NSError *, bool& shouldIgnore) = 0;
 };
 
 class SourceBufferPrivateAVFObjC final
@@ -179,11 +177,7 @@ private:
     void updateTrackIds(Vector<std::pair<TrackID, TrackID>>&&) final;
 
     // WebAVSampleBufferListenerClient
-    void videoRendererDidReceiveError(WebSampleBufferVideoRendering *, NSError *) final;
     void audioRendererWasAutomaticallyFlushed(AVSampleBufferAudioRenderer *, const CMTime&) final;
-    void outputObscuredDueToInsufficientExternalProtectionChanged(bool) final;
-    void videoRendererRequiresFlushToResumeDecodingChanged(WebSampleBufferVideoRendering *, bool) final;
-    void videoRendererReadyForDisplayChanged(WebSampleBufferVideoRendering *, bool isReadyForDisplay) final;
     void audioRendererDidReceiveError(AVSampleBufferAudioRenderer *, NSError *) final;
 
     void processPendingTrackChangeTasks();
@@ -237,7 +231,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
 ALLOW_NEW_API_WITHOUT_GUARDS_END
     const Ref<WebAVSampleBufferListener> m_listener;
 #if PLATFORM(IOS_FAMILY)
-    bool m_displayLayerWasInterrupted { false };
     bool m_applicationIsActive { true };
 #endif
     RetainPtr<NSError> m_hdcpError;


### PR DESCRIPTION
#### 9677741da3ebf84ab0e8a84acec04e517813ff10
<pre>
All errors handling should be done through VideoMediaSampleRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=297581">https://bugs.webkit.org/show_bug.cgi?id=297581</a>
<a href="https://rdar.apple.com/158665967">rdar://158665967</a>

Reviewed by Jer Noble.

Simplify handling of errors in MSE so that all go through the VideoMediaSampleRenderer.

No change in observable behaviour, covered with existing tests.

* Source/WebCore/platform/graphics/WebMResourceClient.h: Make inheritance use Abstract
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h: Remove unneeded renderer parametre; it isn&apos;t used
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.mm:
(WebCore::CDMSessionMediaSourceAVFObjC::videoRendererDidReceiveError): Update function prototype
(WebCore::CDMSessionMediaSourceAVFObjC::audioRendererDidReceiveError): Update function prototype
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::createVideoMediaSampleRendererForRendererer): Remove handling of error,
eit will now be managed by the SourceBufferPrivate (like it used to be)
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setCDMSession):
(WebCore::SourceBufferPrivateAVFObjC::configureVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::invalidateVideoRenderer):
(WebCore::SourceBufferPrivateAVFObjC::videoRendererDidReceiveError): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::videoRendererRequiresFlushToResumeDecodingChanged): Deleted.
(WebCore::SourceBufferPrivateAVFObjC::videoRendererReadyForDisplayChanged): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::videoRendererDidReceiveError): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h: Pass NSError instead of OSStatus
This allows for a simpler change. In the future we will want to simplify this further in order to
allow cross-process communication.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::m_listener):
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::changeRenderer):
(WebCore::VideoMediaSampleRenderer::decodeNextSampleIfNeeded):
(WebCore::VideoMediaSampleRenderer::notifyWhenDecodingErrorOccurred):
(WebCore::VideoMediaSampleRenderer::notifyErrorHasOccurred):
(WebCore::VideoMediaSampleRenderer::videoRendererDidReceiveError): Add listener,
handle case where the error was related to the application being suspended and instead call videoRendererRequiresFlushToResumeDecodingChanged
(WebCore::VideoMediaSampleRenderer::videoRendererRequiresFlushToResumeDecodingChanged):
(WebCore::VideoMediaSampleRenderer::videoRendererReadyForDisplayChanged):
(WebCore::VideoMediaSampleRenderer::outputObscuredDueToInsufficientExternalProtectionChanged): Proxy error
to normal error handling by creating a custom NSError with the &quot;obscured&quot; boolean set as userInfo.

Canonical link: <a href="https://commits.webkit.org/299036@main">https://commits.webkit.org/299036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfc75248e68d2a67d1dfd9a751b4244107a504f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69005 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b583174-5c07-45b7-ac67-de5ec5da281e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88852 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43563 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94ba1f31-5f41-41c6-8fe3-c060f6933d26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69312 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d226ea5-913d-43e9-ae61-ed3f83b9746f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66728 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126205 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97520 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97319 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40282 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49374 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43239 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44946 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->