### PR TITLE
[Autofill Debugging] Part 8: Surface debug descriptions back to the client when performing interactions

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -1,12 +1,12 @@
-PASS clickSucceeded is true
+PASS clickError is ""
 PASS clickCount.textContent is "1"
-PASS textInputSucceeded is true
+PASS textInputError is ""
 PASS textField.value is "bar"
-PASS selectMenuItemSucceeded is true
+PASS selectMenuItemError is ""
 PASS select.value is "Three"
-PASS selectTextSucceeded is true
+PASS selectTextError is ""
 PASS getSelection().toString() is "Subject"
-PASS invalidActionSucceeded is false
+PASS invalidActionError is "Failed to resolve nodeIdentifier 4294967293"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -36,39 +36,39 @@
 
         const debugText = await UIHelper.requestDebugText();
 
-        clickSucceeded = await UIHelper.performTextExtractionInteraction("click", {
+        clickError = await UIHelper.performTextExtractionInteraction("click", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Click Me")
         });
 
-        textInputSucceeded = await UIHelper.performTextExtractionInteraction("textinput", {
+        textInputError = await UIHelper.performTextExtractionInteraction("textinput", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Enter some text"),
             replaceAll: true,
             text: "bar"
         });
 
-        selectMenuItemSucceeded = await UIHelper.performTextExtractionInteraction("selectmenuitem", {
+        selectMenuItemError = await UIHelper.performTextExtractionInteraction("selectmenuitem", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "menu"),
             text: "Three"
         });
 
-        selectTextSucceeded = await UIHelper.performTextExtractionInteraction("selecttext", {
+        selectTextError = await UIHelper.performTextExtractionInteraction("selecttext", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "contentEditable"),
             text: "Subject"
         });
 
-        invalidActionSucceeded = await UIHelper.performTextExtractionInteraction("click", {
-            nodeIdentifier: "invalid_id"
+        invalidActionError = await UIHelper.performTextExtractionInteraction("click", {
+            nodeIdentifier: "4294967293",
         });
 
-        shouldBeTrue("clickSucceeded");
+        shouldBeEqualToString("clickError", "");
         shouldBeEqualToString("clickCount.textContent", "1");
-        shouldBeTrue("textInputSucceeded");
+        shouldBeEqualToString("textInputError", "");
         shouldBeEqualToString("textField.value", "bar");
-        shouldBeTrue("selectMenuItemSucceeded");
+        shouldBeEqualToString("selectMenuItemError", "");
         shouldBeEqualToString("select.value", "Three");
-        shouldBeTrue("selectTextSucceeded");
+        shouldBeEqualToString("selectTextError", "");
         shouldBeEqualToString("getSelection().toString()", "Subject");
-        shouldBeFalse("invalidActionSucceeded");
+        shouldBeEqualToString("invalidActionError", "Failed to resolve nodeIdentifier 4294967293");
 
         finishJSTest();
     });

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2483,12 +2483,10 @@ window.UIHelper = class UIHelper {
             return Promise.resolve(false);
 
         return new Promise(resolve => {
-            testRunner.runUIScript(`
-                uiController.performTextExtractionInteraction("${action}"
-                    , ${JSON.stringify(options)}
-                    , result => uiController.uiScriptComplete(result));`, (result) => {
-                        resolve(result === "true")
-                    });
+            const scriptToRun = `uiController.performTextExtractionInteraction("${action}", ${JSON.stringify(options)}, result => {
+                uiController.uiScriptComplete(result)
+            })`;
+            testRunner.runUIScript(scriptToRun, resolve);
         });
     }
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -41,7 +41,7 @@ namespace TextExtraction {
 WEBCORE_EXPORT Item extractItem(Request&&, Page&);
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 
-WEBCORE_EXPORT void handleInteraction(Interaction&&, Page&, CompletionHandler<void(bool)>&&);
+WEBCORE_EXPORT void handleInteraction(Interaction&&, Page&, CompletionHandler<void(bool, String&&)>&&);
 
 struct RenderedText {
     String textWithReplacedContent;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -143,6 +143,7 @@ typedef NS_ENUM(NSInteger, _WKImmediateActionType) {
 @class _WKTextInputContext;
 @class _WKTextExtractionConfiguration;
 @class _WKTextExtractionInteraction;
+@class _WKTextExtractionInteractionResult;
 @class WKTextExtractionResult;
 @class _WKTextManipulationConfiguration;
 @class _WKTextManipulationItem;
@@ -639,7 +640,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 #endif
 
 - (void)_debugTextWithConfiguration:(_WKTextExtractionConfiguration *)configuration completionHandler:(WK_SWIFT_UI_ACTOR void(^)(NSString *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_debugText(with:completionHandler:));
-- (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(BOOL success))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
+- (void)_performInteraction:(_WKTextExtractionInteraction *)interaction completionHandler:(WK_SWIFT_UI_ACTOR void(^)(_WKTextExtractionInteractionResult *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) NS_SWIFT_NAME(_performInteraction(_:completionHandler:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -67,4 +67,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
 @end
 
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+WK_SWIFT_UI_ACTOR
+NS_REQUIRES_PROPERTY_DEFINITIONS
+@interface _WKTextExtractionInteractionResult : NSObject
+
+@property (nonatomic, readonly, nullable) NSError *error;
+
+@end
+
 NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -26,6 +26,8 @@
 #import "config.h"
 #import "_WKTextExtractionInternal.h"
 
+#import <WebKit/WKError.h>
+
 @implementation _WKTextExtractionConfiguration
 
 - (instancetype)init
@@ -84,6 +86,28 @@
 {
     _hasSetLocation = YES;
     _location = location;
+}
+
+@end
+
+@implementation _WKTextExtractionInteractionResult {
+    RetainPtr<NSError> _error;
+}
+
+- (instancetype)initWithErrorDescription:(NSString *)errorDescription
+{
+    if (!(self = [super init]))
+        return nil;
+
+    if (errorDescription)
+        _error = [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSDebugDescriptionErrorKey: errorDescription }];
+
+    return self;
+}
+
+- (NSError *)error
+{
+    return _error.get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -58,6 +58,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface _WKTextExtractionInteractionResult ()
+
+- (instancetype)initWithErrorDescription:(NSString *)errorDescription;
+
+@end
+
 typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
     WKTextExtractionContainerRoot,
     WKTextExtractionContainerViewportConstrained,

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16527,10 +16527,12 @@ void WebPageProxy::requestTextExtraction(WebCore::TextExtraction::Request&& requ
     sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(WTFMove(request)), WTFMove(completion));
 }
 
-void WebPageProxy::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool)>&& completion)
+void WebPageProxy::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&)>&& completion)
 {
-    if (!hasRunningProcess())
-        return completion(false);
+    if (!hasRunningProcess()) {
+        ASSERT_NOT_REACHED();
+        return completion(false, "Internal inconsistency / unexpected state. Please file a bug"_s);
+    }
 
     sendWithAsyncReply(Messages::WebPage::HandleTextExtractionInteraction(WTFMove(interaction)), WTFMove(completion));
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2618,7 +2618,7 @@ public:
     void takeSnapshotForTargetedElement(const API::TargetedElementInfo&, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
     void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
-    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool)>&&);
+    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
 
     void hasVideoInPictureInPictureDidChange(bool);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10066,7 +10066,7 @@ void WebPage::requestTextExtraction(TextExtraction::Request&& request, Completio
     completion(TextExtraction::extractItem(WTFMove(request), Ref { *corePage() }));
 }
 
-void WebPage::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool)>&& completion)
+void WebPage::handleTextExtractionInteraction(TextExtraction::Interaction&& interaction, CompletionHandler<void(bool, String&&)>&& completion)
 {
     TextExtraction::handleInteraction(WTFMove(interaction), Ref { *corePage() }, WTFMove(completion));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2585,7 +2585,7 @@ private:
     void requestAllTargetableElements(float, CompletionHandler<void(Vector<Vector<WebCore::TargetedElementInfo>>&&)>&&);
 
     void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
-    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool)>&&);
+    void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     static void setHasLaunchedWebContentProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -810,7 +810,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     RequestAllTargetableElements(float hitTestInterval) -> (Vector<Vector<WebCore::TargetedElementInfo>> elements)
 
     RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
-    HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool success)
+    HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool succeeded, String description)
 
 #if PLATFORM(IOS_FAMILY)
     ShouldDismissKeyboardAfterTapAtPoint(WebCore::FloatPoint point) -> (bool shouldDismiss)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -92,14 +92,14 @@ TEST(TextExtractionTests, SelectPopupMenu)
 
     __block bool doneSelectingOption = false;
     __block RetainPtr<NSString> debugTextAfterClickingSelect;
