### PR TITLE
Add checked/dynamic casts for OSObjectPtr

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		4427C5AA21F6D6C300A612A4 /* ASCIICType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */; };
 		4448265228D18CA600D916E8 /* VectorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916E8 /* VectorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4448265228D18CA600D916F9 /* NotificationCenterCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916F9 /* NotificationCenterCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		449EEC7E2D93788B008E7C80 /* TypeCastsOSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 449EEC7D2D93788B008E7C80 /* TypeCastsOSObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		461229722ACF6B3100BB1CCC /* FastCharacterComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4628C0952E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 4628C0942E9D026A00462A50 /* AbstractCanMakeCheckedPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1326,6 +1327,7 @@
 		4448265128D18CA600D916E8 /* VectorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VectorCF.h; sourceTree = "<group>"; };
 		4448265128D18CA600D916F9 /* NotificationCenterCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationCenterCF.h; sourceTree = "<group>"; };
 		4468567225094FE8008CCA05 /* ThreadSanitizerSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSanitizerSupport.h; sourceTree = "<group>"; };
+		449EEC7D2D93788B008E7C80 /* TypeCastsOSObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TypeCastsOSObject.h; sourceTree = "<group>"; };
 		44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCastsCocoa.h; sourceTree = "<group>"; };
 		4606FEE62B1E901800D704F1 /* WeakRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakRef.h; sourceTree = "<group>"; };
 		461229712ACF6B3100BB1CCC /* FastCharacterComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FastCharacterComparison.h; sourceTree = "<group>"; };
@@ -2212,6 +2214,7 @@
 				6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */,
 				53FC70CE23FB950C005B1990 /* OSLogPrintStream.h */,
 				53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */,
+				449EEC7D2D93788B008E7C80 /* TypeCastsOSObject.h */,
 				37C7CC291EA40A73007BD956 /* WeakLinking.h */,
 				44235FF62D76448F00F4A6CB /* XPCExtras.h */,
 				46BD41C92EC723B2002ED70B /* XPCObjectPtr.h */,
@@ -3970,6 +3973,7 @@
 				DD3DC87427A4BF8E007E5B61 /* TypeCasts.h in Headers */,
 				DDF3070C27C086CC006A526F /* TypeCastsCF.h in Headers */,
 				DDF306FD27C086CC006A526F /* TypeCastsCocoa.h in Headers */,
+				449EEC7E2D93788B008E7C80 /* TypeCastsOSObject.h in Headers */,
 				5164042F2AB1D4DD0042B1C3 /* TypeTraits.h in Headers */,
 				FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */,
 				FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */,

--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -27,6 +27,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CTFontDescriptor.h>
+#include <objc/objc.h>
 #include <wtf/Assertions.h>
 #include <wtf/RetainPtr.h>
 
@@ -75,6 +76,28 @@ template<typename T> T checked_cf_cast(CFTypeRef object)
     return static_cast<T>(const_cast<CF_BRIDGED_TYPE(id) void*>(object));
 }
 
+// Use bridgeCFCast to convert from id -> CF without ref churn.
+
+inline CFTypeRef bridgeCFCast(id object)
+{
+#ifdef __OBJC__
+    return (__bridge CFTypeRef)object;
+#else
+    return reinterpret_cast<CFTypeRef>(object);
+#endif
+}
+
+// Use bridge_id_cast to convert from CF -> id without ref churn.
+
+inline id bridge_id_cast(CFTypeRef object)
+{
+#ifdef __OBJC__
+    return (__bridge id)object;
+#else
+    return reinterpret_cast<id>(const_cast<void*>(object));
+#endif
+}
+
 } // namespace WTF
 
 #define WTF_DECLARE_CF_TYPE_TRAIT(ClassName) \
@@ -105,5 +128,7 @@ WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFString, CFMutableString);
 
 #undef WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT
 
+using WTF::bridgeCFCast;
+using WTF::bridge_id_cast;
 using WTF::checked_cf_cast;
 using WTF::dynamic_cf_cast;

--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -29,6 +29,7 @@
 
 #import <wtf/Assertions.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cf/TypeCastsCF.h>
 #import <wtf/cocoa/TollFreeBridging.h>
 
 namespace WTF {
@@ -64,11 +65,7 @@ template<typename T> inline RetainPtr<std::remove_pointer_t<typename CFTollFreeB
 }
 
 // Use bridge_id_cast to convert from CF -> id without ref churn.
