### PR TITLE
Make float16 ImageData tests run faster

### DIFF
--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt
@@ -53,6 +53,55 @@ PASS gotten_imageData_uint8_from_float16.data.at(0) is 0
 PASS gotten_imageData_uint8_from_float16.data.at(1) is 128
 PASS gotten_imageData_uint8_from_float16.data.at(2) is 255
 PASS gotten_imageData_uint8_from_float16.data.at(3) is 255
+PASS canvas.width * canvas.height >= 256 * componentsToTest is true
+PASS pixelOffset is 256 * componentsToTest
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS canvas.width * canvas.height >= (extraValues.length + divisions) * componentsToTest is true
+PASS pixelOffset is (extraValues.length + divisions) * componentsToTest
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_uint8_from_float16.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8_from_float16.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8_from_float16.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8_from_float16.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8_from_float16.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8_from_float16.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
 PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html
+++ b/LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html
@@ -20,24 +20,44 @@ var a = 255;
 context.fillStyle = `rgb(${r} ${g} ${b})`;
 context.fillRect(0, 0, 1, 1);
 
-function shouldBeAround(to_eval, targetNumber, tolerance, quiet)
+const componentsPerPixel = 4;
+
+function shouldBeAround(to_eval, targetNumber, tolerance)
 {
     if (!tolerance)
-        return shouldBe(to_eval, String(targetNumber), quiet);
-    return shouldBeCloseTo(to_eval, targetNumber, tolerance, quiet);
+        return shouldBe(to_eval, String(targetNumber));
+    return shouldBeCloseTo(to_eval, targetNumber, tolerance);
 }
 
-function verifyImageData(variable, constructor, bytesPerElement, red, green, blue, alpha, tolerance, quiet) {
-    shouldBe(variable + '.width', '1', quiet);
-    shouldBe(variable + '.height', '1', quiet);
-    shouldBe(variable + '.data.constructor', constructor, quiet);
-    shouldBe(variable + '.data.BYTES_PER_ELEMENT', String(bytesPerElement), quiet);
-    shouldBe(variable + '.data.length', '4', quiet);
-    shouldBe(variable + '.data.byteLength', String(bytesPerElement * 4), quiet);
-    shouldBeAround(variable + '.data.at(0)', red, tolerance, quiet);
-    shouldBeAround(variable + '.data.at(1)', green, tolerance, quiet);
-    shouldBeAround(variable + '.data.at(2)', blue, tolerance, quiet);
-    shouldBeAround(variable + '.data.at(3)', alpha, tolerance, quiet);
+function verifyImageData(variable, constructor, bytesPerElement, red, green, blue, alpha, tolerance)
+{
+    shouldBe(variable + '.width', '1');
+    shouldBe(variable + '.height', '1');
+    shouldBe(variable + '.data.constructor', constructor);
+    shouldBe(variable + '.data.BYTES_PER_ELEMENT', String(bytesPerElement));
+    shouldBe(variable + '.data.length', '4');
+    shouldBe(variable + '.data.byteLength', String(bytesPerElement * 4));
+    shouldBeAround(variable + '.data.at(0)', red, tolerance);
+    shouldBeAround(variable + '.data.at(1)', green, tolerance);
+    shouldBeAround(variable + '.data.at(2)', blue, tolerance);
+    shouldBeAround(variable + '.data.at(3)', alpha, tolerance);
+}
+
+function areEqualImageData(imageDataActual, imageDataExpected, tolerance)
+{
+    tolerance = 0;
+    shouldBe(imageDataActual + '.width', imageDataExpected + '.width');
+    shouldBe(imageDataActual + '.height', imageDataExpected + '.height');
+    shouldBe(imageDataActual + '.data.constructor', imageDataExpected + '.data.constructor');
+    shouldBe(imageDataActual + '.data.BYTES_PER_ELEMENT', imageDataExpected + '.data.BYTES_PER_ELEMENT');
+    shouldBe(imageDataActual + '.data.length', imageDataExpected + '.data.length');
+    shouldBe(imageDataActual + '.data.byteLength', imageDataExpected + '.data.byteLength');
+    const actualData = eval(imageDataActual).data;
+    const expectedData = eval(imageDataExpected).data;
+    for (component = 0; component < actualData.length; ++component) {
+        if (Math.abs(actualData[component] - expectedData[component]) > tolerance)
+            shouldBeAround(imageDataActual + '.data[' + component + ']', expectedData[component], tolerance, true);
+    }
 }
 
 const uint8_bytes_per_element = 1;
@@ -66,46 +86,79 @@ var gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, 1, 1);
 verifyImageData('gotten_imageData_uint8_from_float16', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
 // Exhaustive uint8->float16->uint8 round-trip test for all possible individual SRGB/uint8 component values. Only log errors.
-const quiet = true;
+canvas.width = 64;
+canvas.height = 16;
+var componentsToTest = componentsPerPixel;
+shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
+
+var input_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+
+var pixelOffset = 0;
 for (let v = 0; v < 256; ++v) {
-    for (component = 0; component < 4; ++component) {
+    for (component = 0; component < componentsToTest; ++component) {
         r = g = b = 0;
         a = 255;
         switch (component) {
         case 0: r = v; break;
         case 1: g = v; break;
         case 2: b = v; break;
-        case 2: r = g = b = 255; a = v; break;
+        case 3: r = g = b = (v ? 255 : 0); a = v; break;
         }
-        created_imageData_uint8.data[0] = r;
-        created_imageData_uint8.data[1] = g;
-        created_imageData_uint8.data[2] = b;
-        created_imageData_uint8.data[3] = a;
-        const prefix = '/* #' + v + "-" + component + ": " + r + "," + g + "," + b + "," + a + " */ ";
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
 
-        context.putImageData(created_imageData_uint8, 0, 0);
-        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
-        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
 
-        context.clearRect(0, 0, 1, 1);
-        context.putImageData(gotten_imageData_float16, 0, 0);
-        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
-        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 2] = b / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 3] = a / 255;
+
+        ++pixelOffset;
     }
 }
