### PR TITLE
Adopt some more smart pointers in UIProcess

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -26,7 +26,5 @@ UIProcess/API/Cocoa/_WKWebPushAction.mm
 UIProcess/API/Cocoa/_WKWebPushDaemonConnection.h
 UIProcess/API/Cocoa/_WKWebPushMessage.h
 UIProcess/mac/WKImmediateActionController.h
-UIProcess/mac/WKPrintingView.h
 UIProcess/mac/WKTextFinderClient.mm
-UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -81,15 +81,11 @@ UIProcess/Inspector/mac/WKInspectorWKWebView.mm
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/PageClientImplMac.mm
 UIProcess/mac/SecItemShimProxy.cpp
-UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
 UIProcess/mac/WKFullScreenWindowController.mm
 UIProcess/mac/WKImmediateActionController.mm
-UIProcess/mac/WKPrintingView.mm
-UIProcess/mac/WKRevealItemPresenter.mm
 UIProcess/mac/WKTextAnimationManagerMac.mm
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
-UIProcess/mac/WebDateTimePickerMac.mm
 UIProcess/mac/WebPopupMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -177,7 +177,7 @@ MachSendRight TiledCoreAnimationDrawingAreaProxy::createFence()
     if (!page)
         return MachSendRight();
 
-    RetainPtr<CAContext> rootLayerContext = [page->acceleratedCompositingRootLayer() context];
+    RetainPtr<CAContext> rootLayerContext = [page->protectedAcceleratedCompositingRootLayer() context];
     if (!rootLayerContext)
         return MachSendRight();
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.h
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.h
@@ -70,7 +70,7 @@ class WebFrameProxy;
     Lock _printingCallbackMutex;
     Condition _printingCallbackCondition;
 
-    NSTimer *_autodisplayResumeTimer;
+    RetainPtr<NSTimer> _autodisplayResumeTimer;
 }
 
 - (id)initWithFrameProxy:(WebKit::WebFrameProxy&)frame view:(NSView *)wkView;

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -127,7 +127,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_autodisplayResumeTimer) {
         _autodisplayResumeTimer = [NSTimer timerWithTimeInterval:0 target:self selector:@selector(_delayedResumeAutodisplayTimerFired) userInfo:nil repeats:NO];
         // The timer must be scheduled on main thread, because printing thread may finish before it fires.
-        [[NSRunLoop mainRunLoop] addTimer:_autodisplayResumeTimer forMode:NSDefaultRunLoopMode];
+        [[NSRunLoop mainRunLoop] addTimer:_autodisplayResumeTimer.get() forMode:NSDefaultRunLoopMode];
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
+++ b/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
@@ -56,7 +56,8 @@
 
     _impl = impl;
     _presenter = adoptNS([PAL::allocRVPresenterInstance() init]);
-    _presentingContext = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:menuLocationInView inView:impl.view() highlightDelegate:self]);
+    RetainPtr view = impl.view();
+    _presentingContext = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:menuLocationInView inView:view.get() highlightDelegate:self]);
     _item = item;
     _frameInView = frameInView;
     _menuLocationInView = menuLocationInView;

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -302,8 +302,9 @@ void WebContextMenuProxyMac::setupServicesMenu()
     [[WKSharingServicePickerDelegate sharedSharingServicePickerDelegate] setHandlesEditingReplacement:includeEditorServices];
     
     NSRect imageRect = m_context.controlledImageBounds();