-
-inline id bridge_id_cast(CFTypeRef object)
-{
-    return (__bridge id)object;
-}
+// See also <wtf/cf/TypeCastsCF.h>.
 
 inline RetainPtr<id> bridge_id_cast(RetainPtr<CFTypeRef>&& object)
 {
@@ -190,7 +187,6 @@ template<typename T> T *dynamic_objc_cast(id object)
 } // namespace WTF
 
 using WTF::bridge_cast;
-using WTF::bridge_id_cast;
 using WTF::checked_objc_cast;
 using WTF::dynamic_objc_cast;
 using WTF::is_objc;

--- a/Source/WTF/wtf/darwin/TypeCastsOSObject.h
+++ b/Source/WTF/wtf/darwin/TypeCastsOSObject.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <CoreFoundation/CFBase.h>
+#import <objc/runtime.h>
+#import <wtf/OSObjectPtr.h>
+#import <wtf/cf/TypeCastsCF.h>
+
+// To add support for a new OSObject type:
+// 1. Import header that defines OSObject type.
+// 2. Add type to an existing WTF_OS_OBJECT_*_TYPES(M) macro, or create a new one.
+//    a. If a new macro is created, add macro to WTF_OS_OBJECT_TYPES(M).
+//    b. If a new macro is created, create OSObjectTypeCastTraits declarations.
+
+#import <Network/Network.h>
+#import <dispatch/dispatch.h>
+
+#define WTF_OS_OBJECT_DISPATCH_TYPES(M) \
+    M(dispatch_group) \
+    M(dispatch_object) \
+    M(dispatch_queue) \
+    M(dispatch_queue_global) \
+    M(dispatch_source)
+
+WTF_EXTERN_C_BEGIN
+#define WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT(TypeName) \
+struct TypeName##_s;
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT)
+#undef WTF_DECLARE_OS_OBJECT_DISPATCH_BASE_STRUCT
+WTF_EXTERN_C_END
+
+#define WTF_OS_OBJECT_NETWORK_TYPES(M) \
+    M(nw_endpoint) \
+    M(nw_path) \
+    M(nw_resolution_report)
+
+WTF_EXTERN_C_BEGIN
+#define WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT(TypeName) \
+struct TypeName;
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT)
+#undef WTF_DECLARE_OS_OBJECT_NETWORK_BASE_STRUCT
+WTF_EXTERN_C_END
+
+#define WTF_OS_OBJECT_TYPES(M) \
+    WTF_OS_OBJECT_DISPATCH_TYPES(M) \
+    WTF_OS_OBJECT_NETWORK_TYPES(M)
+
+// Because ARC enablement is a compile-time choice, and we compile this header
+// both ways, we need a separate copy of our code when ARC is enabled.
+#if __has_feature(objc_arc)
+#define dynamicOSObjectCast dynamicOSObjectCastARC
+#define osObjectCast osObjectCastARC
+#endif
+
+namespace WTF {
+
+template<typename> struct OSObjectTypeCastTraits;
+#define WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, Suffix) \
+template<> struct OSObjectTypeCastTraits<TypeName##_t> { \
+    using BaseType = struct TypeName##Suffix*; \
+};
+
+#define WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS(TypeName) \
+WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, _s)
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS)
+#undef WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS
+
+#define WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS(TypeName) \
+WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, )
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS)
+#undef WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS
+
+#undef WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL
+
+// Must define this for isOSObject<T>() when not building with Objective-C.
+#ifndef OS_OBJECT_CLASS
+#define OS_OBJECT_CLASS(name) OS_##name
+#endif
+
+template<typename T> bool isOSObject(CFTypeRef);
+
+#define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS(TypeName) WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName##_t, STRINGIZE_VALUE_OF(OS_OBJECT_CLASS(TypeName)))
+#define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName, ProtocolString) \
+template<> inline bool isOSObject<OSObjectTypeCastTraits<TypeName>::BaseType>(CFTypeRef object) \
+{ \
+    Class cls = object_getClass(bridge_id_cast(object)); \
+    return class_conformsToProtocol(cls, objc_getProtocol(ProtocolString)); \
+} \
+
+WTF_OS_OBJECT_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS)
+#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL
+#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS
+
+#ifdef __OBJC__
+
+template<typename T> inline bool isOSObject(id object)
+{
+    return isOSObject<T>(bridgeCFCast(object));
+}
+
+template<typename T> inline T osObjectCast(id object)
+{
+    if (!object)
+        return nullptr;
+
+    RELEASE_ASSERT(isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object));
+
+    return static_cast<T>(object);
+}
+
+// The dynamicOSObjectCast<T>() methods that have OSObjectPtr<U> arguments use different template types
+// in Objective-C++ vs. C++, so these Objective-C method definitions do not create an ODR violation
+// with the C++ method definitions below.
+
+template<typename T, typename U> requires (!std::is_same_v<U, T>)
+inline OSObjectPtr<T> dynamicOSObjectCast(OSObjectPtr<U>&& object)
+{
+    if (!object)
+        return nullptr;
+
+    if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object.get()))
+        return nullptr;
+
+    return adoptOSObject(static_cast<T>(object.leakRef()));
+}
+
+template<typename T, typename U> requires (!std::is_same_v<U, T>)
+inline OSObjectPtr<T> dynamicOSObjectCast(const OSObjectPtr<U>& object)
+{
+    if (!object)
+        return nullptr;
+
+    if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object.get()))
+        return nullptr;
+
+    return static_cast<T*>(object.get());
+}
+
+template<typename T> inline T dynamicOSObjectCast(id object)
+{
+    if (!object)
+        return nullptr;
+
+    if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object))
+        return nullptr;
+
+    return reinterpret_cast<T>(object);
+}
+
+#endif // defined(__OBJC__)
+
+template<typename T> inline T osObjectCast(CFTypeRef object)
+{
+    if (!object)
+        return nullptr;
+
+    RELEASE_ASSERT(isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object));
+
+    return static_cast<T>(const_cast<CF_BRIDGED_TYPE(id) void*>(object));
+}
+
+template<typename T> inline T dynamicOSObjectCast(CFTypeRef object)
+{
+    if (!object)
+        return nullptr;
+
+    if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object))
+        return nullptr;
+
+    return static_cast<T>(const_cast<CF_BRIDGED_TYPE(id) void*>(object));
+}
+
+#ifndef __OBJC__
+
+template<typename T, typename U> requires (!std::is_same_v<U, T>)
+inline OSObjectPtr<T> dynamicOSObjectCast(OSObjectPtr<U>&& object)
+{
+    if (!object)
+        return nullptr;
+
+    if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object.get()))
+        return nullptr;
+
+    return adoptOSObject(static_cast<T>(object.leakRef()));
+}
+
+template<typename T, typename U> requires (!std::is_same_v<U, T>)
+inline OSObjectPtr<T> dynamicOSObjectCast(const OSObjectPtr<U>& object)
+{
+    if (!object)
+        return nullptr;
+
+    if (!isOSObject<typename OSObjectTypeCastTraits<T>::BaseType>(object.get()))
+        return nullptr;
+
+    return static_cast<T*>(object.get());
+}
+
+#endif // !defined(__OBJC__)
+
+} // namespace WTF
+
+using WTF::dynamicOSObjectCast;
+using WTF::osObjectCast;

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008 Collin Jackson  <collinj@webkit.org>
- * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,7 @@
 #include <wtf/cf/VectorCF.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #include <wtf/darwin/DispatchExtras.h>