+shouldBe('pixelOffset', '256 * componentsToTest');
+
+context.putImageData(input_imageData_uint8, 0, 0);
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
+
+context.clearRect(0, 0, canvas.width, canvas.height);
+context.putImageData(gotten_imageData_float16, 0, 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
 
 // Deeper float16->(same)float16->uint8->(nearby)float16 round-trip test for many possible individual component values. Only log errors.
-const divisions = 512;
+canvas.width = 100;
+canvas.height = 32;
+const divisions = 1024;
+componentsToTest = 3;
 const maxValue = 2;
 // A few extras:      largest subnormal    smallest normal  largest <1     smallest >1  largest ...
 const extraValues = [ 6.097555160522461e-5, 6.103515625e-5, 0.99951171875, 1.0009765625, 65504, -1, -65504, Infinity, -Infinity ];
+shouldBeTrue('canvas.width * canvas.height >= (extraValues.length + divisions) * componentsToTest');
+
+input_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+expected_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
+expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+
+pixelOffset = 0;
+const uint8_nonzero_tolerance = 1 / 2;
+const clamp01 = (x) => Math.min(Math.max(x, 0), 1);
 for (let division = -extraValues.length; division < divisions; ++division) {
     const floatValue = (division >= 0) ? (maxValue * division / divisions) : extraValues[extraValues.length + division];
-    for (component = 0; component < 3; ++component) {
+    for (component = 0; component < componentsToTest; ++component) {
         r = g = b = 0;
         a = 1;
         switch (component) {
@@ -113,43 +166,49 @@ for (let division = -extraValues.length; division < divisions; ++division) {
         case 1: g = floatValue; break;
         case 2: b = floatValue; break;
         }
-        created_imageData_float16.data[0] = r;
-        created_imageData_float16.data[1] = g;
-        created_imageData_float16.data[2] = b;
-        created_imageData_float16.data[3] = a;
-        const prefix = '/* #' + ((division >= 0) ? division : ((extraValues.length + division) + "extra")) + "-" + component + ": " + r + "," + g + "," + b + "," + a + " */ ";
-
-        context.putImageData(created_imageData_float16, 0, 0);
-        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r, g, b, a, 0, quiet);
+        input_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r;
+        input_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g;
+        input_imageData_float16.data[pixelOffset * componentsPerPixel + 2] = b;
+        input_imageData_float16.data[pixelOffset * componentsPerPixel + 3] = a;
 
         // Convert float16 [0,1] to expected [0,255] value, with a tolerance of half a unit.
-        const uint8_nonzero_tolerance = 1 / 2;
-        let clamp01 = (x) => Math.min(Math.max(x, 0), 1);
         r = clamp01(r) * 255;
         g = clamp01(g) * 255;
         b = clamp01(b) * 255;
         a = clamp01(a) * 255;
-        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, uint8_nonzero_tolerance, quiet);
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
 
-        // Convert rounded uint8 back to float.
-        context.clearRect(0, 0, 1, 1);
-        context.putImageData(gotten_imageData_uint8, 0, 0);
-        r = Math.round(r);
-        g = Math.round(g);
-        b = Math.round(b);
-        a = Math.round(a);
-        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
-        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
+        r = Math.round(r) / 255;
+        g = Math.round(g) / 255;
+        b = Math.round(b) / 255;
+        a = Math.round(a) / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 2] = b;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 3] = a;
+
+        ++pixelOffset;
     }
 }
