### PR TITLE
[WebGPU] webgpu:api,validation,texture,destroy:* CTS test fails

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/destroy-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/destroy-expected.txt
@@ -3,90 +3,30 @@ PASS :base:
 PASS :twice:
 PASS :invalid_texture:
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="valid"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: depth stencil texture device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: depth stencil texture device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="valid"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: depth stencil texture device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: depth stencil texture device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="valid"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: depth stencil texture device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"
-FAIL :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: depth stencil texture device mismatch
-    TestFailedButDeviceReusable@
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:442:44
- Reached unreachable code
+PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"
 PASS :submit_a_destroyed_texture_as_attachment:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1746,7 +1746,6 @@ http/tests/webgpu/webgpu/shader/execution/expression/call/builtin/fwidthFine.htm
 
 # skipped due to debug crashes - https://bugs.webkit.org/show_bug.cgi?id=274972
 http/tests/webgpu/webgpu/api/validation/render_pass/render_pass_descriptor.html [ Skip ]
-http/tests/webgpu/webgpu/api/validation/texture/destroy.html [ Skip ]
 http/tests/webgpu/webgpu/web_platform/canvas/getCurrentTexture.html [ Skip ]
 http/tests/webgpu/webgpu/api/validation/createBindGroupLayout.html [ Skip ]
 

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3496,24 +3496,31 @@ WGPUExtent3D Texture::physicalMiplevelSpecificTextureExtent(uint32_t mipLevel)
 
 WGPUExtent3D Texture::physicalTextureExtent(WGPUTextureDimension dimension, WGPUTextureFormat format, WGPUExtent3D logicalExtent)
 {
-    ASSERT(texelBlockWidth(format));
-    ASSERT(texelBlockHeight(format));
+    auto blockWidth = texelBlockWidth(format);
+    auto blockHeight = texelBlockHeight(format);
+    if (!blockWidth || !blockHeight) {
+        return WGPUExtent3D {
+            .width = 1,
+            .height = 1,
+            .depthOrArrayLayers = 1
+        };
+    }
 
     switch (dimension) {
     case WGPUTextureDimension_1D:
         return {
-            .width = roundUpToMultipleOfNonPowerOfTwo(texelBlockWidth(format), logicalExtent.width),
+            .width = roundUpToMultipleOfNonPowerOfTwo(blockWidth, logicalExtent.width),
             .height = 1,
             .depthOrArrayLayers = logicalExtent.depthOrArrayLayers };
     case WGPUTextureDimension_2D:
         return {
-            .width = roundUpToMultipleOfNonPowerOfTwo(texelBlockWidth(format), logicalExtent.width),
-            .height = roundUpToMultipleOfNonPowerOfTwo(texelBlockHeight(format), logicalExtent.height),
+            .width = roundUpToMultipleOfNonPowerOfTwo(blockWidth, logicalExtent.width),
+            .height = roundUpToMultipleOfNonPowerOfTwo(blockHeight, logicalExtent.height),
             .depthOrArrayLayers = logicalExtent.depthOrArrayLayers };
     case WGPUTextureDimension_3D:
         return {
-            .width = roundUpToMultipleOfNonPowerOfTwo(texelBlockWidth(format), logicalExtent.width),
-            .height = roundUpToMultipleOfNonPowerOfTwo(texelBlockHeight(format), logicalExtent.height),
+            .width = roundUpToMultipleOfNonPowerOfTwo(blockWidth, logicalExtent.width),
+            .height = roundUpToMultipleOfNonPowerOfTwo(blockHeight, logicalExtent.height),
             .depthOrArrayLayers = logicalExtent.depthOrArrayLayers };
     case WGPUTextureDimension_Force32:
         ASSERT_NOT_REACHED();

--- a/Source/WebGPU/WebGPU/TextureView.mm
+++ b/Source/WebGPU/WebGPU/TextureView.mm
@@ -165,7 +165,7 @@ bool TextureView::isDestroyed() const
 
 bool TextureView::isValid() const
 {
-    return m_texture;
+    return m_texture || isDestroyed();
 }
 
 void TextureView::destroy()


### PR DESCRIPTION
#### ec6888c75b91536eb32925c74ae99bc5a9fac6c9
<pre>
[WebGPU] webgpu:api,validation,texture,destroy:* CTS test fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=297615">https://bugs.webkit.org/show_bug.cgi?id=297615</a>
<a href="https://rdar.apple.com/158710135">rdar://158710135</a>

Reviewed by Dan Glastonbury.

286781@main regressed some CTS tests, specifically it considered
destroyed textures as invalid but the specification says they should
be treated as valid but cause GPUCommandBuffer submission failure instead.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/texture/destroy-expected.txt:
All expectations pass.

* LayoutTests/platform/mac-wk2/TestExpectations:
Remove skipped test.

* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::physicalTextureExtent):
* Source/WebGPU/WebGPU/TextureView.mm:
(WebGPU::TextureView::isValid const):

Canonical link: <a href="https://commits.webkit.org/298932@main">https://commits.webkit.org/298932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33bfd588d2d0501c3f83365c847b5e131716272a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69167 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70f39742-e065-43b1-9910-0bc4e2a63930) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88939 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/794122b5-8d60-45b2-8a70-a610d3d0f11f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69426 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23186 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126374 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97610 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42749 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20682 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43932 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45110 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->