### PR TITLE
Workers should handle btoa OOM gracefully

### DIFF
--- a/LayoutTests/workers/btoa-oom-expected.txt
+++ b/LayoutTests/workers/btoa-oom-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS message.data is an instance of RangeError
+

--- a/LayoutTests/workers/btoa-oom.html
+++ b/LayoutTests/workers/btoa-oom.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+</head>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+if (window.testRunner)
+    window.testRunner.waitUntilDone();
+
+async function runWorkerFuzz(){
+    const blob=new Blob([`
+        onmessage=function(e){
+            try {
+                let t=e.data;
+                for (let i = 0; i < 70; i++)
+                    t = btoa(t);
+            } catch (e) {
+                postMessage(e);
+                return;
+            }
+            postMessage("didn't throw");
+        };
+    `], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    let done;
+    let promise = new Promise((resolve) => {
+        done = resolve;
+    });
+
+    worker.onmessage = done;
+    worker.postMessage("A");
+
+    globalThis.message = await promise;
+    shouldBeType("message.data", "RangeError");
+    if (window.testRunner)
+        window.testRunner.notifyDone();
+}
+addEventListener('load', runWorkerFuzz);
+</script>
+
+</body>
+</html>
+

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -46,7 +46,11 @@ ExceptionOr<String> WindowOrWorkerGlobalScope::btoa(const String& stringToEncode
     if (!stringToEncode.containsOnlyLatin1())
         return Exception { ExceptionCode::InvalidCharacterError };
 
-    return base64EncodeToString(byteCast<uint8_t>(stringToEncode.latin1().span()));
+    String encodedString = base64EncodeToStringReturnNullIfOverflow(stringToEncode.latin1());
+    if (!encodedString)
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    return encodedString;
 }
 
 ExceptionOr<String> WindowOrWorkerGlobalScope::atob(const String& encodedString)


### PR DESCRIPTION
#### 0e9472d1a5c407f65030f25e8399e3aa83a96ca0
<pre>
Workers should handle btoa OOM gracefully
<a href="https://bugs.webkit.org/show_bug.cgi?id=297661">https://bugs.webkit.org/show_bug.cgi?id=297661</a>
<a href="https://rdar.apple.com/154896283">rdar://154896283</a>

Reviewed by Yusuke Suzuki.

Right now we call the version of base64EncodeToString that RELEASE_ASSERTs it will succeed.
This change instead calls base64EncodeToStringReturnNullIfOverflow and appropriately throws an
OOM when encoding fails. This matches the behavior of the main web thread.

* LayoutTests/workers/btoa-oom-expected.txt: Added.
* LayoutTests/workers/btoa-oom.html: Added.
* Source/WebCore/page/WindowOrWorkerGlobalScope.cpp:
(WebCore::WindowOrWorkerGlobalScope::btoa):

Canonical link: <a href="https://commits.webkit.org/298965@main">https://commits.webkit.org/298965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d352063cca703e950d72a37592a2e52dd76963e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69303 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/015b2ff6-6b5f-4ec4-98a4-94ad4fa76e69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89034 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43704 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19362174-939f-4c3e-9457-608af4afd143) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69541 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ec5ec4d-128b-4601-928b-72d3ae8efe24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23299 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67089 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126537 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97700 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97495 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20777 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49746 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43543 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45239 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->