### PR TITLE
Avoid GNU folding constant warnings

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1196,14 +1196,18 @@ static void checkJSStringOOBUTF8(void)
     const size_t outCStringSize = cStringSize + sourceCStringSize;
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_WARNINGS_BEGIN("gnu-folding-constant")
     char sourceCString[sourceCStringSize];
+IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_WARNINGS_BEGIN("gnu-folding-constant")
     char outCString[outCStringSize];
+IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(outCString, 0x13, sizeof(outCString));
 
@@ -1231,7 +1235,9 @@ static void checkJSStringOOBUTF16(void)
     const size_t outCStringSize = cStringSize + sourceCStringSize;
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_WARNINGS_BEGIN("gnu-folding-constant")
     char sourceCString[sourceCStringSize];
+IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
@@ -1243,7 +1249,9 @@ IGNORE_WARNINGS_END
     sourceCString[6] = '\x81';
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_WARNINGS_BEGIN("gnu-folding-constant")
     char outCString[outCStringSize];
+IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(outCString, 0x13, sizeof(outCString));
 
@@ -1271,7 +1279,9 @@ static void checkJSStringOOBUTF16AtEnd(void)
     const size_t outCStringSize = cStringSize + sourceCStringSize;
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_WARNINGS_BEGIN("gnu-folding-constant")
     char sourceCString[sourceCStringSize];
+IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(sourceCString, 0, sizeof(sourceCString));
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
@@ -1283,7 +1293,9 @@ IGNORE_WARNINGS_END
     sourceCString[20] = '\x81';
 
 IGNORE_WARNINGS_BEGIN("vla")
+IGNORE_WARNINGS_BEGIN("gnu-folding-constant")
     char outCString[outCStringSize];
+IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
     memset(outCString, 0x13, sizeof(outCString));
 


### PR DESCRIPTION
#### 59fdb341a8f6a32ca2c41d1023e457ff716364bc
<pre>
Avoid GNU folding constant warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=297660">https://bugs.webkit.org/show_bug.cgi?id=297660</a>
<a href="https://rdar.apple.com/158772091">rdar://158772091</a>

Reviewed by Justin Michaud.

Adds extra warning suppressions which may be needed by different toolchains.

* Source/JavaScriptCore/API/tests/testapi.c:
(checkJSStringOOBUTF8):
(checkJSStringOOBUTF16):
(checkJSStringOOBUTF16AtEnd):

Canonical link: <a href="https://commits.webkit.org/299007@main">https://commits.webkit.org/299007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cde2fab4eda56232393239a967abd3b1534d0d90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69294 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b3a19290-f97a-4d0f-9fff-4b00416a846f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89028 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43696 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa3233a3-24e4-44dc-8cfd-0cf5f5311ffb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69535 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d0997aa-751e-434c-97b2-15692a2d6c10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23298 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67081 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109414 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126529 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115816 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97693 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42844 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40556 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49738 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144516 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43535 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37230 "Found 1 new JSC binary failure: testapi, Found 20043 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->