### PR TITLE
[Navigation API] Fix 16% PLT regression by removing Sync IPC

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7091,6 +7091,9 @@ imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/open-
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-crossdocument-crossorigin-sameorigindomain.sub.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/cross-window/submit-samedocument-crossorigin-sameorigindomain.sub.html [ Skip ]
 
+webkit.org/b/298466 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-cross-document-forward-pruning.html [ Failure ]
+webkit.org/b/298467 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-cross-document.html [ Failure ]
+
 # General flakes, almost exclusively on mac-wk2-stress.
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-rejected.html [ Crash Pass ]

--- a/Source/WebCore/history/BackForwardClient.h
+++ b/Source/WebCore/history/BackForwardClient.h
@@ -48,7 +48,7 @@ public:
 
     virtual void goToItem(HistoryItem&) = 0;
 
-    virtual Vector<Ref<HistoryItem>> allItems(FrameIdentifier) = 0;
+    virtual Vector<Ref<HistoryItem>> allItemsForFrame(FrameIdentifier) = 0;
     virtual RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) = 0;
 
     virtual unsigned backListCount() const = 0;

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -175,32 +175,9 @@ RefPtr<HistoryItem> BackForwardController::itemAtIndex(int i, std::optional<Fram
     return m_client->itemAtIndex(i, frameID.value_or(m_page->mainFrame().frameID()));
 }
 
-Vector<Ref<HistoryItem>> BackForwardController::allItems()
+Vector<Ref<HistoryItem>> BackForwardController::allItemsForFrame(FrameIdentifier frameID)
 {
-    return m_client->allItems(m_page->mainFrame().frameID());
-}
-
-Vector<Ref<HistoryItem>> BackForwardController::itemsForFrame(FrameIdentifier frameID)
-{
-    Vector<Ref<HistoryItem>> historyItems;
-    for (Ref item : allItems()) {
-        if (item->frameID() == frameID)
-            historyItems.append(WTFMove(item));
-    }
-
-    return historyItems;
-}
-
-Vector<Ref<HistoryItem>> BackForwardController::reachableItemsForFrame(FrameIdentifier frameID)
-{
-    // Returns only the frame items that correspond to the currently reachable session history.
-    // This is different from itemsForFrame() which returns all frame items across the frame's lifetime.
-    Vector<Ref<HistoryItem>> reachableFrameItems;
-    for (auto& item : allItems()) {
-        if (RefPtr childItem = item->childItemWithFrameID(frameID))
-            reachableFrameItems.append(childItem.releaseNonNull());
-    }
-    return reachableFrameItems;
+    return m_client->allItemsForFrame(frameID);
 }
 
 void BackForwardController::close()

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -74,9 +74,7 @@ public:
     WEBCORE_EXPORT RefPtr<HistoryItem> currentItem(std::optional<FrameIdentifier> = std::nullopt);
     WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem(std::optional<FrameIdentifier> = std::nullopt);
 
-    Vector<Ref<HistoryItem>> allItems();
-    Vector<Ref<HistoryItem>> itemsForFrame(FrameIdentifier);
-    Vector<Ref<HistoryItem>> reachableItemsForFrame(FrameIdentifier);
+    Vector<Ref<HistoryItem>> allItemsForFrame(FrameIdentifier);
 
 private:
     Ref<Page> protectedPage() const;

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -190,7 +190,7 @@ void CachedPage::restore(Page& page)
 
     // Update Navigation API after pageshow events to ensure correct event ordering.
     if (CheckedRef backForwardController = page.backForward(); page.settings().navigationAPIEnabled() && focusedDocument->window() && backForwardController->currentItem()) {
-        auto allItems = backForwardController->allItems();
+        auto allItems = backForwardController->allItemsForFrame(page.mainFrame().frameID());
         Ref currentItem = *backForwardController->currentItem();
         RefPtr previousItem = backForwardController->forwardItem();
         focusedDocument->window()->navigation().updateForReactivation(WTFMove(allItems), currentItem, previousItem.get());
@@ -207,12 +207,12 @@ void CachedPage::restore(Page& page)
             if (!document || !document->window())
                 continue;
             // For iframes, get only the reachable history items from the current session.
-            auto reachableFrameItems = backForwardController->reachableItemsForFrame(child->frameID());
+            auto allItemsForChild = backForwardController->allItemsForFrame(child->frameID());
 
-            if (!reachableFrameItems.isEmpty() && child->loader().history().currentItem()) {
+            if (!allItemsForChild.isEmpty() && child->loader().history().currentItem()) {
                 Ref currentItem = *child->loader().history().currentItem();
                 RefPtr previousItem = backForwardController->forwardItem();
-                document->window()->navigation().updateForReactivation(WTFMove(reachableFrameItems), currentItem, previousItem.get());
+                document->window()->navigation().updateForReactivation(WTFMove(allItemsForChild), currentItem, previousItem.get());
             }
         }
     }

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -83,6 +83,7 @@ public:
     WEBCORE_EXPORT Ref<HistoryItem> copy() const;
 
     BackForwardItemIdentifier itemID() const { return m_itemID; }
