### PR TITLE
Use Seconds literals in more places

### DIFF
--- a/Source/JavaScriptCore/runtime/Watchdog.cpp
+++ b/Source/JavaScriptCore/runtime/Watchdog.cpp
@@ -63,7 +63,7 @@ bool Watchdog::shouldTerminate(JSGlobalObject* globalObject)
     // Adding this leeway shouldn't cause a problem for other platforms
     // (since the "deadline is infinity" case should be the crucial one),
     // but it is a fact that only Windows is experiencing the issue.
-    epsilon = Seconds::fromMilliseconds(20);
+    epsilon = 20_ms;
 #endif
     if (MonotonicTime::timePointFromNow(epsilon) < m_deadline)
         return false; // Just a stale timer firing. Nothing to do.

--- a/Source/WebCore/page/PerformanceEventTiming.h
+++ b/Source/WebCore/page/PerformanceEventTiming.h
@@ -60,9 +60,9 @@ public:
     ASCIILiteral entryType() const final;
 
     static constexpr DOMHighResTimeStamp durationResolutionInMilliseconds = 8;
-    static constexpr Seconds durationResolution = Seconds::fromMilliseconds(8);
-    static constexpr Seconds minimumDurationThreshold = Seconds::fromMilliseconds(16);
-    static constexpr Seconds defaultDurationThreshold = Seconds::fromMilliseconds(104);
+    static constexpr Seconds durationResolution = 8_ms;
+    static constexpr Seconds minimumDurationThreshold = 16_ms;
+    static constexpr Seconds defaultDurationThreshold = 104_ms;
 
 private:
     PerformanceEventTiming(const Candidate&, Seconds duration, bool isFirst);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -659,7 +659,7 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
     static Seconds activityStateUpdateTimeout = [] {
         if (RetainPtr<id> value = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitOverrideActivityStateUpdateTimeout"])
             return Seconds([value doubleValue]);
-        return Seconds::fromMilliseconds(250);
+        return 250_ms;
     }();
 
     WeakPtr weakThis { *this };


### PR DESCRIPTION
#### 07f07b9da9150236945fb4898c65ab4d74763b71
<pre>
Use Seconds literals in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=297678">https://bugs.webkit.org/show_bug.cgi?id=297678</a>
<a href="https://rdar.apple.com/158788349">rdar://158788349</a>

Reviewed by Keith Miller, Richard Robinson, and Tim Horton.

Replace some instances of `Seconds::fromMilliseconds()` with Seconds literals.

Doing this so that the `250_ms` is more findable.

* Source/JavaScriptCore/runtime/Watchdog.cpp:
(JSC::Watchdog::shouldTerminate):
* Source/WebCore/page/PerformanceEventTiming.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):

Canonical link: <a href="https://commits.webkit.org/298980@main">https://commits.webkit.org/298980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e4750c13086a405e7b3a0995c196d564681101

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69335 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1039006-43c2-4ba7-aa1b-032adcc96b2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/119226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89057 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43721 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d3637cf-617a-4b8a-a28b-8d7251e4c513) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5ad7818c-437f-49ca-813c-fa5698f09253) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23332 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67120 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109453 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99419 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23515 "Found 1 new test failure: imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126568 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97718 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97513 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20809 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/40595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44118 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49777 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144555 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43574 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37209 "Found 1 new JSC binary failure: testapi, Found 20040 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInPrimitive.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply.js.default ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->