+shouldBe('pixelOffset', '(extraValues.length + divisions) * componentsToTest');
+
+context.putImageData(input_imageData_float16, 0, 0);
+
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
+
+context.putImageData(gotten_imageData_uint8, 0, 0);
+gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+areEqualImageData('gotten_imageData_uint8_from_float16', 'expected_imageData_uint8', 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
 
 shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")
 </script>
-<script src="../../resources/js-test-post.js"></script>
+<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt
@@ -53,6 +53,32 @@ PASS gotten_imageData_uint8_from_float16.data.at(0) is 0
 PASS gotten_imageData_uint8_from_float16.data.at(1) is 128
 PASS gotten_imageData_uint8_from_float16.data.at(2) is 255
 PASS gotten_imageData_uint8_from_float16.data.at(3) is 255
+PASS canvas.width * canvas.height >= 256 * componentsToTest is true
+PASS pixelOffset is 256 * componentsToTest
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_float16.width is expected_imageData_float16.width
+PASS gotten_imageData_float16.height is expected_imageData_float16.height
+PASS gotten_imageData_float16.data.constructor is expected_imageData_float16.data.constructor
+PASS gotten_imageData_float16.data.BYTES_PER_ELEMENT is expected_imageData_float16.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_float16.data.length is expected_imageData_float16.data.length
+PASS gotten_imageData_float16.data.byteLength is expected_imageData_float16.data.byteLength
+PASS gotten_imageData_uint8.width is expected_imageData_uint8.width
+PASS gotten_imageData_uint8.height is expected_imageData_uint8.height
+PASS gotten_imageData_uint8.data.constructor is expected_imageData_uint8.data.constructor
+PASS gotten_imageData_uint8.data.BYTES_PER_ELEMENT is expected_imageData_uint8.data.BYTES_PER_ELEMENT
+PASS gotten_imageData_uint8.data.length is expected_imageData_uint8.data.length
+PASS gotten_imageData_uint8.data.byteLength is expected_imageData_uint8.data.byteLength
 PASS context.createImageData(1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS context.getImageData(0, 0, 1, 1, { storageFormat: "foo" }) threw exception TypeError: Type error.
 PASS successfullyParsed is true

--- a/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
+++ b/LayoutTests/fast/canvas/imagedata-storageformat-enabled.html
@@ -19,6 +19,8 @@ var a = 255;
 context.fillStyle = `rgb(${r} ${g} ${b})`;
 context.fillRect(0, 0, 1, 1);
 
+const componentsPerPixel = 4;
+
 function shouldBeAround(to_eval, targetNumber, tolerance, quiet)
 {
     if (!tolerance)
@@ -37,6 +39,23 @@ function verifyImageData(variable, constructor, bytesPerElement, red, green, blu
     shouldBeAround(variable + '.data.at(1)', green, tolerance, quiet);
     shouldBeAround(variable + '.data.at(2)', blue, tolerance, quiet);
     shouldBeAround(variable + '.data.at(3)', alpha, tolerance, quiet);
+}
+
+function areEqualImageData(imageDataActual, imageDataExpected, tolerance)
+{
+    tolerance = 0;
+    shouldBe(imageDataActual + '.width', imageDataExpected + '.width');
+    shouldBe(imageDataActual + '.height', imageDataExpected + '.height');
+    shouldBe(imageDataActual + '.data.constructor', imageDataExpected + '.data.constructor');
+    shouldBe(imageDataActual + '.data.BYTES_PER_ELEMENT', imageDataExpected + '.data.BYTES_PER_ELEMENT');
+    shouldBe(imageDataActual + '.data.length', imageDataExpected + '.data.length');
+    shouldBe(imageDataActual + '.data.byteLength', imageDataExpected + '.data.byteLength');
+    const actualData = eval(imageDataActual).data;
+    const expectedData = eval(imageDataExpected).data;
+    for (component = 0; component < actualData.length; ++component) {
+        if (Math.abs(actualData[component] - expectedData[component]) > tolerance)
+            shouldBeAround(imageDataActual + '.data[' + component + ']', expectedData[component], tolerance, true);
+    }
 }
 
 const uint8_bytes_per_element = 1;
@@ -64,38 +83,59 @@ context.putImageData(gotten_imageData_float16, 0, 0);
 var gotten_imageData_uint8_from_float16 = context.getImageData(0, 0, 1, 1);
 verifyImageData('gotten_imageData_uint8_from_float16', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a);
 
-// Exhaustive uint8->float16->uint8 round-trip test for all possible individual component values. Only log errors.
+// Exhaustive uint8->float16->uint8 round-trip test for all possible individual SRGB/uint8 component values. Only log errors.
+canvas.width = 64;
+canvas.height = 16;
+var componentsToTest = componentsPerPixel;
+shouldBeTrue('canvas.width * canvas.height >= 256 * componentsToTest');
+
+var input_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_uint8 = context.createImageData(canvas.width, canvas.height);
+var expected_imageData_float16 = context.createImageData(canvas.width, canvas.height, { storageFormat: "float16" });
+
+var pixelOffset = 0;
 for (let v = 0; v < 256; ++v) {
-    for (component = 0; component < 4; ++component) {
-        const quiet = true;
+    for (component = 0; component < componentsToTest; ++component) {
         r = g = b = 0;
         a = 255;
         switch (component) {
         case 0: r = v; break;
         case 1: g = v; break;
         case 2: b = v; break;
-        case 2: r = g = b = 255; a = v; break;
+        case 3: r = g = b = (v ? 255 : 0); a = v; break;
         }
-        created_imageData_uint8.data[0] = r;
-        created_imageData_uint8.data[1] = g;
-        created_imageData_uint8.data[2] = b;
-        created_imageData_uint8.data[3] = a;
-        const prefix = '/* ' + r + "," + g + "," + b + "," + a + " */ ";
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
+        input_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
 
-        context.putImageData(created_imageData_uint8, 0, 0);
-        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
-        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 0] = r;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 1] = g;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 2] = b;
+        expected_imageData_uint8.data[pixelOffset * componentsPerPixel + 3] = a;
 
-        context.clearRect(0, 0, 1, 1);
-        context.putImageData(gotten_imageData_float16, 0, 0);
-        gotten_imageData_float16 = context.getImageData(0, 0, 1, 1, { storageFormat: "float16" });
-        verifyImageData(prefix + 'gotten_imageData_float16', 'Float16Array', float16_bytes_per_element, r / 255, g / 255, b / 255, a / 255, float16_nonzero_tolerance, quiet);
-        gotten_imageData_uint8 = context.getImageData(0, 0, 1, 1, { storageFormat: "uint8" });
-        verifyImageData(prefix + 'gotten_imageData_uint8', 'Uint8ClampedArray', uint8_bytes_per_element, r, g, b, a, 0, quiet);
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 0] = r / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 1] = g / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 2] = b / 255;
+        expected_imageData_float16.data[pixelOffset * componentsPerPixel + 3] = a / 255;
+
+        ++pixelOffset;
     }
 }
