### PR TITLE
LibWebRTCMediaEndpoint::m_backend can be a const RefPtr

### DIFF
--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -73,7 +73,7 @@ class RTCSessionDescription;
 
 struct LibWebRTCMediaEndpointTransceiverState;
 
-class LibWebRTCMediaEndpoint
+class LibWebRTCMediaEndpoint final
     : public ThreadSafeRefCounted<LibWebRTCMediaEndpoint, WTF::DestructionThread::Main>
     , private webrtc::PeerConnectionObserver
     , private webrtc::RTCStatsCollectorCallback
@@ -83,7 +83,7 @@ class LibWebRTCMediaEndpoint
 {
 public:
     static RefPtr<LibWebRTCMediaEndpoint> create(RTCPeerConnection&, LibWebRTCProvider&, Document&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
-    virtual ~LibWebRTCMediaEndpoint() = default;
+    ~LibWebRTCMediaEndpoint();
 
     void restartIce();
     bool setConfiguration(webrtc::PeerConnectionInterface::RTCConfiguration&&);
@@ -102,7 +102,7 @@ public:
 
     void close();
     void stop();
-    bool isStopped() const { return !m_backend; }
+    bool isStopped() const { return m_isStopped; }
 
     bool addTrack(LibWebRTCRtpSenderBackend&, MediaStreamTrack&, const FixedVector<String>&);
     void removeTrack(LibWebRTCRtpSenderBackend&);
@@ -186,10 +186,11 @@ private:
 #endif
 
     RefPtr<LibWebRTCPeerConnectionBackend> protectedPeerConnectionBackend() const;
+    RefPtr<webrtc::PeerConnectionInterface> createBackend(LibWebRTCProvider&, webrtc::PeerConnectionInterface::RTCConfiguration&&);
 
     WeakPtr<LibWebRTCPeerConnectionBackend> m_peerConnectionBackend;
     const Ref<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
-    RefPtr<webrtc::PeerConnectionInterface> m_backend;
+    const RefPtr<webrtc::PeerConnectionInterface> m_backend;
 
     friend CreateSessionDescriptionObserver<LibWebRTCMediaEndpoint>;
     friend SetLocalSessionDescriptionObserver<LibWebRTCMediaEndpoint>;
@@ -214,6 +215,8 @@ private:
 #endif
     bool m_isGatheringRTCLogs { false };
     bool m_shouldIgnoreNegotiationNeededSignal { false };
+    bool m_isClosed { false };
+    bool m_isStopped { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4811e013a37e990328526808d85ec0149031c098
<pre>
LibWebRTCMediaEndpoint::m_backend can be a const RefPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=297584">https://bugs.webkit.org/show_bug.cgi?id=297584</a>
<a href="https://rdar.apple.com/158669287">rdar://158669287</a>

Reviewed by Jean-Yves Avenard.

We stop nullifying m_backend so that we can make it a const RefPtr
This will delay the backend deallocation until RTCPeerConnection is collected which is ok, and done by other browsers as well.
This allows to simplify a bit the code by no longer refing locally m_backend.
To prevent closing twice m_backend, we add a m_isClosed boolean. This is a mall optimization to not hop to the signalling thread too much.
We add m_isStopped as well since we can no longer use !m_backend as a way to know the stopped state.
We also migrate the last m_backend reference from stop to the destructor to keep the fact that m_backend is not null if LibWebRTCMediaEndpoint is correctly constructed.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::restartIce):
(WebCore::LibWebRTCMediaEndpoint::setConfiguration):
(WebCore::LibWebRTCMediaEndpoint::doSetLocalDescription):
(WebCore::LibWebRTCMediaEndpoint::doSetRemoteDescription):
(WebCore::LibWebRTCMediaEndpoint::addTrack):
(WebCore::LibWebRTCMediaEndpoint::removeTrack):
(WebCore::LibWebRTCMediaEndpoint::doCreateOffer):
(WebCore::LibWebRTCMediaEndpoint::doCreateAnswer):
(WebCore::LibWebRTCMediaEndpoint::gatherDecoderImplementationName):
(WebCore::LibWebRTCMediaEndpoint::getStats):
(WebCore::LibWebRTCMediaEndpoint::collectTransceivers):
(WebCore::LibWebRTCMediaEndpoint::canTrickleIceCandidates const):
(WebCore::LibWebRTCMediaEndpoint::createTransceiverBackends):
(WebCore::LibWebRTCMediaEndpoint::transceiverBackendFromSender):
(WebCore::LibWebRTCMediaEndpoint::close):
(WebCore::LibWebRTCMediaEndpoint::stop):
(WebCore::LibWebRTCMediaEndpoint::addIceCandidate):
(WebCore::LibWebRTCMediaEndpoint::OnIceCandidate):
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::gatherStatsForLogging):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:

Canonical link: <a href="https://commits.webkit.org/299546@main">https://commits.webkit.org/299546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6310b4f6723f2baab748833f292f4e51f9cbc98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/118596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/124773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/70655 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f0c3bb6-f9ce-4937-8bbe-00ead4629a0c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/120474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90011 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/59557 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/654433e7-f785-4515-a9ee-365619e829a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/121549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70515 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/69f7d8ab-fa51-4865-b9fa-30e9b5cfb0a9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/68430 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/24630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127834 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/45503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98643 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/102549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98427 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25177 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42001 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51051 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/46523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->