+#include <wtf/darwin/TypeCastsOSObject.h>
 #include <wtf/posix/SocketPOSIX.h>
 #include <wtf/text/StringHash.h>
 
@@ -165,9 +166,10 @@ void DNSResolveQueueCFNet::performDNSLookup(const String& hostname, Ref<Completi
         Vector<IPAddress> result;
         result.reserveInitialCapacity(count);
         for (size_t i = 0; i < count; i++) {
-            nw_endpoint_t resolvedEndpoint = reinterpret_cast<nw_endpoint_t>(nw_array_get_object_at_index(resolvedEndpoints, i));
-            if (auto address = extractIPAddress(nw_endpoint_get_address(resolvedEndpoint)))
-                result.append(WTF::move(*address));
+            if (OSObjectPtr resolvedEndpoint = dynamicOSObjectCast<nw_endpoint_t>(nw_array_get_object_at_index(resolvedEndpoints, i))) {
+                if (auto address = extractIPAddress(nw_endpoint_get_address(resolvedEndpoint.get())))
+                    result.append(WTF::move(*address));
+            }
         }
         result.shrinkToFit();
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -207,8 +207,11 @@
 		4433A396208044140091ED57 /* SynchronousTimeoutTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4433A395208044130091ED57 /* SynchronousTimeoutTests.mm */; };
 		44449DC12718B4B700E821B5 /* OSObjectPtrCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		44449DC22718B4B700E821B5 /* OSObjectPtrCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44449DC02718B4B700E821B5 /* OSObjectPtrCocoa.mm */; };
