### PR TITLE
[iOS] Backward swipe gesture to return to previous page no longer works in reader mode

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -144,17 +144,21 @@ ViewGestureController* ViewGestureController::controllerForGesture(WebPageProxyI
     return gestureControllerIter->value.ptr();
 }
 
+#if PLATFORM(COCOA)
+
 RefPtr<WebBackForwardListItem> ViewGestureController::itemForSwipeDirection(SwipeDirection direction) const
 {
-    RefPtr page = m_webPageProxy.get();
-    if (!page)
+    RefPtr backForwardList = backForwardListForNavigation();
+    if (!backForwardList)
         return { };
 
     if (direction == SwipeDirection::Back)
-        return page->backForwardList().goBackItemSkippingItemsWithoutUserGesture();
+        return backForwardList->goBackItemSkippingItemsWithoutUserGesture();
 
-    return page->backForwardList().goForwardItemSkippingItemsWithoutUserGesture();
+    return backForwardList->goForwardItemSkippingItemsWithoutUserGesture();
 }
+
+#endif
 
 ViewGestureController::GestureID ViewGestureController::takeNextGestureID()
 {

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -96,6 +96,7 @@ typedef void* PlatformScrollEvent;
 namespace WebKit {
 
 class ViewSnapshot;
+class WebBackForwardList;
 class WebBackForwardListItem;
 class WebPageProxy;
 class WebProcessProxy;
@@ -228,6 +229,10 @@ private:
     void resetState();
 
     void didStartProvisionalOrSameDocumentLoadForMainFrame();
+
+#if PLATFORM(COCOA)
+    WebBackForwardList* backForwardListForNavigation() const;
+#endif
 
     class SnapshotRemovalTracker : public CanMakeCheckedPtr<SnapshotRemovalTracker> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SnapshotRemovalTracker);
@@ -363,7 +368,9 @@ private:
     GRefPtr<GtkStyleContext> createStyleContext(const char*);
 #endif
 
+#if PLATFORM(COCOA)
     RefPtr<WebBackForwardListItem> itemForSwipeDirection(SwipeDirection) const;
+#endif
 
     WeakPtr<WebPageProxy> m_webPageProxy;
     WebPageProxyIdentifier m_webPageProxyIdentifier;

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -494,6 +494,11 @@ bool ViewGestureController::completeSimulatedSwipeInDirectionForTesting(SwipeDir
     return true;
 }
 
+WebBackForwardList* ViewGestureController::backForwardListForNavigation() const
+{
+    return &m_webPageProxyForBackForwardListForCurrentSwipe->backForwardList();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -684,6 +684,14 @@ bool ViewGestureController::completeSimulatedSwipeInDirectionForTesting(SwipeDir
     return true;
 }
 
+WebBackForwardList* ViewGestureController::backForwardListForNavigation() const
+{
+    if (RefPtr page = m_webPageProxy.get())
+        return &page->backForwardList();
+
+    return nullptr;
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### 72992ac7d2cd2fcd9a06dc1f79ef1f66f30be8b4
<pre>
[iOS] Backward swipe gesture to return to previous page no longer works in reader mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=297637">https://bugs.webkit.org/show_bug.cgi?id=297637</a>
<a href="https://rdar.apple.com/156611213">rdar://156611213</a>

Reviewed by Wenson Hsieh.

The refactored swipe navigation logic in 297248@main sources the
 `WebBackForwardList` from the current `WebPageProxy` instead of
`m_webPageProxyForBackForwardListForCurrentSwipe`, resulting in the
list always being empty when in reader mode.

These changes restore the original source for the list on iOS.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::itemForSwipeDirection const):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::backForwardListForNavigation const):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::backForwardListForNavigation const):

Canonical link: <a href="https://commits.webkit.org/298991@main">https://commits.webkit.org/298991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdad64ce67301bb2ecf69836181c0ec36df92c5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123487 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69376 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6551ba0d-fbcb-4d5f-8756-37a037946142) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89076 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43742 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f236fdc-f2aa-4e09-a1f1-7f95ca892343) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69586 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54da83d9-f4aa-4e3e-9cd4-70ddfd0337fd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29100 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67160 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126608 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97742 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97536 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42900 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40635 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49817 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43614 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45310 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->