### PR TITLE
[JSC] Implement `Set#isSubsetOf` in C++

### DIFF
--- a/JSTests/stress/set-prototype-isSubsetOf-empty-sets.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-empty-sets.js
@@ -1,0 +1,47 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+let emptySet1 = new Set();
+let emptySet2 = new Set();
+let result = emptySet1.isSubsetOf(emptySet2);
+shouldBe(result, true);
+
+let set1 = new Set([1, 2, 3]);
+let empty = new Set();
+result = empty.isSubsetOf(set1);
+shouldBe(result, true);
+
+result = set1.isSubsetOf(empty);
+shouldBe(result, false);
+
+let subset = new Set([1, 2]);
+let superset = new Set([1, 2, 3, 4]);
+result = subset.isSubsetOf(superset);
+shouldBe(result, true);
+
+result = superset.isSubsetOf(subset);
+shouldBe(result, false);
+
+let set2 = new Set([2, 3, 4]);
+result = set1.isSubsetOf(set2);
+shouldBe(result, false);
+
+result = set2.isSubsetOf(set1);
+shouldBe(result, false);
+
+let set3 = new Set([1, 2, 3]);
+result = set1.isSubsetOf(set3);
+shouldBe(result, true);
+
+result = set3.isSubsetOf(set1);
+shouldBe(result, true);
+
+let disjoint1 = new Set([1, 2, 3]);
+let disjoint2 = new Set([4, 5, 6]);
+result = disjoint1.isSubsetOf(disjoint2);
+shouldBe(result, false);
+
+result = disjoint2.isSubsetOf(disjoint1);
+shouldBe(result, false);

