### PR TITLE
[SaferCPP] Mark unchanging RemoteGraphicsContextGL members const

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -108,7 +108,7 @@ protected:
     template<typename T>
     IPC::Error send(T&& message) const
     {
-        return Ref { *m_streamConnection }->send(std::forward<T>(message), m_graphicsContextGLIdentifier);
+        return m_connection->send(std::forward<T>(message), m_identifier);
     }
 
     // GraphicsContextGL::Client overrides.
@@ -156,10 +156,6 @@ protected:
     void framebufferDiscard(uint32_t target, std::span<const uint32_t> attachments);
 #endif
 
-#if ENABLE(VIDEO)
-    Ref<RemoteVideoFrameObjectHeap> protectedVideoFrameObjectHeap() const;
-#endif
-
 #if PLATFORM(COCOA)
     using GCGLContext = WebCore::GraphicsContextGLCocoa;
 #elif USE(GBM)
@@ -174,25 +170,23 @@ private:
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
     bool webXREnabled() const;
     bool webXRPromptAccepted() const;
-    Ref<IPC::StreamConnectionWorkQueue> protectedWorkQueue() const { return m_workQueue; }
     RefPtr<GCGLContext> protectedContext();
 
 protected:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
-    Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
-    RefPtr<IPC::StreamServerConnection> m_streamConnection;
+    const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
+    const Ref<IPC::StreamServerConnection> m_connection;
     RefPtr<GCGLContext> m_context WTF_GUARDED_BY_CAPABILITY(workQueue());
-    GraphicsContextGLIdentifier m_graphicsContextGLIdentifier;
-    Ref<RemoteRenderingBackend> m_renderingBackend;
-    Ref<RemoteSharedResourceCache> m_sharedResourceCache;
+    const GraphicsContextGLIdentifier m_identifier;
+    const Ref<RemoteRenderingBackend> m_renderingBackend;
+    const Ref<RemoteSharedResourceCache> m_sharedResourceCache;
 #if ENABLE(VIDEO)
-    Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
+    const Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
 #if PLATFORM(COCOA)
     SharedVideoFrameReader m_sharedVideoFrameReader;
 #endif
 #endif
     ScopedWebGLRenderingResourcesRequest m_renderingResourcesRequest;
-    WebCore::ProcessIdentifier m_webProcessIdentifier;
     SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
     HashMap<uint32_t, PlatformGLObject, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_objectNames;
 };

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
@@ -30,7 +30,7 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection);
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_connection);
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLWC.cpp
@@ -41,6 +41,8 @@ public:
     // RemoteGraphicsContextGL overrides.
     void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) final;
     void prepareForDisplay(CompletionHandler<void(std::optional<WCContentBufferIdentifier>)>&&) final;
+private:
+    WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 
 Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::GraphicsContextGLAttributes&& attributes, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
@@ -52,6 +54,7 @@ Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebP
 
 RemoteGraphicsContextGLWC::RemoteGraphicsContextGLWC(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
     : RemoteGraphicsContextGL(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTFMove(streamConnection))
+    , m_webProcessIdentifier(gpuConnectionToWebProcess.webProcessIdentifier())
 {
 }
 

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -35,6 +35,7 @@
 #include "StreamConnectionWorkQueue.h"
 #include "WCScene.h"
 #include "WCUpdateInfo.h"
+#include <WebCore/ProcessIdentifier.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -92,7 +92,7 @@ context_functions_impl_template = (
 
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_streamConnection);
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_connection);
 
 namespace WebKit {{
 using namespace WebCore;


### PR DESCRIPTION
#### 2404bed7610b57b2daf1e5b7c58e9e57a11f1076
<pre>
[SaferCPP] Mark unchanging RemoteGraphicsContextGL members const
<a href="https://bugs.webkit.org/show_bug.cgi?id=297582">https://bugs.webkit.org/show_bug.cgi?id=297582</a>
<a href="https://rdar.apple.com/158667175">rdar://158667175</a>

Reviewed by Simon Fraser.

Mark unchanging RemoteGraphicsContextGL members as const.
Remove redundant protected*() accessors.
Remove unused m_webProcessIdentifier.
Rename members to avoid redundant words
 - streamConnection -&gt; connection
 - graphicsContextGLIdentifier -&gt; identifier

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::RemoteGraphicsContextGL::~RemoteGraphicsContextGL):
(WebKit::RemoteGraphicsContextGL::initialize):
(WebKit::RemoteGraphicsContextGL::stopListeningForIPC):
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
(WebKit::RemoteGraphicsContextGL::workQueueUninitialize):
(WebKit::RemoteGraphicsContextGL::surfaceBufferToVideoFrame):
(WebKit::RemoteGraphicsContextGL::simulateEventForTesting):
(WebKit::RemoteGraphicsContextGL::protectedVideoFrameObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
(WebKit::RemoteGraphicsContextGL::send const):
(WebKit::RemoteGraphicsContextGL::protectedWorkQueue const): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp:
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/298905@main">https://commits.webkit.org/298905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50bb87139c9dccf18982518c22d1c7fceab55f08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69026 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4c8b16a-1b0b-4589-bb86-5d47536aa4d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88858 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43570 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bee8b9f0-8302-4f64-8f19-92d5ea240eb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104968 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69323 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23076 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66749 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99193 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23230 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126227 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97527 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43260 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->