### PR TITLE
Invariant attribute not transpiled to resulting Metal shader

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-279453.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-279453.html
@@ -31,7 +31,7 @@ async function run() {
         @vertex fn vertex0() -> @builtin(position) vec4f {
             return vec4f();
         }
-        @fragment fn fragment0() -> @location(200) vec4i {
+        @fragment fn fragment0() -> @location(0) vec4i {
             return vec4i();
         }
     `});

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286564-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286564-expected.txt
@@ -1,3 +1,7 @@
+CONSOLE MESSAGE: error
+CONSOLE MESSAGE: GPUPipelineError: location(200) >= maxColorAttachments(8)
+CONSOLE MESSAGE: GPUPipelineError
+CONSOLE MESSAGE: _
+CONSOLE MESSAGE: GPUPipelineError: location(200) >= maxColorAttachments(8) - validation
 promises created
-Pass
 

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-286564.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-286564.html
@@ -134,7 +134,7 @@ async function window0() {
 c = await navigator.gpu.requestAdapter();
 device0 = await c.requestDevice();
 texture1 = device0.createTexture({
-  size : [],
+  size : [1],
   dimension : '1d',
   format : 'rgba16sint',
   usage : GPUTextureUsage.STORAGE_BINDING | []

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-292525.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-292525.html
@@ -71,7 +71,7 @@ struct VertexInput19 {
     return out;
 }
 
-@fragment fn fragment3() -> @location(200) vec4f {
+@fragment fn fragment3() -> @location(0) vec4f {
     var out: vec4f;
     return out;
     _ = override10;

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-293750.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-293750.html
@@ -2239,7 +2239,7 @@ fn vertex3(@location(1) location_1: vec4i, a1: VertexInput13, a2: VertexInput14,
 
 /* used global variables: buffer44, et4, et5 */
 @fragment
-fn fragment4() -> @location(200) vec2i {
+fn fragment4() -> @location(0) vec2i {
   var out: vec2i;
   while bool(tan(unconst_f16(1273.9))) {
   var vf46: vec2u = textureDimensions(et5);

--- a/LayoutTests/fast/webgpu/regression/repro_290739.html
+++ b/LayoutTests/fast/webgpu/regression/repro_290739.html
@@ -156,7 +156,7 @@ async function window0() {
           return vec4f();
         }
 
-        @fragment fn fragment0() -> @location(200) vec4u {
+        @fragment fn fragment0() -> @location(0) vec4u {
           return vec4u();
         }
     `, });