--- a/JSTests/stress/set-prototype-isSubsetOf-generic-object.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-generic-object.js
@@ -1,0 +1,108 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function shouldThrow(func, errorType) {
+    let threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+        shouldBe(e instanceof errorType, true);
+    }
+    shouldBe(threw, true);
+}
+
+let set1 = new Set([1, 2, 3]);
+let setLikeObject = {
+    size: 5,
+    has: function(key) {
+        return [1, 2, 3, 4, 5].includes(key);
+    },
+    keys: function() {
+        let values = [1, 2, 3, 4, 5];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+let result = set1.isSubsetOf(setLikeObject);
+shouldBe(result, true);
+
+let partialMatch = {
+    size: 3,
+    has: function(key) {
+        return [1, 2, 4].includes(key);
+    },
+    keys: function() {
+        let values = [1, 2, 4];
+        let index = 0;
+        return {
+            next: function() {
+                if (index < values.length) {
+                    return { value: values[index++], done: false };
+                }
+                return { done: true };
+            }
+        };
+    }
+};
+
+result = set1.isSubsetOf(partialMatch);
+shouldBe(result, false);
+
+let tooSmall = {
+    size: 2,
+    has: function(key) {
+        return true;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("Should not be called due to size check");
+            }
+        };
+    }
+};
+
+result = set1.isSubsetOf(tooSmall);
+shouldBe(result, false);
+shouldThrow(() => {
+    set1.isSubsetOf({
+        size: 5,
+        has: "not a function",
+        keys: function() { return {}; }
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.isSubsetOf({
+        size: 5,
+        has: function() { return true; },
+        keys: "not a function"
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.isSubsetOf({
+        size: NaN,
+        has: function() { return true; },
+        keys: function() { return {}; }
+    });
+}, TypeError);
+
+shouldThrow(() => {
+    set1.isSubsetOf({
+        size: -1,
+        has: function() { return true; },
+        keys: function() { return {}; }
+    });
+}, RangeError);

--- a/JSTests/stress/set-prototype-isSubsetOf-iterator-effects.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-iterator-effects.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function main() {
+    let set1 = new Set([1, 2, 3, 4, 5]);
+    let hasCallCount = 0;
+    
+    let otherObject = {
+        size: 10,
+        has: function(key) {
+            hasCallCount++;
+            if (hasCallCount === 1) {
+                set1.delete(3);
+                set1.delete(4);
+                set1.add(6);
+            }
+            return [1, 2, 3, 4, 5, 6].includes(key);
+        },
+        keys: function() {
+            return {
+                next: function() {
+                    throw new Error("keys() iterator should not be used in isSubsetOf");
+                }
+            };
+        }
+    };
+    
+    let result = set1.isSubsetOf(otherObject);
+    shouldBe(hasCallCount >= 1, true);
+}
+
+main();
+
+function testHasModification() {
+    let set1 = new Set([1, 2]);
+    let callCount = 0;
+    
+    let otherObject = {
+        size: 5,
+        values: [1, 2, 3, 4, 5],
+        has: function(key) {
+            callCount++;
+            if (callCount === 1) {
+                this.values = [1, 2];
+            }
+            return this.values.includes(key);
+        },
+        keys: function() {
+            return {
+                next: function() {
+                    throw new Error("keys() should not be called");
+                }
+            };
+        }
+    };
+    
+    let result = set1.isSubsetOf(otherObject);
+    shouldBe(result, true);
+}
+
+testHasModification();

--- a/JSTests/stress/set-prototype-isSubsetOf-large-sets.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-large-sets.js
@@ -1,0 +1,57 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function createLargeSet(size, start = 0) {
+    let set = new Set();
+    for (let i = start; i < start + size; i++) {
+        set.add(i);
+    }
+    return set;
+}
+
+let largeSet = createLargeSet(10000, 0);
+let smallSet = createLargeSet(100, 0);
+
+let result = smallSet.isSubsetOf(largeSet);
+shouldBe(result, true);
+
+result = largeSet.isSubsetOf(smallSet);
+shouldBe(result, false);
+
+let set1 = createLargeSet(5000, 0);
+let set2 = createLargeSet(5000, 2500);
+
+result = set1.isSubsetOf(set2);
+shouldBe(result, false);
+
+result = set2.isSubsetOf(set1);
+shouldBe(result, false);
+
+let largeSet1 = createLargeSet(1000, 0);
+let largeSet2 = createLargeSet(1000, 0);
+
+result = largeSet1.isSubsetOf(largeSet2);
+shouldBe(result, true);
+
+result = largeSet2.isSubsetOf(largeSet1);
+shouldBe(result, true);
+
+let perfTestSet = createLargeSet(1000, 0);
+let perfSetLike = {
+    size: 2000,
+    has: function(key) {
+        return key >= 0 && key < 2000;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("keys() should not be called");
+            }
+        };
+    }
+};
+
+result = perfTestSet.isSubsetOf(perfSetLike);
+shouldBe(result, true);

--- a/JSTests/stress/set-prototype-isSubsetOf-property-access-order.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-property-access-order.js
@@ -1,0 +1,75 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let accessOrder = [];
+    let set = new Set([1, 2]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 5;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                return true;
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                return {
+                    next: function() {
+                        throw new Error("keys() should not be used in isSubsetOf");
+                    }
+                };
+            };
+        }
+    };
+    
+    set.isSubsetOf(obj);
+    
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+main();
+
+function testEarlyReturn() {
+    let accessOrder = [];
+    let largeSet = new Set([1, 2, 3, 4, 5]);
+    
+    let obj = {
+        get size() {
+            accessOrder.push('size');
+            return 3;
+        },
+        get has() {
+            accessOrder.push('has');
+            return function(key) {
+                throw new Error("has() should not be called due to size check");
+            };
+        },
+        get keys() {
+            accessOrder.push('keys');
+            return function() {
+                throw new Error("keys() should not be called due to size check");
+            };
+        }
+    };
+    
+    let result = largeSet.isSubsetOf(obj);
+    
+    shouldBe(result, false);
+    shouldBe(accessOrder.length, 3);
+    shouldBe(accessOrder[0], 'size');
+    shouldBe(accessOrder[1], 'has');
+    shouldBe(accessOrder[2], 'keys');
+}
+
+testEarlyReturn();

--- a/JSTests/stress/set-prototype-isSubsetOf-reference.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-reference.js
@@ -1,0 +1,48 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function main() {
+    let modificationDetected = false;
+    const set = new Set([1, 2, 3, 4, 5]);
+
+    try {
+        let hasCallCount = 0;
+
+        set.isSubsetOf({
+            size: 10,
+            has: function(key) {
+                hasCallCount++;
+                
+                if (hasCallCount === 1) {
+                    set.delete(1);
+                    set.delete(2);
+                    set.delete(3);
+                    set.delete(4);
+                    modificationDetected = true;
+                    return true;
+                } else if (hasCallCount === 2) {
+                    throw new Error("Test exception");
+                }
+                
+                return true;
+            },
+            
+            keys: function() {
+                return {
+                    next: function() {
+                        throw new Error("keys() should not be called in isSubsetOf");
+                    }
+                };
+            }
+        });
+    } catch (e) {
+        shouldBe(e.message, "Test exception");
+    }
+
+    shouldBe(modificationDetected, true);
+    shouldBe(set.size, 1);
+}
+
+main();