+    void setItemID(BackForwardItemIdentifier itemID) { m_itemID = itemID; }
     BackForwardFrameItemIdentifier frameItemID() const { return m_frameItemID; }
     const WTF::UUID& uuidIdentifier() const { return m_uuidIdentifier; }
     void setUUIDIdentifier(const WTF::UUID& uuidIdentifier) { m_uuidIdentifier = uuidIdentifier; }

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -122,7 +122,7 @@ class EmptyBackForwardClient final : public BackForwardClient {
     void addItem(Ref<HistoryItem>&&) final { }
     void setChildItem(BackForwardFrameItemIdentifier, Ref<HistoryItem>&&) final { }
     void goToItem(HistoryItem&) final { }
-    Vector<Ref<HistoryItem>> allItems(FrameIdentifier) { return { }; }
+    Vector<Ref<HistoryItem>> allItemsForFrame(FrameIdentifier) { return { }; }
     RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) final { return nullptr; }
     unsigned backListCount() const final { return 0; }
     unsigned forwardListCount() const final { return 0; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -871,7 +871,7 @@ void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow
     }
 
     if (document->settings().navigationAPIEnabled() && document->window() && !document->protectedSecurityOrigin()->isOpaque())
-        document->protectedWindow()->protectedNavigation()->initializeForNewWindow(navigationType, previousWindow);
+        document->protectedWindow()->protectedNavigation()->initializeForNewWindow(navigationType, previousWindow, frame->backForwardList());
 
     history().restoreDocumentState();
 }

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -104,6 +104,8 @@ public:
 
     void clearPolicyItem();
 
+    static bool itemsAreClones(HistoryItem&, HistoryItem*);
+
 private:
     friend class Page;
     bool shouldStopLoadingForHistoryItem(HistoryItem&) const;
@@ -122,10 +124,11 @@ private:
     bool isReloadTypeWithProvisionalItem(FrameLoadType);
     void recursiveUpdateForCommit();
     void recursiveUpdateForSameDocumentNavigation();
-    static bool itemsAreClones(HistoryItem&, HistoryItem*);
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
     bool isFrameLoadComplete() const { return m_frameLoadComplete; }
+
+    void recursiveSetCurrentItemID(BackForwardItemIdentifier);
 
     struct FrameToNavigate;
     static void recursiveGatherFramesToNavigate(LocalFrame&, Vector<FrameToNavigate>&, HistoryItem& targetItem, HistoryItem* fromItem);

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -350,7 +350,7 @@ public:
         bool backwards = entry->index() < localFrame.window()->navigation().currentEntry()->index();
 
         RefPtr page { localFrame.page() };
