### PR TITLE
“Infinite” CSS animation durations render page unresponsive

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+}
+
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+}
+
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Setting 'animation-duration' to an infinite value should not hang</title>
+<link rel="author" title="Antoine Quint" href="mailto:graouts@webkit.org">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=297596">
+<link rel="match" href="animation-duration-infinite-ref.html">
+<meta name="assert" content="Setting 'animation-duration' to an infinite value should not hang">
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+  background-color: black;
+
+  animation-name: slide;
+  animation-duration: calc(infinity * 1s);
+}
+
+@keyframes slide {
+  to { margin-left: 100px }
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/Source/WebCore/platform/animation/TimingFunction.cpp
+++ b/Source/WebCore/platform/animation/TimingFunction.cpp
@@ -102,7 +102,7 @@ double TimingFunction::transformProgress(double progress, double duration, Befor
     switch (type()) {
     case Type::CubicBezierFunction: {
         auto& function = uncheckedDowncast<CubicBezierTimingFunction>(*this);
-        if (function.isLinear())
+        if (function.isLinear() || duration >= std::numeric_limits<double>::max())
             return progress;
         // The epsilon value we pass to UnitBezier::solve given that the animation is going to run over |dur| seconds. The longer the
         // animation, the more precision we need in the timing function result to avoid ugly discontinuities.


### PR DESCRIPTION
#### 179a9082a09b3870ea3a33de975aa5f435453597
<pre>
“Infinite” CSS animation durations render page unresponsive
<a href="https://bugs.webkit.org/show_bug.cgi?id=297596">https://bugs.webkit.org/show_bug.cgi?id=297596</a>
<a href="https://rdar.apple.com/158775366">rdar://158775366</a>

Reviewed by Simon Fraser.

If the duration of an animation is extremely large, don&apos;t attempt to resolve the timing function.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-duration-infinite.html: Added.
* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::TimingFunction::transformProgress const):

Canonical link: <a href="https://commits.webkit.org/298975@main">https://commits.webkit.org/298975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e2cb88921346d02f7441d125917348bb352333

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/36999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/67a213df-846b-4b7d-a728-26e8630f6e72) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89041 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43712 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d694a586-8bc6-49cb-9fb6-b6924914d631) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69548 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fcfb87ad-cbd5-4304-a17a-b026019124f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23309 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67101 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126549 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97705 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44583 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97500 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20787 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/18729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46900 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45251 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->