--- a/JSTests/stress/set-prototype-isSubsetOf-special-values.js
+++ b/JSTests/stress/set-prototype-isSubsetOf-special-values.js
@@ -1,0 +1,91 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+let set = new Set([0, -0, NaN, undefined, null, "", false, true]);
+
+let setLike = {
+    size: 10,
+    has: function(key) {
+        if (key === 0 || key === -0) return true;
+        if (Number.isNaN(key)) return true;
+        if (key === undefined) return true;
+        if (key === null) return true;
+        if (key === "") return true;
+        if (key === false) return true;
+        if (key === true) return true;
+        return false;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("keys() should not be called");
+            }
+        };
+    }
+};
+
+let result = set.isSubsetOf(setLike);
+shouldBe(result, true);
+
+let sym1 = Symbol('test1');
+let sym2 = Symbol('test2');
+let symbolSet = new Set([sym1, sym2]);
+
+let symbolSetLike = {
+    size: 3,
+    has: function(key) {
+        return key === sym1 || key === sym2;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("keys() should not be called");
+            }
+        };
+    }
+};
+
+result = symbolSet.isSubsetOf(symbolSetLike);
+shouldBe(result, true);
+
+let obj1 = { a: 1 };
+let obj2 = { b: 2 };
+let objectSet = new Set([obj1, obj2]);
+
+let objectSetLike = {
+    size: 3,
+    has: function(key) {
+        return key === obj1 || key === obj2;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("keys() should not be called");
+            }
+        };
+    }
+};
+
+result = objectSet.isSubsetOf(objectSetLike);
+shouldBe(result, true);
+
+let differentObj1 = { a: 1 };
+let differentObj2 = { b: 2 };
+let objectSetLikeDifferent = {
+    size: 3,
+    has: function(key) {
+        return key === differentObj1 || key === differentObj2;
+    },
+    keys: function() {
+        return {
+            next: function() {
+                throw new Error("keys() should not be called");
+            }
+        };
+    }
+};
+
+result = objectSet.isSubsetOf(objectSetLikeDifferent);
+shouldBe(result, false);

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -152,44 +152,6 @@ function symmetricDifference(other)
     return result;
 }
 
-function isSubsetOf(other)
-{
-    "use strict";
-
-    if (!@isSet(this))
-        @throwTypeError("Set operation called on non-Set object");
-
-    // Get Set Record
-    var size = @getSetSizeAsInt(other);
-
-    var has = other.has;
-    if (!@isCallable(has))
-        @throwTypeError("Set.prototype.isSubsetOf expects other.has to be callable");
-
-    var keys = other.keys;
-    if (!@isCallable(keys))
-        @throwTypeError("Set.prototype.isSubsetOf expects other.keys to be callable");
-
-    if (this.@size > size)
-        return false;
-
-    var storage = @setStorage(this);
-    var entry = 0;
-
-    do {
-        storage = @setIterationNext(storage, entry);
-        if (storage == @orderedHashTableSentinel)
-            break;
-        entry = @setIterationEntry(storage) + 1;
-        var key = @setIterationEntryKey(storage);
-
-        if (!has.@call(other, key))
-            return false;
-    } while (true);
-
-    return true;
-}
-
 function isSupersetOf(other)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -49,6 +49,7 @@ static JSC_DECLARE_HOST_FUNCTION(setProtoFuncValues);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncEntries);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIntersection);
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncUnion);
+static JSC_DECLARE_HOST_FUNCTION(setProtoFuncIsSubsetOf);
 
 static JSC_DECLARE_HOST_FUNCTION(setProtoFuncSize);
 
@@ -100,7 +101,7 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("intersection"_s, setProtoFuncIntersection, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().differencePublicName(), setPrototypeDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().symmetricDifferencePublicName(), setPrototypeSymmetricDifferenceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSubsetOfPublicName(), setPrototypeIsSubsetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isSubsetOf"_s, setProtoFuncIsSubsetOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isSupersetOfPublicName(), setPrototypeIsSupersetOfCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().isDisjointFromPublicName(), setPrototypeIsDisjointFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
@@ -436,6 +437,125 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncUnion, (JSGlobalObject* globalObject, CallF
     });
 
     return JSValue::encode(result);
