### PR TITLE
[css-anchor-position-1] nested position-visibility should not make force-hidden box visible

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<div class=container>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<div class=container>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Anchor Positioning Test: position-visibility</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#position-visibility">
+<link rel="match" href="position-visibility-no-overflow-nested-ref.html">
+<style>
+.container {
+    position: relative;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+.outer {
+    position: absolute;
+    top: 10px;
+    width: 100px;
+    height: 100px;
+    background: yellow;
+    position-visibility: no-overflow;
+}
+.inner {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    background: red;
+    position-visibility: no-overflow;
+}
+</style>
+<div class=container>
+    <div class=outer>
+        Outer overflows.
+        <div class=inner>
+            Inner doesn't but still shouldn't be visible.
+        </div>
+    </div>
+</div>

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1226,7 +1226,7 @@ public:
     inline void setBlendMode(BlendMode);
     inline bool isInSubtreeWithBlendMode() const;
 
-    inline void setIsForceHidden(bool = true);
+    inline void setIsForceHidden();
     inline bool isForceHidden() const;
 
     inline void setIsolation(Isolation);

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -608,7 +608,7 @@ inline void RenderStyle::setBlendMode(BlendMode mode)
     SET(m_rareInheritedData, isInSubtreeWithBlendMode, mode != BlendMode::Normal);
 }
 
-inline void RenderStyle::setIsForceHidden(bool hide) { SET(m_rareInheritedData, isForceHidden, hide); }
+inline void RenderStyle::setIsForceHidden() { SET(m_rareInheritedData, isForceHidden, true); }
 inline void RenderStyle::setIsolation(Isolation isolation) { SET_NESTED(m_nonInheritedData, rareData, isolation, static_cast<unsigned>(isolation)); }
 
 inline void RenderStyle::setAutoRevealsWhenFound() { SET(m_rareInheritedData, autoRevealsWhenFound, true); }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1712,7 +1712,8 @@ void TreeResolver::updateForPositionVisibility(RenderStyle& style, const Styleab
     };
 
     // FIXME: Implement via "visibility: force-hidden".
-    style.setIsForceHidden(shouldHideAnchorPositioned());
+    if (shouldHideAnchorPositioned())
+        style.setIsForceHidden();
 }
 
 const RenderStyle* TreeResolver::beforeResolutionStyle(const Element& element, std::optional<PseudoElementIdentifier> pseudo)


### PR DESCRIPTION
#### 03be58b89773c43f0a360e61b37401ee94c68fe7
<pre>
[css-anchor-position-1] nested position-visibility should not make force-hidden box visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=297654">https://bugs.webkit.org/show_bug.cgi?id=297654</a>
<a href="https://rdar.apple.com/158765248">rdar://158765248</a>

Reviewed by Alan Baradlay.

A force-hidden subtree should always stay hidden.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-no-overflow-nested.html: Added.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setIsForceHidden):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::updateForPositionVisibility):

Revert this change from <a href="https://commits.webkit.org/298770@main">https://commits.webkit.org/298770@main</a>

Canonical link: <a href="https://commits.webkit.org/298959@main">https://commits.webkit.org/298959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bcf222f0eaa3839296ccf1612657d1b9efc1422

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69282 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45afadfb-d022-484f-8717-4eef624c2575) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89016 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43686 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32178a43-bd63-4452-8a8f-6df7d86b1519) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69523 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23284 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67069 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126517 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97685 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97480 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24823 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40544 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49726 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43523 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->