### PR TITLE
Netflix Video Briefly Disappears and Reappears When Entering Docked Spatial Web View

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8418,8 +8418,10 @@ VideoRendererUseDecompressionSessionForProtected:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(VISION)" : true
       default: false
     WebCore:
+      "PLATFORM(VISION)" : true
       default: false
   sharedPreferenceForWebProcess: true
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -295,6 +295,7 @@ private:
 
     void ensureLayer();
     void destroyLayer();
+    void destroyVideoLayerIfNeeded();
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
@@ -304,9 +305,13 @@ private:
 
     bool shouldEnsureLayerOrVideoRenderer() const;
     void ensureLayerOrVideoRenderer(MediaPlayerEnums::NeedsRenderingModeChanged);
+    void ensureLayerOrVideoRendererWithDecompressionSession(MediaPlayerEnums::NeedsRenderingModeChanged);
     void destroyLayerOrVideoRenderer();
     Ref<VideoMediaSampleRenderer> createVideoMediaSampleRendererForRendererer(WebSampleBufferVideoRendering *);
     void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
+
+    void setVideoRenderer(WebSampleBufferVideoRendering *);
+    void stageVideoRenderer(WebSampleBufferVideoRendering *);
 
     bool shouldBePlaying() const;
     void setSynchronizerRate(double, std::optional<MonotonicTime>&& = std::nullopt);
@@ -367,8 +372,13 @@ private:
     WeakPtrFactory<MediaPlayerPrivateMediaSourceAVFObjC> m_sizeChangeObserverWeakPtrFactory;
     RefPtr<MediaSourcePrivateAVFObjC> m_mediaSourcePrivate;
     RetainPtr<AVAsset> m_asset;
-    RefPtr<VideoMediaSampleRenderer> m_sampleBufferDisplayLayer;
-    RefPtr<VideoMediaSampleRenderer> m_sampleBufferVideoRenderer;
+    RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
+    RetainPtr<AVSampleBufferVideoRenderer> m_sampleBufferVideoRenderer;
+    // Only used if decompressionsession mode isn't active.
+    RefPtr<VideoMediaSampleRenderer> m_rendererWithSampleBufferDisplayLayer;
+    RefPtr<VideoMediaSampleRenderer> m_rendererWithSampleBufferVideoRenderer;
+
+    RefPtr<VideoMediaSampleRenderer> m_videoRenderer;
 
     struct AudioRendererProperties {
         bool hasAudibleSample { false };
@@ -429,6 +439,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     String m_spatialTrackingLabel;
 #endif
     AcceleratedVideoMode m_acceleratedVideoMode { AcceleratedVideoMode::Layer };
+    bool m_needsDestroyVideoLayer { false };
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool m_needNewFrameToProgressStaging { false };
     bool m_updateDisplayLayerPending { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1311,6 +1311,8 @@ void SourceBufferPrivateAVFObjC::setVideoRenderer(VideoMediaSampleRenderer* rend
     if (m_videoRenderer && m_videoRenderer == renderer) {
         if (RefPtr expiringVideoRenderer = std::exchange(m_expiringVideoRenderer, nullptr))
             invalidateVideoRenderer(*expiringVideoRenderer);
+        else
+            configureVideoRenderer(*renderer);
         return;
     }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -240,6 +240,7 @@ private:
     bool shouldEnsureLayerOrVideoRenderer() const;
     void ensureLayer();
     void destroyLayer();
+    void destroyVideoLayerIfNeeded();
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
@@ -413,6 +414,7 @@ private:
     String m_defaultSpatialTrackingLabel;
     String m_spatialTrackingLabel;
 #endif
+    bool m_needsDestroyVideoLayer { false };
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool m_usingLinearMediaPlayer { false };
     RetainPtr<FigVideoTargetRef> m_videoTarget;


### PR DESCRIPTION
#### 8af96a4282c7692ee93b925fdc5d731d8c250deb
<pre>
Netflix Video Briefly Disappears and Reappears When Entering Docked Spatial Web View
<a href="https://bugs.webkit.org/show_bug.cgi?id=297448">https://bugs.webkit.org/show_bug.cgi?id=297448</a>
<a href="https://rdar.apple.com/158557448">rdar://158557448</a>

Reviewed by Jer Noble.

Following-up on 298745@main; we now adopt VideoMediaSampleRenderer::changeRenderer
in the MediaPlayerPrivateMediaSourceAVFObjC. It allows for almost flawless
change from fullscreen to docking on visionOS devices.
For the code to be effective, we need to enable the VideoRendererUseDecompressionSessionForProtected
preference on visionOS so that the VideoMediaSampleRenderer has detailed knowledge of
all video frames decoded.

Covered by existing tests and manually tested on a Vision Pro

The following scenarios were tested with YouTube and Netflix:
Enter fullscreen, enter dock mode, exit dock mode, repeat.
Enter fullscreen, enter dock mode, let multiple videos play, exit dock mode, repeat.
When an ad is playing, enter fullscreen, enter dock mode, exit dock mode, repeat.
When an ad is playing, enter fullscreen, enter dock mode, wait for the next video to play, exit dock mode, repeat.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoLayerIfNeeded):
As the change from AVSBDL to AVSBVR is now instantaneous, we must delay the
call to VideoLayerManagerObjC::didDestroyVideoLayer to prevent a rapid black
flicker when we transition to the AVSBVR and before it entered into fullscreen.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureRenderlessVideoMediaSampleRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRendererWithDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::stageVideoRenderer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::canUseDecompressionSession const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isUsingDecompressionSession const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::layerOrVideoRenderer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setVideoTarget):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::maybeUpdateDisplayLayer):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::destroyVideoLayerIfNeeded):
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::destroyLayer):
(WebCore::MediaPlayerPrivateWebM::stageVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged): Remove the AVSBDL
from its superview once we&apos;ve been notified that the AVSBVR has completed its
transition to fullscreen.

Canonical link: <a href="https://commits.webkit.org/299043@main">https://commits.webkit.org/299043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97f158c84f7eab39e0d8a9a87b6d10d7583b394c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69604 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7dd3acff-a68b-460a-80aa-44f53b92942b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89241 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/45048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ce2ee88f-b04a-4158-8b38-35e1b2f2d90f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105435 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/69742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45621703-8c2a-4b1d-887d-4711c03a7d81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23551 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67377 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109706 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126821 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/116105 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97905 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24868 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43066 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21020 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40857 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50045 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144803 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43828 "Hash 97f158c8 for PR 49586 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37263 "Found 1 new JSC binary failure: testapi, Found 20036 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/nativearray_gen6.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->