+		44516FB12E4A9BD100B97106 /* TypeCastsOSObjectCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44516FB02E4A9BD100B97106 /* TypeCastsOSObjectCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		44516FB22E4A9BD100B97106 /* TypeCastsOSObjectCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44516FAF2E4A9BD100B97106 /* TypeCastsOSObjectCocoa.mm */; };
 		44652CB726FCD405005EC272 /* TypeCastsCocoaARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44652CB626FCD405005EC272 /* TypeCastsCocoaARC.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		448110C2253F40300097FC33 /* WebPreferencesTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 448110C1253F40240097FC33 /* WebPreferencesTest.mm */; };
+		4482E8E02D94710800754D28 /* TypeCastsOSObjectCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4482E8DF2D94710800754D28 /* TypeCastsOSObjectCF.cpp */; };
 		448D7E471EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 448D7E451EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp */; };
 		44AC8BC621D0245A00CAFB34 /* RetainPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC029B161486AD6400817DA9 /* RetainPtr.cpp */; };
 		44B28A0528D18AD20010172C /* RetainPtrHashing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0991C50143C7D68007998F2 /* RetainPtrHashing.cpp */; };
@@ -2905,9 +2908,12 @@
 		4433A395208044130091ED57 /* SynchronousTimeoutTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SynchronousTimeoutTests.mm; sourceTree = "<group>"; };
 		44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSObjectPtrCocoaARC.mm; sourceTree = "<group>"; };
 		44449DC02718B4B700E821B5 /* OSObjectPtrCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OSObjectPtrCocoa.mm; sourceTree = "<group>"; };
+		44516FAF2E4A9BD100B97106 /* TypeCastsOSObjectCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsOSObjectCocoa.mm; sourceTree = "<group>"; };
+		44516FB02E4A9BD100B97106 /* TypeCastsOSObjectCocoaARC.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsOSObjectCocoaARC.mm; sourceTree = "<group>"; };
 		44652CB626FCD405005EC272 /* TypeCastsCocoaARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TypeCastsCocoaARC.mm; sourceTree = "<group>"; };
 		448110C1253F40240097FC33 /* WebPreferencesTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPreferencesTest.mm; sourceTree = "<group>"; };
 		44817A2E1F0486BF00003810 /* WKRequestActivatedElementInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKRequestActivatedElementInfo.mm; sourceTree = "<group>"; };
+		4482E8DF2D94710800754D28 /* TypeCastsOSObjectCF.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; path = TypeCastsOSObjectCF.cpp; sourceTree = "<group>"; };
 		448D7E451EA6C55500ECC756 /* EnvironmentUtilitiesTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EnvironmentUtilitiesTest.cpp; sourceTree = "<group>"; };
 		44A622C114A0E2B60048515B /* WTFTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WTFTestUtilities.h; sourceTree = "<group>"; };
 		44ABED4A2DA6E46600F472EF /* WKFragmentDirectiveGeneration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKFragmentDirectiveGeneration.mm; sourceTree = "<group>"; };
@@ -5617,6 +5623,9 @@
 				7CBBA07619BB8A9100BBF025 /* OSObjectPtr.cpp */,
 				44449DC02718B4B700E821B5 /* OSObjectPtrCocoa.mm */,
 				44449DBF2718B4B600E821B5 /* OSObjectPtrCocoaARC.mm */,
+				4482E8DF2D94710800754D28 /* TypeCastsOSObjectCF.cpp */,
+				44516FAF2E4A9BD100B97106 /* TypeCastsOSObjectCocoa.mm */,
+				44516FB02E4A9BD100B97106 /* TypeCastsOSObjectCocoaARC.mm */,
 				37C7CC2B1EA4146B007BD956 /* WeakLinking.cpp */,
 			);
 			path = darwin;
@@ -7736,6 +7745,9 @@
 				0F2C20B81DCD545000542D9E /* Time.cpp in Sources */,
 				44CDE4D426EE6E4A009F6ACB /* TypeCastsCocoa.mm in Sources */,
 				44652CB726FCD405005EC272 /* TypeCastsCocoaARC.mm in Sources */,
