### PR TITLE
[JSC] Use StructureID comparison for final typed GC type RefCast / RefTest

### DIFF
--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -84,15 +84,10 @@ inline Structure* Structure::create(VM& vm, Structure* previous, DeferredStructu
         result->finishCreation(vm, previous, deferred);
         return result;
     }
-    case StructureVariant::WebAssemblyGC: {
-#if ENABLE(WEBASSEMBLY)
-        auto* result = new (NotNull, allocateCell<WebAssemblyGCStructure>(vm)) WebAssemblyGCStructure(vm, jsCast<WebAssemblyGCStructure*>(previous));
-        result->finishCreation(vm, previous, deferred);
-        return result;
-#else
+    case StructureVariant::WebAssemblyGC:
+        RELEASE_ASSERT_NOT_REACHED();
         return nullptr;
-#endif
-    }
+
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2432,26 +2432,35 @@ void BBQJIT::emitRefTestOrCast(const TypedExpression& typedValue, GPRReg valueGP
         }
     } else {
         Wasm::TypeDefinition& signature = m_info.typeSignatures[toHeapType];
-        if (signature.expand().is<Wasm::FunctionSignature>())
-            m_jit.loadPtr(Address(valueGPR, WebAssemblyFunctionBase::offsetOfRTT()), wasmScratchGPR);
-        else {
+        auto& expanded = signature.expand();
+        if (!expanded.is<Wasm::FunctionSignature>()) {
             // The cell check is only needed for non-functions, as the typechecker does not allow non-Cell values for funcref casts.
             if (!typedValue.type().definitelyIsCellOrNull())
                 failureCases.append(m_jit.branchIfNotCell(valueGPR, DoNotHaveTagRegisters));
             if (!typedValue.type().definitelyIsWasmGCObjectOrNull())
                 failureCases.append(m_jit.branchIfNotType(valueGPR, JSType::WebAssemblyGCObjectType));
-            m_jit.emitLoadStructure(valueGPR, wasmScratchGPR);
-            m_jit.loadPtr(Address(wasmScratchGPR, WebAssemblyGCStructure::offsetOfRTT()), wasmScratchGPR);
         }
 
-        Ref targetRTT = m_info.rtts[toHeapType];
-        if (signature.isFinalType()) {
-            // If signature is final type and pointer equality failed, this value must not be a subtype.
-            failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
+        if (!expanded.is<Wasm::FunctionSignature>() && signature.isFinalType()) {
+            m_jit.load32(MacroAssembler::Address(valueGPR, JSCell::structureIDOffset()), wasmScratchGPR);
+            failureCases.append(m_jit.branch32(CCallHelpers::NotEqual, wasmScratchGPR, Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info.importFunctionCount(), m_info.tableCount(), m_info.globalCount(), toHeapType))));
         } else {
-            doneCases.append(m_jit.branchPtr(CCallHelpers::Equal, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
-            failureCases.append(m_jit.branch32(CCallHelpers::BelowOrEqual, Address(wasmScratchGPR, RTT::offsetOfDisplaySizeExcludingThis()), TrustedImm32(targetRTT->displaySizeExcludingThis())));
-            failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, Address(wasmScratchGPR, (RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(const RTT*))), TrustedImmPtr(targetRTT.ptr())));
+            if (expanded.is<Wasm::FunctionSignature>())
+                m_jit.loadPtr(Address(valueGPR, WebAssemblyFunctionBase::offsetOfRTT()), wasmScratchGPR);
+            else {
+                m_jit.emitLoadStructure(valueGPR, wasmScratchGPR);
+                m_jit.loadPtr(Address(wasmScratchGPR, WebAssemblyGCStructure::offsetOfRTT()), wasmScratchGPR);
+            }
+
+            Ref targetRTT = m_info.rtts[toHeapType];
+            if (signature.isFinalType()) {
+                // If signature is final type and pointer equality failed, this value must not be a subtype.
+                failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
+            } else {
+                doneCases.append(m_jit.branchPtr(CCallHelpers::Equal, wasmScratchGPR, TrustedImmPtr(targetRTT.ptr())));
+                failureCases.append(m_jit.branch32(CCallHelpers::BelowOrEqual, Address(wasmScratchGPR, RTT::offsetOfDisplaySizeExcludingThis()), TrustedImm32(targetRTT->displaySizeExcludingThis())));
+                failureCases.append(m_jit.branchPtr(CCallHelpers::NotEqual, Address(wasmScratchGPR, (RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(const RTT*))), TrustedImmPtr(targetRTT.ptr())));
+            }
         }
     }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3729,12 +3729,8 @@ void OMGIRGenerator::emitRefTestOrCast(CastKind castKind, TypedExpression refere
         }
     } else {
         Wasm::TypeDefinition& signature = m_info.typeSignatures[toHeapType];
-        BasicBlock* slowPath = m_proc.addBlock();
-
-        Value* rtt;
-        if (signature.expand().is<Wasm::FunctionSignature>())
-            rtt = emitLoadRTTFromFuncref(value);
-        else {
+        auto& expanded = signature.expand();
+        if (!expanded.is<Wasm::FunctionSignature>()) {
             // The cell check is only needed for non-functions, as the typechecker does not allow non-Cell values for funcref casts.
             if (!reference.type().definitelyIsCellOrNull())
                 emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), value, constant(Int64, JSValue::NotCellMask)), castFailure, falseBlock);
