### PR TITLE
REGRESSION(296903@main): [ Darwin wk2 ] fast/animation/css-animation-resuming-when-visible-with-style-change2.html is a flakey text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7941,8 +7941,6 @@ fast/snapshot/positioned-abs-relative-body.html [ Skip ]
 
 webkit.org/b/295432 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-zoom.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/295527 fast/animation/css-animation-resuming-when-visible-with-style-change2.html [ Pass Failure ]
-
 webkit.org/b/295557 fast/dom/Range/scale-page-bounding-client-rect.html [ Pass Failure ]
 
 webkit.org/b/295559 [ Release ] media/video-unmuted-after-play-holds-sleep-assertion.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2189,8 +2189,6 @@ webkit.org/b/295439 media/video-unmuted-after-play-holds-sleep-assertion.html [ 
 
 webkit.org/b/295441 [ Release ] fast/scrolling/mac/scrollbars/scrollbar-width-dynamic-none-to-auto.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/295527 fast/animation/css-animation-resuming-when-visible-with-style-change2.html [ Pass Failure ]
-
 webkit.org/b/295738 [ arm64 ] http/tests/images/gif-progressive-load.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/295743 [ Debug ] media/video-display-aspect-ratio.html [ Pass Failure ]

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -268,10 +268,10 @@ void AnimationTimelinesController::suspendAnimations()
     if (m_isSuspended)
         return;
 
-    if (!m_cachedCurrentTime) {
+    if (!m_cachedCurrentTime)
         m_cachedCurrentTime = liveCurrentTime();
-        m_cachedCurrentTimeClearanceTimer.stop();
-    }
+
+    m_cachedCurrentTimeClearanceTimer.stop();
 
     for (Ref timeline : m_timelines)
         timeline->suspendAnimations();
@@ -284,9 +284,9 @@ void AnimationTimelinesController::resumeAnimations()
     if (!m_isSuspended)
         return;
 
-    clearCachedCurrentTime();
-
     m_isSuspended = false;
+
+    clearCachedCurrentTime();
 
     for (Ref timeline : m_timelines)
         timeline->resumeAnimations();
@@ -348,6 +348,7 @@ void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds new
 
 void AnimationTimelinesController::clearCachedCurrentTime()
 {
+    ASSERT(!m_isSuspended);
     m_cachedCurrentTime = std::nullopt;
 }
 


### PR DESCRIPTION
#### 8299256761a811777a18eb3c27869862237dc966
<pre>
REGRESSION(296903@main): [ Darwin wk2 ] fast/animation/css-animation-resuming-when-visible-with-style-change2.html is a flakey text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=295527">https://bugs.webkit.org/show_bug.cgi?id=295527</a>
<a href="https://rdar.apple.com/155235713">rdar://155235713</a>

Reviewed by Tim Nguyen.

We need to make sure we don&apos;t clear the cached current time after we&apos;ve suspended animations
as that cached current time must remain frozen the entire time animations are suspended. We now
make sure to do just that in `AnimationTimelinesController::suspendAnimations()` and add an
assertion that animations aren&apos;t suspended in `AnimationTimelinesController::clearCachedCurrentTime()`.
And so that assertion holds, we switch two lines of code in `AnimationTimelinesController::resumeAnimations()`
such that the flag tracking whether animations are suspended is cleared before we call `clearCachedCurrentTime()`.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::suspendAnimations):
(WebCore::AnimationTimelinesController::resumeAnimations):
(WebCore::AnimationTimelinesController::clearCachedCurrentTime):

Canonical link: <a href="https://commits.webkit.org/298894@main">https://commits.webkit.org/298894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/888b9cc9ff216bfd2bf2a44773bcb341d071387c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69031 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/118902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88862 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43578 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/119962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/104972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69327 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66754 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126237 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97534 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97333 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40308 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18680 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49403 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43266 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/44976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->