### PR TITLE
AX: Fix safer-cpp violations for WebAccessibilityObjectWrapperMac

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -1,6 +1,5 @@
 PAL/pal/graphics/cocoa/WebAVContentKeyGrouping.h
 accessibility/cocoa/AXCoreObjectCocoa.mm
-accessibility/mac/WebAccessibilityObjectWrapperBase.mm
 bridge/objc/WebScriptObject.h
 page/EventHandler.h
 platform/MediaSample.h

--- a/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations
@@ -1,5 +1,4 @@
 PAL/pal/mac/DataDetectorsSoftLink.h
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/cocoa/FileMonitorCocoa.mm
 platform/cocoa/NetworkExtensionContentFilter.mm

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -59,7 +59,6 @@ accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/isolatedtree/AXIsolatedTree.cpp
 accessibility/mac/AXObjectCacheMac.mm
 accessibility/mac/AccessibilityObjectMac.mm
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/AnimationTimelinesController.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -28,7 +28,6 @@ accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedTree.cpp
 accessibility/mac/AccessibilityObjectMac.mm
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
 animation/BlendingKeyframes.cpp
 animation/DocumentTimeline.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -139,8 +139,6 @@ accessibility/AccessibilityTableHeaderContainer.cpp
 accessibility/isolatedtree/AXIsolatedTree.cpp
 accessibility/mac/AXObjectCacheMac.mm
 accessibility/mac/AccessibilityObjectMac.mm
-accessibility/mac/WebAccessibilityObjectWrapperBase.mm
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/AcceleratedEffectStackUpdater.cpp
 animation/AnimationEffectTiming.cpp
 animation/AnimationTimeline.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -28,7 +28,6 @@ accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedObject.h
 accessibility/isolatedtree/AXIsolatedTree.cpp
 accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/KeyframeEffect.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
 contentextensions/ContentExtensionsBackend.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -51,7 +51,6 @@ Modules/webdatabase/DatabaseManager.cpp
 Modules/webdatabase/SQLCallbackWrapper.h
 StyleBuilderGenerated.cpp
 accessibility/AXObjectCache.cpp
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/KeyframeEffect.cpp
 bindings/js/CommonVM.cpp
 bindings/js/DOMWrapperWorld.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations
@@ -1,4 +1,3 @@
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 platform/cocoa/SharedVideoFrameInfo.mm
 platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
 platform/graphics/cv/VideoFrameCV.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -4,7 +4,6 @@ accessibility/cocoa/AccessibilityObjectCocoa.mm
 accessibility/mac/AXObjectCacheMac.mm
 accessibility/mac/AccessibilityObjectMac.mm
 accessibility/mac/WebAccessibilityObjectWrapperBase.mm
-accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 bindings/js/ScriptControllerMac.mm
 bindings/js/SerializedScriptValue.cpp
 bridge/objc/WebScriptObject.mm

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -897,6 +897,9 @@ public:
     virtual bool isWidget() const = 0;
     virtual Widget* widget() const = 0;
     virtual PlatformWidget platformWidget() const = 0;
+#if PLATFORM(COCOA)
+    virtual RetainPtr<PlatformWidget> protectedPlatformWidget() const;
+#endif
     virtual Widget* widgetForAttachmentView() const = 0;
     virtual bool isPlugin() const = 0;
 
@@ -1152,6 +1155,9 @@ public:
     virtual void mathPostscripts(AccessibilityMathMultiscriptPairs&) = 0;
 
     AccessibilityObjectWrapper* wrapper() const { return m_wrapper.get(); }
+#if PLATFORM(COCOA)
+    RetainPtr<AccessibilityObjectWrapper> protectedWrapper() const;
+#endif
     void setWrapper(AccessibilityObjectWrapper* wrapper) { m_wrapper = wrapper; }
     void detachWrapper(AccessibilityDetachmentType);
 

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -32,6 +32,7 @@
 #import "ColorCocoa.h"
 #import "RenderObjectInlines.h"
 #import "WebAccessibilityObjectWrapperBase.h"
+#import "Widget.h"
 
 #if PLATFORM(IOS_FAMILY)
 #import <wtf/SoftLinking.h>
@@ -75,6 +76,17 @@ String AXCoreObject::speechHint() const
         builder.append(" no-punctuation"_s);
 
     return builder.toString();