+}
+
+static EncodedJSValue fastSetIsSubsetOf(JSGlobalObject* globalObject, JSSet* thisSet, JSSet* otherSet)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (thisSet->size() > otherSet->size())
+        return JSValue::encode(jsBoolean(false));
+
+    JSCell* thisStorageCell = thisSet->storageOrSentinel(vm);
+    if (thisStorageCell == vm.orderedHashTableSentinel())
+        return JSValue::encode(jsBoolean(true));
+
+    auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+    JSSet::Helper::Entry entry = 0;
+
+    while (true) {
+        thisStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *thisStorage, entry);
+        if (thisStorageCell == vm.orderedHashTableSentinel())
+            break;
+
+        auto* currentStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+        entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+        JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+        bool otherHasEntry = otherSet->has(globalObject, entryKey);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!otherHasEntry)
+            return JSValue::encode(jsBoolean(false));
+
+        thisStorage = currentStorage;
+    }
+
+    return JSValue::encode(jsBoolean(true));
+}
+
+JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSubsetOf, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSSet* thisSet = getSet(globalObject, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue otherValue = callFrame->argument(0);
+
+    if (otherValue.isCell()) [[likely]] {
+        if (auto* otherSet = jsDynamicCast<JSSet*>(otherValue.asCell())) [[likely]] {
+            if (setPrimordialWatchpointIsValid(vm, otherSet)) [[likely]] {
+                scope.release();
+                return fastSetIsSubsetOf(globalObject, thisSet, otherSet);
+            }
+        }
+    }
+
+    uint32_t otherSize = getSetSizeAsInt(globalObject, otherValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ASSERT(otherValue.isObject());
+    JSObject* otherObject = asObject(otherValue);
+
+    JSValue has = otherObject->get(globalObject, vm.propertyNames->has);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!has.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.isSubsetOf expects other.has to be callable"_s);
+
+    JSValue keys = otherObject->get(globalObject, vm.propertyNames->keys);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!keys.isCallable()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Set.prototype.isSubsetOf expects other.keys to be callable"_s);
+
+    if (thisSet->size() > otherSize)
+        return JSValue::encode(jsBoolean(false));
+
+    CallData hasCallData = JSC::getCallData(has);
+    JSCell* thisStorageCell = thisSet->storageOrSentinel(vm);
+    if (thisStorageCell == vm.orderedHashTableSentinel())
+        return JSValue::encode(jsBoolean(true));
+
+    auto* thisStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+    JSSet::Helper::Entry entry = 0;
+
+    std::optional<CachedCall> cachedHasCall;
+    if (hasCallData.type == CallData::Type::JS) [[likely]] {
+        cachedHasCall.emplace(globalObject, jsCast<JSFunction*>(has), 1);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    while (true) {
+        thisStorageCell = JSSet::Helper::nextAndUpdateIterationEntry(vm, *thisStorage, entry);
+        if (thisStorageCell == vm.orderedHashTableSentinel())
+            break;
+
+        auto* currentStorage = jsCast<JSSet::Storage*>(thisStorageCell);
+        entry = JSSet::Helper::iterationEntry(*currentStorage) + 1;
+        JSValue entryKey = JSSet::Helper::getIterationEntryKey(*currentStorage);
+
+        JSValue hasResult;
+        if (cachedHasCall) [[likely]] {
+            hasResult = cachedHasCall->callWithArguments(globalObject, otherValue, entryKey);
+            RETURN_IF_EXCEPTION(scope, { });
+        } else {
+            MarkedArgumentBuffer args;
+            args.append(entryKey);
+            ASSERT(!args.hasOverflowed());
+            hasResult = call(globalObject, has, hasCallData, otherValue, args);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+
+        bool hasResultBool = hasResult.toBoolean(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        if (!hasResultBool)
+            return JSValue::encode(jsBoolean(false));
+
+        thisStorage = currentStorage;
+    }
+
+    return JSValue::encode(jsBoolean(true));
 }
 
 inline JSValue createSetIteratorObject(JSGlobalObject* globalObject, CallFrame* callFrame, IterationKind kind)


### PR DESCRIPTION
#### eecf4ce3ac787c7a178a94b792a013c5c7654a0b
<pre>
[JSC] Implement `Set#isSubsetOf` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=297600">https://bugs.webkit.org/show_bug.cgi?id=297600</a>

Reviewed by Yusuke Suzuki.

This patch implements `Set.prototype.isSubsetOf` in C++ using the same way
as <a href="https://commits.webkit.org/297882@main.">https://commits.webkit.org/297882@main.</a>

                        TipOfTree                  Patched

set-isSubsetOf        4.9774+-0.1079     ^      1.9430+-0.0337        ^ definitely 2.5617x faster

* JSTests/stress/set-prototype-isSubsetOf-empty-sets.js: Added.
* JSTests/stress/set-prototype-isSubsetOf-generic-object.js: Added.
* JSTests/stress/set-prototype-isSubsetOf-iterator-effects.js: Added.
* JSTests/stress/set-prototype-isSubsetOf-large-sets.js: Added.
* JSTests/stress/set-prototype-isSubsetOf-property-access-order.js: Added.
* JSTests/stress/set-prototype-isSubsetOf-reference.js: Added.
* JSTests/stress/set-prototype-isSubsetOf-special-values.js: Added.
* Source/JavaScriptCore/builtins/SetPrototype.js:
* Source/JavaScriptCore/runtime/SetPrototype.cpp:

Canonical link: <a href="https://commits.webkit.org/298998@main">https://commits.webkit.org/298998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/512bbd673b0e2214b5ced870238378195295981a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69085 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88891 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43607 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23141 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66807 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109188 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126294 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115596 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/43977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97566 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43852 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49464 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144294 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43319 "Built successfully") | | [💥 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37142 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->