### PR TITLE
[web-animations] implement the new endpoint-inclusive active interval behavior for `Animation.commitStyles()`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
@@ -7,27 +7,27 @@ PASS Throws if the target effect is display:none
 PASS Throws if the target effect's ancestor is display:none
 PASS Treats display:contents as rendered
 PASS Treats display:contents in a display:none subtree as not rendered
-FAIL Commits styles assert_approx_equals: expected 0.2 +/- 0.0001 but got 0.1
-FAIL Commits styles for backwards animation assert_approx_equals: expected 0.5 +/- 0.0001 but got 0.1
+PASS Commits styles
+PASS Commits styles for backwards animation
 PASS Commits values calculated mid-interval
 PASS Commits values during the start delay
 PASS Commits value after the active interval
-FAIL Commits the intermediate value of an animation in the middle of stack assert_approx_equals: expected 0.4 +/- 0.0001 but got 0.2
-FAIL Commits the intermediate value of an animation up to the middle of the stack assert_approx_equals: expected 0.4 +/- 0.0001 but got 0.1
-FAIL Commits styles for an animation that has been removed assert_approx_equals: expected 0.2 +/- 0.0001 but got 0.1
-FAIL Commit composites on top of the underlying value assert_approx_equals: expected 0.5 +/- 0.0001 but got 0.3
-FAIL Commits logical properties assert_equals: expected "20px" but got "10px"
+PASS Commits the intermediate value of an animation in the middle of stack
+PASS Commits the intermediate value of an animation up to the middle of the stack
+PASS Commits styles for an animation that has been removed
+PASS Commit composites on top of the underlying value
+PASS Commits logical properties
 FAIL Commits logical properties as physical properties assert_equals: expected "20px" but got "10px"
-FAIL Commits em units as pixel values assert_approx_equals: expected 100 +/- 0.0001 but got 784
+PASS Commits em units as pixel values
 FAIL Commits custom variables assert_approx_equals: expected 0.8 +/- 0.0001 but got 0.5
-FAIL Commits variable references as their computed values assert_approx_equals: expected 0.5 +/- 0.0001 but got 1
-FAIL Commits relative line-height assert_approx_equals: expected 15 +/- 0.0001 but got NaN
-FAIL Commits transforms assert_equals: expected "matrix(1, 0, 0, 1, 20, 20)" but got "none"
-FAIL Commits styles for individual transform properties assert_equals: expected "200px" but got "100px"
-FAIL Commits transforms as a transform list assert_equals: expected "translate(20px, 20px)" but got "none"
+PASS Commits variable references as their computed values
+PASS Commits relative line-height
+PASS Commits transforms
+PASS Commits styles for individual transform properties
+PASS Commits transforms as a transform list
 FAIL Commits matrix-interpolated relative transforms assert_equals: Resolved transform is correct after commit. expected "matrix(2, 0, 0, 2, 100, 0)" but got "matrix(2, 0, 0, 2, 0, 0)"
 PASS Commits 'none' transform
-FAIL Commits shorthand styles assert_equals: expected "20px" but got "10px"
-FAIL Triggers mutation observers when updating style assert_equals: Should have one mutation record expected 1 but got 0
+PASS Commits shorthand styles
+PASS Triggers mutation observers when updating style
 PASS Does NOT trigger mutation observers when the change to style is redundant
 

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -77,7 +77,7 @@ EffectTiming AnimationEffect::getBindingsTiming() const
     return timing;
 }
 
-AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(UseCachedCurrentTime useCachedCurrentTime) const
+AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(UseCachedCurrentTime useCachedCurrentTime, EndpointInclusiveActiveInterval endpointInclusiveActiveInterval) const
 {
     if (!m_animation)
         return { };
@@ -89,6 +89,7 @@ AnimationEffectTiming::ResolutionData AnimationEffect::resolutionData(UseCachedC
         timeline ? timeline->duration() : std::nullopt,
         animation->startTime(),
         animation->currentTime(useCachedCurrentTime),
+        endpointInclusiveActiveInterval,
         animation->playbackRate()
     };
 }
@@ -106,11 +107,11 @@ ComputedEffectTiming AnimationEffect::getBindingsComputedTiming()
     return getComputedTiming();
 }
 