-    imageRect = [m_webView convertRect:imageRect toView:nil];
-    imageRect = [[m_webView window] convertRectToScreen:imageRect];
+    auto webView = m_webView.get();
+    imageRect = [webView convertRect:imageRect toView:nil];
+    imageRect = [[webView window] convertRectToScreen:imageRect];
     [[WKSharingServicePickerDelegate sharedSharingServicePickerDelegate] setSourceFrame:imageRect];
     [[WKSharingServicePickerDelegate sharedSharingServicePickerDelegate] setAttachmentID:m_context.controlledImageAttachmentID()];
 

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -322,7 +322,7 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
 @implementation WKDataListSuggestionsController {
     WeakPtr<WebKit::WebDataListSuggestionsDropdownMac> _dropdown;
     Vector<WebCore::DataListSuggestion> _suggestions;
-    NSView *_presentingView;
+    RetainPtr<NSView> _presentingView;
 
     RetainPtr<NSScrollView> _scrollView;
     RetainPtr<WKDataListSuggestionWindow> _enclosingWindow;

--- a/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm
@@ -191,7 +191,9 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
 
     _presentingView = view;
 
-    NSRect windowRect = [[_presentingView window] convertRectToScreen:[_presentingView convertRect:params.anchorRectInRootView toView:nil]];
+    RetainPtr presentingView = _presentingView.get();
+
+    NSRect windowRect = [[presentingView window] convertRectToScreen:[presentingView convertRect:params.anchorRectInRootView toView:nil]];
     windowRect.origin.y = NSMinY(windowRect) - kCalendarHeight;
     windowRect.size.width = kCalendarWidth;
     windowRect.size.height = kCalendarHeight;
@@ -229,7 +231,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
     _picker = picker;
 
     [[_enclosingWindow contentView] addSubview:_datePicker.get()];
-    [[_presentingView window] addChildWindow:_enclosingWindow.get() ordered:NSWindowAbove];
+    [[_presentingView.get() window] addChildWindow:_enclosingWindow.get() ordered:NSWindowAbove];
 }
 
 - (void)updatePicker:(WebCore::DateTimeChooserParameters&&)params
@@ -269,7 +271,7 @@ void WebDateTimePickerMac::didChooseDate(StringView date)
 
     _dateFormatter = nil;
 
-    [[_presentingView window] removeChildWindow:_enclosingWindow.get()];
+    [[_presentingView.get() window] removeChildWindow:_enclosingWindow.get()];
     [_enclosingWindow close];
     _enclosingWindow = nil;
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -656,10 +656,11 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     self = [super init];
     if (!self)
         return nil;
-    _lastResponderInChain = chain;
-    while (RetainPtr next = [_lastResponderInChain nextResponder])
-        _lastResponderInChain = next.get();
-    [_lastResponderInChain setNextResponder:self];
+    RetainPtr current = chain;
+    while (RetainPtr next = [current nextResponder])
+        current = next.get();
+    [current setNextResponder:self];
+    _lastResponderInChain = current.get();
     return self;
 }
 


### PR DESCRIPTION
#### 1ab7168d3ed16b9eb76a0407530dfea65cff2da8
<pre>
Adopt some more smart pointers in UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=297652">https://bugs.webkit.org/show_bug.cgi?id=297652</a>

Reviewed by Ryosuke Niwa.

Fix more [alpha.webkit.UnretainedCallArgsChecker] warnings in UIProcess.

* Source/WebKit/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::createFence):
* Source/WebKit/UIProcess/mac/WKPrintingView.h:
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _delayedResumeAutodisplay]):
* Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm:
(-[WKRevealItemPresenter initWithWebViewImpl:item:frame:menuLocation:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
* Source/WebKit/UIProcess/mac/WebDateTimePickerMac.mm:
(-[WKDateTimePicker initWithParams:inView:]):
(-[WKDateTimePicker showPicker:]):
(-[WKDateTimePicker invalidate]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKResponderChainSink initWithResponderChain:]):

Canonical link: <a href="https://commits.webkit.org/300923@main">https://commits.webkit.org/300923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9a19eab453f733dcc14a03f236bb6bb8b8bbd80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/124240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/43927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/34650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/131074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/76320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/44670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/52529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/94505 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/62697 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/127194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/35595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/111126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/75093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/34541 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/74554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/105338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/29509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/133745 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/51156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/38998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/102981 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/51545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/107344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/102781 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26173 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/48145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/26392 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/48064 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/51018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/56797 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/50462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/53816 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/52137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->