### PR TITLE
[JSC] Fix Property Key Enumeration Order for Symbols to Align with TC39

### DIFF
--- a/JSTests/stress/symbol-enumeration-order.js
+++ b/JSTests/stress/symbol-enumeration-order.js
@@ -1,0 +1,68 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`Actual: ${actual}, Expected: ${expected}`);
+    }
+}
+
+var log = [];
+function LoggingProxy() {
+    return new Proxy(
+        {},
+        {
+            defineProperty: (t, key, desc) => {
+                log.push(key);
+                return true;
+            },
+        }
+    );
+}
+
+var keys = [1, "before", Symbol(), "during", Symbol.for("during"), Symbol.iterator, 2, "after", 3, true, {}, false];
+var expectedValues = [
+    "1",
+    "2",
+    "3",
+    "before",
+    "during",
+    "after",
+    "true",
+    "[object Object]",
+    "false",
+    "Symbol()",
+    "Symbol(during)",
+    "Symbol(Symbol.iterator)",
+];
+var expectedTypes = [
+    "string",
+    "string",
+    "string",
+    "string",
+    "string",
+    "string",
+    "string",
+    "string",
+    "string",
+    "symbol",
+    "symbol",
+    "symbol",
+];
+
+var descs = {};
+for (var k of keys) {
+    descs[k] = { configurable: true, value: 0 };
+}
+
+function test(descsObj) {
+    log = [];
+    Object.defineProperties(LoggingProxy(), descs);
+    shouldBe(log.length, keys.length);
+    for (let i = 0; i < keys.length; ++i) {
+        shouldBe(log[i].toString(), expectedValues[i]);
+        shouldBe(typeof log[i], expectedTypes[i]);
+    }
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    test(descs);
+    test(new Proxy(descs, {}));
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1362,8 +1362,6 @@ test/staging/sm/RegExp/unicode-braced.js:
   default: 'SyntaxError: Invalid regular expression: regular expression too large'
 test/staging/sm/RegExp/unicode-class-braced.js:
   default: 'SyntaxError: Invalid regular expression: regular expression too large'
-test/staging/sm/Symbol/enumeration-order.js:
-  default: 'Test262Error: Expected ["string", "symbol", "string", "symbol", "symbol", "string"] to be structurally equal to ["string", "string", "string", "symbol", "symbol", "symbol"]. '
 test/staging/sm/TypedArray/constructor-buffer-sequence.js:
   default: 'Error: Assertion failed: expected exception ExpectedError, got Error: Poisoned Value'
 test/staging/sm/TypedArray/iterator-next-with-detached.js:


### PR DESCRIPTION
#### c9fbe88831619b96652c0695de361e928d930d95
<pre>
[JSC] Fix Property Key Enumeration Order for Symbols to Align with TC39
<a href="https://bugs.webkit.org/show_bug.cgi?id=297644">https://bugs.webkit.org/show_bug.cgi?id=297644</a>

Reviewed by Yusuke Suzuki.

This patch fixes property key enumeration order for symbols to align with TC39 [1].

[1]: <a href="https://tc39.es/ecma262/#sec-ordinaryownpropertykeys">https://tc39.es/ecma262/#sec-ordinaryownpropertykeys</a>

* JSTests/stress/symbol-enumeration-order.js: Added.
(shouldBe):
(test):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::defineProperties):

Canonical link: <a href="https://commits.webkit.org/298949@main">https://commits.webkit.org/298949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6211b59ae7912519d4b43c1e2cee5252f9d68e43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69253 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/88991 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/43667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23255 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67040 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109373 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126488 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115775 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20733 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49697 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144475 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43494 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37196 "Found 1 new JSC binary failure: testapi, Found 20029 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->