+}
+
+// FIXME: We should create an AXCoreObjectInline.h file and move protectedWrapper() and protectedPlatformWidget() into it.
+RetainPtr<AccessibilityObjectWrapper> AXCoreObject::protectedWrapper() const
+{
+    return m_wrapper.get();
+}
+
+RetainPtr<PlatformWidget> AXCoreObject::protectedPlatformWidget() const
+{
+    return platformWidget();
 }
 
 // When modifying attributed strings, the range can come from a source which may provide faulty information (e.g. the spell checker).

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2107,14 +2107,17 @@ static RenderObject* rendererForView(WAKView* view)
 
 - (id)_accessibilityParentForSubview:(id)subview
 {
-    RenderObject* renderer = rendererForView(subview);
+    CheckedPtr renderer = rendererForView(subview);
     if (!renderer)
         return nil;
 
-    AccessibilityObject* obj = renderer->document().axObjectCache()->getOrCreate(*renderer);
-    if (obj)
-        return obj->parentObjectUnignored()->wrapper();
-    return nil;
+    CheckedPtr cache = renderer->protectedDocument()->axObjectCache();
+    if (!cache)
+        return nil;
+
+    RefPtr object = cache->getOrCreate(*renderer);
+    RefPtr parent = object ? object->parentObjectUnignored() : nullptr;
+    return parent ? parent->wrapper() : nil;
 }
 
 // These will be used by the UIKit wrapper to calculate an appropriate description of scroll status.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -264,8 +264,8 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
         // We want to return the attachment view instead of the object representing the attachment,
         // otherwise, we get palindrome errors in the AX hierarchy.
         if (child->isAttachment()) {
-            if (id attachmentView = wrapper.attachmentView)
-                return attachmentView;
+            if (RetainPtr<id> attachmentView = wrapper.attachmentView)
+                return attachmentView.get();
         } else if (child->isRemoteFrame() && returnPlatformElements)
             return child->remoteFramePlatformElement().get();
 
@@ -369,8 +369,8 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 - (NSString *)description
 {
     if (RefPtr<AXCoreObject> backingObject = self.axBackingObject) {
-        NSString *backingDescription = backingObject->debugDescription().createNSString().autorelease();
-        return [NSString stringWithFormat:@"wrapper %p { object %@ }", self, backingDescription];
+        RetainPtr<NSString> backingDescription = backingObject->debugDescription().createNSString().autorelease();
+        return [NSString stringWithFormat:@"wrapper %p { object %@ }", self, backingDescription.get()];
     }
     return [NSString stringWithFormat:@"%@ (null backing object)", [super description]];
 }
@@ -411,7 +411,10 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (NSArray<NSString *> *)baseAccessibilitySpeechHint
 {
-    return [self.axBackingObject->speechHint().createNSString() componentsSeparatedByString:@" "];
+    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    if (!backingObject)
+        return nil;
+    return [backingObject->speechHint().createNSString() componentsSeparatedByString:@" "];
 }
 
 #if HAVE(ACCESSIBILITY_FRAMEWORK)
@@ -425,7 +428,8 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
     auto extendedDescription = backingObject->extendedDescription();
     if (extendedDescription.length()) {
         accessibilityCustomContent = adoptNS([[NSMutableArray alloc] init]);
-        AXCustomContent *contentItem = [PAL::getAXCustomContentClass() customContentWithLabel:WEB_UI_STRING("description", "description detail").createNSString().get() value:extendedDescription.createNSString().get()];
+        Class customContentClass = PAL::getAXCustomContentClass();
+        AXCustomContent *contentItem = [customContentClass customContentWithLabel:WEB_UI_STRING("description", "description detail").createNSString().get() value:extendedDescription.createNSString().get()];
         // Set this to high, so that it's always spoken.
         [contentItem setImportance:AXCustomContentImportanceHigh];
         [accessibilityCustomContent addObject:contentItem];
@@ -437,55 +441,56 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 
 - (NSString *)baseAccessibilityHelpText
 {
-    return self.axBackingObject->helpTextAttributeValue().createNSString().autorelease();
+    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    return backingObject ? backingObject->helpTextAttributeValue().createNSString().autorelease() : nil;
 }
 
 struct PathConversionInfo {
-    WebAccessibilityObjectWrapperBase *wrapper;
-    CGMutablePathRef path;
+    RetainPtr<WebAccessibilityObjectWrapperBase> wrapper;
+    RetainPtr<CGMutablePathRef> path;
 };
 
 static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, const PathElement& element)
 {
-    WebAccessibilityObjectWrapperBase *wrapper = conversion.wrapper;
-    CGMutablePathRef newPath = conversion.path;
+    RetainPtr<WebAccessibilityObjectWrapperBase> wrapper = conversion.wrapper;
+    RetainPtr newPath = conversion.path;
     FloatRect rect;
     switch (element.type) {
     case PathElement::Type::MoveToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathMoveToPoint(newPath, nil, newPoint.x, newPoint.y);
+        CGPoint newPoint = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPathMoveToPoint(newPath.get(), nil, newPoint.x, newPoint.y);
         break;
     }
     case PathElement::Type::AddLineToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathAddLineToPoint(newPath, nil, newPoint.x, newPoint.y);
+        CGPoint newPoint = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPathAddLineToPoint(newPath.get(), nil, newPoint.x, newPoint.y);
         break;
     }
     case PathElement::Type::AddQuadCurveToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint1 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPoint newPoint1 = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
 
         rect = FloatRect(element.points[1], FloatSize());