+shouldBe('pixelOffset', '256 * componentsToTest');
+
+context.putImageData(input_imageData_uint8, 0, 0);
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
+
+context.clearRect(0, 0, canvas.width, canvas.height);
+context.putImageData(gotten_imageData_float16, 0, 0);
+gotten_imageData_float16 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "float16" });
+areEqualImageData('gotten_imageData_float16', 'expected_imageData_float16', float16_nonzero_tolerance);
+gotten_imageData_uint8 = context.getImageData(0, 0, canvas.width, canvas.height, { storageFormat: "uint8" });
+areEqualImageData('gotten_imageData_uint8', 'expected_imageData_uint8', 0);
 
 shouldThrowErrorName(`context.createImageData(1, 1, { storageFormat: "foo" })`, "TypeError")
 shouldThrowErrorName(`context.getImageData(0, 0, 1, 1, { storageFormat: "foo" })`, "TypeError")

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2415,8 +2415,6 @@ webkit.org/b/296202 imported/w3c/web-platform-tests/service-workers/service-work
 
 webkit.org/b/297613 [ Debug ] fast/scrolling/mac/stateless-user-scroll-scrollend.html [ Pass Failure ]
 
-webkit.org/b/297614 [ Sequoia Debug x86_64 ] fast/canvas/hdr/float16-canvas-imagedata.html [ Timeout ]
-
 webkit.org/b/297623 [ Release arm64 ] http/wpt/webcodecs/webcodecs-message-gc.html [ Pass Failure ]
 
 webkit.org/b/297674 [ Sonoma Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Pass Failure ]


