### PR TITLE
[WPE] WPE Platform: add initial API tests for WPEView

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WPEPlatform/TestView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WPEPlatform/TestView.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2025 Igalia, S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "WPEDisplayMock.h"
+#include "WPEMockPlatformTest.h"
+#include "WPEScreenMock.h"
+#include "WPEToplevelMock.h"
+#include "WPEViewMock.h"
+
+namespace TestWebKitAPI {
+
+class WPEMockViewTest : public WPEMockPlatformTest {
+public:
+    WPE_PLATFORM_TEST_FIXTURE(WPEMockViewTest);
+
+    WPEMockViewTest()
+        : m_view(adoptGRef(wpe_view_new(m_display.get())))
+    {
+        assertObjectIsDeletedWhenTestFinishes(m_view.get());
+        g_assert_true(wpe_view_get_display(m_view.get()) == display());
+    }
+
+    ~WPEMockViewTest()
+    {
+    }
+
+    WPEView* view() const { return m_view.get(); }
+
+private:
+    GRefPtr<WPEView> m_view;
+};
+
+static void testViewToplevel(WPEMockViewTest* test, gconstpointer)
+{
+    auto* toplevel = wpe_view_get_toplevel(test->view());
+    g_assert_true(WPE_IS_TOPLEVEL_MOCK(toplevel));
+    test->assertObjectIsDeletedWhenTestFinishes(toplevel);
+    g_assert_true(wpe_toplevel_get_display(toplevel) == wpe_view_get_display(test->view()));
+}
+
+static void testViewSize(WPEMockViewTest* test, gconstpointer)
+{
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, 1024);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, 768);
+    auto* toplevel = wpe_view_get_toplevel(test->view());
+    g_assert_true(WPE_IS_TOPLEVEL_MOCK(toplevel));
+    test->assertObjectIsDeletedWhenTestFinishes(toplevel);
+    int width, height;
+    wpe_toplevel_get_size(toplevel, &width, &height);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, width);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, height);
+
+    gboolean viewResized = FALSE;
+    auto viewResizedID = g_signal_connect(test->view(), "resized", G_CALLBACK(+[](WPEView*, gboolean* viewResized) {
+        *viewResized = TRUE;
+    }), &viewResized);
+
+    g_assert_true(wpe_toplevel_resize(toplevel, 800, 600));
+    g_assert_true(viewResized);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, 800);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, 600);
+    wpe_toplevel_get_size(toplevel, &width, &height);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, width);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, height);
+    g_signal_handler_disconnect(test->view(), viewResizedID);
+}
+
+static void testViewScale(WPEMockViewTest* test, gconstpointer)
+{
+    g_assert_cmpfloat(wpe_view_get_scale(test->view()), ==, 1.);
+    auto* toplevel = wpe_view_get_toplevel(test->view());
+    g_assert_true(WPE_IS_TOPLEVEL_MOCK(toplevel));
+    test->assertObjectIsDeletedWhenTestFinishes(toplevel);
+    g_assert_cmpfloat(wpe_view_get_scale(test->view()), ==, wpe_toplevel_get_scale(toplevel));
+
+    wpeDisplayMockAddSecondaryScreen(WPE_DISPLAY_MOCK(test->display()));
+    gboolean viewScaleChanged = FALSE;
+    auto viewScaleChangedID = g_signal_connect(test->view(), "notify::scale", G_CALLBACK(+[](WPEView*, GParamSpec*, gboolean* viewScaleChanged) {
+        *viewScaleChanged = TRUE;
+    }), &viewScaleChanged);
+    wpeToplevelMockSwitchToScreen(WPE_TOPLEVEL_MOCK(toplevel), 1);
+    g_assert_true(viewScaleChanged);
+    g_assert_cmpfloat(wpe_view_get_scale(test->view()), ==, 2.);
+    g_signal_handler_disconnect(test->view(), viewScaleChangedID);
+}
+
+static void testViewToplevelState(WPEMockViewTest* test, gconstpointer)
+{
+    auto state = wpe_view_get_toplevel_state(test->view());
+    g_assert_cmpuint(state, ==, 0);
+    auto* toplevel = wpe_view_get_toplevel(test->view());
+    g_assert_true(WPE_IS_TOPLEVEL_MOCK(toplevel));
+    test->assertObjectIsDeletedWhenTestFinishes(toplevel);
+    g_assert_cmpuint(wpe_view_get_toplevel_state(test->view()), ==, wpe_toplevel_get_state(toplevel));
+
+    gboolean viewStateChanged = FALSE;
+    auto viewStateChangedID = g_signal_connect(test->view(), "notify::toplevel-state", G_CALLBACK(+[](WPEView*, GParamSpec*, gboolean* viewStateChanged) {
+        *viewStateChanged = TRUE;
+    }), &viewStateChanged);
+
+    wpeToplevelMockSetActive(WPE_TOPLEVEL_MOCK(toplevel), TRUE);
+    g_assert_true(viewStateChanged);
+    state = wpe_view_get_toplevel_state(test->view());
+    g_assert_true(state & WPE_TOPLEVEL_STATE_ACTIVE);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_FULLSCREEN);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_MAXIMIZED);
+    g_assert_cmpuint(state, ==, wpe_toplevel_get_state(toplevel));
+
+    gboolean viewResized = FALSE;
+    auto viewResizedID = g_signal_connect(test->view(), "resized", G_CALLBACK(+[](WPEView*, gboolean* viewResized) {
+        *viewResized = TRUE;
+    }), &viewResized);
+
+    viewStateChanged = FALSE;
+    g_assert_true(wpe_toplevel_fullscreen(toplevel));
+    g_assert_true(viewStateChanged);
+    state = wpe_view_get_toplevel_state(test->view());
+    g_assert_true(state & WPE_TOPLEVEL_STATE_ACTIVE);
+    g_assert_true(state & WPE_TOPLEVEL_STATE_FULLSCREEN);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_MAXIMIZED);
+    g_assert_cmpuint(state, ==, wpe_toplevel_get_state(toplevel));
+    g_assert_true(viewResized);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, 1920);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, 1080);
+
+    viewStateChanged = FALSE;
+    viewResized = FALSE;
+    g_assert_true(wpe_toplevel_unfullscreen(toplevel));
+    g_assert_true(viewStateChanged);
+    state = wpe_view_get_toplevel_state(test->view());
+    g_assert_true(state & WPE_TOPLEVEL_STATE_ACTIVE);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_FULLSCREEN);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_MAXIMIZED);
+    g_assert_cmpuint(state, ==, wpe_toplevel_get_state(toplevel));
+    g_assert_true(viewResized);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, 1024);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, 768);
+
+    viewStateChanged = FALSE;
+    g_assert_true(wpe_toplevel_maximize(toplevel));
+    g_assert_true(viewStateChanged);
+    state = wpe_view_get_toplevel_state(test->view());
+    g_assert_true(state & WPE_TOPLEVEL_STATE_ACTIVE);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_FULLSCREEN);
+    g_assert_true(state & WPE_TOPLEVEL_STATE_MAXIMIZED);
+    g_assert_cmpuint(state, ==, wpe_toplevel_get_state(toplevel));
+    g_assert_true(viewResized);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, 1920);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, 1040);
+
+    viewStateChanged = FALSE;
+    viewResized = FALSE;
+    g_assert_true(wpe_toplevel_unmaximize(toplevel));
+    g_assert_true(viewStateChanged);
+    state = wpe_view_get_toplevel_state(test->view());
+    g_assert_true(state & WPE_TOPLEVEL_STATE_ACTIVE);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_FULLSCREEN);
+    g_assert_false(state & WPE_TOPLEVEL_STATE_MAXIMIZED);
+    g_assert_cmpuint(state, ==, wpe_toplevel_get_state(toplevel));
+    g_assert_true(viewResized);
+    g_assert_cmpint(wpe_view_get_width(test->view()), ==, 1024);
+    g_assert_cmpint(wpe_view_get_height(test->view()), ==, 768);
+
+    g_signal_handler_disconnect(test->view(), viewStateChangedID);
+    g_signal_handler_disconnect(test->view(), viewResizedID);
+}
+
+void beforeAll()
+{
+    WPEMockViewTest::add("View", "toplevel", testViewToplevel);
+    WPEMockViewTest::add("View", "size", testViewSize);
+    WPEMockViewTest::add("View", "scale", testViewScale);
+    WPEMockViewTest::add("View", "toplevel-state", testViewToplevelState);
+}
+
+void afterAll()
+{
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/CMakeLists.txt
@@ -111,6 +111,7 @@ endmacro()
 ADD_WPE_PLATFORM_TEST(TestDisplay ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplay.cpp)
 ADD_WPE_PLATFORM_TEST(TestDisplayDefault ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplayDefault.cpp)
 ADD_WPE_PLATFORM_TEST(TestSettings ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestSettings.cpp)
+ADD_WPE_PLATFORM_TEST(TestView ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestView.cpp)
 
 if (ENABLE_WPE_PLATFORM_WAYLAND)
     ADD_WPE_PLATFORM_TEST(TestDisplayWayland ${TOOLS_DIR}/TestWebKitAPI/Tests/WPEPlatform/TestDisplayWayland.cpp)

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/WPEMockPlatformTest.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/WPEMockPlatformTest.h
@@ -40,7 +40,7 @@ public:
 
     WPEDisplay* display() const { return m_display.get(); }
 
-private:
+protected:
     GRefPtr<WPEDisplay> m_display;
 };
 

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/mock/WPEToplevelMock.h
@@ -35,5 +35,6 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(WPEToplevelMock, wpe_toplevel_mock, WPE, TOPLEVEL_MOCK, WPEToplevel)
 
 WPEToplevel* wpeToplevelMockNew(WPEDisplayMock*, guint);
-
+void wpeToplevelMockSwitchToScreen(WPEToplevelMock*, guint);
+void wpeToplevelMockSetActive(WPEToplevelMock*, gboolean);
 G_END_DECLS


### PR DESCRIPTION
#### 6db5f94e1e6dddd51c5a7db772a4f4748862d76f
<pre>
[WPE] WPE Platform: add initial API tests for WPEView
<a href="https://bugs.webkit.org/show_bug.cgi?id=297588">https://bugs.webkit.org/show_bug.cgi?id=297588</a>

Reviewed by Miguel Gomez.

Canonical link: <a href="https://commits.webkit.org/298887@main">https://commits.webkit.org/298887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a741d6af286273596f8c8522a4c2e05e24a6db93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/116989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45250 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88846 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43562 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69307 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/32988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97515 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97316 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40278 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18677 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->