### PR TITLE
digits.t-mobile.com - Safari is not a recommended browser

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5301,9 +5301,10 @@ NavigationAPIEnabled:
 
 NavigatorUserAgentDataJavaScriptAPIEnabled:
   type: bool
-  status: unstable
+  status: internal
   category: dom
-  humanReadableName: "Enable the navigator.userAgentData JavaScript API"
+  humanReadableName: "Navigator userAgentData JavaScript API"
+  humanReadableDescription: "Enable the navigator.userAgentData JavaScript API"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -458,7 +458,7 @@ NavigatorUAData& Navigator::userAgentData() const
     RefPtr frame = this->frame();
     if (frame && frame->page()) {
         RefPtr client = frame->loader().client();
-        if (client->hasCustomUserAgent()) {
+        if (client->hasCustomUserAgent() || (frame->document() && frame->document()->quirks().needsCustomUserAgentData())) {
             auto userAgentString = frame->loader().userAgent({ });
             Ref parser = UserAgentStringParser::create(userAgentString);
             std::optional userAgentStringData = parser->parse();

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -40,4 +40,4 @@ Navigator includes NavigatorServiceWorker;
 Navigator includes NavigatorShare;
 Navigator includes NavigatorStorage;
 Navigator includes NavigatorGPU;
-Navigator includes NavigatorUA;
+[EnabledByQuirk=needsNavigatorUserAgentData] Navigator includes NavigatorUA;

--- a/Source/WebCore/page/NavigatorUAData.h
+++ b/Source/WebCore/page/NavigatorUAData.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
+#include "NavigatorUABrandVersion.h"
 #include <WebCore/IDLTypes.h>
 #include <WebCore/JSDOMPromiseDeferred.h>
-#include "NavigatorUABrandVersion.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1896,6 +1896,16 @@ bool Quirks::needsLimitedMatroskaSupport() const
 #endif
 }
 
+bool Quirks::needsCustomUserAgentData() const
+{
+    return needsQuirks() && m_quirksData.needsCustomUserAgentData;
+}
+
+bool Quirks::needsNavigatorUserAgentDataQuirk() const
+{
+    return needsQuirks() && m_quirksData.needsNavigatorUserAgentDataQuirk;
+}
+
 bool Quirks::needsNowPlayingFullscreenSwapQuirk() const
 {
     return needsQuirks() && m_quirksData.needsNowPlayingFullscreenSwapQuirk;
@@ -2180,6 +2190,18 @@ static void handleICloudQuirks(QuirksData& quirksData, const URL& quirksURL, con
 #endif
 }
 #endif
+
+static void handleTMobileQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
+{
+    UNUSED_PARAM(quirksDomainString);
+    UNUSED_PARAM(documentURL);
+    auto topDocumentHost = quirksURL.host();
+    if (topDocumentHost != "digits.t-mobile.com")
+        return;
+
+    quirksData.needsNavigatorUserAgentDataQuirk = true;
+    quirksData.needsCustomUserAgentData = true;
+}
 
 #if PLATFORM(MAC)
 static void handleCEACStateGovQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)
@@ -2509,7 +2531,7 @@ static void handleGoogleQuirks(QuirksData& quirksData, const URL& quirksURL, con
         quirksData.needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk = startsWithLettersIgnoringASCIICase(quirksURL.path(), "/spreadsheets/"_s);
     } else if (topDocumentHost == "mail.google.com"_s) {
         // mail.google.com rdar://49403416
-        quirksData.needsGMailOverflowScrollQuirk =true;
+        quirksData.needsGMailOverflowScrollQuirk = true;
     } else if (topDocumentHost == "translate.google.com"_s) {
         // translate.google.com rdar://106539018
         quirksData.needsGoogleTranslateScrollingQuirk = true;
@@ -2995,6 +3017,7 @@ void Quirks::determineRelevantQuirks()
         { "digitaltrends"_s, &handleDigitalTrendsQuirks },
         { "steampowered"_s, &handleSteamQuirks },
 #endif
+        { "t-mobile"_s, &handleTMobileQuirks },
         { "descript"_s, &handleDescriptQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "disneyplus"_s, &handleDisneyPlusQuirks },
@@ -3041,7 +3064,7 @@ void Quirks::determineRelevantQuirks()
         { "ralphlauren"_s, &handleRalphLaurenQuirks },
 #endif
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-        { "reddit"_s, & handleRedditQuirks },
+        { "reddit"_s, &handleRedditQuirks },
 #endif
         { "sfusd"_s, &handleSFUSDQuirks },
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -260,6 +260,9 @@ public:
 
     bool needsLimitedMatroskaSupport() const;
 
+    bool needsCustomUserAgentData() const;
+    bool needsNavigatorUserAgentDataQuirk() const;
+
     WEBCORE_EXPORT bool needsNowPlayingFullscreenSwapQuirk() const;
 
     bool needsWebKitMediaTextTrackDisplayQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -187,6 +187,8 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk : 1 { false };
 #endif
 
+    bool needsNavigatorUserAgentDataQuirk : 1 { false };
+    bool needsCustomUserAgentData : 1 { false };
     bool needsNowPlayingFullscreenSwapQuirk : 1 { false };
     bool needsWebKitMediaTextTrackDisplayQuirk : 1 { false };
     bool needsMediaRewriteRangeRequestQuirk : 1 { false };

--- a/Source/WebCore/page/UserAgentStringParser.cpp
+++ b/Source/WebCore/page/UserAgentStringParser.cpp
@@ -219,12 +219,12 @@ inline String UserAgentStringParser::getSubstring()
 }
 
 struct BrowsersSeen {
-    bool brave : 1;
-    bool firefox : 1;
-    bool chrome : 1;
-    bool safari : 1;
-    bool opera : 1;
-    bool edge : 1;
+    bool brave : 1 { false };
+    bool firefox : 1 { false };
+    bool chrome : 1 { false };
+    bool safari : 1 { false };
+    bool opera : 1 { false };
+    bool edge : 1 { false };
     String braveVersion;
     String firefoxVersion;
     String chromeVersion;
@@ -326,7 +326,7 @@ void UserAgentStringParser::populateUserAgentData()
     // chrome based browsers typically list chrome
     if (browsersSeen.chrome) {
         if (browsersSeen.edge) {
-            data->browserName = "Edge"_s;
+            data->browserName = "Microsoft Edge"_s;
             data->browserVersion = browsersSeen.edgeVersion;
         } else if (browsersSeen.brave) {
             data->browserName = "Brave"_s;
@@ -335,7 +335,7 @@ void UserAgentStringParser::populateUserAgentData()
             data->browserName = "Opera"_s;
             data->browserVersion = browsersSeen.operaVersion;
         } else {
-            data->browserName = "Chrome"_s;
+            data->browserName = "Google Chrome"_s;
             data->browserVersion = browsersSeen.chromeVersion;
         }
     }


### PR DESCRIPTION
#### a579d4b73ccf9843bc5efb8ac1974dd05c465f28
<pre>
digits.t-mobile.com - Safari is not a recommended browser
<a href="https://bugs.webkit.org/show_bug.cgi?id=276940">https://bugs.webkit.org/show_bug.cgi?id=276940</a>
<a href="https://rdar.apple.com/132309517">rdar://132309517</a>

Reviewed by Brent Fulgham.

This enables the Navigator UserAgentData API only when the needsNavigatorUserAgentDataQuirk is enabled.
This quirk is enabled on digits.t-mobile.com is loaded.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::userAgentData const):
* Source/WebCore/page/Navigator.idl:
* Source/WebCore/page/NavigatorUAData.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::isStorageAccessQuirkDomainAndElement):
(WebCore::Quirks::needsNavigatorUserAgentDataQuirk const):
(WebCore::handleTMobileQuirks):
(WebCore::handleGoogleQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/page/UserAgentStringParser.cpp:
(WebCore::UserAgentStringParser::populateUserAgentData):

Canonical link: <a href="https://commits.webkit.org/298941@main">https://commits.webkit.org/298941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e91ac4d8e4b458a051d3c3cb1f9449222272559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88967 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67000 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109333 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126448 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115735 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97638 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20707 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49657 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144435 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43454 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/37176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->