### PR TITLE
REGRESSION (iOS 26): Smart Reply text is black when in dark mode

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -3530,6 +3530,67 @@ TEST(WritingTools, SmartRepliesMatchStyle)
     TestWebKitAPI::Util::run(&finished);
 }
 
+TEST(WritingTools, SmartRepliesTextColor)
+{
+    RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
+    [session setCompositionSessionType:WTCompositionSessionTypeSmartReply];
+
+    RetainPtr webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<html><head><style> :root { color-scheme: light dark; font: -apple-system-body; } </style></head><body><br><div id='AppleMailSignature' dir='ltr'>Sent from my iPhone</div></body></html>"]);
+    [webView forceDarkMode];
+    [webView _setEditable:YES];
+
+    NSString *setSelectionJavaScript = @""
+        "(() => {"
+        "  const range = document.createRange();"
+        "  range.setStart(document.body, 0);"
+        "  range.setEnd(document.body, 0);"
+        "  "
+        "  var selection = window.getSelection();"
+        "  selection.removeAllRanges();"
+        "  selection.addRange(range);"
+        "})();";
+    [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
+
+    __block bool done = false;
+    [[webView writingToolsDelegate] willBeginWritingToolsSession:session.get() requestContexts:^(NSArray<WTContext *> *contexts) {
+        [[webView writingToolsDelegate] writingToolsSession:session.get() didReceiveAction:WTActionCompositionRestart];
+        [webView waitForNextPresentationUpdate];
+
+#if PLATFORM(MAC)
+        RetainPtr font = [NSFont preferredFontForTextStyle:NSFontTextStyleBody options:@{ }];
+#else
+        RetainPtr font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+#endif
+
+        RetainPtr attributedText = adoptNS([[NSAttributedString alloc] initWithString:@"Text" attributes: @{
+            NSFontAttributeName: font.get()
+        }]);
+
+        [[webView writingToolsDelegate] compositionSession:session.get() didReceiveText:attributedText.get() replacementRange:NSMakeRange(0, 0) inContext:contexts.firstObject finished:YES];
+        [webView waitForNextPresentationUpdate];
+
+        done = true;
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+
+    // Wait for the animations to finish.
+    TestWebKitAPI::Util::runFor(3.0_s);
+
+    NSString *getTextColorJavaScript = @""
+        "(() => {"
+        "  element = document.evaluate(\"//*[text()='Text']\", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;"
+        "  return getComputedStyle(element).color;"
+        "})();";
+
+    EXPECT_WK_STREQ("rgb(255, 255, 255)", [webView stringByEvaluatingJavaScript:getTextColorJavaScript]);
+
+    [webView forceLightMode];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ("rgb(0, 0, 0)", [webView stringByEvaluatingJavaScript:getTextColorJavaScript]);
+}
+
 TEST(WritingTools, ContextRangeWithNoSelection)
 {
     RetainPtr session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -171,6 +171,7 @@ class Color;
 - (void)waitForNextPresentationUpdate;
 - (void)waitForNextVisibleContentRectUpdate;
 - (void)waitUntilActivityStateUpdateDone;
+- (void)forceLightMode;
 - (void)forceDarkMode;
 - (NSString *)stylePropertyAtSelectionStart:(NSString *)propertyName;
 - (NSString *)stylePropertyAtSelectionEnd:(NSString *)propertyName;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -1179,6 +1179,15 @@ static UIWindowScene *windowScene()
     TestWebKitAPI::Util::run(&done);
 }
 
+- (void)forceLightMode
+{
+#if USE(APPKIT)
+    [self setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameAqua]];
+#else
+    [self setOverrideUserInterfaceStyle:UIUserInterfaceStyleLight];
+#endif
+}
+
 - (void)forceDarkMode
 {
 #if USE(APPKIT)


### PR DESCRIPTION
#### 4a42bf61dfe36584d85b7a1ac6265ad32f2835bc
<pre>
REGRESSION (iOS 26): Smart Reply text is black when in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=297602">https://bugs.webkit.org/show_bug.cgi?id=297602</a>
<a href="https://rdar.apple.com/157514394">rdar://157514394</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

In iOS 26, Mail removed their use of `-apple-color-filter: apple-invert-lightness()`
in cases where the content explicitly supports dark mode. This change broke
smart replies, which are currently always inserted with a black text color
specified in inline style. When the color filter was present, the black text
would become white.

A black text color is specified in inline style because the attributed string
provided by Writing Tools does not have a text color, and markup sanitization
introduces inline style. The context attributed string given to Writing Tools
also does not contain text color information. However, even after adding color
information at context retrieval time, Writing Tools does not preserve the color.
The lack of color preservation is specific to Smart Reply and not other compositions.

Consequently, fix the issue by updating the attributed string *returned* from
Writing Tools use the body&apos;s text color. When the markup is inserted into the
document, the inline style will be removed due to deduplication.

* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::attributedStringApplyingBodyTextColorIfNecessary):

Don&apos;t apply a text color if one is specified.

(WebCore::WritingToolsController::replaceContentsOfRangeInSession):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, SmartRepliesTextColor)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView forceLightMode]):

Canonical link: <a href="https://commits.webkit.org/298968@main">https://commits.webkit.org/298968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cf9dd8fa9c02548fa8e8a87a1258198174fae32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69229 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e819c485-1ae5-4e3a-8306-85d2df5a67ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88975 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43650 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aabc1033-9879-4498-b023-ce62e6c6c9f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73716dda-663e-408b-8e0a-6c5f09fbd639) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23252 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67016 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126464 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44141 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33157 "Found 1 new test failure: ipc/send-gradient.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97645 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97439 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42791 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40491 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18725 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49673 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46815 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45166 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->