### PR TITLE
REGRESSION(298609@main): Broke TestWebKitAPI.WKWebView.RequestAllTextRunsWithSubframes on Debug

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -40,6 +40,7 @@
 #include "ExceptionOr.h"
 #include "FocusController.h"
 #include "FrameSelection.h"
+#include "GeometryUtilities.h"
 #include "HTMLAnchorElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLButtonElement.h"
@@ -869,17 +870,14 @@ static Vector<std::pair<String, FloatRect>> extractAllTextAndRectsRecursive(Docu
         if (!renderer)
             continue;
 
-        IntRect absoluteBounds;
+        FloatRect absoluteBounds;
         auto textRange = iterator.range();
         if (!textRange.collapsed()) {
-            auto textRects = RenderObject::absoluteTextRects(textRange, {
+            absoluteBounds = enclosingIntRect(unionRectIgnoringZeroRects(RenderObject::absoluteBorderAndTextRects(textRange, {
                 RenderObject::BoundingRectBehavior::IgnoreTinyRects,
                 RenderObject::BoundingRectBehavior::IgnoreEmptyTextSelections,
                 RenderObject::BoundingRectBehavior::UseSelectionHeight,
-            });
-
-            for (auto textRect : textRects)
-                absoluteBounds.unite(textRect);
+            })));
         }
 
         if (absoluteBounds.isEmpty())


### PR DESCRIPTION
#### c42679e83219179f24c70a0a11464dad91f08cd0
<pre>
REGRESSION(298609@main): Broke TestWebKitAPI.WKWebView.RequestAllTextRunsWithSubframes on Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=297605">https://bugs.webkit.org/show_bug.cgi?id=297605</a>
<a href="https://rdar.apple.com/158698208">rdar://158698208</a>

Reviewed by Abrar Rahman Protyasha.

`RenderObject::absoluteTextRects` currently ignores both `UseVisibleBounds` and `IgnoreTinyRects`,
which `extractAllTextAndRectsRecursive` attempts to use (resulting in a debug assertion). Avoid this
assertion by using `absoluteBorderAndTextRects` instead.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractAllTextAndRectsRecursive):

Also, use `unionRectIgnoringZeroRects` here instead of iterating through the vector and calling
`unite`.

Canonical link: <a href="https://commits.webkit.org/298930@main">https://commits.webkit.org/298930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/058accbbfe11c7bf59f712f331036118286e861e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/535e0139-0aeb-432c-a18c-6cb92358af83) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88916 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d205fa45-cf65-4784-87e5-b82ad838bb85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69415 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66870 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126355 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97607 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42742 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20661 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43913 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43380 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45100 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->