@@ -3742,29 +3738,41 @@ void OMGIRGenerator::emitRefTestOrCast(CastKind castKind, TypedExpression refere
                 Value* jsType = m_currentBlock->appendNew<MemoryValue>(m_proc, Load8Z, Int32, origin(), value, safeCast<int32_t>(JSCell::typeInfoTypeOffset()));
                 emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, NotEqual, origin(), jsType, constant(Int32, JSType::WebAssemblyGCObjectType)), castFailure, falseBlock);
             }
-            rtt = emitLoadRTTFromObject(value);
         }
 
-        Ref targetRTT = m_info.rtts[toHeapType];
-        auto* targetRTTPointer = constant(pointerType(), std::bit_cast<uintptr_t>(targetRTT.ptr()));
-        BasicBlock* equalBlock;
-        if (castKind == CastKind::Cast)
-            equalBlock = continuation;
-        else
-            equalBlock = trueBlock;
-        m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), rtt, targetRTTPointer), FrequentedBlock(equalBlock), FrequentedBlock(slowPath));
-        equalBlock->addPredecessor(m_currentBlock);
-        slowPath->addPredecessor(m_currentBlock);
-
-        m_currentBlock = slowPath;
-        if (signature.isFinalType()) {
-            // If signature is final type and pointer equality failed, this value must not be a subtype.
-            emitCheckOrBranchForCast(castKind, constant(Int32, 1), castFailure, falseBlock);
+        if (!expanded.is<Wasm::FunctionSignature>() && signature.isFinalType()) {
+            auto* structureID = m_currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int32, origin(), value, safeCast<int32_t>(JSCell::structureIDOffset()));
+            auto* targetStructureID = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int32, origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfGCObjectStructureID(m_info.importFunctionCount(), m_info.tableCount(), m_info.globalCount(), toHeapType)));
+            emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, NotEqual, origin(), structureID, targetStructureID), castFailure, falseBlock);
         } else {
-            auto* displaySizeExcludingThis = m_currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int32, origin(), rtt, safeCast<int32_t>(RTT::offsetOfDisplaySizeExcludingThis()));
-            emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, BelowEqual, origin(), displaySizeExcludingThis, constant(Int32, targetRTT->displaySizeExcludingThis())), castFailure, falseBlock);
-            auto* pointer = m_currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), origin(), rtt, safeCast<uint32_t>(RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(const RTT*)));
-            emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, NotEqual, origin(), pointer, targetRTTPointer), castFailure, falseBlock);
+            BasicBlock* slowPath = m_proc.addBlock();
+            Value* rtt;
+            if (expanded.is<Wasm::FunctionSignature>())
+                rtt = emitLoadRTTFromFuncref(value);
+            else
+                rtt = emitLoadRTTFromObject(value);
+
+            Ref targetRTT = m_info.rtts[toHeapType];
+            auto* targetRTTPointer = constant(pointerType(), std::bit_cast<uintptr_t>(targetRTT.ptr()));
+            BasicBlock* equalBlock;
+            if (castKind == CastKind::Cast)
+                equalBlock = continuation;
+            else
+                equalBlock = trueBlock;
+            m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), m_currentBlock->appendNew<Value>(m_proc, Equal, origin(), rtt, targetRTTPointer), FrequentedBlock(equalBlock), FrequentedBlock(slowPath));
+            equalBlock->addPredecessor(m_currentBlock);
+            slowPath->addPredecessor(m_currentBlock);
+
+            m_currentBlock = slowPath;
+            if (signature.isFinalType()) {
+                // If signature is final type and pointer equality failed, this value must not be a subtype.
+                emitCheckOrBranchForCast(castKind, constant(Int32, 1), castFailure, falseBlock);
+            } else {
+                auto* displaySizeExcludingThis = m_currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, Int32, origin(), rtt, safeCast<int32_t>(RTT::offsetOfDisplaySizeExcludingThis()));
+                emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, BelowEqual, origin(), displaySizeExcludingThis, constant(Int32, targetRTT->displaySizeExcludingThis())), castFailure, falseBlock);
+                auto* pointer = m_currentBlock->appendNew<MemoryValue>(m_proc, B3::Load, pointerType(), origin(), rtt, safeCast<uint32_t>(RTT::offsetOfData() + targetRTT->displaySizeExcludingThis() * sizeof(const RTT*)));
+                emitCheckOrBranchForCast(castKind, m_currentBlock->appendNew<Value>(m_proc, NotEqual, origin(), pointer, targetRTTPointer), castFailure, falseBlock);
+            }
         }
     }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