### PR DESCRIPTION
#### b18005ca314c40618f99efbc0dc50d8e2caa99f1
<pre>
Make float16 ImageData tests run faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=297649">https://bugs.webkit.org/show_bug.cgi?id=297649</a>
<a href="https://rdar.apple.com/158709235">rdar://158709235</a>

Reviewed by Mike Wyrzykowski.

These two tests ran thousands of iterations, each creating tiny
ImageData objects, and comparing all values using string evaluations,
these could take tens of seconds, going past the timeout deadline in
debug builds.

Optimized by only using a few big ImageData objects, and pre-computing
comparisons (with few string evaluations).

* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata-expected.txt:
* LayoutTests/fast/canvas/hdr/float16-canvas-imagedata.html:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled-expected.txt:
* LayoutTests/fast/canvas/imagedata-storageformat-enabled.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/298986@main">https://commits.webkit.org/298986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56c8280f1cd6e65c7f3b4cb6ce5d160f0e1c1332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69268 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/847e2789-eb26-4c95-8495-1bcab34d258b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89001 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43676 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e04a4e03-0978-4b02-bdd1-f437c0507593) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69509 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a8b7b76-d3c7-44f1-985c-3bd146c300e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67055 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126503 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97672 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40530 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44053 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43509 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46854 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->