-ComputedEffectTiming AnimationEffect::getComputedTiming(UseCachedCurrentTime useCachedCurrentTime)
+ComputedEffectTiming AnimationEffect::getComputedTiming(UseCachedCurrentTime useCachedCurrentTime, EndpointInclusiveActiveInterval endpointInclusiveActiveInterval)
 {
     updateComputedTimingPropertiesIfNeeded();
 
-    auto data = resolutionData(useCachedCurrentTime);
+    auto data = resolutionData(useCachedCurrentTime, endpointInclusiveActiveInterval);
     auto resolvedTiming = m_timing.resolve(data);
 
     // https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -55,7 +55,7 @@ public:
     EffectTiming getBindingsTiming() const;
     BasicEffectTiming getBasicTiming();
     ComputedEffectTiming getBindingsComputedTiming();
-    ComputedEffectTiming getComputedTiming(UseCachedCurrentTime = UseCachedCurrentTime::Yes);
+    ComputedEffectTiming getComputedTiming(UseCachedCurrentTime = UseCachedCurrentTime::Yes, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
     ExceptionOr<void> bindingsUpdateTiming(Document&, std::optional<OptionalEffectTiming>);
     ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
 
@@ -115,7 +115,7 @@ protected:
     virtual std::optional<double> progressUntilNextStep(double) const;
 
 private:
-    AnimationEffectTiming::ResolutionData resolutionData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const;
+    AnimationEffectTiming::ResolutionData resolutionData(UseCachedCurrentTime = UseCachedCurrentTime::Yes, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No) const;
     void updateComputedTimingPropertiesIfNeeded();
 
     AnimationEffectTiming m_timing;

--- a/Source/WebCore/animation/AnimationEffectTiming.cpp
+++ b/Source/WebCore/animation/AnimationEffectTiming.cpp
@@ -184,9 +184,9 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
         // An animation effect is in the before phase if the animation effect's local time is not unresolved and
         // either of the following conditions are met:
         //     1. the local time is less than the before-active boundary time, or
-        //     2. the animation direction is "backwards" and the local time is equal to the before-active boundary time
-        //        and not at progress timeline boundary.
-        if (localTime->approximatelyLessThan(beforeActiveBoundaryTime) || (animationIsBackwards && localTime->approximatelyEqualTo(beforeActiveBoundaryTime) && !atProgressTimelineBoundary()))
+        //     2. the animation direction is "backwards", the endpoint-inclusive active interval flag is false,
+        //        and the local time is equal to the before-active boundary time and not at progress timeline boundary.
+        if (localTime->approximatelyLessThan(beforeActiveBoundaryTime) || (animationIsBackwards && data.endpointInclusiveActiveInterval == EndpointInclusiveActiveInterval::No && localTime->approximatelyEqualTo(beforeActiveBoundaryTime) && !atProgressTimelineBoundary()))
             return AnimationEffectPhase::Before;
 
         // https://drafts.csswg.org/web-animations-1/#active-after-boundary-time
@@ -195,9 +195,9 @@ BasicEffectTiming AnimationEffectTiming::getBasicTiming(const ResolutionData& da
         // An animation effect is in the after phase if the animation effect's local time is not unresolved
         // and either of the following conditions are met:
         //     1. the local time is greater than the active-after boundary time, or
-        //     2. the animation direction is "forwards" and the local time is equal to the active-after boundary time
-        //        and not at progress timeline boundary.
-        if (localTime->approximatelyGreaterThan(activeAfterBoundaryTime) || (!animationIsBackwards && localTime->approximatelyEqualTo(activeAfterBoundaryTime) && !atProgressTimelineBoundary()))
+        //     2. the animation direction is "forwards", the endpoint-inclusive active interval flag is false,
+        //        and the local time is equal to the active-after boundary time and not at progress timeline boundary.
+        if (localTime->approximatelyGreaterThan(activeAfterBoundaryTime) || (!animationIsBackwards && data.endpointInclusiveActiveInterval == EndpointInclusiveActiveInterval::No && localTime->approximatelyEqualTo(activeAfterBoundaryTime) && !atProgressTimelineBoundary()))
             return AnimationEffectPhase::After;
 
         // An animation effect is in the active phase if the animation effect’s local time is not unresolved and it is not

--- a/Source/WebCore/animation/AnimationEffectTiming.h
+++ b/Source/WebCore/animation/AnimationEffectTiming.h
@@ -67,6 +67,7 @@ struct AnimationEffectTiming {
         std::optional<WebAnimationTime> timelineDuration;
         std::optional<WebAnimationTime> startTime;
         std::optional<WebAnimationTime> localTime;
+        EndpointInclusiveActiveInterval endpointInclusiveActiveInterval { EndpointInclusiveActiveInterval::No };
         double playbackRate { 0 };
     };
 

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -62,9 +62,9 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
 
 CSSTransition::~CSSTransition() = default;
 
-OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext)
+OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, EndpointInclusiveActiveInterval endpointInclusiveActiveInterval)
 {
-    auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext);
+    auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, endpointInclusiveActiveInterval);
     m_currentStyle = RenderStyle::clonePtr(targetStyle);
     return impact;
 }

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -58,7 +58,7 @@ private:
     CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
     Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
-    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&) final;
+    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1650,7 +1650,7 @@ void KeyframeEffect::didChangeTargetStyleable(const std::optional<const Styleabl
         newTargetStyleable->ensureKeyframeEffectStack().addEffect(*this);
 }
 
-OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext)
+OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, EndpointInclusiveActiveInterval endpointInclusiveActiveInterval)
 {
     OptionSet<AnimationImpact> impact;
     if (!m_target)
@@ -1658,7 +1658,7 @@ OptionSet<AnimationImpact> KeyframeEffect::apply(RenderStyle& targetStyle, const
 
     updateBlendingKeyframes(targetStyle, resolutionContext);
 
-    auto computedTiming = getComputedTiming();
+    auto computedTiming = getComputedTiming(UseCachedCurrentTime::Yes, endpointInclusiveActiveInterval);
 
     if (m_phaseAtLastApplication != computedTiming.phase) {
         m_phaseAtLastApplication = computedTiming.phase;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -133,7 +133,7 @@ public:
     void setBindingsComposite(CompositeOperation);
 
     void getAnimatedStyle(std::unique_ptr<RenderStyle>& animatedStyle);
-    OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&);
+    OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
     void invalidate();
 
     void animationRelevancyDidChange();

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -155,7 +155,7 @@ public:
     bool needsTick() const;
     virtual void tick();
     WEBCORE_EXPORT Seconds timeToNextTick() const;
-    virtual OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&);
+    virtual OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
     void effectTargetDidChange(const std::optional<const Styleable>& previousTarget, const std::optional<const Styleable>& newTarget);
     void acceleratedStateDidChange();
     void willChangeRenderer();

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -57,6 +57,7 @@ enum class AnimationImpact : uint8_t {
 
 enum class UseAcceleratedAction : bool { No, Yes };
 enum class UseCachedCurrentTime : bool { No, Yes };
+enum class EndpointInclusiveActiveInterval : bool { No, Yes };
 
 enum class WebAnimationType : uint8_t { CSSAnimation, CSSTransition, WebAnimation };
 

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -368,6 +368,7 @@ void AcceleratedEffect::apply(WebAnimationTime currentTime, AcceleratedEffectVal
         std::nullopt,
         { m_holdTime ? *m_holdTime : *m_startTime },
         { localTime },
+        EndpointInclusiveActiveInterval::No,
         m_playbackRate
     });
     if (!resolvedTiming.transformedProgress)


### PR DESCRIPTION
#### 6498d9a46fda12563183f9c6209fcf41970eff26
<pre>
[web-animations] implement the new endpoint-inclusive active interval behavior for `Animation.commitStyles()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297594">https://bugs.webkit.org/show_bug.cgi?id=297594</a>
<a href="https://rdar.apple.com/158684709">rdar://158684709</a>

Reviewed by Cameron McCormack.

The behavior of `Animation.commitStyles()` changed to use endpoint-inclusive active intervals [0]:

&gt; In order to simplify the common case of persisting a completed animation, the procedure to commit computed styles uses
&gt; endpoint-*inclusive* timing when determining the phase of the animation. As a result, the following code will persist
&gt; the `transform: translateY(100px)` style in specified style despite not having a fill mode of `forwards` or `both`:
&gt;
&gt;
&gt;```
&gt; elem.animate({ transform: &apos;translateY(100px)&apos; }, 200).finished.then(() =&gt; {
&gt;   elem.commitStyles();
&gt; });
&gt;```

To implement this new behavior, we add a new `EndpointInclusiveActiveInterval` boolean enum and a new member of that
type to the `AnimationEffectTiming::ResolutionData` struct used to resolve timing for animation effects. In order to
pass that value in from `Animation::commitStyles()`, we have to pass such a value through `Element::resolve()` →
`KeyframeEffect::apply()` → `AnimationEffect::getComputedTiming()`.

Then within `Animation::commitStyles()` we make a change not to use the `KeyframeEffectStack` associated with
the animation&apos;s target as that stack would not contain any effect associated with an animation that is no longer
_relevant_ [1], which would be the case of a finished animation that is not forward-filling. So we now make a sorted
copy of all animations associated with the animation&apos;s target and iterate through the associated effects, making
sure to pass `EndpointInclusiveActiveInterval::Yes` when calling `Animation::resolve()` to apply the animation&apos;s value.

Note that there are remaining failures in the WPT test which are not relevant to that spec change and which are tracked
by bug 297657.

[0] <a href="https://github.com/w3c/csswg-drafts/commit/aa2e02d2daee8d8eb146562f7a84d58f54f4b10c">https://github.com/w3c/csswg-drafts/commit/aa2e02d2daee8d8eb146562f7a84d58f54f4b10c</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#relevant-animations-section">https://drafts.csswg.org/web-animations-1/#relevant-animations-section</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::resolutionData const):
(WebCore::AnimationEffect::getComputedTiming):
* Source/WebCore/animation/AnimationEffect.h:
* Source/WebCore/animation/AnimationEffectTiming.cpp:
(WebCore::AnimationEffectTiming::getBasicTiming const):
* Source/WebCore/animation/AnimationEffectTiming.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::resolve):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::apply):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::resolve):
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::apply):

Canonical link: <a href="https://commits.webkit.org/299031@main">https://commits.webkit.org/299031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b45cc601687b1d9d400fd427910a94a7a3f85b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69287 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/167bf867-2651-40a4-94f7-e4f15b886112) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89019 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43691 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/89291316-470f-4f18-99ec-f85db98be453) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69526 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68dcd048-45e2-4aab-b1c2-d0be26c1c03a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23288 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67074 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126522 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97687 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97482 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20766 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40549 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18762 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43528 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->