--- a/Source/WebGPU/WGSL/AST/ASTArrayTypeExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTArrayTypeExpression.h
@@ -29,7 +29,7 @@
 
 namespace WGSL::AST {
 
-class ArrayTypeExpression : public Expression {
+class ArrayTypeExpression final : public Expression {
     WGSL_AST_BUILDER_NODE(ArrayTypeExpression);
 
 public:

--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -44,6 +44,7 @@ enum class StructureRole : uint8_t {
     FragmentInput,
     ComputeInput,
     VertexOutput,
+    VertexOutputWrapper,
     BindGroup,
     UserDefinedResource,
     PackedResource,

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -1022,6 +1022,18 @@ std::optional<Error> RewriteGlobalVariables::visitEntryPoint(const CallGraph::En
     }
     case ShaderStage::Vertex:
         m_entryPointInformation->typedEntryPoint = Reflection::Vertex { false };
+        if (entryPoint.function.returnTypeInvariant())
+            m_entryPointInformation->usesInvariant = true;
+        else if (auto* returnType = entryPoint.function.maybeReturnType()) {
+            if (auto* structType = std::get_if<Types::Struct>(returnType->inferredType())) {
+                for (const auto& member : structType->structure.members()) {
+                    if (member.invariant()) {
+                        m_entryPointInformation->usesInvariant = true;
+                        break;
+                    }
+                }
+            }
+        }
         break;
     case ShaderStage::Fragment:
         m_entryPointInformation->typedEntryPoint = Reflection::Fragment { };

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -156,6 +156,7 @@ public:
     void visit(AST::SizeAttribute&) override;
     void visit(AST::AlignAttribute&) override;
     void visit(AST::InterpolateAttribute&) override;
+    void visit(AST::InvariantAttribute&) override;
 
     void visit(AST::Function&) override;
     void visit(AST::Structure&) override;
@@ -789,7 +790,7 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
                 }
             }
             m_body.append(m_indent, "{ }\n"_s);
-        } else if (structDecl.role() == AST::StructureRole::FragmentOutputWrapper) {
+        } else if (structDecl.role() == AST::StructureRole::FragmentOutputWrapper || structDecl.role() == AST::StructureRole::VertexOutputWrapper) {
             ASSERT(structDecl.members().size() == 1);
             auto& member = structDecl.members()[0];
 
@@ -983,7 +984,7 @@ void FunctionDefinitionWriter::visit(AST::BuiltinAttribute& builtin)
     // Built-in attributes are only valid for parameters. If a struct member originally
     // had a built-in attribute it must have already been hoisted into a parameter, but
     // we keep the original struct so we can reconstruct it.
-    if (m_structRole.has_value() && *m_structRole != AST::StructureRole::VertexOutput && *m_structRole != AST::StructureRole::FragmentOutput && *m_structRole != AST::StructureRole::FragmentOutputWrapper)
+    if (m_structRole.has_value() && *m_structRole != AST::StructureRole::VertexOutput && *m_structRole != AST::StructureRole::VertexOutputWrapper && *m_structRole != AST::StructureRole::FragmentOutput && *m_structRole != AST::StructureRole::FragmentOutputWrapper)
         return;
 
     switch (builtin.builtin()) {
@@ -998,6 +999,7 @@ void FunctionDefinitionWriter::visit(AST::BuiltinAttribute& builtin)
         break;
     case Builtin::InstanceIndex:
         m_body.append("[[instance_id]]"_s);
+        break;
         break;
     case Builtin::LocalInvocationId:
         m_body.append("[[thread_position_in_threadgroup]]"_s);
@@ -1065,6 +1067,7 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         switch (role) {
         case AST::StructureRole::VertexOutput:
         case AST::StructureRole::FragmentInput:
+        case AST::StructureRole::VertexOutputWrapper:
             m_body.append("[[user(loc"_s, location.location().constantValue()->integerValue(), ")]]"_s);
             return;
         case AST::StructureRole::BindGroup:
@@ -1074,7 +1077,6 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         case AST::StructureRole::PackedResource:
             return;
         case AST::StructureRole::FragmentOutputWrapper:
-            RELEASE_ASSERT_NOT_REACHED();
         case AST::StructureRole::FragmentOutput:
             m_body.append("[[color("_s, location.location().constantValue()->integerValue(), ")]]"_s);
             return;
@@ -1139,6 +1141,14 @@ static ASCIILiteral convertToSampleMode(InterpolationType type, InterpolationSam
 void FunctionDefinitionWriter::visit(AST::InterpolateAttribute& attribute)
 {
     m_body.append("[["_s, convertToSampleMode(attribute.type(), attribute.sampling()), "]]"_s);
+}
+
+void FunctionDefinitionWriter::visit(AST::InvariantAttribute&)
+{
+    if (!m_structRole.has_value() || (*m_structRole != AST::StructureRole::VertexOutput && *m_structRole != AST::StructureRole::VertexOutputWrapper))
+        return;
+
+    m_body.append("[[invariant]]"_s);
 }
 
 // Types

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -221,6 +221,7 @@ struct EntryPointInformation {
     Variant<Vertex, Fragment, Compute> typedEntryPoint;
     size_t sizeForWorkgroupVariables { 0 };
     size_t bindingCount { 0 };
+    bool usesInvariant { false };
 };
 
 } // namespace Reflection
@@ -233,6 +234,7 @@ struct PrepareResult {
 struct DeviceState {
     unsigned appleGPUFamily { 4 };
     bool shaderValidationEnabled { false };
+    bool usesInvariant { false };
 };
 
 Variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, PipelineLayout*>&);

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -175,11 +175,11 @@ public:
     {
         m_replacements.append([&current, currentCopy = current]() mutable {
             std::bit_cast<AST::IdentityExpression*>(&current)->~IdentityExpression();
-            new (&current) CurrentType(WTFMove(currentCopy));
+            new (std::bit_cast<void*>(&current)) CurrentType(WTFMove(currentCopy));
         });
 
         current.~CurrentType();
-        new (&current) AST::IdentityExpression(replacement.span(), replacement);
+        new (std::bit_cast<void*>(&current)) AST::IdentityExpression(replacement.span(), replacement);
     }
 
     template<typename CurrentType, typename ReplacementType>

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -175,7 +175,8 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
 
     auto library = ShaderModule::createLibrary(device, msl, label, error, WGSL::DeviceState {
         .appleGPUFamily = shaderModule.device().appleGPUFamily(),
-        .shaderValidationEnabled = shaderModule.device().isShaderValidationEnabled()
+        .shaderValidationEnabled = shaderModule.device().isShaderValidationEnabled(),
+        .usesInvariant = entryPointInformation.usesInvariant
     });
     if (error && *error)
         return { };

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import "ASTInterpolateAttribute.h"
+#import "CallGraph.h"
 #import "WGSL.h"
 #import <variant>
 #import <wtf/FastMalloc.h>
@@ -118,7 +119,7 @@ private:
     FragmentInputs parseFragmentInputs(const WGSL::AST::Function&);
     void populateOutputState(const String&, WGSL::Builtin);
 
-    ShaderModule::FragmentOutputs parseFragmentReturnType(const WGSL::Type&, const String&);
+    ShaderModule::FragmentOutputs parseFragmentReturnType(const WGSL::Type&, const WGSL::CallGraph::EntryPoint&);
 
     const Ref<Device> m_device;
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250441 - this needs to be populated from the compiler

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
@@ -194,6 +194,13 @@ TEST_F(WGSLMetalCompilationTests, Atomics)
 TEST_F(WGSLMetalCompilationTests, Attributes)
 {
     testCompilation(file("attributes.wgsl"_s));
+
+    testCompilation("struct S { @builtin(position) @invariant value : vec4f };"
+        "@vertex fn main() -> S { return S(vec4<f32>()); }"_s,
+        checkLiteral("[[invariant]]"_s));
+
+    testCompilation("@vertex fn main() -> @invariant @builtin(position) vec4<f32> { return vec4<f32>(); }"_s,
+        checkLiteral("[[invariant]]"_s));
 }
 
 TEST_F(WGSLMetalCompilationTests, BindingUIntMax)

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -79,7 +79,16 @@ using __UnpackedType = typename __UnpackedTypeImpl<T>::Type;
 template<typename T>
 using __PackedType = typename __PackedTypeImpl<T>::Type;
 
-[[fragment]] vec<float, 4> function0()
+struct __function0_FragmentOutput {
+    vec<float, 4> __value [[color(0)]];
+
+    template<typename T>
+    __function0_FragmentOutput(T value)
+        : __value(value)
+    { }
+};
+
+[[fragment]] __function0_FragmentOutput function0()
 {
     return vec<float, 4>(1., 0., 0., 1.);
 }


### PR DESCRIPTION
#### 13b646f1849dbb58b8348600b12213ddcf69d16a
<pre>
Invariant attribute not transpiled to resulting Metal shader
<a href="https://bugs.webkit.org/show_bug.cgi?id=297397">https://bugs.webkit.org/show_bug.cgi?id=297397</a>

Reviewed by Mike Wyrzykowski.

The issue required three related fixes:
- The code generator previously just ignored invariant attributes, where it should
  emit `[[invariant]]`
- Attributes on return types were ignored, and in order to correctly emit them we
  need to wrap the return value in a struct
- Our existing mechanism for wrapping the return value, which was previously only
  used for fragment outputs, would only wrap the result if the type was a simple
  identifier, ignoring elaborated types such as `vecN&lt;T&gt;` and `array&lt;T&gt;`

* Source/WebGPU/WGSL/AST/ASTArrayTypeExpression.h:
(WGSL::AST::ArrayTypeExpression::maybeElementType const): Deleted.
(WGSL::AST::ArrayTypeExpression::maybeElementCount const): Deleted.
(WGSL::AST::ArrayTypeExpression::ArrayTypeExpression): Deleted.
* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):
* Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm:
(TestWGSLAPI::TEST_F(WGSLMetalCompilationTests, Attributes)):
* Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp:
(TestWGSLAPI::TEST(WGSLMetalGenerationTests, RedFrag)):

Canonical link: <a href="https://commits.webkit.org/299494@main">https://commits.webkit.org/299494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b0a46a3fd418832da2b961975bcd3705b056605

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119187 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/38869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/29520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/125413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/71250 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5e49a08c-5eb6-48b1-a646-2ec68c403d9a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/39564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/47450 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/90544 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-multicol/crashtests/inline-float-parallel-flow.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/59907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c21ca4cc-d2e5-4719-9357-68544f098033) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/31544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/106842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/70949 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18a557b3-b92b-42ad-8432-1b57ec749827) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/30588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/24957 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69062 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/100990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/128428 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/34836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/46461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/98882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/44351 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/22354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/42673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/45964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/51644 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/45431 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/48779 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->