### PR TITLE
[JSC] Use `if constexpr` instead of `if`

### DIFF
--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -72,7 +72,7 @@ public:
     template<typename T>
     void set(void* logicalAddress, T value)
     {
-        if (sizeof(T) <= s_chunkSize)
+        if constexpr (sizeof(T) <= s_chunkSize)
             m_dirtyBits |= dirtyBitFor(logicalAddress);
         else {
             size_t numberOfChunks = roundUpToMultipleOf<sizeof(T)>(s_chunkSize) / s_chunkSize;

--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -1414,9 +1414,10 @@ public:
             return MacroAssemblerARMv7::BoundsNonDoubleWordOffset::within(offset);
         case MoveDouble:
         case MoveFloat:
-            if (!std::is_signed<Int>::value)
+            if constexpr (!std::is_signed_v<Int>)
                 return !((offset & 3) || (offset > (255 * 4)));
-            return !((offset & 3) || (offset > (255 * 4)) || (static_cast<typename std::make_signed<Int>::type>(offset) < -(255 * 4)));
+            else
+                return !((offset & 3) || (offset > (255 * 4)) || (static_cast<typename std::make_signed<Int>::type>(offset) < -(255 * 4)));
         default:
             return false;
         }

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -2047,7 +2047,7 @@ static void testFMaxMin()
         BasicBlock* root = proc.addBlock();
         Value* a;
         Value* b;
-        if (std::is_same_v<FloatType, float>) {
+        if constexpr (std::same_as<FloatType, float>) {
             a = root->appendNew<ConstFloatValue>(proc, Origin(), arg1);
             b = root->appendNew<ConstFloatValue>(proc, Origin(), arg2);
         } else {

--- a/Source/JavaScriptCore/ftl/FTLOutput.h
+++ b/Source/JavaScriptCore/ftl/FTLOutput.h
@@ -123,17 +123,19 @@ public:
     template<typename T>
     LValue constIntPtr(T* value)
     {
-        static_assert(!std::is_base_of<HeapCell, T>::value, "To use a GC pointer, the graph must be aware of it. Use gcPointer instead and make sure the graph is aware of this reference.");
-        if (sizeof(void*) == 8)
+        static_assert(!std::derived_from<T, HeapCell>, "To use a GC pointer, the graph must be aware of it. Use gcPointer instead and make sure the graph is aware of this reference.");
+        if constexpr (sizeof(void*) == 8)
             return constInt64(std::bit_cast<intptr_t>(value));
-        return constInt32(std::bit_cast<intptr_t>(value));
+        else
+            return constInt32(std::bit_cast<intptr_t>(value));
     }
     template<typename T>
     LValue constIntPtr(T value)
     {
-        if (sizeof(void*) == 8)
+        if constexpr (sizeof(void*) == 8)
             return constInt64(static_cast<intptr_t>(value));
-        return constInt32(static_cast<intptr_t>(value));
+        else
+            return constInt32(static_cast<intptr_t>(value));
     }
     LValue constInt64(int64_t value);
     LValue constDouble(double value);

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -624,7 +624,7 @@ private:
         // arguments should be passed through FPRRegs. This is asserted in the invocation of the lastly-called
         // setupArgumentsImpl(ArgCollection<>) overload, by matching the number of handled GPR and FPR arguments
         // with the corresponding count of properly-typed arguments for this operation.
-        if (!std::is_same_v<ArgumentType, double>) {
+        if constexpr (!std::is_same_v<ArgumentType, double>) {
             // RV64 calling convention requires all 32-bit values to be sign-extended into the whole register.
             // JSC JIT is tailored for other ISAs that pass these values in 32-bit-wide registers, which RISC-V
             // doesn't support, so any 32-bit value passed in argument registers has to be manually sign-extended.
@@ -768,9 +768,10 @@ public:
     static constexpr GPRReg operationExceptionRegister()
     {
         static_assert(assertNotOperationSignature<T>);
-        if (std::is_floating_point_v<typename T::ResultType> || std::is_same_v<typename T::ResultType, void>)
+        if constexpr (std::is_floating_point_v<typename T::ResultType> || std::is_same_v<typename T::ResultType, void>)
             return GPRInfo::returnValueGPR;
-        return GPRInfo::returnValueGPR2;
+        else
+            return GPRInfo::returnValueGPR2;
     }
 #else
     template<typename T>
@@ -778,9 +779,10 @@ public:
     static constexpr GPRReg operationExceptionRegister()
     {
         static_assert(assertNotOperationSignature<T>);
-        if (std::is_same_v<T, ExceptionOperationResult<void>>)
+        if constexpr (std::is_same_v<T, ExceptionOperationResult<void>>)
             return GPRInfo::returnValueGPR;
-        return GPRInfo::returnValueGPR2;
+        else
+            return GPRInfo::returnValueGPR2;
     }
 #endif
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2745,7 +2745,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         // But (1) is not possible because we do not recognize the string literal in ArrowFunctionBodyExpression as directive and this is correct in terms of the spec (`value => "use strict"`).
         // So we only check TreeBuilder's type here.
         ASSERT_UNUSED(functionScopeWasStrictMode, functionScopeWasStrictMode == currentScope()->strictMode());
-        if (!std::is_same<TreeBuilder, SyntaxChecker>::value)
+        if constexpr (!std::is_same_v<TreeBuilder, SyntaxChecker>)
             lexCurrentTokenAgainUnderCurrentContext(context);
     }
 


### PR DESCRIPTION
#### a722bd4d57831d96ac4ce77b1c203734445b77f1
<pre>
[JSC] Use `if constexpr` instead of `if`
<a href="https://bugs.webkit.org/show_bug.cgi?id=297680">https://bugs.webkit.org/show_bug.cgi?id=297680</a>

Reviewed by Darin Adler.

Replace runtime conditionals with compile-time `if constexpr` and
update type traits to use `_v` suffix style.

* Source/JavaScriptCore/assembler/ProbeStack.h:
(JSC::Probe::Page::set):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isValidAddrForm):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testFMaxMin):
* Source/JavaScriptCore/ftl/FTLOutput.h:
(JSC::FTL::Output::constIntPtr):
* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::finalizeGPRArguments):
(JSC::CCallHelpers::operationExceptionRegister):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):

Canonical link: <a href="https://commits.webkit.org/299137@main">https://commits.webkit.org/299137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85740cf27873031c13029cb59869ca0eea7cb160

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/117426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/37096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/123525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/69442 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/37792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/45683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/89112 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/43790 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/120378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/30083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/105288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/69621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/29139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/23403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/67198 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/109531 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/99487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/23585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/126646 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/115933 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/44323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/33315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/97778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/44681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/101523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/97572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/42939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/20876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/40673 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/44196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/49855 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/144633 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/43653 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/37225 "Found 1 new JSC binary failure: testapi, Found 20030 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_slice.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/reverse1.js.default, ChakraCore.yaml/ChakraCore/test/Array/toLocaleString.js.default, ChakraCore.yaml/ChakraCore/test/Date/date_cache_bug.js.default, ChakraCore.yaml/ChakraCore/test/Error/CallNonFunction.js.default, ChakraCore.yaml/ChakraCore/test/Error/stack2.js.default, ChakraCore.yaml/ChakraCore/test/Function/FuncBody.bug227901.js.default, ChakraCore.yaml/ChakraCore/test/Function/StackArgsWithFormals.js.default, ChakraCore.yaml/ChakraCore/test/Function/apply3.js.default ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/46997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/45348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->