### PR TITLE
[Form Control Refresh] Background color for native text inputs does not change when autofilled

### DIFF
--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode-expected.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+    <meta name="color-scheme" content="dark">
+    <script>
+        function setBackground() {
+            var textfield = document.getElementById('devolved');
+
+            if (window.internals)
+                window.internals.setAutofilledAndObscured(textfield, true);
+
+            document.body.style.backgroundColor = window.getComputedStyle(textfield).backgroundColor;
+        }
+    </script>
+    <style>
+        input {
+            margin-top: 40px;
+            display: block;
+            visibility: hidden;
+            border: none;
+        }
+    </style>
+</head>
+<body onload="setBackground()">
+    <p>This tests that background and text colors properly change for autofilled and obscured native inputs. It can only be run using WKTR.</p>
+    <input id="devolved" type="text">
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+    <meta name="color-scheme" content="dark">
+    <script src="resources/autofill-test.js"></script>
+    <style>
+        .shield {
+            display: block;
+            position: absolute;
+        }
+
+        input {
+            margin-top: 40px;
+            display: block;
+        }
+
+        #devolved {
+            border: none;
+            visibility: hidden;
+        }
+    </style>
+</head>
+<body onload="test(true)">
+    <p>This tests that background and text colors properly change for autofilled and obscured native inputs. It can only be run using WKTR.</p>
+    <input type="text" id="textfield">
+    <input type="text" id="devolved">
+    <p id="message"></p>
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode-expected.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <script>
+        function setBackground() {
+            var textfield = document.getElementById('devolved');
+
+            if (window.internals)
+                window.internals.setAutofilledAndObscured(textfield, true);
+
+            document.body.style.backgroundColor = window.getComputedStyle(textfield).backgroundColor;
+        }
+    </script>
+    <style>
+        input {
+            margin-top: 40px;
+            display: block;
+            visibility: hidden;
+            border: none;
+        }
+    </style>
+</head>
+<body onload="setBackground()">
+    <p>This tests that background and text colors properly change for autofilled and obscured native inputs. It can only be run using WKTR.</p>
+    <input id="devolved" type="text">
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+    <script src="resources/autofill-test.js"></script>
+    <style>
+        .shield {
+            display: block;
+            position: absolute;
+        }
+
+        input {
+            margin-top: 40px;
+            display: block;
+        }
+
+        #devolved {
+            border: none;
+            visibility: hidden;
+        }
+    </style>
+</head>
+<body onload="test(true)">
+    <p>This tests that background and text colors properly change for autofilled and obscured native inputs. It can only be run using WKTR.</p>
+    <input type="text" id="textfield">
+    <input type="text" id="devolved">
+    <p id="message"></p>
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-dark-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-dark-mode-expected.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+    <meta name="color-scheme" content="dark">
+    <script>
+        function setBackground() {
+            var textfield = document.getElementById('devolved');
+
+            if (window.internals)
+                window.internals.setAutofilled(textfield, true);
+
+            document.body.style.backgroundColor = window.getComputedStyle(textfield).backgroundColor;
+        }
+    </script>
+    <style>
+        input {
+            margin-top: 40px;
+            display: block;
+            visibility: hidden;
+            border: none;
+        }
+    </style>
+</head>
+<body onload="setBackground()">
+    <p>This tests that background and text colors properly change for autofilled native inputs. It can only be run using WKTR.</p>
+    <input id="devolved" type="text">
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-dark-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-dark-mode.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <meta name="color-scheme" content="dark">
+    <script src="resources/autofill-test.js"></script>
+    <style>
+        .shield {
+            display: block;
+            position: absolute;
+        }
+        input {
+            margin-top: 40px;
+            display: block;
+        }
+        #devolved {
+            border: none;
+            visibility: hidden;
+        }
+    </style>
+</head>
+<body onload="test(false)">
+    <p>This tests that background and text colors properly change for autofilled native inputs. It can only be run using WKTR.</p>
+    <input type="text" id="textfield">
+    <input type="text" id="devolved">
+    <p id="message"></p>
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-light-mode-expected.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-light-mode-expected.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <script>
+        function setBackground() {
+            var textfield = document.getElementById('devolved');
+
+            if (window.internals)
+                window.internals.setAutofilled(textfield, true);
+
+            document.body.style.backgroundColor = window.getComputedStyle(textfield).backgroundColor;
+        }
+    </script>
+    <style>
+        input {
+            margin-top: 40px;
+            display: block;
+            visibility: hidden;
+            border: none;
+        }
+    </style>
+</head>
+<body onload="setBackground()">
+    <p>This tests that background and text colors properly change for autofilled native inputs. It can only be run using WKTR.</p>
+    <input id="devolved" type="text">
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-light-mode.html
+++ b/LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-light-mode.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <script src="resources/autofill-test.js"></script>
+    <style>
+        .shield {
+            display: block;
+            position: absolute;
+        }
+        input {
+            margin-top: 40px;
+            display: block;
+        }
+        #devolved {
+            border: none;
+            visibility: hidden;
+        }
+    </style>
+</head>
+<body onload="test(false)">
+    <p>This tests that background and text colors properly change for autofilled native inputs. It can only be run using WKTR.</p>
+    <input type="text" id="textfield">
+    <input type="text" id="devolved">
+    <p id="message"></p>
+</body>
+</html>