-        CGPoint newPoint2 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathAddQuadCurveToPoint(newPath, nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y);
+        CGPoint newPoint2 = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPathAddQuadCurveToPoint(newPath.get(), nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y);
         break;
     }
     case PathElement::Type::AddCurveToPoint: {
         rect = FloatRect(element.points[0], FloatSize());
-        CGPoint newPoint1 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPoint newPoint1 = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
 
         rect = FloatRect(element.points[1], FloatSize());
-        CGPoint newPoint2 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPoint newPoint2 = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
 
         rect = FloatRect(element.points[2], FloatSize());
-        CGPoint newPoint3 = [wrapper convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
-        CGPathAddCurveToPoint(newPath, nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y, newPoint3.x, newPoint3.y);
+        CGPoint newPoint3 = [wrapper.get() convertRectToSpace:rect space:AccessibilityConversionSpace::Screen].origin;
+        CGPathAddCurveToPoint(newPath.get(), nil, newPoint1.x, newPoint1.y, newPoint2.x, newPoint2.y, newPoint3.x, newPoint3.y);
         break;
     }
     case PathElement::Type::CloseSubpath: {
-        CGPathCloseSubpath(newPath);
+        CGPathCloseSubpath(newPath.get());
         break;
     }
     }
@@ -494,7 +499,7 @@ static void convertPathToScreenSpaceFunction(PathConversionInfo& conversion, con
 - (CGPathRef)convertPathToScreenSpace:(const Path&)path
 {
     auto convertedPath = adoptCF(CGPathCreateMutable());
-    PathConversionInfo conversion = { self, convertedPath.get() };
+    PathConversionInfo conversion = { retainPtr(self), convertedPath };
     path.applyElements([&conversion](const PathElement& pathElement) {
         convertPathToScreenSpaceFunction(conversion, pathElement);
     });
@@ -637,9 +642,9 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
             if ([item isKindOfClass:NSAttributedString.class])
                 [text appendAttributedString:item];
             else if ([item isKindOfClass:WebAccessibilityObjectWrapper.class]) {
+                RetainPtr wrapper = static_cast<WebAccessibilityObjectWrapper *>(item);
 #if PLATFORM(MAC)
-                auto *wrapper = static_cast<WebAccessibilityObjectWrapper *>(item);
-                RefPtr<AXCoreObject> object = wrapper.axBackingObject;
+                RefPtr<AXCoreObject> object = [wrapper axBackingObject];
                 if (!object)
                     continue;
 
@@ -659,8 +664,8 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
                     break;
                 }
 #else
-                RetainPtr<NSString> label = static_cast<WebAccessibilityObjectWrapper *>(item).accessibilityLabel;
-#endif
+                RetainPtr<NSString> label = [wrapper accessibilityLabel];
+#endif // PLATFORM(MAC)
                 if (!label)
                     continue;
 
@@ -698,7 +703,8 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
 
 - (NSString *)ariaLandmarkRoleDescription
 {
-    return self.axBackingObject->ariaLandmarkRoleDescription().createNSString().autorelease();
+    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    return backingObject ? backingObject->ariaLandmarkRoleDescription().createNSString().autorelease() : nil;
 }
 
 - (NSString *)accessibilityPlatformMathSubscriptKey
@@ -715,15 +721,23 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
 
 - (NSArray *)accessibilityMathPostscriptPairs
 {
+    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    if (!backingObject)
+        return nil;
+
     AccessibilityObject::AccessibilityMathMultiscriptPairs pairs;
-    self.axBackingObject->mathPostscripts(pairs);
+    backingObject->mathPostscripts(pairs);
     return convertMathPairsToNSArray(pairs, [self accessibilityPlatformMathSubscriptKey], [self accessibilityPlatformMathSuperscriptKey]);
 }
 
 - (NSArray *)accessibilityMathPrescriptPairs
 {
+    RefPtr<AXCoreObject> backingObject = self.axBackingObject;
+    if (!backingObject)
+        return nil;
+
     AccessibilityObject::AccessibilityMathMultiscriptPairs pairs;
-    self.axBackingObject->mathPrescripts(pairs);
+    backingObject->mathPrescripts(pairs);
     return convertMathPairsToNSArray(pairs, [self accessibilityPlatformMathSubscriptKey], [self accessibilityPlatformMathSuperscriptKey]);
 }
 


### PR DESCRIPTION
#### 8e1385e99bc38eef78ab055b746d9afccce1e78b
<pre>
AX: Fix safer-cpp violations for WebAccessibilityObjectWrapperMac
<a href="https://bugs.webkit.org/show_bug.cgi?id=297606">https://bugs.webkit.org/show_bug.cgi?id=297606</a>
<a href="https://rdar.apple.com/158699090">rdar://158699090</a>

Reviewed by Joshua Hoffman.

Apply the safer CPP rules to this file.

<a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines</a>

* Source/WebCore/SaferCPPExpectations/RetainPtrCtorAdoptCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/299522@main">https://commits.webkit.org/299522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a1a334a3af6e4ed6a57918a2f6e8d0d685802eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71309 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8cce401-69cc-44a2-ac84-0681b83a8dca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47508 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90595 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f2c8b9ea-17f2-47d6-8a24-abc351e6b252) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71009 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ebd2911a-9f9c-4164-8d1e-d83fef6f566c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25013 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69125 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128488 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46156 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34892 "Found 1 new test failure: http/tests/websocket/web-socket-loads-captured-in-per-page-domains.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99160 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25156 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44404 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42729 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45488 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47178 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->