-        auto items = page->checkedBackForward()->allItems();
+        auto items = page->checkedBackForward()->allItemsForFrame(page->mainFrame().frameID());
         for (size_t i = 0 ; i < items.size(); i++) {
             Ref item = items[backwards ? items.size() - 1 - i: i];
             auto index = item->children().findIf([&historyItem](const auto& child) {

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1599,6 +1599,28 @@ RefPtr<SecurityOrigin> LocalFrame::frameDocumentSecurityOrigin() const
     return nullptr;
 }
 
+Vector<Ref<HistoryItem>> LocalFrame::backForwardList() const
+{
+    return m_backForwardList;
+}
+
+void LocalFrame::setBackForwardList(Vector<Ref<HistoryItem>>&& list)
+{
+    m_backForwardList = WTFMove(list);
+}
+
+void LocalFrame::addItemToBackForwardList(Ref<HistoryItem>&& item)
+{
+    for (size_t i = 0; i < m_backForwardList.size(); i++) {
+        if (m_backForwardList[i]->itemID().object() <=> item->itemID().object() == std::strong_ordering::equal) {
+            m_backForwardList[i] = WTFMove(item);
+            return;
+        }
+    }
+
+    m_backForwardList.append(WTFMove(item));
+}
+
 } // namespace WebCore
 
 #undef FRAME_RELEASE_LOG_ERROR

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -76,6 +76,7 @@ class FrameLoader;
 class FrameSelection;
 class HTMLFrameOwnerElement;
 class HTMLTableCellElement;
+class HistoryItem;
 class HitTestResult;
 class ImageBuffer;
 class IntPoint;
@@ -344,6 +345,10 @@ public:
 
     bool frameCanCreatePaymentSession() const final;
 
+    Vector<Ref<HistoryItem>> backForwardList() const;
+    WEBCORE_EXPORT void setBackForwardList(Vector<Ref<HistoryItem>>&&);
+    void addItemToBackForwardList(Ref<HistoryItem>&&);
+
 protected:
     void frameWasDisconnectedFromOwner() const final;
 
@@ -375,6 +380,8 @@ private:
     RefPtr<Document> m_doc;
 
     UniqueRef<ScriptController> m_script;
+
+    Vector<Ref<HistoryItem>> m_backForwardList;
 
 #if ENABLE(DATA_DETECTION)
     std::unique_ptr<DataDetectionResultsStorage> m_dataDetectionResults;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -131,7 +131,7 @@ public:
     bool canGoBack() const;
     bool canGoForward() const;
 
-    void initializeForNewWindow(std::optional<NavigationNavigationType>, LocalDOMWindow* previousWindow);
+    void initializeForNewWindow(std::optional<NavigationNavigationType>, LocalDOMWindow* previousWindow, Vector<Ref<HistoryItem>>);
 
     Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 

--- a/Source/WebKit/Shared/PolicyDecision.h
+++ b/Source/WebKit/Shared/PolicyDecision.h
@@ -29,6 +29,7 @@
 #include "NavigatingToAppBoundDomain.h"
 #include "SafeBrowsingCheckOngoing.h"
 #include "SandboxExtension.h"
+#include "SessionState.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/NavigationIdentifier.h>
 
@@ -54,6 +55,7 @@ struct PolicyDecision {
     std::optional<SandboxExtension::Handle> sandboxExtensionHandle { std::nullopt };
     std::optional<PolicyDecisionConsoleMessage> consoleMessage { std::nullopt };
     SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing { SafeBrowsingCheckOngoing::No };
+    Vector<Ref<FrameState>> backForwardList { };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/PolicyDecision.serialization.in
+++ b/Source/WebKit/Shared/PolicyDecision.serialization.in
@@ -31,6 +31,7 @@ enum class WebKit::SafeBrowsingCheckOngoing : bool;
     std::optional<WebKit::SandboxExtensionHandle> sandboxExtensionHandle;
     std::optional<WebKit::PolicyDecisionConsoleMessage> consoleMessage;
     WebKit::SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing;
+    Vector<Ref<WebKit::FrameState>> backForwardList;
 }
 
 [CustomHeader] struct WebKit::PolicyDecisionConsoleMessage {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3033,7 +3033,7 @@ private:
     void backForwardClearChildren(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
     void backForwardGoToItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardListContainsItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(bool)>&&);
-    void backForwardAllItems(WebCore::FrameIdentifier, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&&);
+    void backForwardAllItemsForFrame(WebCore::FrameIdentifier, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&&);
     void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
     void backForwardUpdateItem(IPC::Connection&, Ref<FrameState>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -214,7 +214,7 @@ messages -> WebPageProxy {
     BackForwardClearChildren(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID)
     BackForwardUpdateItem(Ref<WebKit::FrameState> frameState)
     BackForwardGoToItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
-    BackForwardAllItems(WebCore::FrameIdentifier frameID) -> (Vector<Ref<WebKit::FrameState>> frameStates) Synchronous
+    BackForwardAllItemsForFrame(WebCore::FrameIdentifier frameID) -> (Vector<Ref<WebKit::FrameState>> frameStates) Synchronous
     BackForwardItemAtIndex(int32_t itemIndex, WebCore::FrameIdentifier frameID) -> (RefPtr<WebKit::FrameState> frameState) Synchronous
     BackForwardListContainsItem(WebCore::BackForwardItemIdentifier itemID) -> (bool contains) Synchronous
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -85,13 +85,13 @@ void WebBackForwardListProxy::goToItem(HistoryItem& item)
     m_cachedBackForwardListCounts = backForwardListCounts;
 }
 
-Vector<Ref<HistoryItem>> WebBackForwardListProxy::allItems(FrameIdentifier frameID)
+Vector<Ref<HistoryItem>> WebBackForwardListProxy::allItemsForFrame(FrameIdentifier frameID)
 {
     RefPtr page = m_page.get();
     if (!page)
         return { };
 
-    auto sendResult = m_page->sendSync(Messages::WebPageProxy::BackForwardAllItems(frameID));
+    auto sendResult = m_page->sendSync(Messages::WebPageProxy::BackForwardAllItemsForFrame(frameID));
     auto [allFrameStates] = sendResult.takeReplyOr(Vector<Ref<FrameState>> { });
 
     Ref historyItemClient = page->historyItemClient();

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -51,7 +51,7 @@ private:
 
     void goToItem(WebCore::HistoryItem&) override;
 
-    Vector<Ref<WebCore::HistoryItem>> allItems(WebCore::FrameIdentifier) final;
+    Vector<Ref<WebCore::HistoryItem>> allItemsForFrame(WebCore::FrameIdentifier) final;
     RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
 
     unsigned backListCount() const override;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -75,6 +75,7 @@ struct GlobalWindowIdentifier;
 
 namespace WebKit {
 
+class FrameState;
 class InjectedBundleCSSStyleDeclarationHandle;
 class InjectedBundleHitTestResult;
 class InjectedBundleNodeHandle;
@@ -265,6 +266,8 @@ public:
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
 
     std::optional<WebCore::ResourceResponse> resourceResponseForURL(const URL&) const;
+
+    void setBackForwardList(Vector<Ref<FrameState>>&&);
 
 private:
     WebFrame(WebPage&, WebCore::FrameIdentifier);

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -56,7 +56,7 @@ public:
     RefPtr<WebCore::HistoryItem> currentItem();
     RefPtr<WebCore::HistoryItem> forwardItem();
     RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
-    Vector<Ref<WebCore::HistoryItem>> allItems(WebCore::FrameIdentifier) override { return m_entries; }
+    Vector<Ref<WebCore::HistoryItem>> allItemsForFrame(WebCore::FrameIdentifier) override;
 
     void backListWithLimit(int, Vector<Ref<WebCore::HistoryItem>>&);
     void forwardListWithLimit(int, Vector<Ref<WebCore::HistoryItem>>&);

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -211,6 +211,23 @@ RefPtr<HistoryItem> BackForwardList::itemAtIndex(int index, WebCore::FrameIdenti
     return m_entries[index + m_current].copyRef();
 }
 
+Vector<Ref<WebCore::HistoryItem>> BackForwardList::allItemsForFrame(WebCore::FrameIdentifier frameID)
+{
+    Vector<Ref<HistoryItem>> allItemsForFrame;
+
+    for (auto& item : m_entries) {
+        if (item->frameID() == frameID) {
+            allItemsForFrame.append(item);
+            continue;
+        }
+
+        if (RefPtr childItem = item->childItemWithFrameID(frameID))
+            allItemsForFrame.append(childItem.releaseNonNull());
+    }
+
+    return allItemsForFrame;
+}
+
 #if PLATFORM(IOS_FAMILY)
 unsigned BackForwardList::current()
 {


### PR DESCRIPTION
#### b539f239da5e0740c16d7ca1dd9dd9b0b29bf72a
<pre>
[Navigation API] Fix 16% PLT regression by removing Sync IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=298498">https://bugs.webkit.org/show_bug.cgi?id=298498</a>
<a href="https://rdar.apple.com/160000632">rdar://160000632</a>

Reviewed by NOBODY (OOPS!).

When a new Document is created, it&apos;s Navigation object&apos;s list of history entries
must be initialized. In the initial implementation of the Navigation API in
273532@main, this was done by making a sync IPC to the UI Process to get each
item in the b/f list. (The calls to itemAtIndex()). 298922@main changed this so
the whole list is retrieved in just one sync IPC call (The call to itemsForFrame()).

So enabling the Navigation API means that every time a new Document is created,
a new sync IPC is sent. This is terrible for performance. It&apos;s a ~16% PLT regression.

To fix this, this patch removes this extra sync IPC. The list is still needed, but
now it&apos;s retreived in an IPC that already occurs when a navigation results in a
document&apos;s creation: decidePolicyForNavigationAction.

When a load is triggered, the Web Process sends this IPC to the UI Process to
determine if the navigation should continue. We modify the returned PolicyDecision
object to also contain the b/f list. This list is be stored on the Frame and passed
into the Navigation object when we initialize it for the new Document.

There are some nuances that need fixing to make this work:

1. Missing the navigation-triggering HistoryItem.

   When a navigation occurs, the Web Process only creates and sends the HistoryItem
   associated with this navigation to the UI Process once the UI Process has told
   the Web Process to continue the navigation via decidePolicyForNavigationAction.
   This means that at the time where the b/f list is retrieved via IPC, it will be
   missing the HistoryItem that triggered this navigation. The list is incomplete.

   To fix this, the Web Process appends this missing item to the list once it has
   created it. This occurs in two places:

       1. HistoryController::updateBackForwardListClippedAtTarget()

              Some situations where this is called:
              - The initial load of a main frame
              - A navigation (in either a main frame or subframe) via
                navigation.navigate().

       2. HistoryController::updateForRedirectWithLockedBackForwardList()

              Some situations where this is called:
              - If a main frame navigates, the new HistoryItems for its
                subframes will be created here.
              - Scenarios where a load is of type RedirectWithLockedBackForwardList,
                such as a frame loading but then redirecting to another item
                immediately and without user interaction. In these situations, the
                new HistoryItem replaces the old one, so we replace the item in the
                list rather than append.

              * On a iframe&apos;s load, the HistoryItem created for it here will have
                the same ItemID as the currentItem of it&apos;s parent frame&apos;s
                HistoryController object. This may be stale if the iframe is
                navigating but the parent frame is not. In that case, the HistoryItem
                created for the iframe will be wrong. This scenario occurs in the test
                anchor-fragment-form-submit-withpath.html. To fix this, we ensure that
                when a frame navigates, the currentItems for the other frames in the
                frame tree are also updated.

2. Clones

   Consider two sibling frames A and B. If A navigates, a new history tree
   is created, which will have a HistoryItem for B as well. This item will be
   a clone of the HistoryItem for B in the first history tree. When the list
   of all HistoryItems for B is obtained, it will contain both HistoryItems.
   But B cannot go back and forward between the two items. So we must remove
   the clone.

3. Coalescing with the list from the previous Document&apos;s Navigation object.

   When initializing the Navigation object for a non-main frame, the list is
   initially holds the previous Document&apos;s entries. We must coalesce this list
   with the list received from the UI Process.

   This should have been happening before, but it turns out that prior to this
   patch, due to incorrect logic in itemsForFrame, the list received via sync
   IPC contained no entries for non-main frames.So many tests were passing by
   mistake. In some cases, tests were passing, but the underlying state of
   m_entries was wrong (contained duplicate items).

   The logic to coalesce the list from the previous Document with the list from
   IPC is:

       For all items in the IPC list:
           If it&apos;s already in the previous list, don&apos;t add it **
           Otherwise, append it.

       ** Unless the item in the IPC list has a different URL. This represents the
          scenario where an item has been updated with a locked back forward list
          as described above. Then the new item would have replaced the last item.
          The UI Process will know about this but the previous Document&apos;s Navigation
          object (which is in the Web Process) may not. So in this case, we replace
          the previous entry with the new one from IPC.

The overarching idea is that this list must match the UI Process b/f list. The
UI Process b/f list is the source of truth. If we were to sync IPC to the UI
Process to get the list, it would be correct. But we cannot due to performance.
And since the UI Process&apos;s list is not fully updated at the time of the
decidePolicyForNavigationAction IPC, the Web Process must do the above steps
to reconstruct the missing/updated items to reflect the state the UI Process
list will soon be in.

Bugs found while doing this:
1. navigation.navigate(&lt;url&gt;, { history: &apos;push&apos; }) doesn&apos;t always create a new
   HistoryItem like it should. This means we may be short an item. This causes
   a test to fail. It was passing accidently before.
2. Navigations that cause forward pruning in iframes may not prune the UI Process
   b/f list, which means the list retreived via IPC in the next navigation will
   be incorrect. This causes another test to fail. It was passing accidently before.
3. navigation.navigate(&lt;url&gt;, { history: &apos;replace&apos; }) doesn&apos;t always replace
   the current HistoryItem in the UI Process list, it may instead create a new
   HistoryItem. This is not causing any tests to fail for now, but must be fixed.

* LayoutTests/TestExpectations:

Mark the two tests as failing as described above. They were passing accidently
before this patch.

* Source/WebCore/history/BackForwardClient.h:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::allItemsForFrame):
(WebCore::BackForwardController::allItems): Deleted.
(WebCore::BackForwardController::itemsForFrame): Deleted.
(WebCore::BackForwardController::reachableItemsForFrame): Deleted.
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::setItemID):
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):

When initializing the Navigation object for the new Document,
pass in the b/f list obtained via IPC here.

* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):

This is one location where a new HistoryItem is created after the b/f list
has already been retreived via IPC. So add the missing item.

(WebCore::HistoryController::updateForCommit):

Ensure that on a navigation, the current item for all frames is updated
to have the correct itemID.

(WebCore::HistoryController::recursiveSetCurrentItemID):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):

This is one location where a new HistoryItem is created after the b/f list
has already been retreived via IPC. So add the missing item.

* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::backForwardList const):
(WebCore::LocalFrame::setBackForwardList):
(WebCore::LocalFrame::addItemToBackForwardList):

