### PR TITLE
EditingStyle: Avoid local uncounted variables

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -203,7 +203,6 @@ dom/UIEventWithKeyState.cpp
 editing/ApplyStyleCommand.cpp
 editing/ChangeListTypeCommand.cpp
 editing/Editing.cpp
-editing/EditingStyle.cpp
 editing/Editor.cpp
 editing/EditorCommand.cpp
 editing/FormatBlockCommand.cpp

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -741,7 +741,7 @@ void EditingStyle::overrideTypingStyleAt(const EditingStyle& style, const Positi
     Ref lineThrough = CSSPrimitiveValue::create(CSSValueLineThrough);
     RefPtr value = m_mutableStyle->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
     CSSValueListBuilder valueList;
-    if (auto* list = dynamicDowncast<CSSValueList>(value.get())) {
+    if (RefPtr list = dynamicDowncast<CSSValueList>(value.get())) {
         valueList = list->copyValues();
         applyTextDecorationChangeToValueList(valueList, underlineChange, WTFMove(underline));
         applyTextDecorationChangeToValueList(valueList, strikeThroughChange, WTFMove(lineThrough));
@@ -1186,7 +1186,7 @@ bool EditingStyle::elementIsStyledSpanOrHTMLEquivalent(const HTMLElement& elemen
         matchedAttributes++;
 
     if (element.hasAttribute(HTMLNames::styleAttr)) {
-        if (const auto* style = element.inlineStyle()) {
+        if (const RefPtr style = element.inlineStyle()) {
             for (auto property : *style) {
                 if (!isEditingProperty(property.id()))
                     return false;
@@ -1382,8 +1382,8 @@ void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideM
 
         // text decorations never override values.
         if ((property.id() == CSSPropertyTextDecorationLine || property.id() == CSSPropertyWebkitTextDecorationsInEffect) && value) {
-            if (auto* propertyValueList = dynamicDowncast<CSSValueList>(*property.value())) {
-                if (auto* valueList = dynamicDowncast<CSSValueList>(*value)) {
+            if (RefPtr propertyValueList = dynamicDowncast<CSSValueList>(*property.value())) {
+                if (RefPtr valueList = dynamicDowncast<CSSValueList>(*value)) {
                     auto newValue = valueList->copyValues();
                     mergeTextDecorationValues(newValue, *propertyValueList);
                     auto isImportant = property.isImportant() ? IsImportant::Yes : IsImportant::No;
@@ -1709,7 +1709,7 @@ bool EditingStyle::fontStyleIsItalic()
     if (!fontStyle)
         return false;
 
-    auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*fontStyle);
+    RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*fontStyle);
     auto keyword = primitiveValue ? primitiveValue->valueID() : CSSValueOblique;
     return keyword == CSSValueOblique || keyword == CSSValueItalic;
 }
@@ -1928,7 +1928,7 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
             value = computedStyle.propertyValue(CSSPropertyTextDecorationLine);
 
         CSSValueListBuilder valueList;
-        if (auto* list = dynamicDowncast<CSSValueList>(value.get()))
+        if (RefPtr list = dynamicDowncast<CSSValueList>(value.get()))
             valueList = list->copyValues();
 
         bool hasUnderline = contains(valueList, CSSValueUnderline);
@@ -2061,7 +2061,7 @@ static void diffTextDecorations(MutableStyleProperties& style, CSSPropertyID pro
     if (!textDecoration || !refTextDecorationList)
         return;
     auto newTextDecoration = textDecoration->copyValues();
-    for (auto& value : *refTextDecorationList)
+    for (Ref value : *refTextDecorationList)
         removeAll(newTextDecoration, value);
     setTextDecorationProperty(style, CSSValueList::createSpaceSeparated(WTFMove(newTextDecoration)), propertyID);
 }


### PR DESCRIPTION
#### a08be4b5e972a5b0c14abca31ad9b47f4525cff1
<pre>
EditingStyle: Avoid local uncounted variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=297668">https://bugs.webkit.org/show_bug.cgi?id=297668</a>
<a href="https://rdar.apple.com/158780234">rdar://158780234</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::overrideTypingStyleAt):
(WebCore::EditingStyle::elementIsStyledSpanOrHTMLEquivalent):
(WebCore::EditingStyle::mergeStyle):
(WebCore::EditingStyle::fontStyleIsItalic):
(WebCore::StyleChange::StyleChange):
(WebCore::diffTextDecorations):

Canonical link: <a href="https://commits.webkit.org/298973@main">https://commits.webkit.org/298973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbdb0b30a49157e287e746b3966082a6a2cdf806

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69316 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7490d04-bd5c-409f-b3a2-a0b3c1e25c74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89040 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43711 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6dd9b62-8293-473a-b75a-27dba1779c0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/29999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d01a3b37-6a44-4b91-b297-47b9783b6f83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126550 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97707 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97502 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20791 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49759 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43556 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45252 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->