### PR TITLE
[Coordinated Graphics][GraphicsLayerTextureMapper] Crash with an animation of drop-shadow and currentColor

### DIFF
--- a/LayoutTests/css3/filters/drop-shadow-current-color-expected.html
+++ b/LayoutTests/css3/filters/drop-shadow-current-color-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<style>
+  div {
+      margin: 10px;
+      height: 100px;
+      width: 100px;
+  }
+  .a {
+      background: black;
+      filter: drop-shadow(110px 0 0 black);
+  }
+  .b {
+      background: green;
+      filter: drop-shadow(110px 0 0 green);
+  }
+</style>
+A test of drop-shadow with currentColor and a composited layer.
+After 0.1s animation, you should see 8 boxes. The right and left sides should be the same color.
+<div class="a s"></div>
+<div class="a t"></div>
+<div class="b s"></div>
+<div class="b t"></div>
+</html>

--- a/LayoutTests/css3/filters/drop-shadow-current-color.html
+++ b/LayoutTests/css3/filters/drop-shadow-current-color.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta name="fuzzy" content="maxDifference=0-30; totalPixels=0-500" />
+<style>
+  @keyframes a {
+      from {
+          filter: drop-shadow(110px 0 0 red);
+      }
+      to {
+          filter: drop-shadow(110px 0 0 currentColor);
+      }
+  }
+  @keyframes b {
+      from {
+          filter: drop-shadow(110px 0 0 currentColor);
+      }
+      to {
+          filter: drop-shadow(110px 0 0 green);
+      }
+  }
+  div {
+      margin: 10px;
+      height: 100px;
+      width: 100px;
+  }
+  .a {
+      background: currentColor;
+      animation: a 0.1s both;
+  }
+  .b {
+      background: green;
+      animation: b 0.1s both;
+  }
+  .t {
+      will-change: transform;
+  }
+</style>
+<script>
+  onload = () => {
+      document.addEventListener("webkitAnimationEnd", () => {
+          document.documentElement.classList.remove('reftest-wait');
+      } , false);
+  };
+</script>
+A test of drop-shadow with currentColor and a composited layer.
+After 0.1s animation, you should see 8 boxes. The right and left sides should be the same color.
+<div class="a s"></div>
+<div class="a t"></div>
+<div class="b s"></div>
+<div class="b t"></div>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1741,6 +1741,8 @@ fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-iframe.html [ Skip ]
 # Fetch tests that only timeout in WK1.
 imported/w3c/web-platform-tests/fetch/metadata/unload.https.sub.html [ Skip ]
 
+css3/filters/drop-shadow-current-color.html [ ImageOnlyFailure ]
+
 ### END OF (2) Failures without bug reports
 ########################################
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
@@ -616,6 +616,10 @@ bool GraphicsLayerTextureMapper::addAnimation(const KeyframeValueList& valueList
             return false;
 
         const auto& filters = static_cast<const FilterAnimationValue&>(valueList.at(listIndex)).value();
+        // The animation of drop-shadow filter with currentColor isn't supported yet.
+        // GraphicsLayerCA doesn't accept animations with drap-shadow. Do it here.
+        if (filters.hasFilterOfType<FilterOperation::Type::DropShadowWithStyleColor>())
+            return false;
         if (!filtersCanBeComposited(filters))
             return false;
     }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -603,6 +603,10 @@ bool GraphicsLayerCoordinated::addAnimation(const KeyframeValueList& valueList, 
             return false;
 
         const auto& filters = static_cast<const FilterAnimationValue&>(valueList.at(listIndex)).value();
+        // The animation of drop-shadow filter with currentColor isn't supported yet.
+        // GraphicsLayerCA doesn't accept animations with drap-shadow. Do it here.
+        if (filters.hasFilterOfType<FilterOperation::Type::DropShadowWithStyleColor>())
+            return false;
         if (!filtersCanBeComposited(filters))
             return false;
         break;


### PR DESCRIPTION
#### b83400bc63a873d5e2e0668f62b73af44d66c545
<pre>
[Coordinated Graphics][GraphicsLayerTextureMapper] Crash with an animation of drop-shadow and currentColor
<a href="https://bugs.webkit.org/show_bug.cgi?id=297499">https://bugs.webkit.org/show_bug.cgi?id=297499</a>

Reviewed by Miguel Gomez.

After &lt;<a href="https://commits.webkit.org/293027@main">https://commits.webkit.org/293027@main</a>&gt; added a new filter type
DropShadowWithStyleColor to support the drop-shadow filter with
currentColor, a crash happened in
TextureMapperLayer::paintSelfAndChildrenWithIntermediateSurface if a
content has an animation of the filter.

GraphicsLayerCA doesn&apos;t accept animaitons of any drop-shadow filter.
Do the same thing for GraphicsLayerCoordinated and
GraphicsLayerTextureMapper too.

* LayoutTests/css3/filters/drop-shadow-current-color-expected.html: Added.
* LayoutTests/css3/filters/drop-shadow-current-color.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp:
(WebCore::GraphicsLayerTextureMapper::addAnimation):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::addAnimation):

Canonical link: <a href="https://commits.webkit.org/298987@main">https://commits.webkit.org/298987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7a09f449e0ae9506ebe2de0dfab33ec261d78aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123494 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/69383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45652 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/89084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/69383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23372 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67167 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33286 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/97750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97544 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20846 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44165 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/49824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43621 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->