Store the b/f list here. One alternative considered was to store it
on the Navigation object itself. But that object is owned by the
Document and the Document may not exist at the time of the
decidePolicyForNavigationAction IPC.

* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::getEntryIndexOfHistoryItem):
(WebCore::Navigation::initializeForNewWindow):

Add new logic for removing clones from the IPC list,
and coalescing with the list from the previous Document.

* Source/WebCore/page/Navigation.h:
* Source/WebKit/Shared/PolicyDecision.h:

The PolicyDecision will now also contain the b/f list.

* Source/WebKit/Shared/PolicyDecision.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationActionAsync):
(WebKit::WebPageProxy::decidePolicyForNavigationActionSync):
(WebKit::WebPageProxy::backForwardAllItemsForFrame):
(WebKit::WebPageProxy::backForwardAllItems): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):

Obtain the b/f list from the UI Process in this IPC.

* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::allItemsForFrame):
(WebKit::WebBackForwardListProxy::allItems): Deleted.
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::setBackForwardList):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/BackForwardList.mm:
(BackForwardList::allItemsForFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b539f239da5e0740c16d7ca1dd9dd9b0b29bf72a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71845 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d26ad8c7-5e67-4362-aed4-bd6b13ffac74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60251 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23325547-ca3e-48fc-bcaf-5a118272d239) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71525 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c77ffa97-b646-4ee6-ab60-bd88d32b1355) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25502 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129019 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99568 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99412 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44853 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43265 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52261 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49370 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->