### PR TITLE
[iOS] Web process may crash when running text extraction, if the DOM is deeper than ~100 elements

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-max-depth-no-crash-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-max-depth-no-crash-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-max-depth-no-crash.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-max-depth-no-crash.html
@@ -1,0 +1,45 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Super deep DOM structure</title>
+    <style>
+        body, html {
+            font-family: system-ui;
+            font-size: 16px;
+            white-space: pre-wrap;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        const container = document.getElementById("container");
+        let currentElement = container;
+
+        for (let depth = 1; depth <= 500; depth++) {
+            const section = document.createElement("section");
+            section.textContent = `Depth ${depth}`;
+            section.style.marginLeft = "2px";
+            section.style.borderLeft = "1px solid #ccc";
+
+            currentElement.appendChild(section);
+            currentElement = section;
+        }
+
+        extractedText = await UIHelper.requestDebugText();
+        document.body.innerHTML = "";
+
+        testPassed("Did not crash");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div id="container"></div>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -595,7 +595,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
     }
 
     if (RefPtr container = dynamicDowncast<ContainerNode>(node)) {
-        for (auto& child : composedTreeChildren(*container))
+        for (auto& child : composedTreeChildren<0>(*container))
             extractRecursive(child, item ? *item : parentItem, context);
     }
 


### PR DESCRIPTION
#### a71717e57d42ff056c77eafbb4ad4c4945c26c56
<pre>
[iOS] Web process may crash when running text extraction, if the DOM is deeper than ~100 elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=297636">https://bugs.webkit.org/show_bug.cgi?id=297636</a>
<a href="https://rdar.apple.com/156496565">rdar://156496565</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

The recursive algorithm used to extract visible text context for UIIntelligenceSupport currently
allocates ~1 KB per call frame, most of which is due to the inline capacity reserved when using
`composedTreeChildren`. For a DOM structure deeper than 100 elements, this sometimes causes us to
exceed the stack limit of 1 MB on iPhone, causing the web content process to crash.

Avoid this by explicitly passing an inline capacity of 0 for `composedTreeChildren`, which brings
the stack size back down to a reasonable ~120 bytes, bringing us well below the maximum stack size
limit even at the current maximum DOM tree depth of 500 nodes.

* LayoutTests/fast/text-extraction/debug-text-extraction-max-depth-no-crash-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-max-depth-no-crash.html: Added.

Note that this test only fails on a real iOS device or virtual machine, where the stack size limit
is 1 MB. On a macOS device, this isn&apos;t an issue even at max depth because we still fit comformably
in the 16 MB limit, with the default inline capacity.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):

Canonical link: <a href="https://commits.webkit.org/298939@main">https://commits.webkit.org/298939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32355a0beeaa00836b650795eaaf2e77c0b6fac2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69235 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fffe6f1-c0f4-46c1-903a-a844e4ed8ba9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45507 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/88977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/af59dfa6-3395-483d-b3b5-e14373daa002) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29935 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69479 "Passed tests") | | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/28995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67022 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126470 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44503 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97441 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42790 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44020 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43476 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->