### PR TITLE
[OpenXR] Do not use PlatformDisplay for XRSession graphics

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.cpp
@@ -29,7 +29,6 @@
 #include "XRDeviceLayer.h"
 #include <WebCore/GLContext.h>
 #include <WebCore/GLDisplay.h>
-#include <WebCore/PlatformDisplay.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/unix/UnixFileDescriptor.h>

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRLayer.h
@@ -30,10 +30,6 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
-namespace WebCore {
-class PlatformDisplay;
-}
-
 namespace WebKit {
 
 struct XRDeviceLayer;

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 class GLContext;
-class PlatformDisplay;
+class GLDisplay;
 }
 
 namespace WebKit {
@@ -59,6 +59,7 @@ public:
 
 private:
     void createInstance();
+    RefPtr<WebCore::GLDisplay> createGLDisplay() const;
     void initializeDevice();
     void initializeSystem();
     void initializeBlendModes();
@@ -98,7 +99,7 @@ private:
     XrEnvironmentBlendMode m_vrBlendMode;
     XrEnvironmentBlendMode m_arBlendMode;
     PlatformXR::SessionMode m_sessionMode;
-    std::unique_ptr<WebCore::PlatformDisplay> m_platformDisplay;
+    RefPtr<WebCore::GLDisplay> m_glDisplay;
 
     XrSession m_session { XR_NULL_HANDLE };
     XrSessionState m_sessionState { XR_SESSION_STATE_UNKNOWN };


### PR DESCRIPTION
#### 3cb8dfda77eaf3d1fb0ea734d6b3176b2a01f628
<pre>
[OpenXR] Do not use PlatformDisplay for XRSession graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=297651">https://bugs.webkit.org/show_bug.cgi?id=297651</a>

Reviewed by Fujii Hironori.

We can use GLDisplay directly, since PlatformDisplay is designed to be a
shared display in the web process.

Canonical link: <a href="https://commits.webkit.org/298997@main">https://commits.webkit.org/298997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3996b22a06505c2173b0925b2594d0912048a3cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89008 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43681 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29026 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97678 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97473 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40535 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49717 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46859 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->