-    [webView _performInteraction:click.get() completionHandler:^(BOOL clickSuccess) {
-        EXPECT_TRUE(clickSuccess);
+    [webView _performInteraction:click.get() completionHandler:^(_WKTextExtractionInteractionResult *clickResult) {
+        EXPECT_FALSE(clickResult.error);
         EXPECT_TRUE([[webView synchronouslyGetDebugText:nil] containsString:@"nativePopupMenu"]);
 
         RetainPtr selectOption = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionSelectMenuItem]);
         [selectOption setText:@"Three"];
-        [webView _performInteraction:selectOption.get() completionHandler:^(BOOL selectOptionSuccess) {
-            EXPECT_TRUE(selectOptionSuccess);
+        [webView _performInteraction:selectOption.get() completionHandler:^(_WKTextExtractionInteractionResult *selectOptionResult) {
+            EXPECT_FALSE(selectOptionResult.error);
             doneSelectingOption = true;
         }];
     }];

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -411,11 +411,13 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         [interaction setLocation:CGPointMake(x, y)];
     }
 
-    [webView() _performInteraction:interaction.get() completionHandler:^(BOOL success) {
+    [webView() _performInteraction:interaction.get() completionHandler:^(_WKTextExtractionInteractionResult *result) {
         if (!m_context)
             return;
 
-        m_context->asyncTaskComplete(callbackID, { JSValueMakeBoolean(m_context->jsContext(), success) });
+        RetainPtr description = [result.error.userInfo objectForKey:NSDebugDescriptionErrorKey] ?: @"";
+        JSRetainPtr jsDescription = adopt(JSStringCreateWithCFString((__bridge CFStringRef)description.get()));
+        m_context->asyncTaskComplete(callbackID, { JSValueMakeString(m_context->jsContext(), jsDescription.get()) });
     }];
 }
 


### PR DESCRIPTION
#### 8217dfbe7292cd1f230266716fe34decbdbfd0ab
<pre>
[Autofill Debugging] Part 8: Surface debug descriptions back to the client when performing interactions
<a href="https://bugs.webkit.org/show_bug.cgi?id=297607">https://bugs.webkit.org/show_bug.cgi?id=297607</a>
<a href="https://rdar.apple.com/158700025">rdar://158700025</a>

Reviewed by Abrar Rahman Protyasha and Timothy Hatcher.

Plumb a string description back to the client, in `-_performInteraction:completionHandler:`&apos;s
callback, in the form of a new object (`_WKTextExtractionInteractionResult`) that represents the
result of performing a single `_WKTextExtractionInteraction`. For now, this only contains an
`NSError` with a debug description, but in the future, we&apos;ll expand it to contain more information
(including additional context even in the case where the interaction succeeds, as well as element
selectors and other metadata).

* LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:

Rebaseline an existing test to check the resulting error message.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async performTextExtractionInteraction):

Make this `UIHelper` method return the reason for failure (or empty string, of the interaction was
successful).

(window.UIHelper):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::invalidNodeIdentifierDescription):
(WebCore::TextExtraction::searchTextNotFoundDescription):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::selectText):
(WebCore::TextExtraction::simulateKeyPress):
(WebCore::TextExtraction::focusAndInsertText):
(WebCore::TextExtraction::handleInteraction):

Populate error messages in various codepaths when handling interactions.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _performInteraction:completionHandler:]):

Plumb a new `String` representing a succint debug description of the interaction result, alongside
the `bool` indicating success.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionInteractionResult initWithErrorDescription:]):
(-[_WKTextExtractionInteractionResult error]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleTextExtractionInteraction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::handleTextExtractionInteraction):

This should never be hit in the case where there&apos;s no running web proccess, so we can instead just
`ASSERT_NOT_REACHED()` here.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, SelectPopupMenu)):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/298936@main">https://commits.webkit.org/298936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d299ed92f74b4de07d771fef10d01bf8a9b031d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69189 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92acb175-d450-40bf-b87f-3331180cecac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2707c4dd-8ce8-4641-9db1-57ad01fa6f39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69448 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23209 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66981 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99307 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23382 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97621 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24808 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20689 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49644 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->