--- a/LayoutTests/fast/forms/form-control-refresh/resources/autofill-test.js
+++ b/LayoutTests/fast/forms/form-control-refresh/resources/autofill-test.js
@@ -1,0 +1,76 @@
+function test(shouldObscure) {
+    const topShield = document.createElement("div");
+    const bottomShield = document.createElement("div");
+    const leftShield = document.createElement("div");
+    const rightShield = document.createElement("div");
+
+    function hideElementBorders(element) {
+        const inputBounds = element.getBoundingClientRect();
+
+        topShield.style.left = inputBounds.left + "px";
+        topShield.style.top = inputBounds.top - 4 + "px";
+        topShield.style.width = inputBounds.width + "px";
+        topShield.style.height = "8px";
+
+        bottomShield.style.left = inputBounds.left + "px";
+        bottomShield.style.top = inputBounds.top + inputBounds.height - 4 + "px";
+        bottomShield.style.width = inputBounds.width + "px";
+        bottomShield.style.height = "8px";
+
+        leftShield.style.left = inputBounds.left - 4 + "px";
+        leftShield.style.top = inputBounds.top - 4 + "px";
+        leftShield.style.width = 8 + "px";
+        leftShield.style.height = inputBounds.height + 8 + "px";
+
+        rightShield.style.left = inputBounds.left + inputBounds.width - 4 + "px";
+        rightShield.style.top = inputBounds.top - 4 + "px";
+        rightShield.style.width = 8 + "px";
+        rightShield.style.height = inputBounds.height + 8 + "px";
+
+        topShield.classList.add("shield");
+        bottomShield.classList.add("shield");
+        leftShield.classList.add("shield");
+        rightShield.classList.add("shield");
+
+        document.body.appendChild(topShield);
+        document.body.appendChild(bottomShield);
+        document.body.appendChild(leftShield);
+        document.body.appendChild(rightShield);
+    }
+
+    var textfield = document.getElementById('textfield');
+    hideElementBorders(textfield);
+
+    const nativeCSSBackground = window.getComputedStyle(textfield).background;
+
+    if (window.internals) {
+        if (shouldObscure) {
+            window.internals.setAutofilledAndObscured(textfield, true);
+            window.internals.setAutofilledAndObscured(devolved, true);
+        } else {
+            window.internals.setAutofilled(textfield, true);
+            window.internals.setAutofilled(devolved, true);
+        }
+
+        const nativeCSSBackgroundWithAutoFill = window.getComputedStyle(textfield).background;
+        const devolvedCSSBackgroundWithAutoFill = window.getComputedStyle(devolved).background;
+
+        const nativeCSSColorWithAutoFill = window.getComputedStyle(textfield).color;
+        const devolvedCSSColorWithAutoFill = window.getComputedStyle(devolved).color;
+
+        if (nativeCSSBackground == nativeCSSBackgroundWithAutoFill)
+            message.innerText += "FAIL: The CSS background did not update for the text field after being autofilled.\n";
+
+        if (nativeCSSBackgroundWithAutoFill != devolvedCSSBackgroundWithAutoFill)
+            message.innerText += "FAIL: The CSS background differs between the autofilled native control and the autofilled devolved control.\n";
+
+        if (nativeCSSColorWithAutoFill != devolvedCSSColorWithAutoFill)
+            message.innerText += "FAIL: The CSS color differs between the autofilled native control and the autofilled devolved control.\n";
+
+        topShield.style.background = devolvedCSSBackgroundWithAutoFill;
+        bottomShield.style.background = devolvedCSSBackgroundWithAutoFill;
+        leftShield.style.background = devolvedCSSBackgroundWithAutoFill;
+        rightShield.style.background = devolvedCSSBackgroundWithAutoFill;
+        document.body.style.background = devolvedCSSBackgroundWithAutoFill;
+    }    
+}

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2170,7 +2170,7 @@ static bool paintTextAreaOrTextField(const RenderObject& box, const PaintInfo& p
 #endif
 
     const auto styleColorOptions = box.styleColorOptions();
-    auto backgroundColor = RenderTheme::singleton().systemColor(CSSValueCanvas, styleColorOptions);
+    auto backgroundColor = style->visitedDependentColor(CSSPropertyBackgroundColor);
 #if PLATFORM(MAC)
     const auto prefersContrast = Theme::singleton().userPrefersContrast();
     auto borderColor = prefersContrast ? highContrastOutlineColor(styleColorOptions) : RenderTheme::singleton().systemColor(CSSValueAppleSystemContainerBorder, styleColorOptions);


### PR DESCRIPTION
#### 29e6f4d3eec462798020e2f1a96b071455b96133
<pre>
[Form Control Refresh] Background color for native text inputs does not change when autofilled
<a href="https://bugs.webkit.org/show_bug.cgi?id=297642">https://bugs.webkit.org/show_bug.cgi?id=297642</a>
<a href="https://rdar.apple.com/158720549">rdar://158720549</a>

Reviewed by Aditya Keerthi.

During textarea/textfield painting, use the background color of the renderer&apos;s style so that
the autofill background color applies.

Added tests fast/forms/form-control-refresh/autofilled-and-obscured-text-input.html and
fast/forms/form-control-refresh/autofilled-text-input.html to ensure the correct background
and text colors are used for native text inputs when autofilled, and when autofilled + obscured.

* LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode-expected.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-dark-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode-expected.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-and-obscured-text-input-light-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-dark-mode-expected.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-dark-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-light-mode-expected.html: Added.
* LayoutTests/fast/forms/form-control-refresh/autofilled-text-input-light-mode.html: Added.
* LayoutTests/fast/forms/form-control-refresh/resources/autofill-test.js: Added.
(test.hideElementBorders):
(test):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::paintTextAreaOrTextField):

Canonical link: <a href="https://commits.webkit.org/299088@main">https://commits.webkit.org/299088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402c057f7cbbe329e1274dd252f34d7ece3b643a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/28088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69800 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73c18905-4959-49f2-b1e8-691490089d88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/38150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/46040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/58576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e0768d1f-eebf-41ef-8d9a-74bbe26ca354) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105607 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69879 "Found 1 new API test failure: TestWTF:WTF_Condition.OneProducerOneConsumerOneSlotTimeout (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c85429a1-978b-4525-9150-dc1bd92e873a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67579 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/127007 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/98044 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/45041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97832 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/43218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/21187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/41049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/50229 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/44013 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/47360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->