+				4482E8E02D94710800754D28 /* TypeCastsOSObjectCF.cpp in Sources */,
+				44516FB22E4A9BD100B97106 /* TypeCastsOSObjectCocoa.mm in Sources */,
+				44516FB12E4A9BD100B97106 /* TypeCastsOSObjectCocoaARC.mm in Sources */,
 				E324A6F02041C82000A76593 /* UniqueArray.cpp in Sources */,
 				7429D38C2CCA2AC500858726 /* UniqueRef.cpp in Sources */,
 				3A1337B328F9177600F29B73 /* UniqueRefVector.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/darwin/TypeCastsOSObject.h>
+
+#import "WTFTestUtilities.h"
+#import <dispatch/group.h>
+#import <dispatch/queue.h>
+#import <dispatch/source.h>
+#import <wtf/StdLibExtras.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+#ifdef __OBJC__
+#error This tests TypeCastsOSObject.h in non-Cocoa source.
+#endif
+
+namespace TestWebKitAPI {
+
+using namespace WTF;
+
+TEST(TypeCastsOSObjectCF, osObjectCast)
+{
+    // Null cast.
+    EXPECT_EQ(NULL, osObjectCast<dispatch_object_t>(NULL));
+
+    // Same cast.
+    OSObjectPtr<dispatch_group_t> group = adoptOSObject(dispatch_group_create());
+    CFTypeRef groupPtr = group.get();
+    EXPECT_EQ(group.get(), osObjectCast<dispatch_group_t>(groupPtr));
+    EXPECT_EQ(1L, CFGetRetainCount(groupPtr));
+
+    // Up cast.
+    EXPECT_EQ(group.get(), osObjectCast<dispatch_object_t>(group.get()));
+    EXPECT_EQ(1L, CFGetRetainCount(groupPtr));
+
+    // Down cast.
+    auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+    uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+    EXPECT_EQ(object.get(), osObjectCast<dispatch_group_t>(object.get()));
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+}
+
+TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)
+{
+    // Null cast.
+    EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_object_t>(NULL));
+
+    // Same cast / up cast bad cast from CFTypeRef.
+    {
+        auto objectCF = adoptCF<CFTypeRef>(dispatch_group_create());
+        uintptr_t objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
+        EXPECT_EQ(objectCF.get(), dynamicOSObjectCast<dispatch_group_t>(objectCF.get()));
+        EXPECT_EQ(objectCF.get(), dynamicOSObjectCast<dispatch_object_t>(objectCF.get()));
+        EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_source_t>(objectCF.get()));
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
+    }
+
+    // Down cast / bad cast.
+    {
+        auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(object.get(), dynamicOSObjectCast<dispatch_group_t>(object.get()));
+        EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_source_t>(object.get()));
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Up cast / bad cast.
+    {
+        auto object = adoptOSObject(dispatch_group_create());
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(object.get(), dynamicOSObjectCast<dispatch_object_t>(object.get()));
+        EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_source_t>(object.get()));
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Up cast (excluding dispatch_object_t).
+    {
+        OSObjectPtr object = globalDispatchQueueSingleton(QOS_CLASS_BACKGROUND, 0);
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(object.get(), dynamicOSObjectCast<dispatch_queue_t>(object.get()));
+        EXPECT_EQ(-1L, CFGetRetainCount((CFTypeRef)objectPtr)); // Immortal object.
+    }
+
+    // Bad down cast.
+    {
+        auto object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_queue_global_t>(object.get()));
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+}
+
+TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)
+{
+    // Null cast.
+    {
+        OSObjectPtr<dispatch_object_t> object;
+        auto objectCast = dynamicOSObjectCast<dispatch_group_t>(WTF::move(object));
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, object.get());
+        EXPECT_EQ(NULL, objectCast.get());
+    }
+
+    // Down cast / bad cast.
+    {
+        auto object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_group_t> objectCast = dynamicOSObjectCast<dispatch_group_t>(WTF::move(object));
+        uintptr_t objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, object.get());
+        EXPECT_EQ(objectPtr, objectCastPtr);
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));
+
+        object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+        objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_source_t> objectCastBad = dynamicOSObjectCast<dispatch_source_t>(WTF::move(object));
+        uintptr_t objectPtr2 = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(objectPtr, objectPtr2);
+        EXPECT_EQ(NULL, objectCastBad.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr2));
+    }
+
+    // Up cast.
+    {
+        auto object = adoptOSObject(dispatch_group_create());
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        auto objectCast = dynamicOSObjectCast<dispatch_object_t>(WTF::move(object));
+        uintptr_t objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, object.get());
+        EXPECT_EQ(objectPtr, objectCastPtr);
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));
+    }
+
+    // Bad up cast (excluding dispatch_object_t).
+    {
+        auto object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
+        uintptr_t objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_queue_global_t> objectCastBad = dynamicOSObjectCast<dispatch_queue_global_t>(WTF::move(object));
+        EXPECT_EQ(NULL, objectCastBad.get());
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2011-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/darwin/TypeCastsOSObject.h>
+
+#import "WTFTestUtilities.h"
+
+#if __has_feature(objc_arc)
+#ifndef TYPE_CASTS_OSOBJECT_PTR_TEST_NAME
+#error This tests TypeCastsOSObject.h with ARC disabled.
+#endif
+#define autorelease self
+#endif
+
+#ifndef TYPE_CASTS_OSOBJECT_PTR_TEST_NAME
+#define TYPE_CASTS_OSOBJECT_PTR_TEST_NAME TypeCastsOSObjectCocoa
+#endif
+
+#if __has_feature(objc_arc) && !defined(NDEBUG)
+// Debug builds with ARC enabled cause objects to be autoreleased
+// when assigning adoptOSObject() result to a different OSObjectPtr<> type,
+// and when calling OSObjectPtr<>::get().
+#define AUTORELEASEPOOL_FOR_ARC_DEBUG @autoreleasepool
+#else
+#define AUTORELEASEPOOL_FOR_ARC_DEBUG
+#endif
+
+namespace TestWebKitAPI {
+
+using namespace WTF;
+
+TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, osObjectCast_from_id)
+{
+    // Null cast.
+    EXPECT_EQ(NULL, osObjectCast<dispatch_object_t>(static_cast<id>(NULL)));
+
+    // Same cast.
+    @autoreleasepool {
+        OSObjectPtr<id> group;
+        uintptr_t groupPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            group = adoptOSObject<id>(dispatch_group_create());
+            groupPtr = reinterpret_cast<uintptr_t>(group.get());
+            EXPECT_EQ(group.get(), osObjectCast<dispatch_group_t>(group.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)groupPtr));
+    }
+
+    // Up cast.
+    @autoreleasepool {
+        OSObjectPtr<id> group;
+        uintptr_t groupPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            group = adoptOSObject<id>(dispatch_group_create());
+            groupPtr = reinterpret_cast<uintptr_t>(group.get());
+            EXPECT_EQ(group.get(), osObjectCast<dispatch_object_t>(group.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)groupPtr));
+    }
+
+    // Down cast.
+    @autoreleasepool {
+        OSObjectPtr<id> group;
+        uintptr_t groupPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            group = adoptOSObject<id>(dispatch_group_create());
+            groupPtr = reinterpret_cast<uintptr_t>(group.get());
+            EXPECT_EQ(group.get(), osObjectCast<dispatch_group_t>(group.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)groupPtr));
+    }
+}
+
+TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_OSObjectPtr)
+{
+    // Null cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_object_t> object;
+        auto objectCast = dynamicOSObjectCast<dispatch_group_t>(WTF::move(object));
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, object.get());
+        EXPECT_EQ(NULL, objectCast.get());
+    }
+
+    // Down cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_object_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_group_t> objectCast;
+        uintptr_t objectCastPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCast = dynamicOSObjectCast<dispatch_group_t>(WTF::move(object));
+            objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+            SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, object.get());
+            EXPECT_EQ(objectPtr, objectCastPtr);
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));
+    }
+
+    // Invalid down cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_object_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<dispatch_object_t>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_source_t> objectCastBad;
+        uintptr_t objectPtr2 = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCastBad = dynamicOSObjectCast<dispatch_source_t>(WTF::move(object));
+            EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+            objectPtr2 = reinterpret_cast<uintptr_t>(object.get());
+            EXPECT_EQ(objectPtr, objectPtr2);
+            EXPECT_EQ(NULL, objectCastBad.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Up cast.
+    @autoreleasepool {
+        OSObjectPtr<dispatch_group_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_object_t> objectCast;
+        uintptr_t objectCastPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCast = dynamicOSObjectCast<dispatch_object_t>(WTF::move(object));
+            objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
+            SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, object.get());
+            EXPECT_EQ(objectPtr, objectCastPtr);
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));
+    }
+
+    // Bad up cast (excluding dispatch_object_t).
+    @autoreleasepool {
+        OSObjectPtr<dispatch_queue_t> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject(dispatch_queue_create("testQueue", NULL));
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        OSObjectPtr<dispatch_queue_global_t> objectCastBad;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            objectCastBad = dynamicOSObjectCast<dispatch_queue_global_t>(WTF::move(object));
+            EXPECT_EQ(NULL, objectCastBad.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+}
+
+TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_id)
+{
+    // Null cast.
+    EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_object_t>(static_cast<id>(nil)));
+
+    // Same cast.
+    @autoreleasepool {
+        OSObjectPtr<id> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<id>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+            EXPECT_EQ(object.get(), dynamicOSObjectCast<dispatch_group_t>(object.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Down cast.
+    @autoreleasepool {
+        OSObjectPtr<id> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<id>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            EXPECT_EQ(objectPtr, reinterpret_cast<uintptr_t>(dynamicOSObjectCast<dispatch_group_t>(object.get())));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Invalid down cast.
+    @autoreleasepool {
+        OSObjectPtr<id> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<id>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_source_t>(object.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Up cast.
+    @autoreleasepool {
+        OSObjectPtr<id> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<id>(dispatch_group_create());
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            EXPECT_EQ(objectPtr, reinterpret_cast<uintptr_t>(dynamicOSObjectCast<dispatch_object_t>(object.get())));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+
+    // Bad up cast (excluding dispatch_object_t).
+    @autoreleasepool {
+        OSObjectPtr<id> object;
+        uintptr_t objectPtr = 0;
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            object = adoptOSObject<id>(dispatch_queue_create("testQueue", NULL));
+            objectPtr = reinterpret_cast<uintptr_t>(object.get());
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+
+        AUTORELEASEPOOL_FOR_ARC_DEBUG {
+            EXPECT_EQ(NULL, dynamicOSObjectCast<dispatch_queue_global_t>(object.get()));
+        }
+        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr));
+    }
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoaARC.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoaARC.mm
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This tests TypeCastsOSObject.h with ARC enabled.
+#endif
+
+#define TYPE_CASTS_OSOBJECT_PTR_TEST_NAME TypeCastsOSObjectCocoaARC
+#include "TypeCastsOSObjectCocoa.mm"
+#undef TYPE_CASTS_OSOBJECT_PTR_TEST_NAME


### PR DESCRIPTION
#### d9672f0e75352880994a81f213bfd3bd560141b0
<pre>
Add checked/dynamic casts for OSObjectPtr
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=297639">https://bugs.webkit.org/show_bug.cgi?id=297639</a>&gt;
&lt;<a href="https://rdar.apple.com/158736926">rdar://158736926</a>&gt;

Reviewed by Darin Adler.

OSObject types behave like CF objects in C/C++, but they behave like
Cocoa objects in Objective-C/C++, including opting into ARC.  Unlike
toll-free bridged types, OSObject CF types and the Cocoa types aren&apos;t
defined at the same time, which complicates implementing a shared
solution for both.

For example, an OSObject of type `foo_bar` will be defined like this in
plain C:

  struct foo_bar;
  typedef struct foo_bar *foo_bar_t;

Note that some implementations (like libdispatch) have separate
definitions for C++ with an &quot;_s&quot; suffix:

  typedef struct dispatch_object_s { ... } *dispatch_object_t;

On the other hand, an OSObject of type `foo_bar` will be defined like
this in Objective-C/C++:

  @protocol OS_foo_bar &lt;NSObject&gt; @end
  typedef NSObject&lt;OS_foo_bar&gt; * __attribute__((objc_independent_class)) foo_bar_t;

OSObject &quot;class&quot; inheritance is implemented in Objective-C/C++ by making
the @protocol inherit from the @protocol of the superclass, or inherit
from NSObject if it&apos;s a top-level class.  There is no concept of
inheritence in plain C, although libdispatch does provide inheritance of
struct types in C++:

  typedef struct dispatch_group_s : public dispatch_object_s {} *dispatch_group_t;

However, most OSObject types don&apos;t implement separate C++ definitions,
so that can&apos;t be relied upon to check inheritance.  (These C++
definitions are also not available in Objective-C++ sources, so it would
require implementation of two different type checks, which is less than
ideal.)

Instead, to check whether a given object is of a specific OSObject type,
the Objective-C +[Class conformsToProtocol:] method (or
class_conformsToProtocol() in C) may be used.  Conveniently, any
OSObject that&apos;s currently a plain C/C++ type may be treated as a
CFTypeRef, bridge-cast to `id`, and then used to call either
+conformsToProtocol: or class_conformsToProtocol().

The challenge with implemeting isOSObject&lt;T&gt;() is that an OSObject type,
such as foo_bar_t, is defined differently in plain C++ and
Objective-C++, as noted above.

To make it possible to use a single implementation of isOSObject&lt;T&gt;()
for a type (regardless of the language), OSObjectTypeCastTraits structs
are defined so that `T` is mapped to a common type that&apos;s shared between
C++ and Objective-C++.

If `T` is an OSObject of type `foo_bar_t`, the trait is defined like
this in plain C++ (with the typedef resolved to the underlying type):

  template&lt;&gt; struct OSObjectTypeCastTraits&lt;struct foo_bar*&gt; { using BaseType = struct foo_bar*; };

But it is defined like this in Objective-C++:

  template&lt;&gt; struct OSObjectTypeCastTraits&lt;NSObject&lt;OS_foo_bar&gt; *&gt; { using BaseType = struct foo_bar*; };

While redundant for plain C++, this allows us to map `foo_bar_t` to the
same type no matter which language is used at compile time, and thus
only implement isOSObject&lt;&gt;() once per OSObject type:

  template&lt;&gt; bool isOSObject&lt;OSObjectTypeCastTraits&lt;foo_bar_t&gt;::BaseType&gt;(CFTypeRef object) {
      Class cls = object_getClass(bridge_id_cast(object));
      return class_conformsToProtocol(cls, objc_getProtocol(ProtocolString));
  }

The only downside to this approach is that we must embed some knowledge
of the plain C/C++ struct type when constructing OSObjectTypeCastTraits
for Objective-C++, although it&apos;s only a pre-declared struct.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
- Add TypeCastsOSObject.h to project.
* Source/WTF/wtf/cf/TypeCastsCF.h:
- Add `using WTF::bridgeCFCast` statement.
- Move `using WTF::bridge_id_cast` statement here from TypeCastsCocoa.h.
(WTF::bridgeCFCast): Add.
- Add convenience function to cast from CFTypeRef to id without
  reference churn.  Works in both plain C++ and Objective-C++.
(WTF::bridge_id_cast):
- Move from TypeCastsCocoa.h and make work for CF in plain C++.
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
- Include &lt;wtf/cf/TypeCastsCF.h&gt; for bridge_id_cast().
- Move `using WTF::bridge_id_cast` statement to TypeCastsCF.h.
* Source/WTF/wtf/darwin/TypeCastsOSObject.h: Add.
(WTF::isOSObject): Add.
(WTF::osObjectCast): Add.
(WTF::dynamicOSObjectCast): Add.
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::performDNSLookup):
- Add dynamic cast.
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(extractResolutionReport):
- Add dynamic casts.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
- Add TypeCastsOSObjectCF.cpp, TypeCastsOSObjectCocoa.mm and
  TypeCastsOSObjectCocoaARC.mm to the project.
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCF.cpp: Add.
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, osObjectCast)): Add.
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, dynamicOSObjectCast)): Add.
(TestWebKitAPI::TEST(TypeCastsOSObjectCF, dynamicOSObjectCast_OSObjectPtr)): Add.
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoa.mm: Add.
(TestWebKitAPI::TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, osObjectCast_from_id)): Add.
(TestWebKitAPI::TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_OSObjectPtr)): Add.
(TestWebKitAPI::TEST(TYPE_CASTS_OSOBJECT_PTR_TEST_NAME, dynamicOSObjectCast_from_id)): Add.
* Tools/TestWebKitAPI/Tests/WTF/darwin/TypeCastsOSObjectCocoaARC.mm: Add.

Canonical link: <a href="https://commits.webkit.org/304847@main">https://commits.webkit.org/304847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09d0aacbd6c12d5c2a626e2d9f7eb29cb97b54be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/136639 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/8998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/47926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/144363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/89612 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/484df2b2-dcb2-429d-bc85-5de835644152) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/138511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/9699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/8844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/104482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/75059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8f337c98-b7ec-401c-967b-36fff37e03a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/139584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/7082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/122430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/85319 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8195cc7d-5c69-4ddd-a5de-52d802dca8c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/6726 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/4409 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/4959 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/128600 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/116041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/40619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/147122 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/135125 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/8682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/41193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/112836 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/8700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/7303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/113166 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/6649 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/118723 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/62789 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21070 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/8730 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/36777 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/167904 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/8450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/72296 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/43806 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/8670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/8522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->