### PR TITLE
REGRESSION(298250@main): feConvolveMatrix with large 'order' causes integer overflow

### DIFF
--- a/LayoutTests/svg/filters/feConvolveMatrix-order-overflow-expected.txt
+++ b/LayoutTests/svg/filters/feConvolveMatrix-order-overflow-expected.txt
@@ -1,0 +1,1 @@
+Passes if it does not crash.

--- a/LayoutTests/svg/filters/feConvolveMatrix-order-overflow.svg
+++ b/LayoutTests/svg/filters/feConvolveMatrix-order-overflow.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+    <filter id="f">
+        <feConvolveMatrix in="SourceGraphic" order="4, 1073741828" 
+            kernelMatrix="1 1 1 1
+                          1 1 1 1
+                          1 1 1 1
+                          1 1 1 1" />
+    </filter>
+    <rect x="10" y="30" width="100" height="100" fill="green" filter="url(#f)" />
+    <text x="10" y="10">Passes if it does not crash.</text>
+</svg>

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -277,7 +277,7 @@ RefPtr<FilterEffect> SVGFEConvolveMatrixElement::createFilterEffect(const Filter
     auto& kernelMatrix = this->kernelMatrix();
 
     // The spec says this is a requirement, and should bail out if fails
-    if (order.area() != kernelMatrix.length())
+    if (order.unclampedArea() != kernelMatrix.length())
         return nullptr;
 
     // Spec says the specified divisor cannot be 0.


### PR DESCRIPTION
#### 7f3400f5de0cd1502e3dbc23e251e3102116b0ba
<pre>
REGRESSION(298250@main): feConvolveMatrix with large &apos;order&apos; causes integer overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=297624">https://bugs.webkit.org/show_bug.cgi?id=297624</a>
<a href="https://rdar.apple.com/158670536">rdar://158670536</a>

Reviewed by Cameron McCormack.

The overflow could also have happened before 298250@main. Calling order.area() was
used instead of multiplying (orderXValue * orderYValue). This could have caught
this overflow.

The fix is use IntSize::unclampedArea() since this will never overflow.

* LayoutTests/svg/filters/feConvolveMatrix-order-overflow-expected.txt: Added.
* LayoutTests/svg/filters/feConvolveMatrix-order-overflow.svg: Added.
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::createFilterEffect const):

Canonical link: <a href="https://commits.webkit.org/298946@main">https://commits.webkit.org/298946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d86080d68e40e288db711cfb30058c06921197f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e440d23-6837-4e99-a1da-cad155bad1ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88960 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c425dccb-178f-4f36-bc67-1a1d40f11776) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105103 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69453 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/28984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/66993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126441 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97628 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24816 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40468 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/43991 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49613 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43447 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46792 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45143 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->