### PR TITLE
[GTK][WPE][WebXR] Add the XR session permission request

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -198,6 +198,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWindowProperties.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebsitePolicies.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/webkit.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitColorChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPointerLockPermissionRequest.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -223,6 +223,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebsiteDataManager.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWindowProperties.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitWebsitePolicies.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/webkit.h.in
 )
 

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -189,6 +189,7 @@ UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitWebsiteDataManager.cpp @no-unify
 UIProcess/API/glib/WebKitWindowProperties.cpp @no-unify
 UIProcess/API/glib/WebKitWebsitePolicies.cpp @no-unify
+UIProcess/API/glib/WebKitXRPermissionRequest.cpp @no-unify
 
 UIProcess/API/gtk/DragSourceGtk3.cpp @no-unify
 UIProcess/API/gtk/DragSourceGtk4.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -186,6 +186,7 @@ UIProcess/API/glib/WebKitWebsiteDataAccessPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitWebsiteDataManager.cpp @no-unify
 UIProcess/API/glib/WebKitWindowProperties.cpp @no-unify
 UIProcess/API/glib/WebKitWebsitePolicies.cpp @no-unify
+UIProcess/API/glib/WebKitXRPermissionRequest.cpp @no-unify
 
 UIProcess/API/libwpe/TouchGestureController.cpp @no-unify
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -37,6 +37,7 @@
 #include "WebKitWebViewPrivate.h"
 #include "WebKitWebsiteDataAccessPermissionRequestPrivate.h"
 #include "WebKitWindowPropertiesPrivate.h"
+#include "WebKitXRPermissionRequestPrivate.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
@@ -372,6 +373,12 @@ private:
         auto* query = webkitPermissionStateQueryCreate(permissionName, origin, WTFMove(completionHandler));
         webkitWebViewPermissionStateQuery(m_webView, query);
         webkit_permission_state_query_unref(query);
