### PR TITLE
Reduce use of cacheTestRunnerCallback

### DIFF
--- a/LayoutTests/http/tests/swipe/swipe-back-with-outstanding-load-cancellation.html
+++ b/LayoutTests/http/tests/swipe/swipe-back-with-outstanding-load-cancellation.html
@@ -53,6 +53,13 @@ window.onload = function () {
 
     document.body.innerHTML = isFirstPage() ? "first" : "<iframe src='/resources/slow-image.py'>";
 
+    if (window.testRunner) {
+        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
+    }
+
     if (isFirstPage()) {
         if (hasInitializedSwipeTest()) {
             shouldBe(false, hasRemovedSnapshot, "The snapshot should not have been synchronously removed because of the cancelled forward load.");
@@ -60,11 +67,6 @@ window.onload = function () {
         }
 
         initializeSwipeTest();
-
-        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
 
         testRunner.dumpAsText();
         testRunner.waitUntilDone();

--- a/LayoutTests/swipe/basic-cached-back-swipe.html
+++ b/LayoutTests/swipe/basic-cached-back-swipe.html
@@ -51,16 +51,18 @@ window.onload = async function () {
 
     document.body.innerHTML = isFirstPage() ? "first" : "second";
 
+    if (window.testRunner) {
+        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
+    }
+
     if (isFirstPage()) {
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
         await initializeSwipeTest();
-
-        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
 
         setTimeout(function () { 
             window.location.href = window.location.href + "?second";

--- a/LayoutTests/swipe/main-frame-pinning-requirement.html
+++ b/LayoutTests/swipe/main-frame-pinning-requirement.html
@@ -68,6 +68,13 @@ window.onload = async function () {
 
     document.getElementById("large").innerHTML = isFirstPage() ? "first" : "second";
 
+    if (window.testRunner) {
+        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
+    }
+
     if (isFirstPage()) {
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
@@ -75,11 +82,6 @@ window.onload = async function () {
         await initializeSwipeTest();
 
         window.localStorage["hasFinishedFirstSwipe"] = "NO";
-
-        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
 
         setTimeout(function () {
             window.location.href = window.location.href + "?second";

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener.html
@@ -44,6 +44,12 @@
         logElement = document.getElementById('console');
         logElement.innerHTML = isFirstPage() ? "first" : "second";
 
+        if (window.testRunner) {
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+        }
+        
         if (isFirstPage()) {
             setTimeout(function () { 
                 window.location.href = window.location.href + "?second";
@@ -56,10 +62,6 @@
             testRunner.waitUntilDone();
 
             await initializeSwipeTest();
-        
-            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
 
             return;
         }

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html
@@ -44,6 +44,12 @@
         logElement = document.getElementById('console');
         logElement.innerHTML = isFirstPage() ? "first" : "second";
 
+        if (window.testRunner) {
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+        }
+
         if (isFirstPage()) {
             setTimeout(function () { 
                 window.location.href = window.location.href + "?second";
@@ -56,10 +62,6 @@
             testRunner.waitUntilDone();
 
             await initializeSwipeTest();
-        
-            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
 
             return;
         }

--- a/LayoutTests/swipe/swipe-disables-view-transition-expected.txt
+++ b/LayoutTests/swipe/swipe-disables-view-transition-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Skipping view transition because skipTransition() was called.
 startSwipeGesture
 didBeginSwipe
 completeSwipeGesture

--- a/LayoutTests/swipe/swipe-disables-view-transition.html
+++ b/LayoutTests/swipe/swipe-disables-view-transition.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!-- webkit-test-runner [ UsesBackForwardCache=true dumpJSConsoleLogInStdErr=true ] -->
 <head>
 <style>
 html {
@@ -53,16 +53,18 @@ window.onload = async function () {
 
     document.body.innerHTML = isFirstPage() ? "first" : "second";
 
+    if (window.testRunner) {
+        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
+    }
+
     if (isFirstPage()) {
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
         await initializeSwipeTest();
-
-        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-        testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-        testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-        testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
 
         onpagereveal = (e) => {
             shouldBe(e.viewTransition, null, "View transitions should be disabled when using a swipe animation");

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -280,12 +280,6 @@ interface TestRunner {
     object numberOfDFGCompiles(object function);
     object neverInlineFunction(object function);
 
-    // Swipe gestures
-    undefined installDidBeginSwipeCallback(object callback);
-    undefined installWillEndSwipeCallback(object callback);
-    undefined installDidEndSwipeCallback(object callback);
-    undefined installDidRemoveSwipeSnapshotCallback(object callback);
-
     unsigned long imageCountInGeneralPasteboard();
 
     // UI Process Testing

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -248,30 +248,6 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidBeginSwipeCallback")) {
-        if (m_testRunner)
-            m_testRunner->callDidBeginSwipeCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallWillEndSwipeCallback")) {
-        if (m_testRunner)
-            m_testRunner->callWillEndSwipeCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidEndSwipeCallback")) {
-        if (m_testRunner)
-            m_testRunner->callDidEndSwipeCallback();
-        return;
-    }
-
-    if (WKStringIsEqualToUTF8CString(messageName, "CallDidRemoveSwipeSnapshotCallback")) {
-        if (m_testRunner)
-            m_testRunner->callDidRemoveSwipeSnapshotCallback();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "NotifyDownloadDone")) {
         if (m_testRunner && m_testRunner->shouldFinishAfterDownload())
             m_testRunner->notifyDone();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -590,11 +590,7 @@ static CallbackMap& callbackMap()
 }
 
 enum {
-    DidBeginSwipeCallbackID = 1,
-    WillEndSwipeCallbackID,
-    DidEndSwipeCallbackID,
-    DidRemoveSwipeSnapshotCallbackID,
-    TextDidChangeInTextFieldCallbackID,
+    TextDidChangeInTextFieldCallbackID = 1,
     TextFieldDidBeginEditingCallbackID,
     TextFieldDidEndEditingCallbackID,
     FirstUIScriptCallbackID = 100
@@ -1114,46 +1110,6 @@ void TestRunner::setAllowedMenuActions(JSContextRef context, JSValueRef actions)
         WKArrayAppendItem(messageBody.get(), toWKString(context, value).get());
     }
     postPageMessage("SetAllowedMenuActions", messageBody);
-}
-
-void TestRunner::installDidBeginSwipeCallback(JSContextRef context, JSValueRef callback)
-{
-    cacheTestRunnerCallback(context, DidBeginSwipeCallbackID, callback);
-}
-
-void TestRunner::installWillEndSwipeCallback(JSContextRef context, JSValueRef callback)
-{
-    cacheTestRunnerCallback(context, WillEndSwipeCallbackID, callback);
-}
-
-void TestRunner::installDidEndSwipeCallback(JSContextRef context, JSValueRef callback)
-{
-    cacheTestRunnerCallback(context, DidEndSwipeCallbackID, callback);
-}
-
-void TestRunner::installDidRemoveSwipeSnapshotCallback(JSContextRef context, JSValueRef callback)
-{
-    cacheTestRunnerCallback(context, DidRemoveSwipeSnapshotCallbackID, callback);
-}
-
-void TestRunner::callDidBeginSwipeCallback()
-{
-    callTestRunnerCallback(DidBeginSwipeCallbackID);
-}
-
-void TestRunner::callWillEndSwipeCallback()
-{
-    callTestRunnerCallback(WillEndSwipeCallbackID);
-}
-
-void TestRunner::callDidEndSwipeCallback()
-{
-    callTestRunnerCallback(DidEndSwipeCallbackID);
-}
-
-void TestRunner::callDidRemoveSwipeSnapshotCallback()
-{
-    callTestRunnerCallback(DidRemoveSwipeSnapshotCallbackID);
 }
 
 void TestRunner::clearStatisticsDataForDomain(JSStringRef domain)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -392,15 +392,6 @@ public:
     // Contextual menu actions
     void setAllowedMenuActions(JSContextRef, JSValueRef);
 
-    void installDidBeginSwipeCallback(JSContextRef, JSValueRef);
-    void installWillEndSwipeCallback(JSContextRef, JSValueRef);
-    void installDidEndSwipeCallback(JSContextRef, JSValueRef);
-    void installDidRemoveSwipeSnapshotCallback(JSContextRef, JSValueRef);
-    void callDidBeginSwipeCallback();
-    void callWillEndSwipeCallback();
-    void callDidEndSwipeCallback();
-    void callDidRemoveSwipeSnapshotCallback();
-
     void clearTestRunnerCallbacks();
 
     void accummulateLogsForChannel(JSStringRef channel);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1515,26 +1515,6 @@ void TestInvocation::outputText(const WTF::String& text)
     m_textOutput.append(text);
 }
 
-void TestInvocation::didBeginSwipe()
-{
-    postPageMessage("CallDidBeginSwipeCallback");
-}
-
-void TestInvocation::willEndSwipe()
-{
-    postPageMessage("CallWillEndSwipeCallback");
-}
-
-void TestInvocation::didEndSwipe()
-{
-    postPageMessage("CallDidEndSwipeCallback");
-}
-
-void TestInvocation::didRemoveSwipeSnapshot()
-{
-    postPageMessage("CallDidRemoveSwipeSnapshotCallback");
-}
-
 void TestInvocation::notifyDownloadDone()
 {
     postPageMessage("NotifyDownloadDone");

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -69,11 +69,6 @@ public:
     static void dumpWebProcessUnresponsiveness(const char* errorMessage);
     void outputText(const String&);
 
-    void didBeginSwipe();
-    void willEndSwipe();
-    void didEndSwipe();
-    void didRemoveSwipeSnapshot();
-
     void notifyDownloadDone();
 
     void dumpResourceLoadStatistics();


### PR DESCRIPTION
#### af8bdbec9897c5bc2d195c14353c7037e9528764
<pre>
Reduce use of cacheTestRunnerCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=297631">https://bugs.webkit.org/show_bug.cgi?id=297631</a>
<a href="https://rdar.apple.com/158727561">rdar://158727561</a>

Reviewed by Brady Eidson.

cacheTestRunnerCallback keeps state in the web content process, which doesn&apos;t work
well with site isolation.  It also keeps state globally in the process, which isn&apos;t great.
I replace it with use of a user script and script message handlers.
Some tests needed modifying to stop relying on process global state and register a listener
for each navigation.

swipe/swipe-disables-view-transition.html had nondeterministic console output when run in
stress mode, and Tim verified that the console log from skipTransition is not what the test
is intended to cover.

* LayoutTests/swipe/main-frame-pinning-requirement.html:
* LayoutTests/swipe/swipe-back-with-active-wheel-listener.html:
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener.html:
* LayoutTests/swipe/swipe-disables-view-transition.html:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::installDidBeginSwipeCallback): Deleted.
(WTR::TestRunner::installWillEndSwipeCallback): Deleted.
(WTR::TestRunner::installDidEndSwipeCallback): Deleted.
(WTR::TestRunner::installDidRemoveSwipeSnapshotCallback): Deleted.
(WTR::TestRunner::callDidBeginSwipeCallback): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::tooltipDidChange):
(WTR::TestController::Callbacks::notifyListeners):
(WTR::TestController::listenForTooltipChanges):
(WTR::TestController::listenForBeginSwipe):
(WTR::TestController::listenForWillEndSwipe):
(WTR::TestController::listenForDidEndSwipe):
(WTR::TestController::listenForDidRemoveSwipeSnapshot):
(WTR::TestController::resetStateToConsistentValues):
(WTR::if):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::Callbacks::append):
(WTR::TestController::Callbacks::clear):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didBeginSwipe): Deleted.
(WTR::TestInvocation::willEndSwipe): Deleted.
(WTR::TestInvocation::didEndSwipe): Deleted.
(WTR::TestInvocation::didRemoveSwipeSnapshot): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:

Canonical link: <a href="https://commits.webkit.org/299020@main">https://commits.webkit.org/299020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6764afbf37e141365548a7bbb8ae95ca6a8c0fd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27799 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/123605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69506 "Failed to checkout and rebase branch from PR 49626") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff9ed04d-70a1-4a02-a649-b7228132df64) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45760 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/123605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/69506 "Failed to checkout and rebase branch from PR 49626") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ea6a203-8e5a-40d1-a68e-3a6325a92ba1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120452 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/30158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/123605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b19390df-1d38-4924-8be8-37e59d82949b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/29218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/67277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126725 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44403 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/33405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44761 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/43006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18756 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44274 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/43731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47080 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/45424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->