@@ -86,14 +86,12 @@ bool WebAssemblyGCObjectBase::deletePropertyByIndex(JSCell*, JSGlobalObject* glo
     return typeError(globalObject, scope, true, "Cannot delete property for WebAssembly GC object"_s);
 }
 
-void WebAssemblyGCObjectBase::getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray& propertyNameArray, DontEnumPropertiesMode)
+void WebAssemblyGCObjectBase::getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode)
 {
-#if ASSERT_ENABLED
-    ASSERT(!propertyNameArray.size());
-#else
-    UNUSED_PARAM(propertyNameArray);
-#endif
-    return;
+}
+
+void WebAssemblyGCObjectBase::getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode)
+{
 }
 
 bool WebAssemblyGCObjectBase::defineOwnProperty(JSObject*, JSGlobalObject* globalObject, PropertyName, const PropertyDescriptor&, bool shouldThrow)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -37,7 +37,7 @@ namespace JSC {
 class WebAssemblyGCObjectBase : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetPrototype | OverridesPut | OverridesIsExtensible | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesGetOwnSpecialPropertyNames | OverridesGetPrototype | OverridesPut | OverridesIsExtensible | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | ProhibitsPropertyCaching | GetOwnPropertySlotIsImpure | GetOwnPropertySlotIsImpureForPropertyAbsence | GetOwnPropertySlotMayBeWrongAboutDontEnum;
 
     DECLARE_INFO;
 
@@ -58,6 +58,7 @@ protected:
     JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
     JS_EXPORT_PRIVATE static bool deletePropertyByIndex(JSCell*, JSGlobalObject*, unsigned);
     JS_EXPORT_PRIVATE static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
+    JS_EXPORT_PRIVATE static void getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
     JS_EXPORT_PRIVATE static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
     JS_EXPORT_PRIVATE static JSValue getPrototype(JSObject*, JSGlobalObject*);
     JS_EXPORT_PRIVATE static bool setPrototype(JSObject*, JSGlobalObject*, JSValue, bool shouldThrowIfCantSet);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
@@ -37,15 +37,10 @@ WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, JSGlobalObject* globalObj
     , m_rtt(WTFMove(rtt))
     , m_type(WTFMove(type))
 {
+    setMayBePrototype(true);
+    setHasBeenFlattenedBefore(true);
+    setHasBeenDictionary(true);
 }
-
-WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, WebAssemblyGCStructure* previous)
-    : Structure(vm, StructureVariant::WebAssemblyGC, previous)
-    , m_rtt(previous->m_rtt)
-    , m_type(previous->m_type)
-{
-}
-
 
 WebAssemblyGCStructure* WebAssemblyGCStructure::create(VM& vm, JSGlobalObject* globalObject, const TypeInfo& typeInfo, const ClassInfo* classInfo, Ref<const Wasm::TypeDefinition>&& type, Ref<const Wasm::RTT>&& rtt)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -60,7 +60,6 @@ public:
 
 private:
     WebAssemblyGCStructure(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&&, Ref<const Wasm::RTT>&&);
-    WebAssemblyGCStructure(VM&, WebAssemblyGCStructure* previous);
 
     Ref<const Wasm::RTT> m_rtt;
     Ref<const Wasm::TypeDefinition> m_type;


### PR DESCRIPTION
#### 0bfea79c6d2fd8c664d6b3c883327db2a6f1ea5d
<pre>
[JSC] Use StructureID comparison for final typed GC type RefCast / RefTest
<a href="https://bugs.webkit.org/show_bug.cgi?id=297671">https://bugs.webkit.org/show_bug.cgi?id=297671</a>
<a href="https://rdar.apple.com/158784268">rdar://158784268</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::create):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp:
(JSC::WebAssemblyGCObjectBase::getOwnPropertyNames):
(JSC::WebAssemblyGCObjectBase::getOwnSpecialPropertyNames):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp:
(JSC::WebAssemblyGCStructure::WebAssemblyGCStructure):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bfea79c6d2fd8c664d6b3c883327db2a6f1ea5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69323 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88b190fc-114e-4146-b2e1-5c10510d769d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89043 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43714 "Found 1 new test failure: js/structuredClone/structured-clone-of-CachedString-in-map.html (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc95b8b7-a323-4285-9431-00f15f7ecfdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69550 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f0913190-e680-4166-a668-39dcf54ed975) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23320 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67108 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109441 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126556 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115843 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97717 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97512 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40583 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49765 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144543 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43562 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37205 "Found 1 new JSC binary failure: testapi, Found 20037 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/blue_1086262.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug215238.shrua-2.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->