+    }
+
+    void requestPermissionOnXRSessionFeatures(WebKit::WebPageProxy&, const WebCore::SecurityOriginData& origin, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& granted, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler) final
+    {
+        GRefPtr<WebKitXRPermissionRequest> request = webkitXRPermissionRequestCreate(origin, mode, granted, WTFMove(completionHandler));
+        webkitWebViewMakePermissionRequest(m_webView, WEBKIT_PERMISSION_REQUEST(request.get()));
     }
 
 #if ENABLE(WEBXR) && USE(OPENXR)

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitXRPermissionRequest.h"
+
+#include "WebKitPermissionRequest.h"
+#include "WebKitSecurityOriginPrivate.h"
+#include "WebKitXRPermissionRequestPrivate.h"
+#include <wtf/glib/WTFGType.h>
+
+#if !ENABLE(2022_GLIB_API)
+typedef WebKitPermissionRequestIface WebKitPermissionRequestInterface;
+#endif
+
+/**
+ * WebKitXRPermissionRequest:
+ * @See_also: #WebKitPermissionRequest, #WebKitWebView
+ *
+ * A permission request for accessing virtual reality (VR) and
+ * augmented reality (AR) devices, including sensors and head-mounted
+ * displays.
+ *
+ * WebKitXRPermissionRequest represents a request for permission to
+ * decide whether WebKit can initialize an XR session through the
+ * WebXR API.
+ *
+ * When a WebKitXRPermissionRequest is not handled by the user,
+ * it is denied by default.
+ *
+ * Since: 2.52
+ */
+
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface*);
+
+struct _WebKitXRPermissionRequestPrivate {
+    WebKitSecurityOrigin* securityOrigin;
+    WebKitXRSessionMode mode;
+    PlatformXR::Device::FeatureList grantedFeatures;
+    CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)> completionHandler;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WebKitXRPermissionRequest, webkit_xr_permission_request, G_TYPE_OBJECT, GObject,
+    G_IMPLEMENT_INTERFACE(WEBKIT_TYPE_PERMISSION_REQUEST, webkit_permission_request_interface_init))
+
+static void webkitXRPermissionRequestAllow(WebKitPermissionRequest* request)
+{
+    ASSERT(WEBKIT_IS_XR_PERMISSION_REQUEST(request));
+
+    WebKitXRPermissionRequestPrivate* priv = WEBKIT_XR_PERMISSION_REQUEST(request)->priv;
+
+    if (priv->completionHandler)
+        priv->completionHandler(WTFMove(priv->grantedFeatures));
+}
+
+static void webkitXRPermissionRequestDeny(WebKitPermissionRequest* request)
+{
+    ASSERT(WEBKIT_IS_XR_PERMISSION_REQUEST(request));
+
+    WebKitXRPermissionRequestPrivate* priv = WEBKIT_XR_PERMISSION_REQUEST(request)->priv;
+
+    if (priv->completionHandler)
+        priv->completionHandler(std::nullopt);
+}
+
+static void webkit_permission_request_interface_init(WebKitPermissionRequestInterface* iface)
+{
+    iface->allow = webkitXRPermissionRequestAllow;
+    iface->deny = webkitXRPermissionRequestDeny;
+}
+
+static void webkitXRPermissionRequestDispose(GObject* object)
+{
+    // Default behaviour when no decision has been made is denying the request.
+    webkitXRPermissionRequestDeny(WEBKIT_PERMISSION_REQUEST(object));
+    WebKitXRPermissionRequestPrivate* priv = WEBKIT_XR_PERMISSION_REQUEST(object)->priv;
+    g_clear_pointer(&priv->securityOrigin, webkit_security_origin_unref);
+    G_OBJECT_CLASS(webkit_xr_permission_request_parent_class)->dispose(object);
+}
+
+static void webkit_xr_permission_request_class_init(WebKitXRPermissionRequestClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->dispose = webkitXRPermissionRequestDispose;
+}
+
+/**
+ * webkit_xr_permission_request_get_security_origin
+ * @request: a #WebKitXRPermissionRequest
+ *
+ * Get the origin of this request.
+ *
+ * Returns: (transfer none): A #WebKitSecurityOrigin of @request
+ *
+ * Since: 2.52
+ */
+WebKitSecurityOrigin* webkit_xr_permission_request_get_security_origin(WebKitXRPermissionRequest* request)
+{
+    g_return_val_if_fail(WEBKIT_IS_XR_PERMISSION_REQUEST(request), nullptr);
+    return request->priv->securityOrigin;
+}
+
+/**
+ * webkit_xr_permission_request_get_session_mode
+ * @request: a #WebKitXRPermissionRequest
+ *
+ * Get the XRSessionMode of this request.
+ *
+ * Returns: The #WebKitXRSessionMode of @request
+ *
+ * Since: 2.52
+ */
+WebKitXRSessionMode webkit_xr_permission_request_get_session_mode(WebKitXRPermissionRequest* request)
+{
+    g_return_val_if_fail(WEBKIT_IS_XR_PERMISSION_REQUEST(request), WEBKIT_XR_SESSION_MODE_INLINE);
+    return request->priv->mode;
+}
+
+static WebKitXRSessionMode toWebKitXRSessionMode(PlatformXR::SessionMode mode)
+{
+    switch (mode) {
+    case PlatformXR::SessionMode::ImmersiveVr:
+        return WEBKIT_XR_SESSION_MODE_IMMERSIVE_VR;
+    case PlatformXR::SessionMode::ImmersiveAr:
+        return WEBKIT_XR_SESSION_MODE_IMMERSIVE_AR;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+    return WEBKIT_XR_SESSION_MODE_INLINE;
+}
+
+WebKitXRPermissionRequest* webkitXRPermissionRequestCreate(const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& granted, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&& completionHandler)
+{
+    WebKitXRPermissionRequest* xrPermissionRequest = WEBKIT_XR_PERMISSION_REQUEST(g_object_new(WEBKIT_TYPE_XR_PERMISSION_REQUEST, nullptr));
+    xrPermissionRequest->priv->securityOrigin = webkitSecurityOriginCreate(WebCore::SecurityOriginData { securityOriginData });
+    xrPermissionRequest->priv->mode = toWebKitXRSessionMode(mode);
+    xrPermissionRequest->priv->grantedFeatures = granted;
+    xrPermissionRequest->priv->completionHandler = WTFMove(completionHandler);
+    return xrPermissionRequest;
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitXRPermissionRequest_h
+#define WebKitXRPermissionRequest_h
+
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+#include <@API_INCLUDE_PREFIX@/WebKitSecurityOrigin.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_XR_PERMISSION_REQUEST            (webkit_xr_permission_request_get_type())
+#if !ENABLE(2022_GLIB_API)
+#define WEBKIT_XR_PERMISSION_REQUEST(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), WEBKIT_TYPE_XR_PERMISSION_REQUEST, WebKitXRPermissionRequest))
+#define WEBKIT_XR_PERMISSION_REQUEST_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  WEBKIT_TYPE_XR_PERMISSION_REQUEST, WebKitXRPermissionRequestClass))
+#define WEBKIT_IS_XR_PERMISSION_REQUEST(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), WEBKIT_TYPE_XR_PERMISSION_REQUEST))
+#define WEBKIT_IS_XR_PERMISSION_REQUEST_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  WEBKIT_TYPE_XR_PERMISSION_REQUEST))
+#define WEBKIT_XR_PERMISSION_REQUEST_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  WEBKIT_TYPE_XR_PERMISSION_REQUEST, WebKitXRPermissionRequestClass))
+
+struct _WebKitXRPermissionRequestClass {
+    GObjectClass parent_class;
+};
+#endif
+
+WEBKIT_DECLARE_FINAL_TYPE (WebKitXRPermissionRequest, webkit_xr_permission_request, WEBKIT, XR_PERMISSION_REQUEST, GObject)
+
+/**
+ * WebKitXRSessionMode:
+ * @WEBKIT_XR_SESSION_MODE_INLINE: inline session mode.
+ * @WEBKIT_XR_SESSION_MODE_IMMERSIVE_VR: immersive-vr session mode.
+ * @WEBKIT_XR_SESSION_MODE_IMMERSIVE_AR: immersive-ar session mode.
+ *
+ * Enum values representing the XR session mode.
+ *
+ * Since: 2.52
+ */
+typedef enum {
+    WEBKIT_XR_SESSION_MODE_INLINE,
+    WEBKIT_XR_SESSION_MODE_IMMERSIVE_VR,
+    WEBKIT_XR_SESSION_MODE_IMMERSIVE_AR,
+} WebKitXRSessionMode;
+
+WEBKIT_API WebKitSecurityOrigin *
+webkit_xr_permission_request_get_security_origin             (WebKitXRPermissionRequest *request);
+
+WEBKIT_API WebKitXRSessionMode
+webkit_xr_permission_request_get_session_mode                (WebKitXRPermissionRequest *request);
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequestPrivate.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebKitXRPermissionRequest.h"
+#include <WebCore/PlatformXR.h>
+#include <wtf/CompletionHandler.h>
+
+WebKitXRPermissionRequest* webkitXRPermissionRequestCreate(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& granted, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -141,6 +141,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitWebsiteDataAccessPermissionRequest.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebsiteDataManager.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWindowProperties.h>
+#include <@API_INCLUDE_PREFIX@/WebKitXRPermissionRequest.h>
 
 #include <@API_INCLUDE_PREFIX@/WebKitAutocleanups.h>
 

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -321,6 +321,21 @@ static void permissionRequestDialogResponse(GtkWidget *dialog, gint response, Pe
     g_clear_pointer(&requestData, permissionRequestDataFree);
 }
 
+static const gchar *webKitXRSessionModeToString(WebKitXRSessionMode mode)
+{
+    switch (mode) {
+    case WEBKIT_XR_SESSION_MODE_INLINE:
+        return "inline";
+    case WEBKIT_XR_SESSION_MODE_IMMERSIVE_VR:
+        return "immersive-vr";
+    case WEBKIT_XR_SESSION_MODE_IMMERSIVE_AR:
+        return "immersive-ar";
+    default:
+        break;
+    }
+    return "unknown";
+}
+
 static gboolean decidePermissionRequest(WebKitWebView *webView, WebKitPermissionRequest *request, BrowserTab *tab)
 {
     const gchar *title = NULL;
@@ -398,6 +413,14 @@ static gboolean decidePermissionRequest(WebKitWebView *webView, WebKitPermission
         title = "Clipboard access request";
         text = g_strdup_printf("Do you want to allow \"%s\" to read the contents of the clipboard?", origin);
         g_free(origin);
+    } else if (WEBKIT_IS_XR_PERMISSION_REQUEST(request)) {
+        title = "XR session request";
+        WebKitXRPermissionRequest *xrRequest = WEBKIT_XR_PERMISSION_REQUEST(request);
+        WebKitSecurityOrigin *origin = webkit_xr_permission_request_get_security_origin(xrRequest);
+        WebKitXRSessionMode mode = webkit_xr_permission_request_get_session_mode(xrRequest);
+        gchar *originStr = webkit_security_origin_to_string(origin);
+        text = g_strdup_printf("Allow XR device access?\norigin=%s mode=%s", originStr, webKitXRSessionModeToString(mode));
+        g_free(originStr);
     } else {
         g_print("%s request not handled\n", G_OBJECT_TYPE_NAME(request));
         return FALSE;


### PR DESCRIPTION
#### fcc54d1d1bb4aa3942544f4fbeb6f6d51f00a660
<pre>
[GTK][WPE][WebXR] Add the XR session permission request
<a href="https://bugs.webkit.org/show_bug.cgi?id=297450">https://bugs.webkit.org/show_bug.cgi?id=297450</a>

Reviewed by Carlos Garcia Campos.

Added a new API for XR session permission request.

Co-authored-by: Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.cpp: Added.
(webkitXRPermissionRequestAllow):
(webkitXRPermissionRequestDeny):
(webkit_permission_request_interface_init):
(webkitXRPermissionRequestDispose):
(webkit_xr_permission_request_class_init):
(webkit_xr_permission_request_get_security_origin):
(webkit_xr_permission_request_get_session_mode):
(toWebKitXRSessionMode):
(webkitXRPermissionRequestCreate):
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequest.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitXRPermissionRequestPrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(webKitXRSessionModeToString):
(decidePermissionRequest):

Canonical link: <a href="https://commits.webkit.org/298944@main">https://commits.webkit.org/298944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d33e1103ade41fdf5e2e334f9a845c179c78c66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120206 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/29955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/105146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69500 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/23260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67045 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/99354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/23442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126493 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33179 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44526 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/101382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/97459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/42812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/20738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18712 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44043 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43499 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46844 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->