### PR TITLE
LocalDOMWindow::length should include RemoteFrames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/domwindow-length-with-remote-frames-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/domwindow-length-with-remote-frames-expected.txt
@@ -1,0 +1,9 @@
+CONSOLE MESSAGE: Frame loaded with query: ?frame=same1
+CONSOLE MESSAGE: Parent length visible to this frame: 1
+CONSOLE MESSAGE: Frame loaded with query: ?frame=cross1
+CONSOLE MESSAGE: Parent length visible to this frame: 2
+CONSOLE MESSAGE: Frame loaded with query: ?frame=same2
+CONSOLE MESSAGE: Parent length visible to this frame: 3
+CONSOLE MESSAGE: Frame loaded with query: ?frame=cross2
+CONSOLE MESSAGE: Parent length visible to this frame: 4
+

--- a/LayoutTests/http/tests/site-isolation/domwindow-length-with-remote-frames.html
+++ b/LayoutTests/http/tests/site-isolation/domwindow-length-with-remote-frames.html
@@ -1,0 +1,34 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    function loadNextFrame() {
+        const frames = [
+            'http://127.0.0.1:8000/site-isolation/resources/domwindow-length-tester.html?frame=same1',
+            'http://localhost:8000/site-isolation/resources/domwindow-length-tester.html?frame=cross1',
+            'http://127.0.0.1:8000/site-isolation/resources/domwindow-length-tester.html?frame=same2',
+            'http://localhost:8000/site-isolation/resources/domwindow-length-tester.html?frame=cross2'
+        ];
+
+        let currentFrame = 0;
+        (function createFrame() {
+            if (currentFrame >= frames.length) {
+                if (window.testRunner) { testRunner.notifyDone(); }
+                return;
+            }
+
+            const iframe = document.createElement('iframe');
+            iframe.src = frames[currentFrame];
+            iframe.onload = () => {
+                currentFrame++;
+                setTimeout(createFrame, 100);
+            };
+            document.body.appendChild(iframe);
+        })();
+    }
+
+    window.onload = loadNextFrame;
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/domwindow-length-tester.html
+++ b/LayoutTests/http/tests/site-isolation/resources/domwindow-length-tester.html
@@ -1,0 +1,4 @@
+<script>
+console.log("Frame loaded with query: " + window.location.search);
+console.log("Parent length visible to this frame: " + window.parent.length);
+</script>

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -243,7 +243,6 @@ bool JSDOMWindow::getOwnPropertySlotByIndex(JSObject* object, JSGlobalObject* le
     ASSERT(lexicalGlobalObject->vm().currentThreadIsHoldingAPILock());
     // These are also allowed cross-origin, so come before the access check.
     if (frame) {
-        // FIXME: <rdar://118263337> DOMWindow::length needs to include RemoteFrames.
         // FIXME: scopedChild/scopedChildCount and RemoteFrame need to work together well. We're using using child/childCount until then.
         if (is<LocalFrame>(frame)) {
             if (index < frame->tree().scopedChildCount()) {


### PR DESCRIPTION
#### e660ac8d92f54508fc028570b38d021dc7742eea
<pre>
LocalDOMWindow::length should include RemoteFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=297622">https://bugs.webkit.org/show_bug.cgi?id=297622</a>
<a href="https://rdar.apple.com/118263337">rdar://118263337</a>

Reviewed by Alex Christensen.

LocalDOMWindow::length previously did not include RemoteFrames in the count. As site isolation has further developed, this functionality was added in. This change adds a test which exercises and verifies that code path works as expected.

* LayoutTests/http/tests/site-isolation/domwindow-length-with-remote-frames-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/domwindow-length-with-remote-frames.html: Added.
* LayoutTests/http/tests/site-isolation/resources/domwindow-length-tester.html: Added.
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::getOwnPropertySlotByIndex):

Canonical link: <a href="https://commits.webkit.org/299023@main">https://commits.webkit.org/299023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d503c8fab9e5e8de97aefc0a04a3b4fc9066b3a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88953 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43632 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23217 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126424 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97620 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42756 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20697 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40452 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49642 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->